### PR TITLE
fix(aws): fix ECS service nil pointer

### DIFF
--- a/internal/providers/terraform/aws/ecs_service.go
+++ b/internal/providers/terraform/aws/ecs_service.go
@@ -45,9 +45,18 @@ func NewECSService(d *schema.ResourceData, u *schema.ResourceData) *schema.Resou
 	if d.Get("desired_count").Exists() {
 		desiredCount = d.Get("desired_count").Int()
 	}
-	taskDefinition := d.References("task_definition")[0]
-	memory := convertResourceString(taskDefinition.Get("memory").String())
-	cpu := convertResourceString(taskDefinition.Get("cpu").String())
+
+	var taskDefinition *schema.ResourceData
+	refs := d.References("task_definition")
+	if len(refs) > 0 {
+		taskDefinition = refs[0]
+	}
+	memory := decimal.Zero
+	cpu := decimal.Zero
+	if taskDefinition != nil {
+		memory = convertResourceString(taskDefinition.Get("memory").String())
+		cpu = convertResourceString(taskDefinition.Get("cpu").String())
+	}
 
 	costComponents := []*schema.CostComponent{
 		{
@@ -80,7 +89,7 @@ func NewECSService(d *schema.ResourceData, u *schema.ResourceData) *schema.Resou
 		},
 	}
 
-	if taskDefinition.Get("inference_accelerator.0").Exists() {
+	if taskDefinition != nil && taskDefinition.Get("inference_accelerator.0").Exists() {
 		deviceType := taskDefinition.Get("inference_accelerator.0.device_type").String()
 		costComponents = append(costComponents, &schema.CostComponent{
 			Name:           fmt.Sprintf("Inference accelerator (%s)", deviceType),


### PR DESCRIPTION
If no task definition was provided we had a nil pointer issue.
We can't yet show costs for EXTERNAL ECS deployments, but we can show the prices.