### PR TITLE
Add EC2 detailed monitoring

### DIFF
--- a/docs/generated/supported_resources.md
+++ b/docs/generated/supported_resources.md
@@ -24,7 +24,7 @@ Support for the following is not currently included:
 | `aws_ecs_task_definition` |  |
 | `aws_elasticsearch_domain` |  |
 | `aws_elb` |  |
-| `aws_instance` |  Costs associated with non-standard Linux AMIs, such as Windows and RHEL are not supported.<br />  EC2 Detailed Monitoring is not supported.<br />  If a root volume is not specified then an 8Gi gp2 volume is assumed.<br />  |
+| `aws_instance` |  Costs associated with non-standard Linux AMIs, such as Windows and RHEL are not supported.<br />  EC2 detailed monitoring assumes the standard 7 metrics and the lowest tier of prices for CloudWatch.<br />  If a root volume is not specified then an 8Gi gp2 volume is assumed.<br />  |
 | `aws_lambda_function` |  Provisioned concurrency is not yet supported.<br />  |
 | `aws_launch_configuration` |  |
 | `aws_launch_template` |  |

--- a/pkg/prices/query.go
+++ b/pkg/prices/query.go
@@ -90,6 +90,11 @@ func (q *GraphQLQueryRunner) buildQuery(product *schema.ProductFilter, price *sc
 func (q *GraphQLQueryRunner) getQueryResults(queries []GraphQLQuery) ([]gjson.Result, error) {
 	results := make([]gjson.Result, 0, len(queries))
 
+	if len(queries) == 0 {
+		log.Debug("skipping GraphQL request as no queries have been specified")
+		return results, nil
+	}
+
 	queriesBody, err := json.Marshal(queries)
 	if err != nil {
 		return results, errors.Wrap(err, "error marshalling queries")

--- a/pkg/schema/filters.go
+++ b/pkg/schema/filters.go
@@ -14,6 +14,8 @@ type PriceFilter struct {
 	Unit               *string `json:"unit,omitempty"`
 	Description        *string `json:"description,omitempty"`
 	DescriptionRegex   *string `json:"description_regex,omitempty"`
+	StartUsageAmount   *string `json:"startUsageAmount,omitempty"`
+	EndUsageAmount     *string `json:"endUsageAmount,omitempty"`
 	TermLength         *string `json:"termLength,omitempty"`
 	TermPurchaseOption *string `json:"termPurchaseOption,omitempty"`
 	TermOfferingClass  *string `json:"termOfferingClass,omitempty"`


### PR DESCRIPTION
**Depends on https://github.com/infracost/cloud-pricing-api/pull/21 and https://github.com/infracost/infracost/pull/126**

**Objective**:

Add EC2 detailed monitoring costs for `aws_instance`.

**Example output**:

```
  aws_instance.web_app
  ├─ CPU credits                                       0  vCPU-hours  0.0500       0.0000        0.0000
  ├─ EC2 detailed monitoring                           7  metrics     0.3000       0.0029        2.1000
  ├─ Linux/UNIX usage (on-demand, t3.micro)          730  hours       0.0104       0.0104        7.5920
  └─ root_block_device
     └─ Storage                                       15  GB-months   0.1000       0.0021        1.5000
  Total                                                                            0.0153       11.1920                                                                                                 0.3541      258.4900
```

**Pricing details**:

EC2 detailed monitoring prices are charged when `monitoring = true`. The price is dependent on the CloudWatch tier - we will assume the lowest just now. The cost depends on the number of metrics that the instance type supports - for most instance types this is 7 metrics, so we will assume this just now.

**Status**:

- [x] Add EC2 detailed monitoring costs
- [x] Add CPU credits costs
- [x] Add integration tests

**Useful links**:

- Pricing:
  - https://aws.amazon.com/ec2/pricing/on-demand/
  - https://aws.amazon.com/cloudwatch/pricing/
- Terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
