### PR TITLE
Add more Autoscaling Group prices and costs

### DIFF
--- a/docs/generated/supported_resources.md
+++ b/docs/generated/supported_resources.md
@@ -12,7 +12,7 @@ Support for the following is not currently included:
 | Terraform resource           | Notes |
 | ---                          | ---   |
 | `aws_alb` |  |
-| `aws_autoscaling_group` |  |
+| `aws_autoscaling_group` |  See aws_instance<br />  |
 | `aws_db_instance` |  |
 | `aws_docdb_cluster_instance` |  |
 | `aws_dynamodb_table` |  DAX is not yet supported.<br />  |

--- a/internal/providers/terraform/aws/autoscaling_group.go
+++ b/internal/providers/terraform/aws/autoscaling_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/infracost/infracost/pkg/schema"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/shopspring/decimal"
 	"github.com/tidwall/gjson"
@@ -12,6 +13,9 @@ import (
 func GetAutoscalingGroupRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_autoscaling_group",
+		Notes: []string{
+			"See aws_instance",
+		},
 		RFunc: NewAutoscalingGroup,
 	}
 }
@@ -41,14 +45,39 @@ func NewAutoscalingGroup(d *schema.ResourceData, u *schema.ResourceData) *schema
 	mixedInstanceLaunchTemplateRef := d.References("mixed_instances_policy.0.launch_template.0.launch_template_specification.0.launch_template_id")
 
 	if len(launchConfigurationRef) > 0 {
-		launchConfiguration := newLaunchConfiguration(launchConfigurationRef[0].Address, launchConfigurationRef[0], region)
-		multiplyQuantities(launchConfiguration, desiredCapacity)
-		subResources = append(subResources, launchConfiguration)
+		lc := newLaunchConfiguration(launchConfigurationRef[0].Address, launchConfigurationRef[0], region)
+
+		// AutoscalingGroup should show as not supported LaunchConfiguration is not supported
+		if lc == nil {
+			return nil
+		}
+		multiplyQuantities(lc, desiredCapacity)
+		subResources = append(subResources, lc)
+
 	} else if len(launchTemplateRef) > 0 {
-		subResources = append(subResources, newLaunchTemplate(launchTemplateRef[0].Address, launchTemplateRef[0], region, desiredCapacity, decimal.Zero))
+		onDemandCount := desiredCapacity
+		spotCount := decimal.Zero
+		if launchTemplateRef[0].Get("instance_market_options.0.market_type").String() == "spot" {
+			onDemandCount = decimal.Zero
+			spotCount = desiredCapacity
+		}
+		lt := newLaunchTemplate(launchTemplateRef[0].Address, launchTemplateRef[0], region, onDemandCount, spotCount)
+
+		// AutoscalingGroup should show as not supported LaunchTemplate is not supported
+		if lt == nil {
+			return nil
+		}
+		subResources = append(subResources, lt)
+
 	} else if len(mixedInstanceLaunchTemplateRef) > 0 {
 		mixedInstancesPolicy := d.Get("mixed_instances_policy.0")
-		subResources = append(subResources, newMixedInstancesAwsLaunchTemplate(mixedInstanceLaunchTemplateRef[0].Address, mixedInstanceLaunchTemplateRef[0], region, desiredCapacity, mixedInstancesPolicy))
+		lt := newMixedInstancesAwsLaunchTemplate(mixedInstanceLaunchTemplateRef[0].Address, mixedInstanceLaunchTemplateRef[0], region, desiredCapacity, mixedInstancesPolicy)
+
+		// AutoscalingGroup should show as not supported LaunchTemplate is not supported
+		if lt == nil {
+			return nil
+		}
+		subResources = append(subResources, lt)
 	}
 
 	return &schema.Resource{
@@ -58,39 +87,95 @@ func NewAutoscalingGroup(d *schema.ResourceData, u *schema.ResourceData) *schema
 }
 
 func newLaunchConfiguration(name string, d *schema.ResourceData, region string) *schema.Resource {
+	tenancy := "Shared"
+	if d.Get("placement_tenancy").String() == "host" {
+		log.Warnf("Skipping resource %s. Infracost currently does not support host tenancy for AWS Launch Configurations", d.Address)
+		return nil
+	} else if d.Get("placement_tenancy").String() == "dedicated" {
+		tenancy = "Dedicated"
+	}
+
 	subResources := make([]*schema.Resource, 0)
 	subResources = append(subResources, newRootBlockDevice(d.Get("root_block_device.0"), region))
 	subResources = append(subResources, newEbsBlockDevices(d.Get("ebs_block_device"), region)...)
 
+	purchaseOption := "on_demand"
+	if d.Get("spot_price").String() != "" {
+		purchaseOption = "spot"
+	}
+	costComponents := []*schema.CostComponent{computeCostComponent(d, purchaseOption, tenancy)}
+
+	if d.Get("ebs_optimized").Bool() {
+		costComponents = append(costComponents, ebsOptimizedCostComponent(d))
+	}
+
+	// Detailed monitoring is enabled by default for launch configurations
+	if d.Get("enable_monitoring").Bool() {
+		costComponents = append(costComponents, detailedMonitoringCostComponent(d))
+	}
+
+	c := cpuCreditsCostComponent(d)
+	if c != nil {
+		costComponents = append(costComponents, c)
+	}
+
 	return &schema.Resource{
 		Name:           name,
 		SubResources:   subResources,
-		CostComponents: computeCostComponents(d, region, "on_demand"),
+		CostComponents: costComponents,
 	}
 }
 
 func newLaunchTemplate(name string, d *schema.ResourceData, region string, onDemandCount decimal.Decimal, spotCount decimal.Decimal) *schema.Resource {
+	tenancy := "Shared"
+	if d.Get("placement.0.tenancy").String() == "host" {
+		log.Warnf("Skipping resource %s. Infracost currently does not support host tenancy for AWS Launch Templates", d.Address)
+		return nil
+	} else if d.Get("placement.0.tenancy").String() == "dedicated" {
+		tenancy = "Dedicated"
+	}
+
+	totalCount := onDemandCount.Add(spotCount)
+
 	costComponents := make([]*schema.CostComponent, 0)
 
+	if d.Get("ebs_optimized").Bool() {
+		c := ebsOptimizedCostComponent(d)
+		c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(totalCount))
+		costComponents = append(costComponents, c)
+	}
+
+	if d.Get("elastic_inference_accelerator.0.type").Exists() {
+		c := elasticInferenceAcceleratorCostComponent(d)
+		c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(totalCount))
+		costComponents = append(costComponents, c)
+	}
+
+	if d.Get("monitoring.0.enabled").Bool() {
+		c := detailedMonitoringCostComponent(d)
+		c.MonthlyQuantity = decimalPtr(c.MonthlyQuantity.Mul(totalCount))
+		costComponents = append(costComponents, c)
+	}
+
+	c := cpuCreditsCostComponent(d)
+	if c != nil {
+		c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(totalCount))
+		costComponents = append(costComponents, c)
+	}
+
 	if onDemandCount.GreaterThan(decimal.Zero) {
-		cs := computeCostComponents(d, region, "on_demand")
-		for _, c := range cs {
-			c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(onDemandCount))
-		}
-		costComponents = append(costComponents, cs...)
+		c := computeCostComponent(d, "on_demand", tenancy)
+		c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(onDemandCount))
+		costComponents = append(costComponents, c)
 	}
 
 	if spotCount.GreaterThan(decimal.Zero) {
-		cs := computeCostComponents(d, region, "spot")
-		for _, c := range cs {
-			c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(spotCount))
-		}
-		costComponents = append(costComponents, cs...)
+		c := computeCostComponent(d, "spot", tenancy)
+		c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(spotCount))
+		costComponents = append(costComponents, c)
 	}
 
 	subResources := make([]*schema.Resource, 0)
