### PR TITLE
Add aws_eip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,15 +90,15 @@ When adding your first resource, we recommend you look at one of the existing re
 We distinguish the **price** of a resource from its **cost**. Price is the per-unit price advertised by a cloud vendor. The cost of a resource is calculated by multiplying its price by its usage. For example, an EC2 instance might be priced at $0.02 per hour, and if run for 100 hours (its usage), it'll cost $2.00. When adding resources to Infracost, we can always show their price, but if the resource has a usage-based cost component, we can't show its cost. To solve this problem, new resources in Infracost go through two levels of support:
 
 #### Level 1 support
-You can add all price components for the resource, even ones that are usage-based, so the price column in the table output is always populated. The hourly and monthly cost for these components will show $0.0000 as illustrated in the following output for AWS Lambda. Once this is done, please send a pull-request to this repo so someone can review/merge it. Please use [this pull request description](https://github.com/infracost/infracost/pull/91) as a guide on the level of details to include in your PR, including required integration tests.
+You can add all price components for the resource, even ones that are usage-based, so the price column in the table output is always populated. The hourly and monthly cost for these components will show `-` as illustrated in the following output for AWS Lambda. Once this is done, please send a pull-request to this repo so someone can review/merge it. Please use [this pull request description](https://github.com/infracost/infracost/pull/91) as a guide on the level of details to include in your PR, including required integration tests.
 
   ```
-  NAME                              MONTHLY QTY  UNIT         PRICE   HOURLY COST  MONTHLY COST
+  NAME                                        MONTHLY QTY  UNIT         PRICE   HOURLY COST  MONTHLY COST
 
-  aws_lambda_function.lambda
-  ├─ Duration                                 0  GB-seconds    2e-05       0.0000        0.0000
-  └─ Requests                                 0  requests      2e-07       0.0000        0.0000
-  Total                                                                    0.0000        0.0000
+  aws_lambda_function.hello_world
+  ├─ Requests                                           -  1M requests  0.2000            -             -
+  └─ Duration                                           -  GB-seconds    2e-05            -             -
+  Total                                                                                   -             -
   ```
 
 #### Level 2 support
@@ -106,15 +106,15 @@ The [Infracost Terraform provider](https://github.com/infracost/terraform-provid
 
   ```hcl
   # Use the infracost provider to get cost estimates for Lambda requests and duration
-  data "infracost_aws_lambda_function" "lambda" {
-    resources = [aws_lambda_function.lambda.id]
+  data "infracost_aws_lambda_function" "hello_world_usage" {
+    resources = [aws_lambda_function.hello_world.id]
 
     monthly_requests {
       value = 100000000
     }
 
     average_request_duration {
-      value = 350
+      value = 250
     }
   }
   ```
@@ -122,12 +122,12 @@ The [Infracost Terraform provider](https://github.com/infracost/terraform-provid
   Infracost output shows the hourly/monthly cost columns populated with non-zero values:
 
   ```
-  NAME                              MONTHLY QTY  UNIT         PRICE   HOURLY COST  MONTHLY COST
+  NAME                                        MONTHLY QTY  UNIT         PRICE   HOURLY COST  MONTHLY COST
 
-  aws_lambda_function.lambda
-  ├─ Duration                          20000000  GB-seconds    2e-05       0.4566      333.3340
-  └─ Requests                         100000000  requests      2e-07       0.0274       20.0000
-  Total                                                                    0.4840      353.3340
+  aws_lambda_function.hello_world
+  ├─ Requests                                         100  1M requests  0.2000       0.0274       20.0000
+  └─ Duration                                   3,750,000  GB-seconds    2e-05       0.0856       62.5001
+  Total                                                                              0.1130       82.5001
   ```
 
 ### Cost component names and units

--- a/examples/terraform/main.tf
+++ b/examples/terraform/main.tf
@@ -48,6 +48,7 @@ data "infracost_aws_lambda_function" "hello_world" {
   average_request_duration { value = 250 } # <<<<< Try changing this to 100 (milliseconds) to compare costs
 }
 
-resource "aws_eip" "nat_eip" {
-  vpc = true
+# Example non-supported resource
+resource "aws_simpledb_domain" "users" {
+  name = "users"
 }

--- a/internal/providers/terraform/aws/eip.go
+++ b/internal/providers/terraform/aws/eip.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func GetEIPRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_eip",
+		RFunc: NewEIP,
+	}
+}
+
+func NewEIP(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	// The IP address is probably used if it has an instance or network_interface, the instance might
+	// be stopped but that's probably less likely
+	if (d.Get("customer_owned_ipv4_pool").Exists() && d.Get("customer_owned_ipv4_pool").String() != "") ||
+		d.Get("instance").Exists() || d.Get("network_interface").Exists() {
+		return &schema.Resource{
+			NoPrice:   true,
+			IsSkipped: true,
+		}
+	}
+
+	region := d.Get("region").String()
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:           "IP address (if unused)",
+				Unit:           "hours",
+				UnitMultiplier: 1,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("aws"),
+					Region:        strPtr(region),
+					Service:       strPtr("AmazonEC2"),
+					ProductFamily: strPtr("IP Address"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "usagetype", ValueRegex: strPtr("/ElasticIP:IdleAddress/")},
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					StartUsageAmount: strPtr("1"),
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/aws/eip_test.go
+++ b/internal/providers/terraform/aws/eip_test.go
@@ -1,0 +1,45 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestEIP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_eip" "eip1" {}
+
+		resource "aws_eip" "eip2" {
+			customer_owned_ipv4_pool = "pool1"
+		}
+
+		resource "aws_eip" "eip3" {
+			instance = "instance1"
+		}
+
+		resource "aws_eip" "eip4" {
+			network_interface = "network1"
+		}
+		`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_eip.eip1",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:      "IP address (if unused)",
+					PriceHash: "42572a6ef29dcca6f60464c0c0a900f7-d2c98780d7b6e36641b521f1f8145c6f",
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/elb.go
+++ b/internal/providers/terraform/aws/elb.go
@@ -11,6 +11,6 @@ func GetELBRegistryItem() *schema.RegistryItem {
 
 func NewELB(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
 	productFamily := "Load Balancer"
-	costComponentName := "Per classic load balancer"
+	costComponentName := "Classic load balancer"
 	return newLBResource(d, productFamily, costComponentName)
 }

--- a/internal/providers/terraform/aws/elb_test.go
+++ b/internal/providers/terraform/aws/elb_test.go
@@ -30,7 +30,7 @@ func TestELB(t *testing.T) {
 			Name: "aws_elb.elb1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Per classic load balancer",
+					Name:            "Classic load balancer",
 					PriceHash:       "52de45f6e7bf85e2d047a2d9674d9eb2-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},

--- a/internal/providers/terraform/aws/free_resources.go
+++ b/internal/providers/terraform/aws/free_resources.go
@@ -130,12 +130,13 @@ var (
 		"aws_load_balancer_listener_policy",
 		"aws_load_balancer_policy",
 
-		// Others
-		"aws_launch_configuration",
-		"aws_launch_template",
+		// Others (sorted alphabetically)
+		"aws_rds_cluster",
 		"aws_ecs_cluster",
 		"aws_ecs_task_definition",
-		"aws_rds_cluster",
+		"aws_eip_association",
+		"aws_launch_configuration",
+		"aws_launch_template",
 	}
 )
 

--- a/internal/providers/terraform/aws/lb.go
+++ b/internal/providers/terraform/aws/lb.go
@@ -20,10 +20,10 @@ func GetALBRegistryItem() *schema.RegistryItem {
 }
 
 func NewLB(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
-	costComponentName := "Per application load balancer"
+	costComponentName := "Application load balancer"
 	productFamily := "Load Balancer-Application"
 	if d.Get("load_balancer_type").String() == "network" {
-		costComponentName = "Per network load balancer"
+		costComponentName = "Network load balancer"
 		productFamily = "Load Balancer-Network"
 	}
 

--- a/internal/providers/terraform/aws/lb_test.go
+++ b/internal/providers/terraform/aws/lb_test.go
@@ -32,7 +32,7 @@ func TestLB(t *testing.T) {
 			Name: "aws_lb.lb1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Per application load balancer",
+					Name:            "Application load balancer",
 					PriceHash:       "e31cdaab3eb4b520a8e845c058e09e75-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -47,7 +47,7 @@ func TestLB(t *testing.T) {
 			Name: "aws_alb.alb1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Per application load balancer",
+					Name:            "Application load balancer",
 					PriceHash:       "e31cdaab3eb4b520a8e845c058e09e75-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -62,7 +62,7 @@ func TestLB(t *testing.T) {
 			Name: "aws_lb.nlb1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Per network load balancer",
+					Name:            "Network load balancer",
 					PriceHash:       "cb019b908c3e3b33bb563bc3040f2e0b-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},

--- a/internal/providers/terraform/aws/nat_gateway.go
+++ b/internal/providers/terraform/aws/nat_gateway.go
@@ -25,7 +25,7 @@ func NewNATGateway(d *schema.ResourceData, u *schema.ResourceData) *schema.Resou
 		Name: d.Address,
 		CostComponents: []*schema.CostComponent{
 			{
-				Name:           "Per NAT gateway",
+				Name:           "NAT gateway",
 				Unit:           "hours",
 				UnitMultiplier: 1,
 				HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),

--- a/internal/providers/terraform/aws/nat_gateway_test.go
+++ b/internal/providers/terraform/aws/nat_gateway_test.go
@@ -26,7 +26,7 @@ func TestNATGateway(t *testing.T) {
 			Name: "aws_nat_gateway.nat",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Per NAT gateway",
+					Name:            "NAT gateway",
 					PriceHash:       "6e137a9da0718f0ec80fb60866730ba9-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -67,7 +67,7 @@ func TestNATGateway_usage(t *testing.T) {
 			Name: "aws_nat_gateway.nat",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Per NAT gateway",
+					Name:            "NAT gateway",
 					PriceHash:       "6e137a9da0718f0ec80fb60866730ba9-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},

--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -12,6 +12,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetEBSSnapshotRegistryItem(),
 	GetEBSVolumeRegistryItem(),
 	GetECSServiceRegistryItem(),
+	GetEIPRegistryItem(),
 	GetElasticsearchDomainRegistryItem(),
 	GetELBRegistryItem(),
 	GetInstanceRegistryItem(),

--- a/internal/providers/terraform/aws/route53_record.go
+++ b/internal/providers/terraform/aws/route53_record.go
@@ -14,7 +14,8 @@ func GetRoute53RecordRegistryItem() *schema.RegistryItem {
 func NewRoute53Record(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
 	if d.Get("alias.0").Exists() && d.References("alias.0.name")[0].Type != "aws_route53_record" {
 		return &schema.Resource{
-			NoPrice: true,
+			NoPrice:   true,
+			IsSkipped: true,
 		}
 	}
 

--- a/internal/providers/terraform/aws/route53_zone.go
+++ b/internal/providers/terraform/aws/route53_zone.go
@@ -18,7 +18,7 @@ func NewRoute53Zone(d *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 		Name: d.Address,
 		CostComponents: []*schema.CostComponent{
 			{
-				Name:            "Per hosted zone",
+				Name:            "Hosted zone",
 				Unit:            "months",
 				UnitMultiplier:  1,
 				MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),

--- a/internal/providers/terraform/aws/route53_zone_test.go
+++ b/internal/providers/terraform/aws/route53_zone_test.go
@@ -26,7 +26,7 @@ func TestRoute53Zone(t *testing.T) {
 			Name: "aws_route53_zone.zone1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Per hosted zone",
+					Name:            "Hosted zone",
 					PriceHash:       "11a88b17c107a718b150e048d21ce5ac-48bca87a3e73bd3aa593065935882019",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -26,7 +26,7 @@ func createResource(d *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 				ResourceType: d.Type,
 				IsSkipped:    true,
 				NoPrice:      true,
-				SkipMessage:  "This resource is free",
+				SkipMessage:  "Free resource.",
 			}
 		}
 

--- a/internal/providers/terraform/parser_internal_test.go
+++ b/internal/providers/terraform/parser_internal_test.go
@@ -35,7 +35,7 @@ func TestCreateResource(t *testing.T) {
 				ResourceType: "null_resource",
 				IsSkipped:    true,
 				NoPrice:      true,
-				SkipMessage:  "This resource is free",
+				SkipMessage:  "Free resource.",
 			},
 		},
 		{


### PR DESCRIPTION
**Objective**:

Add support for `aws_eip`.

**Example output**:

```
  NAME                                        MONTHLY QTY  UNIT         PRICE   HOURLY COST  MONTHLY COST

  aws_eip.free
  └─ IP address (if unused)                             -  hours        0.0050            -             -
  Total                                                                                   -             -
```

**Status**:

- [x] Added to resource_registry.go
- [x] Added resource file
- [x] Added related free resources
- [x] Added integration tests
- [x] Added unit tests if applicable - Not applicable

**Issues**:

- Whilst we could show costs for this, I think it's best not to as we don't know for sure if the EIP is unused (that requires us to check the user's AWS account)
- Remapping and carrier costs can’t be supported as Terraform doesn’t seem to support them (they should be minor). Finding additional EIPs is not yet supported.

**Useful links**:

- Pricing: https://aws.amazon.com/ec2/pricing/on-demand/ (Elastic IP Addresses) and https://aws.amazon.com/premiumsupport/knowledge-center/elastic-ip-charges/
- Terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip
