### PR TITLE
Show skipped resources

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -154,9 +154,9 @@ func main() {
 			var out []byte
 			switch strings.ToLower(c.String("output")) {
 			case "json":
-				out, err = output.ToJSON(resources)
+				out, err = output.ToJSON(resources, c)
 			default:
-				out, err = output.ToTable(resources)
+				out, err = output.ToTable(resources, c)
 			}
 
 			s.Stop()
@@ -166,8 +166,6 @@ func main() {
 			}
 
 			fmt.Println(string(out))
-
-			terraform.ShowSkippedResources(resources, c.Bool("show-skipped"))
 
 			return nil
 		},

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -85,6 +85,11 @@ func main() {
 				Usage: "Prints the version of infracost and terraform",
 				Value: false,
 			},
+			&cli.BoolFlag{
+				Name:  "show-skipped",
+				Usage: "Prints the list of free and unsupported resources",
+				Value: false,
+			},
 		},
 		OnUsageError: func(c *cli.Context, err error, isSubcommand bool) error {
 			return customError(c, err.Error())

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -167,6 +167,8 @@ func main() {
 
 			fmt.Println(string(out))
 
+			terraform.ShowSkippedResources(resources, c.Bool("show-skipped"))
+
 			return nil
 		},
 	}

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/infracost/infracost/pkg/schema"
 
-	"github.com/tidwall/gjson"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 )
 
 // These show differently in the plan JSON for Terraform 0.12 and 0.13
@@ -22,7 +22,10 @@ func createResource(r *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 		return rFunc(r, u)
 	}
 
