### PR TITLE
Change price explorer scritps for a better output and fix bug

### DIFF
--- a/scripts/price_explorer/2_find_product_families.sh
+++ b/scripts/price_explorer/2_find_product_families.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+echo "List of Product Families for $1:"
 gq https://pricing.infracost.io/graphql -q "
 query {
     products (
@@ -10,4 +11,4 @@ query {
   ){
         productFamily
     }
-}" | jq '.data.products | map ({ (.productFamily): .__typename} ) | add'
+}" | jq '.data.products | map ({ (.productFamily): .__typename} ) | add' | jq "keys"

--- a/scripts/price_explorer/3_find_attribute_keys.sh
+++ b/scripts/price_explorer/3_find_attribute_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 attribs=$(
 gq https://pricing.infracost.io/graphql -q "
 query {
@@ -13,18 +13,21 @@ query {
     	productHash
     	attributes { key , value }
     }
-}" | jq -r '.data.products[] | @base64' | head -2
+}" | jq -r '.data.products[] | @base64'
 )
 
-i=0
-for x in $attribs; do
-    echo $x | base64 --decode | jq '.attributes | map ({ (.key): .value} ) | add' | jq ".$3"  | tee tmp-$i >/dev/null
-    i=$(expr $i + 1)
-done
-echo Found $i different products
-echo "\n#####################################\n"
+N_files=$(echo $attribs | wc -w)
 
-if [ $i -ne 1 ]; then
-     diff -U1 tmp-0 tmp-1 | grep -v "__typename"
+if [ $N_files -ne 1 ]; then
+  echo -e "\n#####################################\n"
+  echo Found $N_files different products
+  echo -e "------------------\n"
+
+  f=$(echo $attribs | cut -d' ' -f1 | base64 --decode | jq '.attributes ')
+  s=$(echo $attribs | cut -d' ' -f2 | base64 --decode | jq '.attributes ')
+
+  diff -U1 <( echo "$f" ) <( echo "$s" ) | grep -v "__typename" | grep -v "/dev/fd/"
+else
+  echo "Only 1 Match product found"
 fi
 

--- a/scripts/price_explorer/3_find_attribute_keys.sh
+++ b/scripts/price_explorer/3_find_attribute_keys.sh
@@ -28,6 +28,6 @@ if [ $N_files -ne 1 ]; then
 
   diff -U1 <( echo "$f" ) <( echo "$s" ) | grep -v "__typename" | grep -v "/dev/fd/"
 else
-  echo "Only 1 Match product found"
+  echo "Only 1 match product found"
 fi
 

--- a/scripts/price_explorer/3_find_attribute_keys.sh
+++ b/scripts/price_explorer/3_find_attribute_keys.sh
@@ -18,7 +18,12 @@ query {
 
 N_files=$(echo $attribs | wc -w)
 
-if [ $N_files -ne 1 ]; then
+if [ $N_files -eq 0 ]; then
+  echo "No match product found"
+elif [ $N_files -eq 1 ]; then
+  echo "Only 1 match product found"
+  echo ProductHash: $(echo $attribs | cut -d' ' -f1 | base64 --decode | jq '.productHash')
+else
   echo -e "\n#####################################\n"
   echo Found $N_files different products
   echo -e "------------------\n"
@@ -27,7 +32,5 @@ if [ $N_files -ne 1 ]; then
   s=$(echo $attribs | cut -d' ' -f2 | base64 --decode | jq '.attributes ')
 
   diff -U1 <( echo "$f" ) <( echo "$s" ) | grep -v "__typename" | grep -v "/dev/fd/"
-else
-  echo "Only 1 match product found"
 fi
 

--- a/scripts/price_explorer/README.md
+++ b/scripts/price_explorer/README.md
@@ -50,9 +50,9 @@ When adding a new resource to infracost, a `productFilter` has to be added that 
 
     ```sh
     {
-      "Aurora Global Database": "Product",
-      "CPU Credits": "Product",
-      "Database Instance": "Product"
+      "Aurora Global Database",
+      "CPU Credits",
+      "Database Instance"
     }
     ```
 
@@ -65,11 +65,18 @@ When adding a new resource to infracost, a `productFilter` has to be added that 
   For example, running `./3_find_attribute_keys.sh AmazonRDS "Database Instance"` returns the following abbreviated output, which shows there are different `instanceType` and `databaseEngine` attribute:
 
     ```sh
-    -  "instanceType": "db.m3.large",
-    +  "instanceType": "db.r4.4xlarge",
+     Found 1000 different products
+    ------------------
+    
+    @@ -18,3 +18,3 @@
+         "key": "instanceType",
+    -    "value": "db.m3.large",
+    +    "value": "db.r4.4xlarge",
+    @@ -28,3 +28,3 @@
+         "key": "databaseEngine",
+    -    "value": "MySQL",
+    +    "value": "MariaDB",
     ...
-    -  "databaseEngine": "Oracle",
-    +  "databaseEngine": "MariaDB",
     ```
 
 * Identify desired `attributes` value using the `service` name, `productFamily` and `attribute key` found in previous steps:


### PR DESCRIPTION
- [x] Price explorer script `3_find_attribute_keys.sh` always outputs `2 different products found.`
- [x] creating tmp files pollute the directory and it's not a clean solution
- [x] The output for the scripts can be enhanced

Closes #95 