### PR TITLE
Add more EC2 instance costs

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -32,7 +32,7 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add --force docs/generated
-        git commit -m "Generate docs"
+        git diff --staged --quiet docs/generated || git commit -m "Generate docs"
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ vendor/
 examples/*/plan.save
 examples/*/plan.json
 
+# Test artifacts
+.test_cache
+
 #script generated files
 scripts/price_explorer/tmp-*
 scripts/price_explorer/index.json

--- a/docs/generated/supported_resources.md
+++ b/docs/generated/supported_resources.md
@@ -15,15 +15,15 @@ Support for the following is not currently included:
 | `aws_autoscaling_group` |  |
 | `aws_db_instance` |  |
 | `aws_docdb_cluster_instance` |  |
-| `aws_dynamodb_table` |  DAX is not yet supported.  |
+| `aws_dynamodb_table` |  DAX is not yet supported.<br />  |
 | `aws_ebs_snapshot` |  |
 | `aws_ebs_snapshot_copy` |  |
 | `aws_ebs_volume` |  |
-| `aws_ecs_service` |  Only supports Fargate on-demand.  |
+| `aws_ecs_service` |  Only supports Fargate on-demand.<br />  |
 | `aws_elasticsearch_domain` |  |
 | `aws_elb` |  |
-| `aws_instance` |  Non-Linux EC2 instances such as Windows and RHEL are not supported, a lookup is needed to find the OS of AMIs.  |
-| `aws_lambda_function` |  Provisioned concurrency is not yet supported.  |
+| `aws_instance` |  Costs associated with non-standard Linux AMIs, such as Windows and RHEL are not supported.<br />  EC2 Detailed Monitoring is not supported.<br />  If a root volume is not specified then an 8Gi gp2 volume is assumed.<br />  |
+| `aws_lambda_function` |  Provisioned concurrency is not yet supported.<br />  |
 | `aws_lb` |  |
 | `aws_nat_gateway` |  |
 | `aws_rds_cluster_instance` |  |

--- a/docs/templates/supported_resources.md
+++ b/docs/templates/supported_resources.md
@@ -11,7 +11,7 @@ Support for the following is not currently included:
 
 | Terraform resource           | Notes |
 | ---                          | ---   |
-{{ range $key, $value := . }}| `{{ $key }}` | {{ range $note := $value.Notes }} {{ $note }} {{ end }} |
+{{ range $key, $value := . }}| `{{ $key }}` | {{ range $note := $value.Notes }} {{ $note }}<br /> {{ end }} |
 {{ end }}
 
 ## The resource I want isn't supported

--- a/examples/terraform/main.tf
+++ b/examples/terraform/main.tf
@@ -58,28 +58,3 @@ data "infracost_aws_lambda_function" "lambda" {
     value = 250
   }
 }
-
-resource "aws_dynamodb_table" "my_dynamodb_table" {
-  name           = "GameScores"
-  billing_mode   = "PAY_PER_REQUEST"
-  hash_key       = "UserId"
-  range_key      = "GameTitle"
-  
-  attribute {
-    name = "UserId"
-    type = "S"
-  }
-  
-  attribute {
-    name = "GameTitle"
-    type = "S"
-  }
-  
-  replica {
-    region_name = "us-east-2"
-  }
-  
-  replica {
-    region_name = "us-west-1"
-  }
-}

--- a/internal/providers/terraform/aws/autoscaling_group.go
+++ b/internal/providers/terraform/aws/autoscaling_group.go
@@ -44,8 +44,6 @@ func NewAutoscalingGroup(d *schema.ResourceData, u *schema.ResourceData) *schema
 }
 
 func newLaunchConfiguration(name string, d *schema.ResourceData, region string) *schema.Resource {
-	compute := computeCostComponent(d, region, "on_demand")
-
 	subResources := make([]*schema.Resource, 0)
 	subResources = append(subResources, newRootBlockDevice(d.Get("root_block_device.0"), region))
 	subResources = append(subResources, newEbsBlockDevices(d.Get("ebs_block_device"), region)...)
@@ -53,22 +51,27 @@ func newLaunchConfiguration(name string, d *schema.ResourceData, region string) 
 	return &schema.Resource{
 		Name:           name,
 		SubResources:   subResources,
-		CostComponents: []*schema.CostComponent{compute},
+		CostComponents: computeCostComponents(d, region, "on_demand"),
 	}
 }
 
 func newLaunchTemplate(name string, d *schema.ResourceData, region string, onDemandCount decimal.Decimal, spotCount decimal.Decimal) *schema.Resource {
 	costComponents := make([]*schema.CostComponent, 0)
+
 	if onDemandCount.GreaterThan(decimal.Zero) {
-		onDemandCompute := computeCostComponent(d, region, "on_demand")
-		onDemandCompute.HourlyQuantity = decimalPtr(onDemandCompute.HourlyQuantity.Mul(onDemandCount))
-		costComponents = append(costComponents, onDemandCompute)
+		cs := computeCostComponents(d, region, "on_demand")
+		for _, c := range cs {
+			c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(onDemandCount))
+		}
+		costComponents = append(costComponents, cs...)
 	}
 
 	if spotCount.GreaterThan(decimal.Zero) {
-		spotCompute := computeCostComponent(d, region, "spot")
-		spotCompute.HourlyQuantity = decimalPtr(spotCompute.HourlyQuantity.Mul(spotCount))
-		costComponents = append(costComponents, spotCompute)
+		cs := computeCostComponents(d, region, "spot")
+		for _, c := range cs {
+			c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(spotCount))
+		}
+		costComponents = append(costComponents, cs...)
 	}
 
 	subResources := make([]*schema.Resource, 0)

