### PR TITLE
Add version flag

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/infracost/infracost/pkg/output"
 	"github.com/infracost/infracost/pkg/prices"
 	"github.com/infracost/infracost/pkg/schema"
+	"github.com/infracost/infracost/pkg/version"
 
 	"github.com/infracost/infracost/internal/providers/terraform"
 
@@ -65,6 +66,11 @@ func main() {
 				Name:  "api-url",
 				Usage: "Price List API URL",
 			},
+			&cli.BoolFlag{
+				Name:  "version",
+				Usage: "Prints the version of infracost and terraform",
+				Value: false,
+			},
 		},
 		OnUsageError: func(c *cli.Context, err error, isSubcommand bool) error {
 			log.Error(err)
@@ -73,6 +79,11 @@ func main() {
 			return nil
 		},
 		Action: func(c *cli.Context) error {
+			if c.Bool("version") {
+				fmt.Println("Infracost", version.Version)
+				err := terraform.TerraformVersion()
+				return err
+			}
 			if c.Bool("no-color") {
 				config.Config.NoColor = true
 				formatter.DisableColors = true

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -81,7 +81,8 @@ func main() {
 		Action: func(c *cli.Context) error {
 			if c.Bool("version") {
 				fmt.Println("Infracost", version.Version)
-				err := terraform.TerraformVersion()
+				v, err := terraform.TerraformVersion()
+				fmt.Println(v)
 				return err
 			}
 			if c.Bool("no-color") {

--- a/internal/providers/terraform/cmd.go
+++ b/internal/providers/terraform/cmd.go
@@ -3,7 +3,6 @@ package terraform
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -46,5 +45,4 @@ func TerraformVersion() (string, error) {
 	}
 	out, err := exec.Command(terraformBinary, "-version").Output()
 	return strings.SplitN(string(out), "\n", 2)[0], err
-}
 }

--- a/internal/providers/terraform/cmd.go
+++ b/internal/providers/terraform/cmd.go
@@ -39,16 +39,12 @@ func terraformCmd(options *cmdOptions, args ...string) ([]byte, error) {
 	return outbuf.Bytes(), err
 }
 
-func TerraformVersion() error {
+func TerraformVersion() (string, error) {
 	terraformBinary := os.Getenv("TERRAFORM_BINARY")
 	if terraformBinary == "" {
 		terraformBinary = "terraform"
 	}
 	out, err := exec.Command(terraformBinary, "-version").Output()
-	firstLine := string(out)[0:strings.Index(string(out), "\n")]
-	if err == nil {
-		fmt.Println(firstLine)
-	}
-
-	return err
+	return strings.SplitN(string(out), "\n", 2)[0], err
+}
 }

--- a/internal/providers/terraform/cmd.go
+++ b/internal/providers/terraform/cmd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/infracost/infracost/pkg/config"
 
@@ -44,8 +45,9 @@ func TerraformVersion() error {
 		terraformBinary = "terraform"
 	}
 	out, err := exec.Command(terraformBinary, "-version").Output()
+	firstLine := string(out)[0:strings.Index(string(out), "\n")]
 	if err == nil {
-		fmt.Printf("%s", out)
+		fmt.Println(firstLine)
 	}
 
 	return err

--- a/internal/providers/terraform/cmd.go
+++ b/internal/providers/terraform/cmd.go
@@ -3,6 +3,7 @@ package terraform
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -35,4 +36,17 @@ func terraformCmd(options *cmdOptions, args ...string) ([]byte, error) {
 	cmd.Stderr = log.StandardLogger().WriterLevel(log.ErrorLevel)
 	err := cmd.Run()
 	return outbuf.Bytes(), err
+}
+
+func TerraformVersion() error {
+	terraformBinary := os.Getenv("TERRAFORM_BINARY")
+	if terraformBinary == "" {
+		terraformBinary = "terraform"
+	}
+	out, err := exec.Command(terraformBinary, "-version").Output()
+	if err == nil {
+		fmt.Printf("%s", out)
+	}
+
+	return err
 }


### PR DESCRIPTION
Sample output of `infracost --version`

```
Infracost v0.5.1-15-g779d8bf-dirty
Terraform v0.12.29

Your version of Terraform is out of date! The latest version
is 0.13.2. You can update by downloading from https://www.terraform.io/downloads.html
```

Fixes #97 