-	return nil
+	return &schema.Resource{
+		Name:      r.Address,
+		IsSkipped: true,
+	}
 }
 
 func parsePlanJSON(j []byte) []*schema.Resource {
@@ -138,7 +141,7 @@ func parseReferences(resData map[string]*schema.ResourceData, conf gjson.Result)
 
 				// if there's a count ref value then try with the array index of the count ref
 				if !ok && containsString(refs, "count.index") {
-					a := fmt.Sprintf("%s[%d]", refAddr, addressCountIndex(addr))	
+					a := fmt.Sprintf("%s[%d]", refAddr, addressCountIndex(addr))
 					refData, ok = resData[a]
 					if ok {
 						log.Debugf("reference specifies a count: using resource %s for %s.%s", a, addr, attr)

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -19,7 +19,12 @@ func createResource(r *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 	registry := getResourceRegistry()
 
 	if rFunc, ok := (*registry)[r.Type]; ok {
-		return rFunc(r, u)
+		r := rFunc(r, u)
+		if r.IsFree() {
+			r.IsSkipped = true
+			r.SkipMessage = "This resource is free"
+		}
+		return r
 	}
 
 	return &schema.Resource{

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -19,18 +19,20 @@ func createResource(r *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 	registry := getResourceRegistry()
 
 	if rFunc, ok := (*registry)[r.Type]; ok {
-		r := rFunc(r, u)
-		if r.IsFree() {
-			r.IsSkipped = true
-			r.SkipMessage = "This resource is free"
+		res := rFunc(r, u)
+		res.ResourceType = r.Type
+		if res.IsFree() {
+			res.IsSkipped = true
+			res.SkipMessage = "This resource is free"
 		}
-		return r
+		return res
 	}
 
 	return &schema.Resource{
-		Name:        r.Address,
-		IsSkipped:   true,
-		SkipMessage: "This resource is not currently supported",
+		Name:         r.Address,
+		ResourceType: r.Type,
+		IsSkipped:    true,
+		SkipMessage:  "This resource is not currently supported",
 	}
 }
 

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -21,10 +21,6 @@ func createResource(r *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 	if rFunc, ok := (*registry)[r.Type]; ok {
 		res := rFunc(r, u)
 		res.ResourceType = r.Type
-		if res.IsFree() {
-			res.IsSkipped = true
-			res.SkipMessage = "This resource is free"
-		}
 		return res
 	}
 

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -23,8 +23,9 @@ func createResource(r *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 	}
 
 	return &schema.Resource{
-		Name:      r.Address,
-		IsSkipped: true,
+		Name:        r.Address,
+		IsSkipped:   true,
+		SkipMessage: "This resource is not currently supported",
 	}
 }
 

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -102,3 +102,19 @@ func generatePlanJSON(dir string, path string) ([]byte, error) {
 
 	return out, nil
 }
+
+func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
+	skippedCount := 0
+	unSupportedCount := 0
+	for _, r := range resources {
+		if r.IsSkipped {
+			skippedCount++
+			unSupportedCount++
+			if showDetails {
+				fmt.Printf("Skipped %s | This resource is not currently supported.\n", r.Name)
+			}
+		}
+	}
+	message := "%d out of %d resources were skipped, %d aren't supported in Infracost yet (https://www.infracost.io/docs/supported_resources), re-run with --show-skipped to see the list.\n"
+	fmt.Printf(message, skippedCount, len(resources), unSupportedCount)
+}

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -111,7 +111,11 @@ func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 			skippedCount++
 			unSupportedCount++
 			if showDetails {
-				fmt.Printf("Skipped %s | This resource is not currently supported.\n", r.Name)
+				message := fmt.Sprintf("Skipped %s", r.Name)
+				if r.SkipMessage != "" {
+					message += fmt.Sprintf(" | %s.", r.SkipMessage)
+				}
+				fmt.Printf("%s\n", message)
 			}
 		}
 	}

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -115,7 +115,7 @@ func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 			} else {
 				unSupportedCount++
 			}
-			if showDetails {
+			if showDetails && !r.IsFree() {
 				message := fmt.Sprintf("Skipped %s", r.Name)
 				if r.SkipMessage != "" {
 					message += fmt.Sprintf(" | %s.", r.SkipMessage)

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -124,6 +124,12 @@ func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 			}
 		}
 	}
-	message := "%d out of %d resources were skipped, %d are free, and %d aren't supported in Infracost yet(https://www.infracost.io/docs/supported_resources), re-run with --show-skipped to see the list.\n"
-	fmt.Printf(message, skippedCount, len(resources), freeCount, unSupportedCount)
+	message := "%d out of %d resources couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)"
+	if showDetails {
+		message += ".\n"
+	} else {
+		message += ", re-run with --show-skipped to see the list.\n"
+	}
+	fmt.Printf(message, unSupportedCount, len(resources))
+	fmt.Println("We're continually adding new resources, please create an issue if you'd like us to prioritize your list.")
 }

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -122,6 +122,9 @@ func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 			}
 		}
 	}