--- a/internal/providers/terraform/aws/autoscaling_group.go
+++ b/internal/providers/terraform/aws/autoscaling_group.go
@@ -16,6 +16,20 @@ func GetAutoscalingGroupRegistryItem() *schema.RegistryItem {
 	}
 }
 
+func GetLaunchConfigurationRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:   "aws_launch_configuration",
+		NoCost: true,
+	}
+}
+
+func GetLaunchTemplateRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:   "aws_launch_template",
+		NoCost: true,
+	}
+}
+
 func NewAutoscalingGroup(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
 	region := d.Get("region").String()
 	desiredCapacity := decimal.NewFromInt(d.Get("desired_capacity").Int())

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -45,7 +45,7 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 					Name: "aws_launch_configuration.lc1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Compute (on-demand, t3.small)",
+							Name:            "Linux/UNIX Usage (on-demand, t3.small)",
 							PriceHash:       "ed297854a1dd56ba7b6e2b958de7ac53-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
@@ -125,7 +125,7 @@ func TestAutoscalingGroup_launchTemplate(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Compute (on-demand, t3.medium)",
+							Name:            "Linux/UNIX Usage (on-demand, t3.medium)",
 							PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
@@ -223,12 +223,12 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplate(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Compute (on-demand, t3.large)",
+							Name:            "Linux/UNIX Usage (on-demand, t3.large)",
 							PriceHash:       "3a45cd05e73384099c2ff360bdb74b74-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 						{
-							Name:            "Compute (spot, t3.large)",
+							Name:            "Linux/UNIX Usage (spot, t3.large)",
 							PriceHash:       "3a45cd05e73384099c2ff360bdb74b74-803d7f1cd2f621429b63f791730e7935",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 						},
@@ -299,12 +299,12 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplateDynamic(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Compute (on-demand, t3.large)",
+							Name:            "Linux/UNIX Usage (on-demand, t3.large)",
 							PriceHash:       "3a45cd05e73384099c2ff360bdb74b74-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 						{
-							Name:            "Compute (spot, t3.large)",
+							Name:            "Linux/UNIX Usage (spot, t3.large)",
 							PriceHash:       "3a45cd05e73384099c2ff360bdb74b74-803d7f1cd2f621429b63f791730e7935",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 						},

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -18,7 +18,7 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 	tf := `
 		resource "aws_launch_configuration" "lc1" {
 			image_id      = "fake_ami"
-			instance_type = "t3.small"
+			instance_type = "t2.medium"
 
 			root_block_device {
 				volume_size = 10
@@ -45,8 +45,8 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 					Name: "aws_launch_configuration.lc1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Linux/UNIX Usage (on-demand, t3.small)",
-							PriceHash:       "ed297854a1dd56ba7b6e2b958de7ac53-d2c98780d7b6e36641b521f1f8145c6f",
+							Name:            "Linux/UNIX Usage (on-demand, t2.medium)",
+							PriceHash:       "250382a8c0da495d6048e6fc57e526bc-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 					},
@@ -88,7 +88,7 @@ func TestAutoscalingGroup_launchTemplate(t *testing.T) {
 	tf := `
 		resource "aws_launch_template" "lt1" {
 			image_id      = "fake_ami"
-			instance_type = "t3.medium"
+			instance_type = "t2.medium"
 
 			block_device_mappings {
 				device_name = "xvdf"
@@ -125,8 +125,8 @@ func TestAutoscalingGroup_launchTemplate(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Linux/UNIX Usage (on-demand, t3.medium)",
-							PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-d2c98780d7b6e36641b521f1f8145c6f",
+							Name:            "Linux/UNIX Usage (on-demand, t2.medium)",
+							PriceHash:       "250382a8c0da495d6048e6fc57e526bc-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 					},
@@ -183,7 +183,7 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplate(t *testing.T) {
 	tf := `
 		resource "aws_launch_template" "lt1" {
 			image_id      = "fake_ami"
-			instance_type = "t3.small"
+			instance_type = "t2.medium"
 		}
 
 		resource "aws_autoscaling_group" "asg1" {
@@ -198,12 +198,12 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplate(t *testing.T) {
 					}
 
 					override {
-						instance_type     = "t3.large"
+						instance_type     = "t2.large"
 						weighted_capacity = "2"
 					}
 
 					override {
-						instance_type     = "t3.xlarge"
+						instance_type     = "t2.xlarge"
 						weighted_capacity = "4"
 					}
 				}
@@ -223,13 +223,13 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplate(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Linux/UNIX Usage (on-demand, t3.large)",
-							PriceHash:       "3a45cd05e73384099c2ff360bdb74b74-d2c98780d7b6e36641b521f1f8145c6f",
+							Name:            "Linux/UNIX Usage (on-demand, t2.large)",
+							PriceHash:       "3aa92af51438c0eba9dc1c62539adf5b-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 						{
-							Name:            "Linux/UNIX Usage (spot, t3.large)",
-							PriceHash:       "3a45cd05e73384099c2ff360bdb74b74-803d7f1cd2f621429b63f791730e7935",
+							Name:            "Linux/UNIX Usage (spot, t2.large)",
+							PriceHash:       "3aa92af51438c0eba9dc1c62539adf5b-803d7f1cd2f621429b63f791730e7935",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 						},
 					},
@@ -261,7 +261,7 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplateDynamic(t *testing.T) {
 	tf := `
 		resource "aws_launch_template" "lt1" {
 			image_id      = "fake_ami"
-			instance_type = "t3.small"
+			instance_type = "t2.medium"
 		}
 
 		resource "aws_autoscaling_group" "asg1" {
@@ -276,7 +276,7 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplateDynamic(t *testing.T) {
 					}
 
 					dynamic "override" {
-						for_each = ["t3.large", "t3.xlarge"]
+						for_each = ["t2.large", "t2.xlarge"]
 
 						content {
 							instance_type = override.value
@@ -299,13 +299,13 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplateDynamic(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Linux/UNIX Usage (on-demand, t3.large)",
-							PriceHash:       "3a45cd05e73384099c2ff360bdb74b74-d2c98780d7b6e36641b521f1f8145c6f",
+							Name:            "Linux/UNIX Usage (on-demand, t2.large)",
+							PriceHash:       "3aa92af51438c0eba9dc1c62539adf5b-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 						{
-							Name:            "Linux/UNIX Usage (spot, t3.large)",
-							PriceHash:       "3a45cd05e73384099c2ff360bdb74b74-803d7f1cd2f621429b63f791730e7935",
+							Name:            "Linux/UNIX Usage (spot, t2.large)",
+							PriceHash:       "3aa92af51438c0eba9dc1c62539adf5b-803d7f1cd2f621429b63f791730e7935",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 						},
 					},

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -45,7 +45,7 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 					Name: "aws_launch_configuration.lc1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Linux/UNIX Usage (on-demand, t2.medium)",
+							Name:            "Linux/UNIX usage (on-demand, t2.medium)",
 							PriceHash:       "250382a8c0da495d6048e6fc57e526bc-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
@@ -125,7 +125,7 @@ func TestAutoscalingGroup_launchTemplate(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Linux/UNIX Usage (on-demand, t2.medium)",
+							Name:            "Linux/UNIX usage (on-demand, t2.medium)",
 							PriceHash:       "250382a8c0da495d6048e6fc57e526bc-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
@@ -223,12 +223,12 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplate(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Linux/UNIX Usage (on-demand, t2.large)",
+							Name:            "Linux/UNIX usage (on-demand, t2.large)",
 							PriceHash:       "3aa92af51438c0eba9dc1c62539adf5b-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 						{
-							Name:            "Linux/UNIX Usage (spot, t2.large)",
+							Name:            "Linux/UNIX usage (spot, t2.large)",
 							PriceHash:       "3aa92af51438c0eba9dc1c62539adf5b-803d7f1cd2f621429b63f791730e7935",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 						},
@@ -299,12 +299,12 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplateDynamic(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Linux/UNIX Usage (on-demand, t2.large)",
+							Name:            "Linux/UNIX usage (on-demand, t2.large)",
 							PriceHash:       "3aa92af51438c0eba9dc1c62539adf5b-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 						{
-							Name:            "Linux/UNIX Usage (spot, t2.large)",
+							Name:            "Linux/UNIX usage (spot, t2.large)",
 							PriceHash:       "3aa92af51438c0eba9dc1c62539adf5b-803d7f1cd2f621429b63f791730e7935",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 						},

--- a/internal/providers/terraform/aws/docdb_cluster_instance.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance.go
@@ -22,7 +22,7 @@ func NewDocDBClusterInstance(d *schema.ResourceData, u *schema.ResourceData) *sc
 
 	costComponents := []*schema.CostComponent{
 		{
-			Name:           fmt.Sprintf("Database Instance (%s, %s)", "on_demand", instanceType),
+			Name:           fmt.Sprintf("Database instance (%s, %s)", "on-demand", instanceType),
 			Unit:           "hours",
 			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 			ProductFilter: &schema.ProductFilter{
@@ -68,7 +68,7 @@ func NewDocDBClusterInstance(d *schema.ResourceData, u *schema.ResourceData) *sc
 			},
 		},
 		{
-			Name: "Backup Storage",
+			Name: "Backup storage",
 			Unit: "GB-months",
 			ProductFilter: &schema.ProductFilter{
 				VendorName:    strPtr("aws"),
@@ -84,7 +84,7 @@ func NewDocDBClusterInstance(d *schema.ResourceData, u *schema.ResourceData) *sc
 
 	if strings.HasPrefix(instanceType, "db.t3.") {
 		costComponents = append(costComponents, &schema.CostComponent{
-			Name: "CPU Credits",
+			Name: "CPU credits",
 			Unit: "vCPU-hours",
 			ProductFilter: &schema.ProductFilter{
 				VendorName:    strPtr("aws"),

--- a/internal/providers/terraform/aws/docdb_cluster_instance_test.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance_test.go
@@ -28,41 +28,21 @@ func TestNewDocDBClusterInstance(t *testing.T) {
 					PriceHash:       "b21c3c7708229fb149bff23b4cfe6833-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
-			},
-		},
-		{
-			Name: "aws_docdb_cluster_instance.db",
-			CostComponentChecks: []testutil.CostComponentCheck{
 				{
 					Name:            "Storage",
 					PriceHash:       "856b9e5bd87c953bffd1df698a6a1b3d-ee3dd7e4624338037ca6fea0933a662f",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
-			},
-		},
-		{
-			Name: "aws_docdb_cluster_instance.db",
-			CostComponentChecks: []testutil.CostComponentCheck{
 				{
 					Name:            "I/O",
 					PriceHash:       "c6f1f44a4f05ef22044c5af6490b6808-5be345988e7c9a0759c5cf8365868ee4",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
-			},
-		},
-		{
-			Name: "aws_docdb_cluster_instance.db",
-			CostComponentChecks: []testutil.CostComponentCheck{
 				{
 					Name:            "Backup Storage",
 					PriceHash:       "b508a58e978730edb23511dd40ad77d6-ee3dd7e4624338037ca6fea0933a662f",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
-			},
-		},
-		{
-			Name: "aws_docdb_cluster_instance.db",
-			CostComponentChecks: []testutil.CostComponentCheck{
 				{
 					Name:            "CPU Credits",
 					PriceHash:       "f6d2bda62e25c6eb08020075859e5a97-e8e892be2fbd1c8f42fd6761ad8977d8",

--- a/internal/providers/terraform/aws/docdb_cluster_instance_test.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance_test.go
@@ -24,7 +24,7 @@ func TestNewDocDBClusterInstance(t *testing.T) {
 			Name: "aws_docdb_cluster_instance.db",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Database Instance (on_demand, db.t3.medium)",
+					Name:            "Database instance (on-demand, db.t3.medium)",
 					PriceHash:       "b21c3c7708229fb149bff23b4cfe6833-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -39,12 +39,12 @@ func TestNewDocDBClusterInstance(t *testing.T) {
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 				{
-					Name:            "Backup Storage",
+					Name:            "Backup storage",
 					PriceHash:       "b508a58e978730edb23511dd40ad77d6-ee3dd7e4624338037ca6fea0933a662f",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 				{
-					Name:            "CPU Credits",
+					Name:            "CPU credits",
 					PriceHash:       "f6d2bda62e25c6eb08020075859e5a97-e8e892be2fbd1c8f42fd6761ad8977d8",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},

--- a/internal/providers/terraform/aws/ebs_snapshot_copy_test.go
+++ b/internal/providers/terraform/aws/ebs_snapshot_copy_test.go
@@ -32,6 +32,14 @@ func TestEBSSnapshotCopy(t *testing.T) {
 
 	resourceChecks := []testutil.ResourceCheck{
 		{
+			Name:      "aws_ebs_volume.gp2",
+			SkipCheck: true,
+		},
+		{
+			Name:      "aws_ebs_snapshot.gp2",
+			SkipCheck: true,
+		},
+		{
 			Name: "aws_ebs_snapshot_copy.gp2",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{

--- a/internal/providers/terraform/aws/ebs_snapshot_test.go
+++ b/internal/providers/terraform/aws/ebs_snapshot_test.go
@@ -27,6 +27,10 @@ func TestEBSSnapshot(t *testing.T) {
 
 	resourceChecks := []testutil.ResourceCheck{
 		{
+			Name:      "aws_ebs_volume.gp2",
+			SkipCheck: true,
+		},
+		{
 			Name: "aws_ebs_snapshot.gp2",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{

--- a/internal/providers/terraform/aws/ecs_service.go
+++ b/internal/providers/terraform/aws/ecs_service.go
@@ -19,6 +19,20 @@ func GetECSServiceRegistryItem() *schema.RegistryItem {
 	}
 }
 
+func GetECSClusterRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:   "aws_ecs_cluster",
+		NoCost: true,
+	}
+}
+
+func GetECSTaskDefinitionRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:   "aws_ecs_task_definition",
+		NoCost: true,
+	}
+}
+
 func NewECSService(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
 	launchType := d.Get("launch_type").String()
 	if launchType != "FARGATE" {

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -52,7 +52,7 @@ func computeCostComponents(d *schema.ResourceData, region string, purchaseOption
 
 	costComponents := []*schema.CostComponent{
 		{
-			Name:           fmt.Sprintf("Linux/UNIX Usage (%s, %s)", purchaseOptionLabel, instanceType),
+			Name:           fmt.Sprintf("Linux/UNIX usage (%s, %s)", purchaseOptionLabel, instanceType),
 			Unit:           "hours",
 			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 			ProductFilter: &schema.ProductFilter{
@@ -76,7 +76,7 @@ func computeCostComponents(d *schema.ResourceData, region string, purchaseOption
 
 	if d.Get("ebs_optimized").Bool() {
 		costComponents = append(costComponents, &schema.CostComponent{
-			Name:                 "EBS-Optimized Usage",
+			Name:                 "EBS-Optimized usage",
 			Unit:                 "hours",
 			HourlyQuantity:       decimalPtr(decimal.NewFromInt(1)),
 			IgnoreIfMissingPrice: true,
@@ -102,7 +102,7 @@ func computeCostComponents(d *schema.ResourceData, region string, purchaseOption
 		prefix := strings.SplitN(instanceType, ".", 2)[0]
 
 		costComponents = append(costComponents, &schema.CostComponent{
-			Name:           "CPU Credits",
+			Name:           "CPU credits",
 			Unit:           "vCPU-hours",
 			HourlyQuantity: decimalPtr(decimal.NewFromInt(0)),
 			ProductFilter: &schema.ProductFilter{

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -45,7 +45,7 @@ func computeCostComponents(d *schema.ResourceData, region string, purchaseOption
 
 	costComponents := []*schema.CostComponent{
 		{
-			Name:           fmt.Sprintf("Compute (%s, %s)", purchaseOptionLabel, instanceType),
+			Name:           fmt.Sprintf("Linux/UNIX Usage (%s, %s)", purchaseOptionLabel, instanceType),
 			Unit:           "hours",
 			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 			ProductFilter: &schema.ProductFilter{

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/infracost/infracost/pkg/schema"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/shopspring/decimal"
 	"github.com/tidwall/gjson"
@@ -18,6 +19,11 @@ func GetInstanceRegistryItem() *schema.RegistryItem {
 }
 
 func NewInstance(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	if d.Get("tenancy").Exists() && d.Get("tenancy").String() == "host" {
+		log.Warnf("Skipping resource %s. Infracost currently does not support host tenancy for AWS EC2 instances", d.Address)
+		return nil
+	}
+
 	region := d.Get("region").String()
 	subResources := make([]*schema.Resource, 0)
 	subResources = append(subResources, newRootBlockDevice(d.Get("root_block_device.0"), region))

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -13,8 +13,12 @@ import (
 
 func GetInstanceRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
-		Name:  "aws_instance",
-		Notes: []string{"Non-Linux EC2 instances such as Windows and RHEL are not supported, a lookup is needed to find the OS of AMIs."},
+		Name: "aws_instance",
+		Notes: []string{
+			"Costs associated with non-standard Linux AMIs, such as Windows and RHEL are not supported.",
+			"EC2 Detailed Monitoring is not supported.",
+			"If a root volume is not specified then an 8Gi gp2 volume is assumed.",
+		},
 		RFunc: NewInstance,
 	}
 }

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -54,7 +54,7 @@ func TestInstance(t *testing.T) {
 			Name: "aws_instance.instance1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Linux/UNIX Usage (on-demand, m3.medium)",
+					Name:            "Linux/UNIX usage (on-demand, m3.medium)",
 					PriceHash:       "666e02bbe686f6950fd8a47a55e83a75-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -145,7 +145,7 @@ func TestInstance_ebsOptimized(t *testing.T) {
 			Name: "aws_instance.instance1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Linux/UNIX Usage (on-demand, m3.large)",
+					Name:            "Linux/UNIX usage (on-demand, m3.large)",
 					PriceHash:       "1abac89a8296443758727a2728579a2a-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -161,12 +161,12 @@ func TestInstance_ebsOptimized(t *testing.T) {
 			Name: "aws_instance.instance2",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Linux/UNIX Usage (on-demand, r3.xlarge)",
+					Name:            "Linux/UNIX usage (on-demand, r3.xlarge)",
 					PriceHash:       "5fc0daede99fac3cce64d575979d7233-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
-					Name:            "EBS-Optimized Usage",
+					Name:            "EBS-Optimized usage",
 					PriceHash:       "7f4fb9da921a628aedfbe150d930e255-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -253,11 +253,11 @@ func TestInstance_cpuCredits(t *testing.T) {
 			Name: "aws_instance.t3_default",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:      "Linux/UNIX Usage (on-demand, t3.medium)",
+					Name:      "Linux/UNIX usage (on-demand, t3.medium)",
 					SkipCheck: true,
 				},
 				{
-					Name:      "CPU Credits",
+					Name:      "CPU credits",
 					PriceHash: "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
 				},
 			},
@@ -272,11 +272,11 @@ func TestInstance_cpuCredits(t *testing.T) {
 			Name: "aws_instance.t3_unlimited",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:      "Linux/UNIX Usage (on-demand, t3.medium)",
+					Name:      "Linux/UNIX usage (on-demand, t3.medium)",
 					SkipCheck: true,
 				},
 				{
-					Name:            "CPU Credits",
+					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.Zero),
 				},
@@ -292,7 +292,7 @@ func TestInstance_cpuCredits(t *testing.T) {
 			Name: "aws_instance.t3_standard",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:      "Linux/UNIX Usage (on-demand, t3.medium)",
+					Name:      "Linux/UNIX usage (on-demand, t3.medium)",
 					SkipCheck: true,
 				},
 			},
@@ -307,7 +307,7 @@ func TestInstance_cpuCredits(t *testing.T) {
 			Name: "aws_instance.t2_default",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:      "Linux/UNIX Usage (on-demand, t2.medium)",
+					Name:      "Linux/UNIX usage (on-demand, t2.medium)",
 					SkipCheck: true,
 				},
 			},
@@ -322,11 +322,11 @@ func TestInstance_cpuCredits(t *testing.T) {
 			Name: "aws_instance.t2_unlimited",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:      "Linux/UNIX Usage (on-demand, t2.medium)",
+					Name:      "Linux/UNIX usage (on-demand, t2.medium)",
 					SkipCheck: true,
 				},
 				{
-					Name:            "CPU Credits",
+					Name:            "CPU credits",
 					PriceHash:       "4aaa3d22a88b57f7997e91888f867be9-e8e892be2fbd1c8f42fd6761ad8977d8",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.Zero),
 				},
@@ -342,7 +342,7 @@ func TestInstance_cpuCredits(t *testing.T) {
 			Name: "aws_instance.t2_standard",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:      "Linux/UNIX Usage (on-demand, t2.medium)",
+					Name:      "Linux/UNIX usage (on-demand, t2.medium)",
 					SkipCheck: true,
 				},
 			},

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -54,7 +54,7 @@ func TestInstance(t *testing.T) {
 			Name: "aws_instance.instance1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Compute (on-demand, m3.medium)",
+					Name:            "Linux/UNIX Usage (on-demand, m3.medium)",
 					PriceHash:       "666e02bbe686f6950fd8a47a55e83a75-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -145,7 +145,7 @@ func TestInstance_ebsOptimized(t *testing.T) {
 			Name: "aws_instance.instance1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Compute (on-demand, m3.large)",
+					Name:            "Linux/UNIX Usage (on-demand, m3.large)",
 					PriceHash:       "1abac89a8296443758727a2728579a2a-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -161,7 +161,7 @@ func TestInstance_ebsOptimized(t *testing.T) {
 			Name: "aws_instance.instance2",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Compute (on-demand, r3.xlarge)",
+					Name:            "Linux/UNIX Usage (on-demand, r3.xlarge)",
 					PriceHash:       "5fc0daede99fac3cce64d575979d7233-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -195,7 +195,11 @@ func TestInstance_hostTenancy(t *testing.T) {
 			tenancy       = "host"
 		}`
 
-	resourceChecks := []testutil.ResourceCheck{}
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_instance.instance1",
+		},
+	}
 
 	tftest.ResourceTests(t, tf, resourceChecks)
 }

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -182,3 +182,20 @@ func TestInstance_ebsOptimized(t *testing.T) {
 
 	tftest.ResourceTests(t, tf, resourceChecks)
 }
+
+func TestInstance_hostTenancy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_instance" "instance1" {
+			ami           = "fake_ami"
+			instance_type = "m3.medium"
+			tenancy       = "host"
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/nat_gateway.go
+++ b/internal/providers/terraform/aws/nat_gateway.go
@@ -25,7 +25,7 @@ func NewNATGateway(d *schema.ResourceData, u *schema.ResourceData) *schema.Resou
 		Name: d.Address,
 		CostComponents: []*schema.CostComponent{
 			{
-				Name:           "Per NAT Gateway",
+				Name:           "Per NAT gateway",
 				Unit:           "hours",
 				HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 				ProductFilter: &schema.ProductFilter{

--- a/internal/providers/terraform/aws/nat_gateway_test.go
+++ b/internal/providers/terraform/aws/nat_gateway_test.go
@@ -26,7 +26,7 @@ func TestNATGateway(t *testing.T) {
 			Name: "aws_nat_gateway.nat",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Per NAT Gateway",
+					Name:            "Per NAT gateway",
 					PriceHash:       "6e137a9da0718f0ec80fb60866730ba9-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -67,7 +67,7 @@ func TestNATGateway_usage(t *testing.T) {
 			Name: "aws_nat_gateway.nat",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Per NAT Gateway",
+					Name:            "Per NAT gateway",
 					PriceHash:       "6e137a9da0718f0ec80fb60866730ba9-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},

--- a/internal/providers/terraform/aws/rds_cluster_instance.go
+++ b/internal/providers/terraform/aws/rds_cluster_instance.go
@@ -13,6 +13,13 @@ func GetRDSClusterInstanceRegistryItem() *schema.RegistryItem {
 	}
 }
 
+func GetRDSClusterRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:   "aws_rds_cluster",
+		NoCost: true,
+	}
+}
+
 func NewRDSClusterInstance(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
 	region := d.Get("region").String()
 

--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -4,6 +4,8 @@ import "github.com/infracost/infracost/pkg/schema"
 
 var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAutoscalingGroupRegistryItem(),
+	GetLaunchConfigurationRegistryItem(),
+	GetLaunchTemplateRegistryItem(),
 	GetDBInstanceRegistryItem(),
 	GetDocDBClusterInstanceRegistryItem(),
 	GetDynamoDBTableRegistryItem(),
@@ -11,6 +13,8 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetEBSSnapshotRegistryItem(),
 	GetEBSVolumeRegistryItem(),
 	GetECSServiceRegistryItem(),
+	GetECSClusterRegistryItem(),
+	GetECSTaskDefinitionRegistryItem(),
 	GetElasticsearchDomainRegistryItem(),
 	GetELBRegistryItem(),
 	GetInstanceRegistryItem(),
@@ -19,4 +23,5 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetALBRegistryItem(),
 	GetNATGatewayRegistryItem(),
 	GetRDSClusterInstanceRegistryItem(),
+	GetRDSClusterRegistryItem(),
 }

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -20,8 +20,10 @@ func createResource(r *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 
 	if registryItem, ok := (*registryMap)[r.Type]; ok {
 		res := registryItem.RFunc(r, u)
-    res.ResourceType = r.Type
-		return res
+		if res != nil {
+			res.ResourceType = r.Type
+			return res
+		}
 	}
 
 	return &schema.Resource{

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -19,6 +19,10 @@ func createResource(r *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 	registryMap := GetResourceRegistryMap()
 
 	if registryItem, ok := (*registryMap)[r.Type]; ok {
+		if registryItem.NoCost {
+			return nil
+		}
+
 		res := registryItem.RFunc(r, u)
 		if res != nil {
 			res.ResourceType = r.Type

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -131,10 +131,10 @@ func SkippedResourcesMessage(resources []*schema.Resource, showDetails bool) str
 	} else {
 		message += ", re-run with --show-skipped to see the list.\n"
 	}
-	message += "We're continually adding new resources, please create an issue if you'd like us to prioritize your list.\n"
+	message += "We're continually adding new resources, please create an issue if you'd like us to prioritize your list."
 	if showDetails {
 		for rType, count := range unsupportedTypeCount {
-			message += fmt.Sprintf("%d x %s\n", count, rType)
+			message += fmt.Sprintf("\n%d x %s", count, rType)
 		}
 	}
 	return message

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -76,7 +76,7 @@ func generatePlanJSON(dir string, path string) ([]byte, error) {
 	}
 
 	if path == "" {
-		_, err := terraformCmd(opts, "init")
+		_, err := terraformCmd(opts, "init", "-no-color")
 		if err != nil {
 			return []byte{}, errors.Wrap(err, "error initializing terraform working directory")
 		}
@@ -87,7 +87,7 @@ func generatePlanJSON(dir string, path string) ([]byte, error) {
 		}
 		defer os.Remove(f.Name())
 
-		_, err = terraformCmd(opts, "plan", "-input=false", "-lock=false", fmt.Sprintf("-out=%s", f.Name()))
+		_, err = terraformCmd(opts, "plan", "-input=false", "-lock=false", "-no-color", fmt.Sprintf("-out=%s", f.Name()))
 		if err != nil {
 			return []byte{}, errors.Wrap(err, "error generating terraform execution plan")
 		}

--- a/internal/providers/terraform/provider_test.go
+++ b/internal/providers/terraform/provider_test.go
@@ -29,7 +29,8 @@ func TestLoadResources_rootModule(t *testing.T) {
 
 	resourceChecks := []testutil.ResourceCheck{
 		{
-			Name: "aws_nat_gateway.nat1",
+			Name:      "aws_nat_gateway.nat1",
+			SkipCheck: true,
 		},
 	}
 
@@ -78,10 +79,12 @@ func TestLoadResources_nestedModule(t *testing.T) {
 
 	resourceChecks := []testutil.ResourceCheck{
 		{
-			Name: "module.module1.aws_nat_gateway.nat1",
+			Name:      "module.module1.aws_nat_gateway.nat1",
+			SkipCheck: true,
 		},
 		{
-			Name: "module.module1.module.module2.aws_nat_gateway.nat2",
+			Name:      "module.module1.module.module2.aws_nat_gateway.nat2",
+			SkipCheck: true,
 		},
 	}
 

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -55,7 +55,7 @@ func WithProviders(tf string) string {
 	return fmt.Sprintf("%s%s", tfProviders, tf)
 }
 
-func ResourceTests(t *testing.T, tf string, resourceChecks []testutil.ResourceCheck) {
+func ResourceTests(t *testing.T, tf string, checks []testutil.ResourceCheck) {
 	project := Project{
 		Files: []File{
 			{
@@ -65,18 +65,16 @@ func ResourceTests(t *testing.T, tf string, resourceChecks []testutil.ResourceCh
 		},
 	}
 
-	ResourceTestsForProject(t, project, resourceChecks)
+	ResourceTestsForProject(t, project, checks)
 }
 
-func ResourceTestsForProject(t *testing.T, project Project, resourceChecks []testutil.ResourceCheck) {
+func ResourceTestsForProject(t *testing.T, project Project, checks []testutil.ResourceCheck) {
 	resources, err := RunCostCalculations(project)
 	if err != nil {
 		t.Error(err)
 	}
 
-	for _, resourceCheck := range resourceChecks {
-		testutil.TestResource(t, resources, resourceCheck)
-	}
+	testutil.TestResources(t, resources, checks)
 }
 
 func RunCostCalculations(project Project) ([]*schema.Resource, error) {

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -19,6 +19,7 @@ import (
 
 var tfProviders = `
 	terraform {
+		plugin_cache_dir = ".test_cache/terraform_plugins"
 		required_providers {
 			aws = {
 				source  = "hashicorp/aws"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -13,9 +14,41 @@ import (
 
 // ConfigSpec contains mapping of environment variable names to config values
 type ConfigSpec struct {
-	Logger  *logrus.Logger
-	NoColor bool
-	ApiUrl  string `envconfig:"INFRACOST_API_URL"  required:"true"  default:"https://pricing.infracost.io"`
+	NoColor  bool
+	ApiUrl   string `envconfig:"INFRACOST_API_URL"  required:"true"  default:"https://pricing.infracost.io"`
+	LogLevel string `envconfig:"INFRACOST_LOG_LEVEL"  required:"false"`
+}
+
+func (c *ConfigSpec) SetLogLevel(l string) error {
+	c.LogLevel = l
+
+	// Disable logging if no log level is set
+	if c.LogLevel == "" {
+		logrus.SetOutput(ioutil.Discard)
+		return nil
+	}
+	logrus.SetOutput(os.Stderr)
+
+	level, err := logrus.ParseLevel(c.LogLevel)
+	if err != nil {
+		return err
+	}
+	logrus.SetLevel(level)
+	return nil
+}
+
+func (c *ConfigSpec) IsLogging() bool {
+	return c.LogLevel != ""
+}
+
+func LogSortingFunc(keys []string) {
+	// Put message at the end
+	for i, key := range keys {
+		if key == "msg" && i != len(keys)-1 {
+			keys[i], keys[len(keys)-1] = keys[len(keys)-1], keys[i]
+			break
+		}
+	}
 }
 
 func rootDir() string {
@@ -58,7 +91,16 @@ func loadConfig() *ConfigSpec {
 		log.Fatal(err)
 	}
 
-	logrus.SetLevel(logrus.WarnLevel)
+	logrus.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+		DisableColors: true,
+		SortingFunc:   LogSortingFunc,
+	})
+
+	err = config.SetLogLevel(config.LogLevel)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	return &config
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,7 +51,7 @@ func LogSortingFunc(keys []string) {
 	}
 }
 
-func rootDir() string {
+func RootDir() string {
 	_, b, _, _ := runtime.Caller(0)
 	return filepath.Join(filepath.Dir(b), "../..")
 }
@@ -71,7 +71,7 @@ func loadConfig() *ConfigSpec {
 
 	config.NoColor = false
 
-	envLocalPath := filepath.Join(rootDir(), ".env.local")
+	envLocalPath := filepath.Join(RootDir(), ".env.local")
 	if fileExists(envLocalPath) {
 		err = godotenv.Load(envLocalPath)
 		if err != nil {

--- a/pkg/output/table.go
+++ b/pkg/output/table.go
@@ -75,7 +75,7 @@ func ToTable(resources []*schema.Resource, c *cli.Context) ([]byte, error) {
 
 	skippedResourcesMessage := terraform.SkippedResourcesMessage(resources, c.Bool("show-skipped"))
 	if skippedResourcesMessage != "" {
-		_, err := bufw.WriteString(skippedResourcesMessage)
+		_, err := bufw.WriteString(fmt.Sprintf("\n%s", skippedResourcesMessage))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/prices/prices.go
+++ b/pkg/prices/prices.go
@@ -42,6 +42,12 @@ func setCostComponentPrice(r *schema.Resource, c *schema.CostComponent, res gjso
 
 	products := res.Get("data.products").Array()
 	if len(products) == 0 {
+		if c.IgnoreIfMissingPrice {
+			log.Debugf("No products found for %s %s, ignoring since IgnoreIfMissingPrice is set.", r.Name, c.Name)
+			r.RemoveCostComponent(c)
+			return
+		}
+
 		log.Warnf("No products found for %s %s, using 0.00", r.Name, c.Name)
 		c.SetPrice(decimal.Zero)
 		return
@@ -52,6 +58,12 @@ func setCostComponentPrice(r *schema.Resource, c *schema.CostComponent, res gjso
 
 	prices := products[0].Get("prices").Array()
 	if len(prices) == 0 {
+		if c.IgnoreIfMissingPrice {
+			log.Debugf("No prices found for %s %s, ignoring since IgnoreIfMissingPrice is set.", r.Name, c.Name)
+			r.RemoveCostComponent(c)
+			return
+		}
+
 		log.Warnf("No prices found for %s %s, using 0.00", r.Name, c.Name)
 		c.SetPrice(decimal.Zero)
 		return

--- a/pkg/schema/cost_component.go
+++ b/pkg/schema/cost_component.go
@@ -5,16 +5,17 @@ import (
 )
 
 type CostComponent struct {
-	Name            string
-	Unit            string
-	ProductFilter   *ProductFilter
-	PriceFilter     *PriceFilter
-	HourlyQuantity  *decimal.Decimal
-	MonthlyQuantity *decimal.Decimal
-	price           decimal.Decimal
-	priceHash       string
-	hourlyCost      decimal.Decimal
-	monthlyCost     decimal.Decimal
+	Name                 string
+	Unit                 string
+	IgnoreIfMissingPrice bool
+	ProductFilter        *ProductFilter
+	PriceFilter          *PriceFilter
+	HourlyQuantity       *decimal.Decimal
+	MonthlyQuantity      *decimal.Decimal
+	price                decimal.Decimal
+	priceHash            string
+	hourlyCost           decimal.Decimal
+	monthlyCost          decimal.Decimal
 }
 
 func (c *CostComponent) CalculateCosts() {

--- a/pkg/schema/registry_item.go
+++ b/pkg/schema/registry_item.go
@@ -1,7 +1,8 @@
 package schema
 
 type RegistryItem struct {
-	Name  string
-	Notes []string
-	RFunc ResourceFunc
+	Name   string
+	Notes  []string
+	RFunc  ResourceFunc
+	NoCost bool
 }

--- a/pkg/schema/resource.go
+++ b/pkg/schema/resource.go
@@ -66,6 +66,16 @@ func (r *Resource) FlattenedSubResources() []*Resource {
 	return resources
 }
 
+func (r *Resource) RemoveCostComponent(costComponent *CostComponent) {
+	n := make([]*CostComponent, 0, len(r.CostComponents)-1)
+	for _, c := range r.CostComponents {
+		if c != costComponent {
+			n = append(n, c)
+		}
+	}
+	r.CostComponents = n
+}
+
 func SortResources(resources []*Resource) {
 	sort.Slice(resources, func(i, j int) bool {
 		return resources[i].Name < resources[j].Name


### PR DESCRIPTION
**Objective**:

Add more options for `aws_instance`.

**Example output**:

```
  aws_instance.t3_unlimited
  ├─ CPU credits                                                                  0  vCPU-hours   0.0500       0.0000        0.0000
  ├─ Linux/UNIX usage (on-demand, t3.medium)                                    730  hours        0.0416       0.0416       30.3680
  └─ Storage (root_block_device)                                                  8  GB-months    0.1000       0.0011        0.8000
  Total                                                                                                        0.0427       31.1680

  aws_instance.ebs_optimized
  ├─ EBS-optimized usage                                                        730  hours        0.0200       0.0200       14.6000
  ├─ Linux/UNIX usage (on-demand, r3.xlarge)                                    730  hours        0.3330       0.3330      243.0900
  └─ Storage (root_block_device)                                                  8  GB-months    0.1000       0.0011        0.8000
  Total                                                                                                        0.3541      258.4900
```

**Pricing details**:

 * EBS-optimized usage costs are charged for previous generation instances that have `ebs_optimized = true` set.
 * t3 and t4g instances launch by default in "Unlimited" mode which means that CPU credit costs can apply. This depends on the number of vCPU-hours that are used by these instances over the baseline. t2 instances also support "Unlimited" mode, but this is disabled by default.

**Status**:

- [x] Add EBS-optimized costs 
- [x] Add CPU credits prices
- [x] Add a warning if tenancy is host
- [x] Update "Compute" to "Linux/UNIX Usage" to be consistent with AWS pricing page
- [x] Add integration tests

**Others changes**:

- [x] Refactor logging
- [x] Add provider cache to speed up tests

**Useful links**:

- Pricing: https://aws.amazon.com/ec2/pricing/on-demand/
- Terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
