### PR TITLE
Add support for on-demand DynamoDB

### DIFF
--- a/internal/providers/terraform/aws/dynamodb_table.go
+++ b/internal/providers/terraform/aws/dynamodb_table.go
@@ -86,7 +86,7 @@ func wcuCostComponent(d *schema.ResourceData) *schema.CostComponent {
 	region := d.Get("region").String()
 	return &schema.CostComponent{
 		Name:           "Write capacity unit (WCU)",
-		Unit:           "WCU/hours",
+		Unit:           "WCU-hours",
 		HourlyQuantity: decimalPtr(decimal.NewFromInt(d.Get("write_capacity").Int())),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("aws"),
@@ -108,7 +108,7 @@ func rcuCostComponent(d *schema.ResourceData) *schema.CostComponent {
 	region := d.Get("region").String()
 	return &schema.CostComponent{
 		Name:           "Read capacity unit (RCU)",
-		Unit:           "RCU/hours",
+		Unit:           "RCU-hours",
 		HourlyQuantity: decimalPtr(decimal.NewFromInt(d.Get("read_capacity").Int())),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("aws"),
@@ -153,7 +153,7 @@ func newProvisionedDynamoDBGlobalTable(name string, d gjson.Result, region strin
 			// Replicated write capacity units (rWCU)
 			{
 				Name:           "Replicated write capacity unit (rWCU)",
-				Unit:           "rWCU/hours",
+				Unit:           "rWCU-hours",
 				HourlyQuantity: decimalPtr(decimal.NewFromInt(capacity)),
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("aws"),
@@ -180,7 +180,7 @@ func newOnDemandDynamoDBGlobalTable(name string, d gjson.Result, region string, 
 			// Replicated write capacity units (rWCU)
 			{
 				Name:            "Replicated write request unit (rWRU)",
-				Unit:            "rWRU",
+				Unit:            "rWRU-months",
 				MonthlyQuantity: decimalPtr(decimal.NewFromInt(capacity)),
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("aws"),
@@ -200,7 +200,7 @@ func wruCostComponent(d *schema.ResourceData, u *schema.ResourceData) *schema.Co
 	region := d.Get("region").String()
 	return &schema.CostComponent{
 		Name:            "Write request unit (WRU)",
-		Unit:            "WRU",
+		Unit:            "WRU-months",
 		MonthlyQuantity: decimalPtr(decimal.NewFromInt(u.Get("monthly_write_request_units.0.value").Int())),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("aws"),
@@ -221,7 +221,7 @@ func rruCostComponent(d *schema.ResourceData, u *schema.ResourceData) *schema.Co
 	region := d.Get("region").String()
 	return &schema.CostComponent{
 		Name:            "Read request unit (RRU)",
-		Unit:            "RRU",
+		Unit:            "RRU-months",
 		MonthlyQuantity: decimalPtr(decimal.NewFromInt(u.Get("monthly_read_request_units.0.value").Int())),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("aws"),
@@ -297,7 +297,7 @@ func restoreCostComponent(d *schema.ResourceData, u *schema.ResourceData) *schem
 	region := d.Get("region").String()
 	return &schema.CostComponent{
 		Name:            "Restore data size",
-		Unit:            "GB",
+		Unit:            "GB-months",
 		MonthlyQuantity: decimalPtr(decimal.NewFromInt(u.Get("monthly_gb_restore.0.value").Int())),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("aws"),
@@ -311,8 +311,8 @@ func restoreCostComponent(d *schema.ResourceData, u *schema.ResourceData) *schem
 func streamCostComponent(d *schema.ResourceData, u *schema.ResourceData) *schema.CostComponent {
 	region := d.Get("region").String()
 	return &schema.CostComponent{
-		Name:            "Streams read request unit",
-		Unit:            "Read request units",
+		Name:            "Streams read request unit (sRRU)",
+		Unit:            "sRRU-months",
 		MonthlyQuantity: decimalPtr(decimal.NewFromInt(u.Get("monthly_streams_read_request_units.0.value").Int())),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("aws"),

--- a/internal/providers/terraform/aws/dynamodb_table_test.go
+++ b/internal/providers/terraform/aws/dynamodb_table_test.go
@@ -100,6 +100,28 @@ func TestNewDynamoDBTableOnDemand(t *testing.T) {
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(230)),
 				},
 			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "us-east-2",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Replicated write request unit (rWRU)",
+							PriceHash:       "bd1c30b527edcc061037142f79c06955-cf867fc796b8147fa126205baed2922c",
+							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(3000000)),
+						},
+					},
+				},
+				{
+					Name: "us-west-1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Replicated write request unit (rWRU)",
+							PriceHash:       "67f1a3e0472747acf74cd5e925422fbb-cf867fc796b8147fa126205baed2922c",
+							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(3000000)),
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/providers/terraform/aws/dynamodb_table_test.go
+++ b/internal/providers/terraform/aws/dynamodb_table_test.go
@@ -62,6 +62,9 @@ func TestNewDynamoDBTableOnDemand(t *testing.T) {
 		monthly_gb_restore {
 			value = 230
 		}
+		monthly_streams_read_request_units {
+			value = 2000000
+		}
 	}
 	  `
 
@@ -98,6 +101,11 @@ func TestNewDynamoDBTableOnDemand(t *testing.T) {
 					Name:            "Restore data size",
 					PriceHash:       "38fc5fdbec6f4ef5e3bdf6967dbe1cb2-b1ae3861dc57e2db217fa83a7420374f",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(230)),
+				},
+				{
+					Name:            "Streams read request unit",
+					PriceHash:       "070bce0aa726427d947f5215eecd3f6f-4a9dfd3965ffcbab75845ead7a27fd47",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2000000)),
 				},
 			},
 			SubResourceChecks: []testutil.ResourceCheck{

--- a/internal/providers/terraform/aws/dynamodb_table_test.go
+++ b/internal/providers/terraform/aws/dynamodb_table_test.go
@@ -53,6 +53,15 @@ func TestNewDynamoDBTableOnDemand(t *testing.T) {
 		monthly_gb_data_storage {
 		 	value = 230
 		}
+		monthly_gb_continuous_backup_storage {
+			value = 2300
+		}
+		monthly_gb_on_demand_backup_storage {
+			value = 460
+		}
+		monthly_gb_restore {
+			value = 230
+		}
 	}
 	  `
 
@@ -73,6 +82,21 @@ func TestNewDynamoDBTableOnDemand(t *testing.T) {
 				{
 					Name:            "Data storage",
 					PriceHash:       "a9781acb5ee117e6c50ab836dd7285b5-ee3dd7e4624338037ca6fea0933a662f",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(230)),
+				},
+				{
+					Name:            "Continuous backup (PITR) storage",
+					PriceHash:       "b4ed90c18b808ffff191ffbc16090c8e-ee3dd7e4624338037ca6fea0933a66",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2300)),
+				},
+				{
+					Name:            "On-demand backup storage",
+					PriceHash:       "0e228653f3f9c663398e91a605c911bd-8753f776c1e737f1a5548191571abc76",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(460)),
+				},
+				{
+					Name:            "Restore data size",
+					PriceHash:       "38fc5fdbec6f4ef5e3bdf6967dbe1cb2-b1ae3861dc57e2db217fa83a7420374f",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(230)),
 				},
 			},

--- a/internal/providers/terraform/aws/dynamodb_table_test.go
+++ b/internal/providers/terraform/aws/dynamodb_table_test.go
@@ -89,7 +89,7 @@ func TestNewDynamoDBTableOnDemand(t *testing.T) {
 				},
 				{
 					Name:            "Continuous backup (PITR) storage",
-					PriceHash:       "b4ed90c18b808ffff191ffbc16090c8e-ee3dd7e4624338037ca6fea0933a66",
+					PriceHash:       "b4ed90c18b808ffff191ffbc16090c8e-ee3dd7e4624338037ca6fea0933a662f",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2300)),
 				},
 				{
@@ -103,8 +103,8 @@ func TestNewDynamoDBTableOnDemand(t *testing.T) {
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(230)),
 				},
 				{
-					Name:            "Streams read request unit",
-					PriceHash:       "070bce0aa726427d947f5215eecd3f6f-4a9dfd3965ffcbab75845ead7a27fd47",
+					Name:            "Streams read request unit (sRRU)",
+					PriceHash:       "dd063861f705295d00a801050a700b3e-4a9dfd3965ffcbab75845ead7a27fd47",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2000000)),
 				},
 			},

