### PR TITLE
Add --use-tfstate flag

### DIFF
--- a/cmd/infracost/default.go
+++ b/cmd/infracost/default.go
@@ -27,7 +27,7 @@ func defaultCmd() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:      "tfplan",
-				Usage:     "Path to Terraform plan file relative to 'tfdir'. Requires 'tfdir' to be set",
+				Usage:     "Path to Terraform plan file relative to 'tfdir'",
 				TakesFile: true,
 			},
 			&cli.BoolFlag{

--- a/cmd/infracost/default.go
+++ b/cmd/infracost/default.go
@@ -30,6 +30,11 @@ func defaultCmd() *cli.Command {
 				Usage:     "Path to Terraform plan file relative to 'tfdir'. Requires 'tfdir' to be set",
 				TakesFile: true,
 			},
+			&cli.BoolFlag{
+				Name:  "use-tfstate",
+				Usage: "Use Terraform state instead of generating a plan",
+				Value: false,
+			},
 			&cli.StringFlag{
 				Name:        "tfdir",
 				Usage:       "Path to the Terraform code directory",

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -110,11 +110,11 @@ Example:
 	# Run infracost with a Terraform directory and var file
 	infracost --tfdir /path/to/code --tfflags "-var-file=myvars.tfvars"
 
-	# Run infracost with a JSON Terraform plan file
-	infracost --tfjson /path/to/plan.json
+	# Run infracost against a Terraform state
+	infracost --tfdir /path/to/code --use-tfstate
 
-	# Run infracost with a Terraform directory and a plan file in it
-	infracost --tfdir /path/to/code --tfplan plan.save`,
+	# Run infracost with a JSON Terraform plan file
+	infracost --tfjson /path/to/plan.json`,
 		EnableBashCompletion: true,
 		Version:              version.Version,
 		Flags: append([]cli.Flag{

--- a/internal/providers/terraform/aws/autoscaling_group.go
+++ b/internal/providers/terraform/aws/autoscaling_group.go
@@ -14,6 +14,11 @@ func GetAutoscalingGroupRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_autoscaling_group",
 		RFunc: NewAutoscalingGroup,
+		ReferenceAttributes: []string{
+			"launch_configuration",
+			"launch_template.0.id",
+			"mixed_instances_policy.0.launch_template.0.launch_template_specification.0.launch_template_id",
+		},
 	}
 }
 

--- a/internal/providers/terraform/aws/ebs_snapshot.go
+++ b/internal/providers/terraform/aws/ebs_snapshot.go
@@ -8,8 +8,9 @@ import (
 
 func GetEBSSnapshotRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
-		Name:  "aws_ebs_snapshot",
-		RFunc: NewEBSSnapshot,
+		Name:                "aws_ebs_snapshot",
+		RFunc:               NewEBSSnapshot,
+		ReferenceAttributes: []string{"volume_id"},
 	}
 }
 

--- a/internal/providers/terraform/aws/ebs_snapshot_copy.go
+++ b/internal/providers/terraform/aws/ebs_snapshot_copy.go
@@ -10,6 +10,10 @@ func GetEBSSnapshotCopyRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_ebs_snapshot_copy",
 		RFunc: NewEBSSnapshotCopy,
+		ReferenceAttributes: []string{
+			"volume_id",
+			"source_snapshot_id",
+		},
 	}
 }
 

--- a/internal/providers/terraform/aws/ebs_volume.go
+++ b/internal/providers/terraform/aws/ebs_volume.go
@@ -38,6 +38,10 @@ func NewEBSVolume(d *schema.ResourceData, u *schema.ResourceData) *schema.Resour
 }
 
 func ebsVolumeCostComponents(region string, volumeAPIName string, gbVal decimal.Decimal, iopsVal decimal.Decimal) []*schema.CostComponent {
+	if volumeAPIName == "" {
+		volumeAPIName = "gp2"
+	}
+
 	var name string
 	switch volumeAPIName {
 	case "standard":

--- a/internal/providers/terraform/aws/ecs_service.go
+++ b/internal/providers/terraform/aws/ecs_service.go
@@ -13,9 +13,10 @@ import (
 
 func GetECSServiceRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
-		Name:  "aws_ecs_service",
-		Notes: []string{"Only supports Fargate on-demand."},
-		RFunc: NewECSService,
+		Name:                "aws_ecs_service",
+		Notes:               []string{"Only supports Fargate on-demand."},
+		RFunc:               NewECSService,
+		ReferenceAttributes: []string{"task_definition"},
 	}
 }
 

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -161,7 +161,7 @@ func cpuCreditsCostComponent(d *schema.ResourceData) *schema.CostComponent {
 			ProductFamily: strPtr("CPU Credits"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "operatingSystem", Value: strPtr("Linux")},
-				{Key: "usagetype", Value: strPtr(fmt.Sprintf("CPUCredits:%s", prefix))},
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/CPUCredits:%s/", prefix))},
 			},
 		},
 	}