-
-	totalCount := onDemandCount.Add(spotCount)
 	rootBlockDevice := newRootBlockDevice(d.Get("root_block_device.0"), region)
 	multiplyQuantities(rootBlockDevice, totalCount)
 	subResources = append(subResources, rootBlockDevice)
@@ -118,6 +203,26 @@ func newMixedInstancesAwsLaunchTemplate(name string, d *schema.ResourceData, reg
 	onDemandCount, spotCount := calculateOnDemandAndSpotCounts(mixedInstancePolicyData, totalCount)
 
 	return newLaunchTemplate(name, d, region, onDemandCount, spotCount)
+}
+
+func elasticInferenceAcceleratorCostComponent(d *schema.ResourceData) *schema.CostComponent {
+	region := d.Get("region").String()
+	deviceType := d.Get("elastic_inference_accelerator.0.type").String()
+
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("Inference accelerator (%s)", deviceType),
+		Unit:           "hours",
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEI"),
+			ProductFamily: strPtr("Elastic Inference"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/", deviceType))},
+			},
+		},
+	}
 }
 
 func getInstanceTypeAndCount(mixedInstancePolicyData gjson.Result, capacity decimal.Decimal) (string, decimal.Decimal) {

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -49,6 +49,11 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 							PriceHash:       "250382a8c0da495d6048e6fc57e526bc-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
+						{
+							Name:            "EC2 detailed monitoring",
+							PriceHash:       "df2e2141bd6d5e2b758fa0617157ff46-fd21869c4f4d79599eea951b2b7353e6",
+							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(14)),
+						},
 					},
 					SubResourceChecks: []testutil.ResourceCheck{
 						{
@@ -70,6 +75,220 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchConfiguration_spot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_configuration" "lc1" {
+			image_id          = "fake_ami"
+			instance_type     = "t2.medium"
+			spot_price        = 1.00
+			enable_monitoring = false
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_configuration = aws_launch_configuration.lc1.id
+			desired_capacity     = 2
+			max_size             = 3
+			min_size             = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_configuration.lc1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (spot, t2.medium)",
+							PriceHash:       "250382a8c0da495d6048e6fc57e526bc-803d7f1cd2f621429b63f791730e7935",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchConfiguration_ebsOptimized(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_configuration" "lc1" {
+			image_id          = "fake_ami"
+			instance_type     = "r3.xlarge"
+			enable_monitoring = false
+			ebs_optimized     = true
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_configuration = aws_launch_configuration.lc1.id
+			desired_capacity     = 2
+			max_size             = 3
+			min_size             = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_configuration.lc1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (on-demand, r3.xlarge)",
+							PriceHash:       "5fc0daede99fac3cce64d575979d7233-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+						{
+							Name:            "EBS-Optimized usage",
+							PriceHash:       "7f4fb9da921a628aedfbe150d930e255-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchConfiguration_tenancy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_configuration" "lc1" {
+			image_id          = "fake_ami"
+			instance_type     = "m3.medium"
+			placement_tenancy = "dedicated"
+			enable_monitoring = false
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_configuration = aws_launch_configuration.lc1.id
+			desired_capacity     = 2
+			max_size             = 3
+			min_size             = 1
+		}
+
+		resource "aws_launch_configuration" "lc2" {
+			image_id          = "fake_ami"
+			instance_type     = "m3.medium"
+			placement_tenancy = "host"
+			enable_monitoring = false
+		}
+
+		resource "aws_autoscaling_group" "asg2" {
+			launch_configuration = aws_launch_configuration.lc2.id
+			desired_capacity     = 2
+			max_size             = 3
+			min_size             = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_configuration.lc1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (on-demand, m3.medium)",
+							PriceHash:       "68c80ad31fd5a0747855b8196e3de65b-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "aws_autoscaling_group.asg2",
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchConfiguration_cpuCredits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_configuration" "lc1" {
+			image_id          = "fake_ami"
+			instance_type     = "t3.medium"
+			enable_monitoring = false
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_configuration = aws_launch_configuration.lc1.id
+			desired_capacity     = 2
+			max_size             = 3
+			min_size             = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_configuration.lc1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (on-demand, t3.medium)",
+							PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+						{
+							Name:             "CPU credits",
+							PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
 						},
 					},
 				},
@@ -108,13 +327,12 @@ func TestAutoscalingGroup_launchTemplate(t *testing.T) {
 		}
 
 		resource "aws_autoscaling_group" "asg1" {
-			desired_capacity = 2
-			max_size         = 3
-			min_size         = 1
-
 			launch_template {
 				id = aws_launch_template.lt1.id
 			}
+			desired_capacity = 2
+			max_size         = 3
+			min_size         = 1
 		}`
 
 	resourceChecks := []testutil.ResourceCheck{
@@ -165,6 +383,341 @@ func TestAutoscalingGroup_launchTemplate(t *testing.T) {
 									HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(400)),
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchTemplate_spot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_template" "lt1" {
+			image_id          = "fake_ami"
+			instance_type     = "t2.medium"
+			instance_market_options {
+				market_type = "spot"
+			}
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_template {
+				id = aws_launch_template.lt1.id
+			}
+			desired_capacity = 2
+			max_size         = 3
+			min_size         = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_template.lt1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (spot, t2.medium)",
+							PriceHash:       "250382a8c0da495d6048e6fc57e526bc-803d7f1cd2f621429b63f791730e7935",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchTemplate_tenancy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_template" "lt1" {
+			image_id      = "fake_ami"
+			instance_type = "m3.medium"
+			placement {
+				tenancy = "dedicated"
+			}
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_template {
+				id = aws_launch_template.lt1.id
+			}
+			desired_capacity = 2
+			max_size         = 3
+			min_size         = 1
+		}
+
+		resource "aws_launch_template" "lt2" {
+			image_id      = "fake_ami"
+			instance_type = "m3.medium"
+			placement {
+				tenancy = "host"
+			}
+		}
+
+		resource "aws_autoscaling_group" "asg2" {
+			launch_template {
+				id = aws_launch_template.lt2.id
+			}
+			desired_capacity = 2
+			max_size         = 3
+			min_size         = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_template.lt1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (on-demand, m3.medium)",
+							PriceHash:       "68c80ad31fd5a0747855b8196e3de65b-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "aws_autoscaling_group.asg2",
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchTemplate_ebsOptimized(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_template" "lt1" {
+			image_id      = "fake_ami"
+			instance_type = "r3.xlarge"
+			ebs_optimized = true
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_template {
+				id = aws_launch_template.lt1.id
+			}
+			desired_capacity = 2
+			max_size         = 3
+			min_size         = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_template.lt1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (on-demand, r3.xlarge)",
+							PriceHash:       "5fc0daede99fac3cce64d575979d7233-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+						{
+							Name:            "EBS-Optimized usage",
+							PriceHash:       "7f4fb9da921a628aedfbe150d930e255-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchTemplate_elasticInferenceAccelerator(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_template" "lt1" {
+			image_id      = "fake_ami"
+			instance_type = "t2.medium"
+			elastic_inference_accelerator {
+				type = "eia2.medium"
+			}
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_template {
+				id = aws_launch_template.lt1.id
+			}
+			desired_capacity = 2
+			max_size         = 3
+			min_size         = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_template.lt1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (on-demand, t2.medium)",
+							PriceHash:       "250382a8c0da495d6048e6fc57e526bc-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+						{
+							Name:            "Inference accelerator (eia2.medium)",
+							PriceHash:       "498a3aadc034dfaf873005fdd3f56bbf-1fb365d8a0bc1f462690ec9d444f380c",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchTemplate_monitoring(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_template" "lt1" {
+			image_id      = "fake_ami"
+			instance_type = "t2.medium"
+			monitoring {
+				enabled = true
+			}
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_template {
+				id = aws_launch_template.lt1.id
+			}
+			desired_capacity = 2
+			max_size         = 3
+			min_size         = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_template.lt1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (on-demand, t2.medium)",
+							PriceHash:       "250382a8c0da495d6048e6fc57e526bc-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+						{
+							Name:            "EC2 detailed monitoring",
+							PriceHash:       "df2e2141bd6d5e2b758fa0617157ff46-fd21869c4f4d79599eea951b2b7353e6",
+							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(14)),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}
+
+func TestAutoscalingGroup_launchTemplate_cpuCredits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_launch_template" "lt1" {
+			image_id          = "fake_ami"
+			instance_type     = "t3.medium"
+		}
+
+		resource "aws_autoscaling_group" "asg1" {
+			launch_template {
+				id = aws_launch_template.lt1.id
+			}
+			desired_capacity = 2
+			max_size         = 3
+			min_size         = 1
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.asg1",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_template.lt1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Linux/UNIX usage (on-demand, t3.medium)",
+							PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+						},
+						{
+							Name:             "CPU credits",
+							PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
 						},
 					},
 				},

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -26,9 +26,12 @@ func GetInstanceRegistryItem() *schema.RegistryItem {
 }
 
 func NewInstance(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
-	if d.Get("tenancy").Exists() && d.Get("tenancy").String() == "host" {
+	tenancy := "Shared"
+	if d.Get("tenancy").String() == "host" {
 		log.Warnf("Skipping resource %s. Infracost currently does not support host tenancy for AWS EC2 instances", d.Address)
 		return nil
+	} else if d.Get("tenancy").String() == "dedicated" {
+		tenancy = "Dedicated"
 	}
 
 	region := d.Get("region").String()
@@ -36,113 +39,129 @@ func NewInstance(d *schema.ResourceData, u *schema.ResourceData) *schema.Resourc
 	subResources = append(subResources, newRootBlockDevice(d.Get("root_block_device.0"), region))
 	subResources = append(subResources, newEbsBlockDevices(d.Get("ebs_block_device"), region)...)
 
+	costComponents := []*schema.CostComponent{computeCostComponent(d, "on_demand", tenancy)}
+	if d.Get("ebs_optimized").Bool() {
+		costComponents = append(costComponents, ebsOptimizedCostComponent(d))
+	}
+	if d.Get("monitoring").Bool() {
+		costComponents = append(costComponents, detailedMonitoringCostComponent(d))
+	}
+	c := cpuCreditsCostComponent(d)
+	if c != nil {
+		costComponents = append(costComponents, c)
+	}
+
 	return &schema.Resource{
 		Name:           d.Address,
 		SubResources:   subResources,
-		CostComponents: computeCostComponents(d, region, "on_demand"),
+		CostComponents: costComponents,
 	}
 }
 
-func computeCostComponents(d *schema.ResourceData, region string, purchaseOption string) []*schema.CostComponent {
+func computeCostComponent(d *schema.ResourceData, purchaseOption string, tenancy string) *schema.CostComponent {
+	region := d.Get("region").String()
 	instanceType := d.Get("instance_type").String()
-
-	tenancy := "Shared"
-	if d.Get("tenancy").Exists() && d.Get("tenancy").String() == "dedicated" {
-		tenancy = "Dedicated"
-	}
 
 	purchaseOptionLabel := map[string]string{
 		"on_demand": "on-demand",
 		"spot":      "spot",
 	}[purchaseOption]
 
-	costComponents := []*schema.CostComponent{
-		{
-			Name:           fmt.Sprintf("Linux/UNIX usage (%s, %s)", purchaseOptionLabel, instanceType),
-			Unit:           "hours",
-			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Region:        strPtr(region),
-				Service:       strPtr("AmazonEC2"),
-				ProductFamily: strPtr("Compute Instance"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "instanceType", Value: strPtr(instanceType)},
-					{Key: "tenancy", Value: strPtr(tenancy)},
-					{Key: "operatingSystem", Value: strPtr("Linux")},
-					{Key: "preInstalledSw", Value: strPtr("NA")},
-					{Key: "capacitystatus", Value: strPtr("Used")},
-				},
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("Linux/UNIX usage (%s, %s)", purchaseOptionLabel, instanceType),
+		Unit:           "hours",
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEC2"),
+			ProductFamily: strPtr("Compute Instance"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "instanceType", Value: strPtr(instanceType)},
+				{Key: "tenancy", Value: strPtr(tenancy)},
+				{Key: "operatingSystem", Value: strPtr("Linux")},
+				{Key: "preInstalledSw", Value: strPtr("NA")},
+				{Key: "capacitystatus", Value: strPtr("Used")},
 			},
-			PriceFilter: &schema.PriceFilter{
-				PurchaseOption: &purchaseOption,
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: &purchaseOption,
+		},
+	}
+}
+
+func ebsOptimizedCostComponent(d *schema.ResourceData) *schema.CostComponent {
+	region := d.Get("region").String()
+	instanceType := d.Get("instance_type").String()
+
+	return &schema.CostComponent{
+		Name:                 "EBS-Optimized usage",
+		Unit:                 "hours",
+		HourlyQuantity:       decimalPtr(decimal.NewFromInt(1)),
+		IgnoreIfMissingPrice: true,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEC2"),
+			ProductFamily: strPtr("Compute Instance"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "instanceType", Value: strPtr(instanceType)},
+				{Key: "usagetype", ValueRegex: strPtr("/EBSOptimized/")},
 			},
 		},
 	}
+}
 
-	if d.Get("ebs_optimized").Bool() {
-		costComponents = append(costComponents, &schema.CostComponent{
-			Name:                 "EBS-Optimized usage",
-			Unit:                 "hours",
-			HourlyQuantity:       decimalPtr(decimal.NewFromInt(1)),
-			IgnoreIfMissingPrice: true,
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Region:        strPtr(region),
-				Service:       strPtr("AmazonEC2"),
-				ProductFamily: strPtr("Compute Instance"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "instanceType", Value: strPtr(instanceType)},
-					{Key: "usagetype", ValueRegex: strPtr("/EBSOptimized/")},
-				},
-			},
-		})
-	}
+func detailedMonitoringCostComponent(d *schema.ResourceData) *schema.CostComponent {
+	region := d.Get("region").String()
 
-	if d.Get("monitoring").Bool() {
-		costComponents = append(costComponents, &schema.CostComponent{
-			Name:                 "EC2 detailed monitoring",
-			Unit:                 "metrics",
-			MonthlyQuantity:      decimalPtr(decimal.NewFromInt(int64(defaultEC2InstanceMetricCount))),
-			IgnoreIfMissingPrice: true,
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Region:        strPtr(region),
-				Service:       strPtr("AmazonCloudWatch"),
-				ProductFamily: strPtr("Metric"),
-			},
-			PriceFilter: &schema.PriceFilter{
-				StartUsageAmount: strPtr("0"),
-			},
-		})
+	return &schema.CostComponent{
+		Name:                 "EC2 detailed monitoring",
+		Unit:                 "metrics",
+		MonthlyQuantity:      decimalPtr(decimal.NewFromInt(int64(defaultEC2InstanceMetricCount))),
+		IgnoreIfMissingPrice: true,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonCloudWatch"),
+			ProductFamily: strPtr("Metric"),
+		},
+		PriceFilter: &schema.PriceFilter{
+			StartUsageAmount: strPtr("0"),
+		},
 	}
+}
+
+func cpuCreditsCostComponent(d *schema.ResourceData) *schema.CostComponent {
+	region := d.Get("region").String()
+	instanceType := d.Get("instance_type").String()
 
 	cpuCredits := d.Get("credit_specification.0.cpu_credits").String()
 	if cpuCredits == "" && (strings.HasPrefix(instanceType, "t3.") || strings.HasPrefix(instanceType, "t4g.")) {
 		cpuCredits = "unlimited"
 	}
 
-	if cpuCredits == "unlimited" {
-		prefix := strings.SplitN(instanceType, ".", 2)[0]
-
-		costComponents = append(costComponents, &schema.CostComponent{
-			Name:           "CPU credits",
-			Unit:           "vCPU-hours",
-			HourlyQuantity: decimalPtr(decimal.NewFromInt(0)),
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Region:        strPtr(region),
-				Service:       strPtr("AmazonEC2"),
-				ProductFamily: strPtr("CPU Credits"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "operatingSystem", Value: strPtr("Linux")},
-					{Key: "usagetype", Value: strPtr(fmt.Sprintf("CPUCredits:%s", prefix))},
-				},
-			},
-		})
+	if cpuCredits != "unlimited" {
+		return nil
 	}
 
-	return costComponents
+	prefix := strings.SplitN(instanceType, ".", 2)[0]
+
+	return &schema.CostComponent{
+		Name:           "CPU credits",
+		Unit:           "vCPU-hours",
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(0)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEC2"),
+			ProductFamily: strPtr("CPU Credits"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "operatingSystem", Value: strPtr("Linux")},
+				{Key: "usagetype", Value: strPtr(fmt.Sprintf("CPUCredits:%s", prefix))},
+			},
+		},
+	}
 }
 
 func newRootBlockDevice(d gjson.Result, region string) *schema.Resource {
@@ -159,9 +178,9 @@ func newEbsBlockDevices(d gjson.Result, region string) []*schema.Resource {
 }
 
 func newEbsBlockDevice(name string, d gjson.Result, region string) *schema.Resource {
-	volumeApiName := "gp2"
+	volumeAPIName := "gp2"
 	if d.Get("volume_type").Exists() {
-		volumeApiName = d.Get("volume_type").String()
+		volumeAPIName = d.Get("volume_type").String()
 	}
 
 	gbVal := decimal.NewFromInt(int64(defaultVolumeSize))
@@ -176,6 +195,6 @@ func newEbsBlockDevice(name string, d gjson.Result, region string) *schema.Resou
 
 	return &schema.Resource{
 		Name:           name,
-		CostComponents: ebsVolumeCostComponents(region, volumeApiName, gbVal, iopsVal),
+		CostComponents: ebsVolumeCostComponents(region, volumeAPIName, gbVal, iopsVal),
 	}
 }

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -261,8 +261,9 @@ func TestInstance_cpuCredits(t *testing.T) {
 					SkipCheck: true,
 				},
 				{
-					Name:      "CPU credits",
-					PriceHash: "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					Name:             "CPU credits",
+					PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 			},
 			SubResourceChecks: []testutil.ResourceCheck{
@@ -280,9 +281,9 @@ func TestInstance_cpuCredits(t *testing.T) {
 					SkipCheck: true,
 				},
 				{
-					Name:            "CPU credits",
-					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.Zero),
+					Name:             "CPU credits",
+					PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 			},
 			SubResourceChecks: []testutil.ResourceCheck{
@@ -330,9 +331,9 @@ func TestInstance_cpuCredits(t *testing.T) {
 					SkipCheck: true,
 				},
 				{
-					Name:            "CPU credits",
-					PriceHash:       "4aaa3d22a88b57f7997e91888f867be9-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.Zero),
+					Name:             "CPU credits",
+					PriceHash:        "4aaa3d22a88b57f7997e91888f867be9-e8e892be2fbd1c8f42fd6761ad8977d8",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 			},
 			SubResourceChecks: []testutil.ResourceCheck{


### PR DESCRIPTION
**Objective**:

Add more options for `aws_autoscaling_group`.

**Example output**:

```
  aws_autoscaling_group.asg1
  └─ aws_launch_configuration.lc1
     ├─ EC2 detailed monitoring                           14  metrics      0.3000       0.0058        4.2000
     ├─ Linux/UNIX usage (on-demand, m3.medium)         1460  hours        0.0740       0.1480      108.0400
     └─ root_block_device
        └─ Storage                                        16  GB-months    0.1000       0.0022        1.6000
  Total                                                                                 0.1559      113.8400

  aws_autoscaling_group.asg2
  └─ aws_launch_template.lt1
     ├─ EBS-Optimized usage                             1460  hours        0.0200       0.0400       29.2000
     ├─ EC2 detailed monitoring                           14  metrics      0.3000       0.0058        4.2000
     ├─ Inference accelerator (eia2.medium)             1460  hours        0.1200       0.2400      175.2000
     ├─ Linux/UNIX usage (on-demand, r3.xlarge)         1460  hours        0.3330       0.6660      486.1800
     └─ root_block_device
        └─ Storage                                        16  GB-months    0.1000       0.0022        1.6000
  Total                                                                                 0.9539      696.3800                                                                                                   0.3541      258.4900
```

**Pricing details**:

 * EBS-optimized usage costs are charged for previous generation instances that have `ebs_optimized = true` set.
 * t3 and t4g instances launch by default in "Unlimited" mode which means that CPU credit costs can apply. This depends on the number of vCPU-hours that are used by these instances over the baseline. t2 instances also support "Unlimited" mode, but this is disabled by default.
 * Launch configurations have EC2 detailed monitoring turned on by default

**Status**:

- [x] Add EBS-optimized costs 
- [x] Add EC2 detailed monitoring prices
- [x] Add CPU credits prices
- [x] Add a warning if tenancy is host
- [x] Update "Compute" to "Linux/UNIX Usage" to be consistent with AWS pricing page
- [x] Add Elastic inference accelerator costs
- [x] Add spot pricing for Launch Configurations and Launch Template
- [x] Fix tenancy costs
- [x] Add integration tests

**Useful links**:

- Pricing: https://aws.amazon.com/ec2/pricing
- Terraform:
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template
