### PR TITLE
Add support for aws_docdb_cluster_instance - used as an example of how to add new resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean:
 	rm -rf build/$(BINARY)*
 
 test:
-	go test $(LD_FLAGS) ./... $(or $(ARGS), -v -cover)
+	go test -timeout 15m $(LD_FLAGS) ./... $(or $(ARGS), -v -cover)
 
 fmt:
 	go fmt ./...

--- a/internal/providers/terraform/aws/docdb_cluster_instance.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance.go
@@ -1,0 +1,99 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/pkg/schema"
+
+	"github.com/shopspring/decimal"
+)
+
+func NewDocDBClusterInstance(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	region := d.Get("region").String()
+
+	instanceType := d.Get("instance_class").String()
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name:           fmt.Sprintf("Database Instance (%s, %s)", "on_demand", instanceType),
+			Unit:           "hours",
+			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonDocDB"),
+				ProductFamily: strPtr("Database Instance"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "instanceType", Value: strPtr(instanceType)},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("on_demand"),
+			},
+		},
+		{
+			Name: "Storage",
+			Unit: "GB-months",
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonDocDB"),
+				ProductFamily: strPtr("Database Storage"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", Value: strPtr("StorageUsage")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("on_demand"),
+			},
+		},
+		{
+			Name: "I/O",
+			Unit: "requests",
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonDocDB"),
+				ProductFamily: strPtr("System Operation"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", Value: strPtr("StorageIOUsage")},
+				},
+			},
+		},
+		{
+			Name: "Backup Storage",
+			Unit: "GB-months",
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonDocDB"),
+				ProductFamily: strPtr("Storage Snapshot"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", Value: strPtr("BackupUsage")},
+				},
+			},
+		},
+	}
+
+	if strings.HasPrefix(instanceType, "db.t3.") {
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name: "CPU Credits",
+			Unit: "vCPU-hours",
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonDocDB"),
+				ProductFamily: strPtr("CPU Credits"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", Value: strPtr("CPUCredits:db.t3")},
+				},
+			},
+		})
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/providers/terraform/aws/docdb_cluster_instance.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/infracost/infracost/pkg/schema"
-
 	"github.com/shopspring/decimal"
 )
 

--- a/internal/providers/terraform/aws/docdb_cluster_instance_test.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance_test.go
@@ -3,10 +3,8 @@ package aws_test
 import (
 	"testing"
 
-	"github.com/infracost/infracost/pkg/testutil"
-
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
-
+	"github.com/infracost/infracost/pkg/testutil"
 	"github.com/shopspring/decimal"
 )
 

--- a/internal/providers/terraform/aws/docdb_cluster_instance_test.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance_test.go
@@ -1,0 +1,78 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/pkg/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestNewDocDBClusterInstance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_docdb_cluster_instance" "db" {
+			cluster_identifier = "fake123"
+			instance_class     = "db.t3.medium"
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_docdb_cluster_instance.db",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Database Instance (on_demand, db.t3.medium)",
+					PriceHash:       "b21c3c7708229fb149bff23b4cfe6833-d2c98780d7b6e36641b521f1f8145c6f",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "aws_docdb_cluster_instance.db",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Storage",
+					PriceHash:       "856b9e5bd87c953bffd1df698a6a1b3d-ee3dd7e4624338037ca6fea0933a662f",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+			},
+		},
+		{
+			Name: "aws_docdb_cluster_instance.db",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "I/O",
+					PriceHash:       "c6f1f44a4f05ef22044c5af6490b6808-5be345988e7c9a0759c5cf8365868ee4",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+			},
+		},
+		{
+			Name: "aws_docdb_cluster_instance.db",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Backup Storage",
+					PriceHash:       "b508a58e978730edb23511dd40ad77d6-ee3dd7e4624338037ca6fea0933a662f",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+			},
+		},
+		{
+			Name: "aws_docdb_cluster_instance.db",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "CPU Credits",
+					PriceHash:       "f6d2bda62e25c6eb08020075859e5a97-e8e892be2fbd1c8f42fd6761ad8977d8",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -3,18 +3,19 @@ package aws
 import "github.com/infracost/infracost/pkg/schema"
 
 var ResourceRegistry map[string]schema.ResourceFunc = map[string]schema.ResourceFunc{
-	"aws_alb":                  NewLB, // alias for aws_lb
-	"aws_autoscaling_group":    NewAutoscalingGroup,
-	"aws_db_instance":          NewDBInstance,
-	"aws_dynamodb_table":       NewDynamoDBTable,
-	"aws_ebs_snapshot":         NewEBSSnapshot,
-	"aws_ebs_snapshot_copy":    NewEBSSnapshotCopy,
-	"aws_ebs_volume":           NewEBSVolume,
-	"aws_ecs_service":          NewECSService,
-	"aws_elb":                  NewELB,
-	"aws_instance":             NewInstance,
-	"aws_lambda_function":      NewLambdaFunction,
-	"aws_lb":                   NewLB,
-	"aws_nat_gateway":          NewNATGateway,
-	"aws_rds_cluster_instance": NewRDSClusterInstance,
+	"aws_alb":                    NewLB, // alias for aws_lb
+	"aws_autoscaling_group":      NewAutoscalingGroup,
+	"aws_db_instance":            NewDBInstance,
+	"aws_docdb_cluster_instance": NewDocDBClusterInstance,
+	"aws_dynamodb_table":         NewDynamoDBTable,
+	"aws_ebs_snapshot":           NewEBSSnapshot,
+	"aws_ebs_snapshot_copy":      NewEBSSnapshotCopy,
+	"aws_ebs_volume":             NewEBSVolume,
+	"aws_ecs_service":            NewECSService,
+	"aws_elb":                    NewELB,
+	"aws_instance":               NewInstance,
+	"aws_lambda_function":        NewLambdaFunction,
+	"aws_lb":                     NewLB,
+	"aws_nat_gateway":            NewNATGateway,
+	"aws_rds_cluster_instance":   NewRDSClusterInstance,
 }


### PR DESCRIPTION
**Objective**:

Add support for `aws_docdb_cluster_instance`.

**Example output**:

```
  aws_docdb_cluster_instance.db
  ├─ Backup Storage                                         0  GB-month     0.0210       0.0000        0.0000
  ├─ CPU Credits                                            0  vCPU-hour    0.0900       0.0000        0.0000
  ├─ Database Instance (on_demand, db.t3.medium)          730  hours        0.0780       0.0780       56.9400
  ├─ I/O                                                    0  requests      2e-07       0.0000        0.0000
  └─ Storage                                                0  GB-month     0.1000       0.0000        0.0000
  Total                                                                                  0.0780       56.9400
```

**Pricing details**:

The `aws_docdb_cluster_instance` has 4 price components described in https://aws.amazon.com/documentdb/pricing/. There is no support for Reserved Instances nor Spot prices.

T3 instances have an additional price for CPU Credits, this is charged per vCPU-hour and https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/unlimited-mode-examples.html suggests that the pricing is independent of the number of CPU cores in the T3 instance; instead the total number of vCPU-hours are calculated and multiplied by the price.

The `count` parameter replicates the resource in the Terraform plan JSON so there is no need to handle it in the resource/test file.

**Status**:

- [x] Added to resource_registry.go
- [x] Added resource file
- [x] Added integration tests
- [ ] Added unit tests if applicable - Not applicable
- [x] Added to https://github.com/infracost/docs/blob/master/docs/supported_resources.md
  See https://github.com/infracost/docs/pull/8

**Issues**:

- None

**Useful links**:

- Pricing: https://aws.amazon.com/documentdb/pricing/
- Terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/docdb_cluster_instance