--- a/internal/providers/terraform/aws/route53_record.go
+++ b/internal/providers/terraform/aws/route53_record.go
@@ -6,8 +6,9 @@ import (
 
 func GetRoute53RecordRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
-		Name:  "aws_route53_record",
-		RFunc: NewRoute53Record,
+		Name:                "aws_route53_record",
+		RFunc:               NewRoute53Record,
+		ReferenceAttributes: []string{"alias.0.name"},
 	}
 }
 

--- a/internal/providers/terraform/parser_internal_test.go
+++ b/internal/providers/terraform/parser_internal_test.go
@@ -239,3 +239,101 @@ func TestParseResourceData(t *testing.T) {
 		assert.Equal(t, expectedRegions[k], v.Get("region").String())
 	}
 }
+
+func TestParseReferences_plan(t *testing.T) {
+	vol1 := schema.NewResourceData(
+		"aws_ebs_volume",
+		"aws",
+		"aws_ebs_volume.volume1",
+		gjson.Result{
+			Type: gjson.JSON,
+			Raw:  `{}`,
+		},
+	)
+
+	snap1 := schema.NewResourceData(
+		"aws_ebs_snapshot",
+		"aws",
+		"aws_ebs_snapshot.snapshot1",
+		gjson.Result{
+			Type: gjson.JSON,
+			Raw:  `{}`,
+		},
+	)
+
+	resData := map[string]*schema.ResourceData{
+		vol1.Address:  vol1,
+		snap1.Address: snap1,
+	}
+
+	conf := gjson.Result{
+		Type: gjson.JSON,
+		Raw: `{
+			"resources": [
+				{
+					"address": "aws_ebs_volume.volume1",
+					"mode": "managed",
+          "type": "aws_ebs_volume",
+          "name": "volume1",
+          "provider_config_key": "aws",
+          "expressions": {}
+				},
+				{
+					"address": "aws_ebs_snapshot.snapshot1",
+					"mode": "managed",
+          "type": "aws_ebs_snapshot",
+          "name": "snapshot1",
+          "provider_config_key": "aws",
+          "expressions": {
+            "volume_id": {
+              "references": [
+                "aws_ebs_volume.volume1"
+              ]
+            }
+					}
+				}
+			],
+		}`,
+	}
+
+	parseReferences(resData, conf)
+
+	assert.Equal(t, []*schema.ResourceData{vol1}, resData["aws_ebs_snapshot.snapshot1"].References("volume_id"))
+}
+
+func TestParseReferences_state(t *testing.T) {
+	vol1 := schema.NewResourceData(
+		"aws_ebs_volume",
+		"aws",
+		"aws_ebs_volume.volume1",
+		gjson.Result{
+			Type: gjson.JSON,
+			Raw: `{
+				"id": "vol-12345"
+			}`,
+		},
+	)
+
+	snap1 := schema.NewResourceData(
+		"aws_ebs_snapshot",
+		"aws",
+		"aws_ebs_snapshot.snapshot1",
+		gjson.Result{
+			Type: gjson.JSON,
+			Raw: `{
+				"volume_id": "vol-12345"
+			}`,
+		},
+	)
+
+	resData := map[string]*schema.ResourceData{
+		vol1.Address:  vol1,
+		snap1.Address: snap1,
+	}
+
+	conf := gjson.Result{}
+
+	parseReferences(resData, conf)
+
+	assert.Equal(t, []*schema.ResourceData{vol1}, resData["aws_ebs_snapshot.snapshot1"].References("volume_id"))
+}

--- a/internal/providers/terraform/provider.go
+++ b/internal/providers/terraform/provider.go
@@ -45,10 +45,6 @@ func (p *terraformProvider) ProcessArgs(c *cli.Context) error {
 		return errors.New("Please provide either a Terraform Plan JSON file (tfjson) or a Terraform Plan file (tfplan)")
 	}
 
-	if p.planFile != "" && p.dir == "" {
-		return errors.New("Please provide a path to the Terraform project (tfdir) if providing a Terraform Plan file (tfplan)")
-	}
-
 	return nil
 }
 

--- a/internal/schema/registry_item.go
+++ b/internal/schema/registry_item.go
@@ -1,8 +1,9 @@
 package schema
 
 type RegistryItem struct {
-	Name    string
-	Notes   []string
-	RFunc   ResourceFunc
-	NoPrice bool
+	Name                string
+	Notes               []string
+	RFunc               ResourceFunc
+	ReferenceAttributes []string
+	NoPrice             bool
 }


### PR DESCRIPTION
This adds an `--use-tfstate` flag which allows the user to use the state instead of a plan of the Terraform code.
This works by running `terraform show -json` inside the Terraform directory so it works with both local and remote state.