### PR TITLE
Fix 'infracost --version' in the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .*
+!.git
 !.env
 Dockerfile
 build/


### PR DESCRIPTION
The version is found by using git SHAs so we need to include the .git directory in the builder stage of the Dockerfile.