### PR TITLE
Add more EBS prices and costs

### DIFF
--- a/internal/providers/terraform/aws/autoscaling_group.go
+++ b/internal/providers/terraform/aws/autoscaling_group.go
@@ -12,7 +12,7 @@ import (
 
 func GetAutoscalingGroupRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
-		Name:  "aws_autoscaling_group",
+		Name: "aws_autoscaling_group",
 		Notes: []string{
 			"See aws_instance",
 		},

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -60,7 +60,7 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 							Name: "root_block_device",
 							CostComponentChecks: []testutil.CostComponentCheck{
 								{
-									Name:             "Storage",
+									Name:             "General Purpose SSD storage (gp2)",
 									PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
 									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
 								},
@@ -70,7 +70,7 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 							Name: "ebs_block_device[0]",
 							CostComponentChecks: []testutil.CostComponentCheck{
 								{
-									Name:             "Storage",
+									Name:             "General Purpose SSD storage (gp2)",
 									PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
 									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
 								},
@@ -353,7 +353,7 @@ func TestAutoscalingGroup_launchTemplate(t *testing.T) {
 							Name: "root_block_device",
 							CostComponentChecks: []testutil.CostComponentCheck{
 								{
-									Name:             "Storage",
+									Name:             "General Purpose SSD storage (gp2)",
 									PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
 									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(16)),
 								},
@@ -363,7 +363,7 @@ func TestAutoscalingGroup_launchTemplate(t *testing.T) {
 							Name: "block_device_mapping[0]",
 							CostComponentChecks: []testutil.CostComponentCheck{
 								{
-									Name:             "Storage",
+									Name:             "General Purpose SSD storage (gp2)",
 									PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
 									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
 								},
@@ -373,12 +373,12 @@ func TestAutoscalingGroup_launchTemplate(t *testing.T) {
 							Name: "block_device_mapping[1]",
 							CostComponentChecks: []testutil.CostComponentCheck{
 								{
-									Name:            "Storage",
+									Name:            "Provisioned IOPS SSD storage (io1)",
 									PriceHash:       "99450513de8c131ee2151e1b319d8143-ee3dd7e4624338037ca6fea0933a662f",
 									HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(40)),
 								},
 								{
-									Name:            "Storage IOPS",
+									Name:            "Provisioned IOPS",
 									PriceHash:       "d5c5e1fb9b8ded55c336f6ae87aa2c3b-9c483347596633f8cf3ab7fdd5502b78",
 									HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(400)),
 								},
@@ -791,7 +791,7 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplate(t *testing.T) {
 							Name: "root_block_device",
 							CostComponentChecks: []testutil.CostComponentCheck{
 								{
-									Name:             "Storage",
+									Name:             "General Purpose SSD storage (gp2)",
 									PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
 									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(24)),
 								},
@@ -867,7 +867,7 @@ func TestAutoscalingGroup_mixedInstanceLaunchTemplateDynamic(t *testing.T) {
 							Name: "root_block_device",
 							CostComponentChecks: []testutil.CostComponentCheck{
 								{
-									Name:             "Storage",
+									Name:             "General Purpose SSD storage (gp2)",
 									PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
 									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(24)),
 								},

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -165,7 +165,7 @@ func TestAutoscalingGroup_launchConfiguration_ebsOptimized(t *testing.T) {
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 						{
-							Name:            "EBS-Optimized usage",
+							Name:            "EBS-optimized usage",
 							PriceHash:       "7f4fb9da921a628aedfbe150d930e255-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
@@ -547,7 +547,7 @@ func TestAutoscalingGroup_launchTemplate_ebsOptimized(t *testing.T) {
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 						{
-							Name:            "EBS-Optimized usage",
+							Name:            "EBS-optimized usage",
 							PriceHash:       "7f4fb9da921a628aedfbe150d930e255-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},

--- a/internal/providers/terraform/aws/ebs_snapshot.go
+++ b/internal/providers/terraform/aws/ebs_snapshot.go
@@ -34,7 +34,7 @@ func NewEBSSnapshot(d *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 func ebsSnapshotCostComponents(region string, gbVal decimal.Decimal) []*schema.CostComponent {
 	return []*schema.CostComponent{
 		{
-			Name:            "Storage",
+			Name:            "EBS snapshot storage",
 			Unit:            "GB-months",
 			MonthlyQuantity: &gbVal,
 			ProductFilter: &schema.ProductFilter{
@@ -44,6 +44,62 @@ func ebsSnapshotCostComponents(region string, gbVal decimal.Decimal) []*schema.C
 				ProductFamily: strPtr("Storage Snapshot"),
 				AttributeFilters: []*schema.AttributeFilter{
 					{Key: "usagetype", ValueRegex: strPtr("/EBS:SnapshotUsage$/")},
+				},
+			},
+		},
+		{
+			Name:           "Fast snapshot restore",
+			Unit:           "DSU-hours",
+			HourlyQuantity: decimalPtr(decimal.Zero),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonEC2"),
+				ProductFamily: strPtr("Fast Snapshot Restore"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/EBS:FastSnapshotRestore$/")},
+				},
+			},
+		},
+		{
+			Name:           "ListChangedBlocks & ListSnapshotBlocks API requests",
+			Unit:           "requests",
+			HourlyQuantity: decimalPtr(decimal.Zero),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonEC2"),
+				ProductFamily: strPtr("EBS direct API Requests"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/EBS:directAPI.snapshot.List$/")},
+				},
+			},
+		},
+		{
+			Name:           "GetSnapshotBlock API requests",
+			Unit:           "SnapshotAPIUnits",
+			HourlyQuantity: decimalPtr(decimal.Zero),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonEC2"),
+				ProductFamily: strPtr("EBS direct API Requests"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/EBS:directAPI.snapshot.Get$/")},
+				},
+			},
+		},
+		{
+			Name:           "PutSnapshotBlock API requests",
+			Unit:           "SnapshotAPIUnits",
+			HourlyQuantity: decimalPtr(decimal.Zero),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonEC2"),
+				ProductFamily: strPtr("EBS direct API Requests"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/EBS:directAPI.snapshot.Put$/")},
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/ebs_snapshot_copy_test.go
+++ b/internal/providers/terraform/aws/ebs_snapshot_copy_test.go
@@ -43,9 +43,29 @@ func TestEBSSnapshotCopy(t *testing.T) {
 			Name: "aws_ebs_snapshot_copy.gp2",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Storage",
+					Name:            "EBS snapshot storage",
 					PriceHash:       "63a6765e67e0ebcd29f15f1570b5e692-ee3dd7e4624338037ca6fea0933a662f",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "Fast snapshot restore",
+					PriceHash:       "c8e7cffde49d51c97e8ec2cfb97e4557-1fb365d8a0bc1f462690ec9d444f380c",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+				{
+					Name:            "ListChangedBlocks & ListSnapshotBlocks API requests",
+					PriceHash:       "c5e9f6869c2ca75ebfbf6d1b0fb99a16-4a9dfd3965ffcbab75845ead7a27fd47",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+				{
+					Name:            "GetSnapshotBlock API requests",
+					PriceHash:       "7e9c5258c113e0c54f63e43889ade9a7-d41397dab24f1e4fcce3916e21c3cec4",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+				{
+					Name:            "PutSnapshotBlock API requests",
+					PriceHash:       "16002a3a5d722ade9816ff144a7dd91a-d41397dab24f1e4fcce3916e21c3cec4",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/ebs_snapshot_test.go
+++ b/internal/providers/terraform/aws/ebs_snapshot_test.go
@@ -34,9 +34,29 @@ func TestEBSSnapshot(t *testing.T) {
 			Name: "aws_ebs_snapshot.gp2",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Storage",
+					Name:            "EBS snapshot storage",
 					PriceHash:       "63a6765e67e0ebcd29f15f1570b5e692-ee3dd7e4624338037ca6fea0933a662f",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "Fast snapshot restore",
+					PriceHash:       "c8e7cffde49d51c97e8ec2cfb97e4557-1fb365d8a0bc1f462690ec9d444f380c",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+				{
+					Name:            "ListChangedBlocks & ListSnapshotBlocks API requests",
+					PriceHash:       "c5e9f6869c2ca75ebfbf6d1b0fb99a16-4a9dfd3965ffcbab75845ead7a27fd47",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+				{
+					Name:            "GetSnapshotBlock API requests",
+					PriceHash:       "7e9c5258c113e0c54f63e43889ade9a7-d41397dab24f1e4fcce3916e21c3cec4",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+				{
+					Name:            "PutSnapshotBlock API requests",
+					PriceHash:       "16002a3a5d722ade9816ff144a7dd91a-d41397dab24f1e4fcce3916e21c3cec4",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/ebs_volume_test.go
+++ b/internal/providers/terraform/aws/ebs_volume_test.go
@@ -34,6 +34,13 @@ func TestEBSVolume(t *testing.T) {
 			iops              = 300
 		}
 
+		resource "aws_ebs_volume" "io2" {
+			availability_zone = "us-east-1a"
+			type              = "io2"
+			size              = 30
+			iops              = 300
+		}
+
 		resource "aws_ebs_volume" "st1" {
 			availability_zone = "us-east-1a"
 			size              = 40
@@ -51,9 +58,9 @@ func TestEBSVolume(t *testing.T) {
 			Name: "aws_ebs_volume.gp2",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Storage",
-					PriceHash:       "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+					Name:             "General Purpose SSD storage (gp2)",
+					PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
 				},
 			},
 		},
@@ -61,9 +68,14 @@ func TestEBSVolume(t *testing.T) {
 			Name: "aws_ebs_volume.standard",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Storage",
-					PriceHash:       "0ed17ed1777b7be91f5b5ce79916d8d8-ee3dd7e4624338037ca6fea0933a662f",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
+					Name:             "Magnetic storage",
+					PriceHash:        "0ed17ed1777b7be91f5b5ce79916d8d8-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
+				},
+				{
+					Name:             "I/O requests",
+					PriceHash:        "3085cb7cbdb1e1f570812e7400f8dbc6-5be345988e7c9a0759c5cf8365868ee4",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 			},
 		},
@@ -71,14 +83,29 @@ func TestEBSVolume(t *testing.T) {
 			Name: "aws_ebs_volume.io1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Storage",
-					PriceHash:       "99450513de8c131ee2151e1b319d8143-ee3dd7e4624338037ca6fea0933a662f",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(30)),
+					Name:             "Provisioned IOPS SSD storage (io1)",
+					PriceHash:        "99450513de8c131ee2151e1b319d8143-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(30)),
 				},
 				{
-					Name:            "Storage IOPS",
-					PriceHash:       "d5c5e1fb9b8ded55c336f6ae87aa2c3b-9c483347596633f8cf3ab7fdd5502b78",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(300)),
+					Name:             "Provisioned IOPS",
+					PriceHash:        "d5c5e1fb9b8ded55c336f6ae87aa2c3b-9c483347596633f8cf3ab7fdd5502b78",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(300)),
+				},
+			},
+		},
+		{
+			Name: "aws_ebs_volume.io2",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Provisioned IOPS SSD storage (io2)",
+					PriceHash:        "9e420d5e498eddb54a405d09b89a668e-c86ea75c5a17b237464f7c8cc81c1ab8",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(30)),
+				},
+				{
+					Name:             "Provisioned IOPS",
+					PriceHash:        "9cff4839500aaabec26f2bace787491b-9c483347596633f8cf3ab7fdd5502b78",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(300)),
 				},
 			},
 		},
@@ -86,9 +113,9 @@ func TestEBSVolume(t *testing.T) {
 			Name: "aws_ebs_volume.st1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Storage",
-					PriceHash:       "eea972b50a795c92487cbcb96e8fdc29-ee3dd7e4624338037ca6fea0933a662f",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(40)),
+					Name:             "Throughput Optimized HDD storage (st1)",
+					PriceHash:        "eea972b50a795c92487cbcb96e8fdc29-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(40)),
 				},
 			},
 		},
@@ -96,9 +123,9 @@ func TestEBSVolume(t *testing.T) {
 			Name: "aws_ebs_volume.sc1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Storage",
-					PriceHash:       "3122df29367c2460c76537cccf0eadb5-ee3dd7e4624338037ca6fea0933a662f",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(50)),
+					Name:             "Cold HDD storage (sc1)",
+					PriceHash:        "3122df29367c2460c76537cccf0eadb5-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(50)),
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -95,7 +95,7 @@ func ebsOptimizedCostComponent(d *schema.ResourceData) *schema.CostComponent {
 	instanceType := d.Get("instance_type").String()
 
 	return &schema.CostComponent{
-		Name:                 "EBS-Optimized usage",
+		Name:                 "EBS-optimized usage",
 		Unit:                 "hours",
 		HourlyQuantity:       decimalPtr(decimal.NewFromInt(1)),
 		IgnoreIfMissingPrice: true,

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -64,7 +64,7 @@ func TestInstance(t *testing.T) {
 					Name: "root_block_device",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Storage",
+							Name:            "General Purpose SSD storage (gp2)",
 							PriceHash:       "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
 							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
 						},
@@ -74,7 +74,7 @@ func TestInstance(t *testing.T) {
 					Name: "ebs_block_device[0]",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Storage",
+							Name:            "General Purpose SSD storage (gp2)",
 							PriceHash:       "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
 							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
 						},
@@ -84,9 +84,14 @@ func TestInstance(t *testing.T) {
 					Name: "ebs_block_device[1]",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Storage",
+							Name:            "Magnetic storage",
 							PriceHash:       "0ed17ed1777b7be91f5b5ce79916d8d8-ee3dd7e4624338037ca6fea0933a662f",
 							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
+						},
+						{
+							Name:             "I/O requests",
+							PriceHash:        "3085cb7cbdb1e1f570812e7400f8dbc6-5be345988e7c9a0759c5cf8365868ee4",
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 						},
 					},
 				},
@@ -94,7 +99,7 @@ func TestInstance(t *testing.T) {
 					Name: "ebs_block_device[2]",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Storage",
+							Name:            "Cold HDD storage (sc1)",
 							PriceHash:       "3122df29367c2460c76537cccf0eadb5-ee3dd7e4624338037ca6fea0933a662f",
 							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(30)),
 						},
@@ -104,12 +109,12 @@ func TestInstance(t *testing.T) {
 					Name: "ebs_block_device[3]",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Storage",
+							Name:            "Provisioned IOPS SSD storage (io1)",
 							PriceHash:       "99450513de8c131ee2151e1b319d8143-ee3dd7e4624338037ca6fea0933a662f",
 							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(40)),
 						},
 						{
-							Name:            "Storage IOPS",
+							Name:            "Provisioned IOPS",
 							PriceHash:       "d5c5e1fb9b8ded55c336f6ae87aa2c3b-9c483347596633f8cf3ab7fdd5502b78",
 							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
 						},

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -171,7 +171,7 @@ func TestInstance_ebsOptimized(t *testing.T) {
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
-					Name:            "EBS-Optimized usage",
+					Name:            "EBS-optimized usage",
 					PriceHash:       "7f4fb9da921a628aedfbe150d930e255-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},


### PR DESCRIPTION
**Objective**:

Add more options for `aws_ebs_volume`, `aws_ebs_snapshot` and `aws_ebs_snapshot_copy`.

**Example output**:

```
  aws_ebs_snapshot.gp2
  ├─ EBS snapshot storage                                            10  GB-months         0.0500       0.0007        0.5000
  ├─ Fast snapshot restore                                            0  DSU-hours         0.7500       0.0000        0.0000
  ├─ GetSnapshotBlock API requests                                    0  requests           3e-06       0.0000        0.0000
  ├─ ListChangedBlocks and ListSnapshotBlocks API requests            0  requests           6e-07       0.0000        0.0000
  └─ PutSnapshotBlock API requests                                    0  requests           6e-06       0.0000        0.0000
  Total                                                                                                 0.0007        0.5000

  aws_ebs_snapshot_copy.gp2
  ├─ EBS snapshot storage                                            10  GB-months         0.0500       0.0007        0.5000
  ├─ Fast snapshot restore                                            0  DSU-hours         0.7500       0.0000        0.0000
  ├─ GetSnapshotBlock API requests                                    0  SnapshotAPIUnits   3e-06       0.0000        0.0000
  ├─ ListChangedBlocks and ListSnapshotBlocks API requests            0  requests           6e-07       0.0000        0.0000
  └─ PutSnapshotBlock API requests                                    0  SnapshotAPIUnits   6e-06       0.0000        0.0000
  Total                                                                                                 0.0007        0.5000

  aws_ebs_volume.gp2
  └─ General Purpose SSD (gp2) storage                               10  GB-months         0.1000       0.0014        1.0000
  Total                                                                                                 0.0014        1.0000

  aws_ebs_volume.standard
  ├─ I/O requests                                                     0  Per request        5e-08       0.0000        0.0000
  └─ Magnetic (standard) storage                                     20  GB-months         0.0500       0.0014        1.0000
  Total                                                                                                 0.0014 
```

**Pricing details**:

 * Magnetic storage also has an I/O price
 * Snapshots have API prices and Fast restore prices

**Status**:

- [x] Rename storage cost components
- [x] Add magnetic storage I/O prices
- [x] Add snapshot fast restore prices
- [x] Add snapshot API prices
- [x] Add integration tests

**Useful links**:

- Pricing: https://aws.amazon.com/ebs/pricing/
- Terraform:
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_snapshot
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_snapshot_copy
