### PR TITLE
Add support for EKS clusters

### DIFF
--- a/internal/providers/terraform/aws/eks_node_group.go
+++ b/internal/providers/terraform/aws/eks_node_group.go
@@ -11,8 +11,8 @@ func NewEKSNodeGroup(d *schema.ResourceData, u *schema.ResourceData) *schema.Res
 	vcpuVal := desiredSize.Mul(decimal.NewFromInt(1))              // TODO find flavor
 	costComponents := make([]*schema.CostComponent, 0)
 
-	costComponents = append(costComponents, hoursCostComponent(d, vcpuVal))
-	costComponents = append(costComponents, vcpuCostComponent(d))
+	costComponents = append(costComponents, hoursCostComponent(d))
+	costComponents = append(costComponents, vcpuCostComponent(d, vcpuVal))
 
 	return &schema.Resource{
 		Name:           d.Address,
@@ -20,12 +20,12 @@ func NewEKSNodeGroup(d *schema.ResourceData, u *schema.ResourceData) *schema.Res
 	}
 }
 
-func hoursCostComponent(d *schema.ResourceData, vcpuVal decimal.Decimal) *schema.CostComponent {
+func hoursCostComponent(d *schema.ResourceData) *schema.CostComponent {
 	region := d.Get("region").String()
 	return &schema.CostComponent{
 		Name:           "EKS Cluster",
 		Unit:           "hours",
-		HourlyQuantity: decimalPtr(vcpuVal),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("aws"),
 			Region:        strPtr(region),
@@ -41,12 +41,12 @@ func hoursCostComponent(d *schema.ResourceData, vcpuVal decimal.Decimal) *schema
 	}
 }
 
-func vcpuCostComponent(d *schema.ResourceData) *schema.CostComponent {
+func vcpuCostComponent(d *schema.ResourceData, vcpuVal decimal.Decimal) *schema.CostComponent {
 	region := d.Get("region").String()
 	return &schema.CostComponent{
 		Name:           "EKS Cluster",
 		Unit:           "vCPU-hours",
-		HourlyQuantity: &allocatedStorageVal,
+		HourlyQuantity: decimalPtr(vcpuVal),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("aws"),
 			Region:        strPtr(region),

--- a/internal/providers/terraform/aws/eks_node_group.go
+++ b/internal/providers/terraform/aws/eks_node_group.go
@@ -1,0 +1,63 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/pkg/schema"
+
+	"github.com/shopspring/decimal"
+)
+
+func NewEKSNodeGroup(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	desiredSize := decimal.NewFromInt(d.Get("desired_size").Int()) // TODO in block
+	vcpuVal := desiredSize.Mul(decimal.NewFromInt(1))              // TODO find flavor
+	costComponents := make([]*schema.CostComponent, 0)
+
+	costComponents = append(costComponents, hoursCostComponent(d, vcpuVal))
+	costComponents = append(costComponents, vcpuCostComponent(d))
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}
+
+func hoursCostComponent(d *schema.ResourceData, vcpuVal decimal.Decimal) *schema.CostComponent {
+	region := d.Get("region").String()
+	return &schema.CostComponent{
+		Name:           "EKS Cluster",
+		Unit:           "hours",
+		HourlyQuantity: decimalPtr(vcpuVal),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEKS"),
+			ProductFamily: strPtr("Compute"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", Value: strPtr("USE1-AmazonEKS-Hours:perCluster")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("on_demand"),
+		},
+	}
+}
+
+func vcpuCostComponent(d *schema.ResourceData) *schema.CostComponent {
+	region := d.Get("region").String()
+	return &schema.CostComponent{
+		Name:           "EKS Cluster",
+		Unit:           "vCPU-hours",
+		HourlyQuantity: &allocatedStorageVal,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEKS"),
+			ProductFamily: strPtr("Compute"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", Value: strPtr("USE1-Fargate-vCPU-Hours:perCPU")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("on_demand"),
+		},
+	}
+}

--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -17,4 +17,5 @@ var ResourceRegistry map[string]schema.ResourceFunc = map[string]schema.Resource
 	"aws_lb":                   NewLB,
 	"aws_nat_gateway":          NewNATGateway,
 	"aws_rds_cluster_instance": NewRDSClusterInstance,
+	"aws_eks_node_group":       NewEKSNodeGroup,
 }


### PR DESCRIPTION
**Objective:**

Add support for `aws_eks_node_group`

**Example output:**

// TODO
  
**Pricing details:**

//TODO

**Status:**

- [x] Added to resource_registry.go
- [ ] Added resource file
- [ ] Added integration tests
- [x] Added unit tests if applicable - Not applicable
- [x] Added to https://github.com/infracost/docs/blob/master/docs/supported_resources.md
        see https://github.com/infracost/docs/pull/9

**Issues:**

Closes #82 

**Useful links:**

- Pricing: https://aws.amazon.com/eks/pricing/
- Terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group