### PR TITLE
Add support for AWS Lightsail instances

### DIFF
--- a/internal/providers/terraform/aws/lightsail_instance.go
+++ b/internal/providers/terraform/aws/lightsail_instance.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/infracost/infracost/internal/schema"
+	log "github.com/sirupsen/logrus"
+
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+func GetLightsailInstanceRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_lightsail_instance",
+		RFunc: NewLightsailInstance,
+	}
+}
+
+func NewLightsailInstance(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	region := d.Get("region").String()
+
+	type bundleSpecs struct {
+		vcpu   string
+		memory string
+	}
+
+	bundlePrefixMappings := map[string]bundleSpecs{
+		"nano":    {"1", "0.5GB"},
+		"micro":   {"1", "1GB"},
+		"small":   {"1", "2GB"},
+		"medium":  {"2", "4GB"},
+		"large":   {"2", "8GB"},
+		"xlarge":  {"4", "16GB"},
+		"2xlarge": {"8", "32GB"},
+	}
+
+	operatingSystem := "Linux"
+	operatingSystemLabel := "Linux/UNIX"
+
+	if strings.Contains(d.Get("bundle_id").String(), "_win_") {
+		operatingSystem = "Windows"
+		operatingSystemLabel = "Windows"
+	}
+
+	bundlePrefix := strings.Split(d.Get("bundle_id").String(), "_")[0]
+
+	specs, ok := bundlePrefixMappings[bundlePrefix]
+	if !ok {
+		log.Warnf("Skipping resource %s. Unrecognised bundle_id %s", d.Address, d.Get("bundle_id").String())
+		return nil
+	}
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:           fmt.Sprintf("Virtual server (%s)", operatingSystemLabel),
+				Unit:           "hours",
+				HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("aws"),
+					Region:        strPtr(region),
+					Service:       strPtr("AmazonLightsail"),
+					ProductFamily: strPtr("Lightsail Instance"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "operatingSystem", Value: strPtr(operatingSystem)},
+						{Key: "vcpu", Value: strPtr(specs.vcpu)},
+						{Key: "memory", Value: strPtr(specs.memory)},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/aws/lightsail_instance_test.go
+++ b/internal/providers/terraform/aws/lightsail_instance_test.go
@@ -1,0 +1,57 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestLightsailInstance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_lightsail_instance" "linux1" {
+			name              = "linux1"
+			availability_zone = "us-east-1a"
+			blueprint_id      = "centos_7_1901_01"
+			bundle_id         = "xlarge_2_0"
+		}
+
+		resource "aws_lightsail_instance" "win1" {
+			name              = "win1"
+			availability_zone = "us-east-1a"
+			blueprint_id      = "windows_2019"
+			bundle_id         = "small_win_2_0"
+		}		`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_lightsail_instance.linux1",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Virtual server (Linux/UNIX)",
+					PriceHash:       "d1a975f1c2f812954c1e0d1b25c15117-d2c98780d7b6e36641b521f1f8145c6f",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "aws_lightsail_instance.win1",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Virtual server (Windows)",
+					PriceHash:       "0163422d7cc913ae205cb3626e3d98b2-d2c98780d7b6e36641b521f1f8145c6f",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -17,6 +17,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetInstanceRegistryItem(),
 	GetLambdaFunctionRegistryItem(),
 	GetLBRegistryItem(),
+	GetLightsailInstanceRegistryItem(),
 	GetALBRegistryItem(),
 	GetNATGatewayRegistryItem(),
 	GetRDSClusterInstanceRegistryItem(),


### PR DESCRIPTION
**Objective**:

Add support for `aws_lightsail_instance`.

**Example output**:

```
  aws_lightsail_instance.pricing_api
  └─ Virtual server (Linux/UNIX)               730  hours      0.1075       0.1075       78.4969
  Total                                                                     0.1075       78.4969
```

**Status**:

- [x] Added to resource_registry.go
- [x] Added resource file
- [x] Added integration tests
- [x] Added unit tests if applicable - Not applicable

**Issues**:

- Terraform only supports the Lightsail bundles so we can't add support for the CDN, managed DBs, load balancer, etc.
- Lightsail prices are listed per 744-hour month on the AWS Lightsail pricing page, but are actually charged at an hourly rate. We use 730-hour months since that's what most other AWS pricing seems to use.

**Useful links**:

- Pricing: https://aws.amazon.com/lightsail/pricing/
- Terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/aws_lightsail_instance