+	if unSupportedCount == 0 {
+		return
+	}
 	message := "%d out of %d resources couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)"
 	if showDetails {
 		message += ".\n"

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -103,7 +103,7 @@ func generatePlanJSON(dir string, path string) ([]byte, error) {
 	return out, nil
 }
 
-func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
+func CountSkippedResources(resources []*schema.Resource) (map[string]int, int, int, int) {
 	skippedCount := 0
 	unSupportedCount := 0
 	freeCount := 0
@@ -111,31 +111,13 @@ func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 	for _, r := range resources {
 		if r.IsSkipped {
 			skippedCount++
-			if r.IsFree() {
-				freeCount++
-			} else {
-				unSupportedCount++
-				if _, ok := unSupportedTypeCount[r.ResourceType]; !ok {
-					unSupportedTypeCount[r.ResourceType] = 0
-				}
-				unSupportedTypeCount[r.ResourceType]++
+			// FIXME: Count free resources when https://github.com/infracost/infracost/issues/121 is done
+			unSupportedCount++
+			if _, ok := unSupportedTypeCount[r.ResourceType]; !ok {
+				unSupportedTypeCount[r.ResourceType] = 0
 			}
+			unSupportedTypeCount[r.ResourceType]++
 		}
 	}
-	if unSupportedCount == 0 {
-		return
-	}
-	message := "%d out of %d resources couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)"
-	if showDetails {
-		message += ".\n"
-	} else {
-		message += ", re-run with --show-skipped to see the list.\n"
-	}
-	fmt.Printf(message, unSupportedCount, len(resources))
-	if showDetails {
-		for rType, count := range unSupportedTypeCount {
-			fmt.Printf("%d x %s \n", count, rType)
-		}
-	}
-	fmt.Println("We're continually adding new resources, please create an issue if you'd like us to prioritize your list.")
+	return unSupportedTypeCount, skippedCount, unSupportedCount, freeCount
 }

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -121,3 +121,23 @@ func CountSkippedResources(resources []*schema.Resource) (map[string]int, int, i
 	}
 	return unSupportedTypeCount, skippedCount, unSupportedCount, freeCount
 }
+
+func SkippedResourcesMessage(resources []*schema.Resource, showDetails bool) string {
+	unSupportedTypeCount, _, unSupportedCount, _ := CountSkippedResources(resources)
+	if unSupportedCount == 0 {
+		return ""
+	}
+	message := fmt.Sprintf("%d out of %d resources couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)", unSupportedCount, len(resources))
+	if showDetails {
+		message += ".\n"
+	} else {
+		message += ", re-run with --show-skipped to see the list.\n"
+	}
+	message += "We're continually adding new resources, please create an issue if you'd like us to prioritize your list.\n"
+	if showDetails {
+		for rType, count := range unSupportedTypeCount {
+			message += fmt.Sprintf("%d x %s\n", count, rType)
+		}
+	}
+	return message
+}

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -103,15 +103,13 @@ func generatePlanJSON(dir string, path string) ([]byte, error) {
 	return out, nil
 }
 
-func CountSkippedResources(resources []*schema.Resource) (map[string]int, int, int, int) {
+func CountSkippedResources(resources []*schema.Resource) (map[string]int, int, int) {
 	skippedCount := 0
 	unsupportedCount := 0
-	freeCount := 0
 	unsupportedTypeCount := make(map[string]int)
 	for _, r := range resources {
 		if r.IsSkipped {
 			skippedCount++
-			// FIXME: Count free resources when https://github.com/infracost/infracost/issues/121 is done
 			unsupportedCount++
 			if _, ok := unsupportedTypeCount[r.ResourceType]; !ok {
 				unsupportedTypeCount[r.ResourceType] = 0
@@ -119,11 +117,11 @@ func CountSkippedResources(resources []*schema.Resource) (map[string]int, int, i
 			unsupportedTypeCount[r.ResourceType]++
 		}
 	}
-	return unsupportedTypeCount, skippedCount, unsupportedCount, freeCount
+	return unsupportedTypeCount, skippedCount, unsupportedCount
 }
 
 func SkippedResourcesMessage(resources []*schema.Resource, showDetails bool) string {
-	unsupportedTypeCount, _, unsupportedCount, _ := CountSkippedResources(resources)
+	unsupportedTypeCount, _, unsupportedCount := CountSkippedResources(resources)
 	if unsupportedCount == 0 {
 		return ""
 	}

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -105,29 +105,29 @@ func generatePlanJSON(dir string, path string) ([]byte, error) {
 
 func CountSkippedResources(resources []*schema.Resource) (map[string]int, int, int, int) {
 	skippedCount := 0
-	unSupportedCount := 0
+	unsupportedCount := 0
 	freeCount := 0
-	unSupportedTypeCount := make(map[string]int)
+	unsupportedTypeCount := make(map[string]int)
 	for _, r := range resources {
 		if r.IsSkipped {
 			skippedCount++
 			// FIXME: Count free resources when https://github.com/infracost/infracost/issues/121 is done
-			unSupportedCount++
-			if _, ok := unSupportedTypeCount[r.ResourceType]; !ok {
-				unSupportedTypeCount[r.ResourceType] = 0
+			unsupportedCount++
+			if _, ok := unsupportedTypeCount[r.ResourceType]; !ok {
+				unsupportedTypeCount[r.ResourceType] = 0
 			}
-			unSupportedTypeCount[r.ResourceType]++
+			unsupportedTypeCount[r.ResourceType]++
 		}
 	}
-	return unSupportedTypeCount, skippedCount, unSupportedCount, freeCount
+	return unsupportedTypeCount, skippedCount, unsupportedCount, freeCount
 }
 
 func SkippedResourcesMessage(resources []*schema.Resource, showDetails bool) string {
-	unSupportedTypeCount, _, unSupportedCount, _ := CountSkippedResources(resources)
-	if unSupportedCount == 0 {
+	unsupportedTypeCount, _, unsupportedCount, _ := CountSkippedResources(resources)
+	if unsupportedCount == 0 {
 		return ""
 	}
-	message := fmt.Sprintf("%d out of %d resources couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)", unSupportedCount, len(resources))
+	message := fmt.Sprintf("%d out of %d resources couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)", unsupportedCount, len(resources))
 	if showDetails {
 		message += ".\n"
 	} else {
@@ -135,7 +135,7 @@ func SkippedResourcesMessage(resources []*schema.Resource, showDetails bool) str
 	}
 	message += "We're continually adding new resources, please create an issue if you'd like us to prioritize your list.\n"
 	if showDetails {
-		for rType, count := range unSupportedTypeCount {
+		for rType, count := range unsupportedTypeCount {
 			message += fmt.Sprintf("%d x %s\n", count, rType)
 		}
 	}

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -106,10 +106,15 @@ func generatePlanJSON(dir string, path string) ([]byte, error) {
 func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 	skippedCount := 0
 	unSupportedCount := 0
+	freeCount := 0
 	for _, r := range resources {
 		if r.IsSkipped {
 			skippedCount++
-			unSupportedCount++
+			if r.IsFree() {
+				freeCount++
+			} else {
+				unSupportedCount++
+			}
 			if showDetails {
 				message := fmt.Sprintf("Skipped %s", r.Name)
 				if r.SkipMessage != "" {
@@ -119,6 +124,6 @@ func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 			}
 		}
 	}
-	message := "%d out of %d resources were skipped, %d aren't supported in Infracost yet (https://www.infracost.io/docs/supported_resources), re-run with --show-skipped to see the list.\n"
-	fmt.Printf(message, skippedCount, len(resources), unSupportedCount)
+	message := "%d out of %d resources were skipped, %d are free, and %d aren't supported in Infracost yet(https://www.infracost.io/docs/supported_resources), re-run with --show-skipped to see the list.\n"
+	fmt.Printf(message, skippedCount, len(resources), freeCount, unSupportedCount)
 }

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -107,6 +107,7 @@ func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 	skippedCount := 0
 	unSupportedCount := 0
 	freeCount := 0
+	unSupportedTypeCount := make(map[string]int)
 	for _, r := range resources {
 		if r.IsSkipped {
 			skippedCount++
@@ -114,13 +115,10 @@ func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 				freeCount++
 			} else {
 				unSupportedCount++
-			}
-			if showDetails && !r.IsFree() {
-				message := fmt.Sprintf("Skipped %s", r.Name)
-				if r.SkipMessage != "" {
-					message += fmt.Sprintf(" | %s.", r.SkipMessage)
+				if _, ok := unSupportedTypeCount[r.ResourceType]; !ok {
+					unSupportedTypeCount[r.ResourceType] = 0
 				}
-				fmt.Printf("%s\n", message)
+				unSupportedTypeCount[r.ResourceType]++
 			}
 		}
 	}
@@ -131,5 +129,10 @@ func ShowSkippedResources(resources []*schema.Resource, showDetails bool) {
 		message += ", re-run with --show-skipped to see the list.\n"
 	}
 	fmt.Printf(message, unSupportedCount, len(resources))
+	if showDetails {
+		for rType, count := range unSupportedTypeCount {
+			fmt.Printf("%d x %s \n", count, rType)
+		}
+	}
 	fmt.Println("We're continually adding new resources, please create an issue if you'd like us to prioritize your list.")
 }

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -56,6 +56,9 @@ func ToJSON(resources []*schema.Resource) ([]byte, error) {
 	arr := make([]resourceJSON, 0, len(resources))
 
 	for _, r := range resources {
+		if r.IsSkipped {
+			continue
+		}
 		arr = append(arr, newResourceJSON(r))
 	}
 

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -2,10 +2,17 @@ package output
 
 import (
 	"encoding/json"
+	"fmt"
 
+	"github.com/infracost/infracost/internal/providers/terraform"
 	"github.com/infracost/infracost/pkg/schema"
+	"github.com/urfave/cli/v2"
 )
 
+type outputJSON struct {
+	Resources *[]resourceJSON `json:"resources"`
+	Warnings  []string        `json:"warnings"`
+}
 type costComponentJSON struct {
 	Name            string `json:"name"`
 	Unit            string `json:"unit"`
@@ -52,7 +59,27 @@ func newResourceJSON(r *schema.Resource) resourceJSON {
 	}
 }
 
-func ToJSON(resources []*schema.Resource) ([]byte, error) {
+func showSkippedResourcesJSON(resources []*schema.Resource, showDetails bool) []string {
+	unSupportedTypeCount, _, unSupportedCount, _ := terraform.CountSkippedResources(resources)
+	if unSupportedCount == 0 {
+		return nil
+	}
+	message := fmt.Sprintf("\n%d out of %d resources couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)", unSupportedCount, len(resources))
+	if showDetails {
+		message += ".\n"
+	} else {
+		message += ", re-run with --show-skipped to see the list.\n"
+	}
+	message += "We're continually adding new resources, please create an issue if you'd like us to prioritize your list.\n"
+	if showDetails {
+		for rType, count := range unSupportedTypeCount {
+			message += fmt.Sprintf("%d x %s\n", count, rType)
+		}
+	}
+	return []string{message}
+}
+
+func ToJSON(resources []*schema.Resource, c *cli.Context) ([]byte, error) {
 	arr := make([]resourceJSON, 0, len(resources))
 
 	for _, r := range resources {
@@ -62,5 +89,11 @@ func ToJSON(resources []*schema.Resource) ([]byte, error) {
 		arr = append(arr, newResourceJSON(r))
 	}
 
-	return json.Marshal(arr)
+	out := outputJSON{
+		Resources: &arr,
+	}
+
+	out.Warnings = append(out.Warnings, showSkippedResourcesJSON(resources, c.Bool("show-skipped"))...)
+
+	return json.Marshal(out)
 }

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -15,26 +15,6 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func showSkippedResourcesTable(resources []*schema.Resource, showDetails bool, bufw *bufio.Writer) {
-	unSupportedTypeCount, _, unSupportedCount, _ := terraform.CountSkippedResources(resources)
-	if unSupportedCount == 0 {
-		return
-	}
-	message := fmt.Sprintf("\n%d out of %d resources couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)", unSupportedCount, len(resources))
-	if showDetails {
-		message += ".\n"
-	} else {
-		message += ", re-run with --show-skipped to see the list.\n"
-	}
-	message += "We're continually adding new resources, please create an issue if you'd like us to prioritize your list.\n"
-	if showDetails {
-		for rType, count := range unSupportedTypeCount {
-			message += fmt.Sprintf("%d x %s\n", count, rType)
-		}
-	}
-	bufw.WriteString(message)
-}
-
 func ToTable(resources []*schema.Resource, c *cli.Context) ([]byte, error) {
 	var buf bytes.Buffer
 	bufw := bufio.NewWriter(&buf)
@@ -93,7 +73,10 @@ func ToTable(resources []*schema.Resource, c *cli.Context) ([]byte, error) {
 
 	t.Render()
 
-	showSkippedResourcesTable(resources, c.Bool("show-skipped"), bufw)
+	skippedResourcesMessage := terraform.SkippedResourcesMessage(resources, c.Bool("show-skipped"))
+	if skippedResourcesMessage != "" {
+		bufw.WriteString(skippedResourcesMessage)
+	}
 
 	bufw.Flush()
 	return buf.Bytes(), nil

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -75,7 +75,10 @@ func ToTable(resources []*schema.Resource, c *cli.Context) ([]byte, error) {
 
 	skippedResourcesMessage := terraform.SkippedResourcesMessage(resources, c.Bool("show-skipped"))
 	if skippedResourcesMessage != "" {
-		bufw.WriteString(skippedResourcesMessage)
+		_, err := bufw.WriteString(skippedResourcesMessage)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	bufw.Flush()

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -82,6 +82,9 @@ func ToTable(resources []*schema.Resource) ([]byte, error) {
 	}
 
 	for _, r := range resources {
+		if r.IsSkipped {
+			continue
+		}
 		t.Append([]string{r.Name, "", "", "", "", ""})
 
 		lineItemCount := getLineItemCount(r)

--- a/pkg/schema/resource.go
+++ b/pkg/schema/resource.go
@@ -81,7 +81,5 @@ func SortResources(resources []*Resource) {
 }
 
 func (r *Resource) IsFree() bool {
-	// FIXME: Remove after https://github.com/infracost/infracost/issues/121 is done.
-	return false
 	return len(r.CostComponents) == 0
 }

--- a/pkg/schema/resource.go
+++ b/pkg/schema/resource.go
@@ -79,7 +79,3 @@ func SortResources(resources []*Resource) {
 		})
 	}
 }
-
-func (r *Resource) IsFree() bool {
-	return len(r.CostComponents) == 0
-}

--- a/pkg/schema/resource.go
+++ b/pkg/schema/resource.go
@@ -17,6 +17,7 @@ type Resource struct {
 	hourlyCost     decimal.Decimal
 	monthlyCost    decimal.Decimal
 	IsSkipped      bool
+	SkipMessage    string
 }
 
 func CalculateCosts(resources []*Resource) {

--- a/pkg/schema/resource.go
+++ b/pkg/schema/resource.go
@@ -16,6 +16,7 @@ type Resource struct {
 	SubResources   []*Resource
 	hourlyCost     decimal.Decimal
 	monthlyCost    decimal.Decimal
+	IsSkipped      bool
 }
 
 func CalculateCosts(resources []*Resource) {

--- a/pkg/schema/resource.go
+++ b/pkg/schema/resource.go
@@ -78,3 +78,9 @@ func SortResources(resources []*Resource) {
 		})
 	}
 }
+
+func (r *Resource) IsFree() bool {
+	// FIXME: Remove after https://github.com/infracost/infracost/issues/121 is done.
+	return false
+	return len(r.CostComponents) == 0
+}

--- a/pkg/schema/resource.go
+++ b/pkg/schema/resource.go
@@ -18,6 +18,7 @@ type Resource struct {
 	monthlyCost    decimal.Decimal
 	IsSkipped      bool
 	SkipMessage    string
+	ResourceType   string
 }
 
 func CalculateCosts(resources []*Resource) {


### PR DESCRIPTION
Fixes #84 

Here's a sample output with no flag:
```
  NAME           MONTHLY QTY  UNIT  PRICE  HOURLY COST  MONTHLY COST  

  OVERALL TOTAL                                 0.0000        0.0000  

3 out of 3 resources were skipped, 1 are free, and 2 aren't supported in Infracost yet(https://www.infracost.io/docs/supported_resources), re-run with --show-skipped to see the list.
```

And with `--show-skipped` flag:
```
  NAME           MONTHLY QTY  UNIT  PRICE  HOURLY COST  MONTHLY COST  

  OVERALL TOTAL                                 0.0000        0.0000  

Skipped aws_proxy_configuration.my_proxy_configuration | This resource is free.
Skipped aws_dynamodb_table.my_dynamodb_table | This resource is not currently supported.
Skipped aws_db_instance.my_db_instance | This resource is not currently supported.
3 out of 3 resources were skipped, 1 are free, and 2 aren't supported in Infracost yet(https://www.infracost.io/docs/supported_resources), re-run with --show-skipped to see the list.
```