--- a/internal/providers/terraform/aws/dynamodb_table_test.go
+++ b/internal/providers/terraform/aws/dynamodb_table_test.go
@@ -50,6 +50,9 @@ func TestNewDynamoDBTableOnDemand(t *testing.T) {
 		monthly_read_request_units {
 			value = 8000000
 		}
+		monthly_gb_data_storage {
+		 	value = 230
+		}
 	}
 	  `
 
@@ -66,6 +69,11 @@ func TestNewDynamoDBTableOnDemand(t *testing.T) {
 					Name:            "Read request unit (RRU)",
 					PriceHash:       "641aa07510d472901906f3e97cee96c4-668942c2f9f9b475e74de593d4c32257",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(8000000)),
+				},
+				{
+					Name:            "Data storage",
+					PriceHash:       "a9781acb5ee117e6c50ab836dd7285b5-ee3dd7e4624338037ca6fea0933a662f",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(230)),
 				},
 			},
 		},


### PR DESCRIPTION
**Status:**

- [x] Read and write requests
- [x] Data storage
- [x] Continuous backup
- [x] On-demand backup
- [x] Restore from backup
- [x] On-demand global tables
- [x] DynamoDB Streams

**Issues:**
- Fixes #83 

Useful links:
- Overview: https://aws.amazon.com/dynamodb/
- Pricing: https://aws.amazon.com/dynamodb/pricing/on-demand/
- Terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table