### PR TITLE
Added API Gateway v2 HTTP & Websocket support

### DIFF
--- a/internal/providers/terraform/aws/apigatewayv2_api.go
+++ b/internal/providers/terraform/aws/apigatewayv2_api.go
@@ -7,10 +7,7 @@ import (
 
 func GetAPIGatewayv2ApiRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
-		Name: "aws_apigatewayv2_api",
-		Notes: []string{
-			"WebSocket Connection minutes is not yet supported",
-		},
+		Name:  "aws_apigatewayv2_api",
 		RFunc: NewAPIGatewayv2Api,
 	}
 }
@@ -117,6 +114,8 @@ func websocketAPICostComponent(d *schema.ResourceData, u *schema.ResourceData) [
 	monthlyMessages := decimal.Zero
 	messageSize := decimal.NewFromInt(32)
 
+	monthlyConnectionMinutes := decimal.Zero
+
 	billableRequestSize := decimal.NewFromInt(32)
 
 	var apiTierRequests = map[string]decimal.Decimal{
@@ -162,6 +161,21 @@ func websocketAPICostComponent(d *schema.ResourceData, u *schema.ResourceData) [
 			},
 			PriceFilter: &schema.PriceFilter{
 				StartUsageAmount: strPtr("0"),
+			},
+		},
+		{
+			Name:            "Connection duration",
+			Unit:            "minutes",
+			UnitMultiplier:  1000000,
+			MonthlyQuantity: &monthlyConnectionMinutes,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonApiGateway"),
+				ProductFamily: strPtr("WebSocket"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/ApiGatewayMinute/")},
+				},
 			},
 		},
 	}

--- a/internal/providers/terraform/aws/apigatewayv2_api.go
+++ b/internal/providers/terraform/aws/apigatewayv2_api.go
@@ -1,0 +1,209 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetApiGatewayv2ApiRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_apigatewayv2_api",
+		Notes: []string{
+			"WebSocket Connection minutes is not yet supported",
+		},
+		RFunc: NewApiGatewayv2Api,
+	}
+}
+
+func NewApiGatewayv2Api(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	var costComponents []*schema.CostComponent
+
+	protocolType := d.Get("protocol_type").String()
+
+	if protocolType == "WEBSOCKET" {
+		costComponents = websocketApiCostComponent(d, u)
+	}
+
+	if protocolType == "HTTP" {
+		costComponents = httpApiCostComponent(d, u)
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}
+
+func httpApiCostComponent(d *schema.ResourceData, u *schema.ResourceData) []*schema.CostComponent {
+	region := d.Get("region").String()
+	monthlyRequests := decimal.Zero
+	requestSize := decimal.NewFromInt(0)
+
+	billableRequestSize := decimal.NewFromInt(512)
+
+	var apiTierRequests = map[string]decimal.Decimal{
+		"apiRequestTierOne": decimal.Zero,
+		"apiRequestTierTwo": decimal.Zero,
+	}
+
+	// httpApi request tiers
+	apiTierOneLimit := decimal.NewFromInt(300000000)
+	apiTierTwoLimit := decimal.NewFromInt(300000001)
+
+	if u != nil && u.Get("monthly_requests.0.value").Exists() {
+		monthlyRequests = decimal.NewFromInt(u.Get("monthly_requests.0.value").Int())
+	}
+
+	if u != nil && u.Get("request_size.0.value").Exists() {
+		requestSize = decimal.NewFromInt(u.Get("request_size.0.value").Int())
+	}
+
+	if requestSize.GreaterThan(billableRequestSize) {
+		monthlyRequests = calculateBillableRequests(requestSize, billableRequestSize, monthlyRequests)
+	}
+
+	apiRequestQuantities := calculateApiRequests(monthlyRequests, apiTierRequests, apiTierOneLimit, apiTierTwoLimit)
+
+	apiTierOne := apiRequestQuantities["apiRequestTierOne"]
+	apiTierTwo := apiRequestQuantities["apiRequestTierTwo"]
+
+	return []*schema.CostComponent{
+		{
+			Name:            "Requests (first 300m)",
+			Unit:            "requests",
+			MonthlyQuantity: &apiTierOne,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonApiGateway"),
+				ProductFamily: strPtr("API Calls"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "description", Value: strPtr("HTTP API Requests")},
+					{Key: "usagetype", ValueRegex: strPtr("/ApiGatewayHttpRequest/")},
+					{Key: "operation", Value: strPtr("ApiGatewayHttpApi")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				StartUsageAmount: strPtr("0"),
+			},
+		},
+		{
+			Name:            "Requests (over 300m)",
+			Unit:            "requests",
+			MonthlyQuantity: &apiTierTwo,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonApiGateway"),
+				ProductFamily: strPtr("API Calls"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "description", Value: strPtr("HTTP API Requests")},
+					{Key: "usagetype", ValueRegex: strPtr("/ApiGatewayHttpRequest/")},
+					{Key: "operation", Value: strPtr("ApiGatewayHttpApi")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				StartUsageAmount: strPtr("300000000"),
+			},
+		},
+	}
+}
+
+func websocketApiCostComponent(d *schema.ResourceData, u *schema.ResourceData) []*schema.CostComponent {
+	region := d.Get("region").String()
+	monthlyMessages := decimal.Zero
+	messageSize := decimal.NewFromInt(0)
+
+	billableRequestSize := decimal.NewFromInt(32)
+
+	var apiTierRequests = map[string]decimal.Decimal{
+		"apiRequestTierOne": decimal.Zero,
+		"apiRequestTierTwo": decimal.Zero,
+	}
+
+	// Websocket request tiers
+	apiTierOneLimt := decimal.NewFromInt(1000000000)
+	apiTierTwoLimit := decimal.NewFromInt(1000000001)
+
+	if u != nil && u.Get("monthly_messages.0.value").Exists() {
+		monthlyMessages = decimal.NewFromInt(u.Get("monthly_messages.0.value").Int())
+	}
+
+	if u != nil && u.Get("average_message_size.0.value").Exists() {
+		messageSize = decimal.NewFromInt(u.Get("average_message_size.0.value").Int())
+	}
+
+	if messageSize.GreaterThan(billableRequestSize) {
+		monthlyMessages = calculateBillableRequests(messageSize, billableRequestSize, monthlyMessages)
+	}
+
+	apiRequestQuantities := calculateApiRequests(monthlyMessages, apiTierRequests, apiTierOneLimt, apiTierTwoLimit)
+
+	apiTierOne := apiRequestQuantities["apiRequestTierOne"]
+	apiTierTwo := apiRequestQuantities["apiRequestTierTwo"]
+
+	return []*schema.CostComponent{
+		{
+			Name:            "Requests (first 1B message transfers)",
+			Unit:            "requests",
+			MonthlyQuantity: &apiTierOne,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonApiGateway"),
+				ProductFamily: strPtr("WebSocket"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "description", Value: strPtr("WebSocket Messages")},
+					{Key: "usagetype", ValueRegex: strPtr("/ApiGatewayMessage/")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				StartUsageAmount: strPtr("0"),
+			},
+		},
+		{
+			Name:            "Requests (over 1B message transfers)",
+			Unit:            "requests",
+			MonthlyQuantity: &apiTierTwo,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonApiGateway"),
+				ProductFamily: strPtr("WebSocket"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "description", Value: strPtr("WebSocket Messages")},
+					{Key: "usagetype", ValueRegex: strPtr("/ApiGatewayMessage/")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				StartUsageAmount: strPtr("1000000000"),
+			},
+		},
+	}
+
+}
+
+func calculateApiRequests(requests decimal.Decimal, apiRequestTiers map[string]decimal.Decimal, apiTierOneLimit decimal.Decimal, apiTierTwoLimit decimal.Decimal) map[string]decimal.Decimal {
+
+	if requests.GreaterThanOrEqual(apiTierOneLimit) {
+		apiRequestTiers["apiRequestTierOne"] = apiTierOneLimit
+	} else {
+		apiRequestTiers["apiRequestTierOne"] = requests
+		return apiRequestTiers
+	}
+
+	if requests.GreaterThanOrEqual(apiTierTwoLimit) {
+		apiRequestTiers["apiRequestTierTwo"] = apiTierTwoLimit
+	} else {
+		apiRequestTiers["apiRequestTierTwo"] = requests.Sub(apiTierOneLimit)
+		return apiRequestTiers
+	}
+
+	return apiRequestTiers
+}
+
+func calculateBillableRequests(requestSize decimal.Decimal, billableRequestSize decimal.Decimal, requests decimal.Decimal) decimal.Decimal {
+	return requests.Mul(requestSize.Div(billableRequestSize).Ceil())
+}
+
+

--- a/internal/providers/terraform/aws/apigatewayv2_api_internal_test.go
+++ b/internal/providers/terraform/aws/apigatewayv2_api_internal_test.go
@@ -1,0 +1,52 @@
+package aws
+
+import (
+    "github.com/shopspring/decimal"
+    "github.com/stretchr/testify/assert"
+    "testing"
+)
+
+func TestCalcApiV2Requests(t *testing.T) {
+    oneMillionApi := decimal.NewFromInt(1000000)
+    oneBillionApi := decimal.NewFromInt(1000000000)
+
+    apiTierOneLimit := decimal.NewFromInt(300000000)
+    apiTierTwoLimit := decimal.NewFromInt(300000001)
+
+    var apiTierRequests = map[string]decimal.Decimal{
+        "apiRequestTierOne":   decimal.Zero,
+        "apiRequestTierTwo":   decimal.Zero,
+    }
+
+    var apiTierOneRequests = map[string]decimal.Decimal{
+        "apiRequestTierOne":   decimal.NewFromInt(1000000),
+        "apiRequestTierTwo":   decimal.Zero,
+    }
+
+    var apiTierTwoRequests = map[string]decimal.Decimal{
+        "apiRequestTierOne":   decimal.NewFromInt(300000000),
+        "apiRequestTierTwo":   decimal.NewFromInt(1),
+    }
+
+    tests := []struct {
+        requests          decimal.Decimal
+        inputTierRequests map[string]decimal.Decimal
+        expected          map[string]decimal.Decimal
+    }{
+        {requests: oneMillionApi, inputTierRequests: apiTierRequests, expected: apiTierOneRequests},
+        {requests: oneBillionApi, inputTierRequests: apiTierRequests, expected: apiTierTwoRequests},
+    }
+
+    for _, test := range tests {
+        actual := calculateApiV2Requests(test.requests, test.inputTierRequests, apiTierOneLimit, apiTierTwoLimit)
+
+        if test.requests == oneMillionApi {
+            assert.Equal(t, test.expected["tierOne"], actual["tierOne"])
+        }
+
+        if test.requests == oneBillionApi {
+            assert.Equal(t, test.expected["tierOne"], actual["tierOne"])
+            assert.Equal(t, test.expected["tierTwo"], actual["tierTwo"])
+        }
+    }
+}

--- a/internal/providers/terraform/aws/apigatewayv2_api_internal_test.go
+++ b/internal/providers/terraform/aws/apigatewayv2_api_internal_test.go
@@ -1,52 +1,52 @@
 package aws
 
 import (
-    "github.com/shopspring/decimal"
-    "github.com/stretchr/testify/assert"
-    "testing"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestCalcApiV2Requests(t *testing.T) {
-    oneMillionApi := decimal.NewFromInt(1000000)
-    oneBillionApi := decimal.NewFromInt(1000000000)
+	oneMillionAPI := decimal.NewFromInt(1000000)
+	oneBillionAPI := decimal.NewFromInt(1000000000)
 
-    apiTierOneLimit := decimal.NewFromInt(300000000)
-    apiTierTwoLimit := decimal.NewFromInt(300000001)
+	apiTierOneLimit := decimal.NewFromInt(300000000)
+	apiTierTwoLimit := decimal.NewFromInt(300000001)
 
-    var apiTierRequests = map[string]decimal.Decimal{
-        "apiRequestTierOne":   decimal.Zero,
-        "apiRequestTierTwo":   decimal.Zero,
-    }
+	var apiTierRequests = map[string]decimal.Decimal{
+		"apiRequestTierOne": decimal.Zero,
+		"apiRequestTierTwo": decimal.Zero,
+	}
 
-    var apiTierOneRequests = map[string]decimal.Decimal{
-        "apiRequestTierOne":   decimal.NewFromInt(1000000),
-        "apiRequestTierTwo":   decimal.Zero,
-    }
+	var apiTierOneRequests = map[string]decimal.Decimal{
+		"apiRequestTierOne": decimal.NewFromInt(1000000),
+		"apiRequestTierTwo": decimal.Zero,
+	}
 
-    var apiTierTwoRequests = map[string]decimal.Decimal{
-        "apiRequestTierOne":   decimal.NewFromInt(300000000),
-        "apiRequestTierTwo":   decimal.NewFromInt(1),
-    }
+	var apiTierTwoRequests = map[string]decimal.Decimal{
+		"apiRequestTierOne": decimal.NewFromInt(300000000),
+		"apiRequestTierTwo": decimal.NewFromInt(1),
+	}
 
-    tests := []struct {
-        requests          decimal.Decimal
-        inputTierRequests map[string]decimal.Decimal
-        expected          map[string]decimal.Decimal
-    }{
-        {requests: oneMillionApi, inputTierRequests: apiTierRequests, expected: apiTierOneRequests},
-        {requests: oneBillionApi, inputTierRequests: apiTierRequests, expected: apiTierTwoRequests},
-    }
+	tests := []struct {
+		requests          decimal.Decimal
+		inputTierRequests map[string]decimal.Decimal
+		expected          map[string]decimal.Decimal
+	}{
+		{requests: oneMillionAPI, inputTierRequests: apiTierRequests, expected: apiTierOneRequests},
+		{requests: oneBillionAPI, inputTierRequests: apiTierRequests, expected: apiTierTwoRequests},
+	}
 
-    for _, test := range tests {
-        actual := calculateApiV2Requests(test.requests, test.inputTierRequests, apiTierOneLimit, apiTierTwoLimit)
+	for _, test := range tests {
+		actual := calculateAPIV2Requests(test.requests, test.inputTierRequests, apiTierOneLimit, apiTierTwoLimit)
 
-        if test.requests == oneMillionApi {
-            assert.Equal(t, test.expected["tierOne"], actual["tierOne"])
-        }
+		if test.requests == oneMillionAPI {
+			assert.Equal(t, test.expected["tierOne"], actual["tierOne"])
+		}
 
-        if test.requests == oneBillionApi {
-            assert.Equal(t, test.expected["tierOne"], actual["tierOne"])
-            assert.Equal(t, test.expected["tierTwo"], actual["tierTwo"])
-        }
-    }
+		if test.requests == oneBillionAPI {
+			assert.Equal(t, test.expected["tierOne"], actual["tierOne"])
+			assert.Equal(t, test.expected["tierTwo"], actual["tierTwo"])
+		}
+	}
 }

--- a/internal/providers/terraform/aws/apigatewayv2_api_test.go
+++ b/internal/providers/terraform/aws/apigatewayv2_api_test.go
@@ -42,6 +42,11 @@ func TestApiGatewayv2Api(t *testing.T) {
 					PriceHash:        "a05bc87146da4c5fb7e1f26842932733-9feb253daec90eea89ff2b27827298c1",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
+				{
+					Name:             "Connection duration",
+					PriceHash:        "7d0a09a4b1594a4ea3302640bd5ab41c-a62d9273fef0987b8d1b9a67a508acdc",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
 			},
 		},
 	}

--- a/internal/providers/terraform/aws/apigatewayv2_api_test.go
+++ b/internal/providers/terraform/aws/apigatewayv2_api_test.go
@@ -32,23 +32,13 @@ func TestApiGatewayv2Api(t *testing.T) {
 					PriceHash:        "af24853fd5a2d7b09b6c998c68aae0fb-4a9dfd3965ffcbab75845ead7a27fd47",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
-				{
-					Name:             "Requests (over 300m)",
-					PriceHash:        "af24853fd5a2d7b09b6c998c68aae0fb-4a9dfd3965ffcbab75845ead7a27fd47",
-					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
-				},
 			},
 		},
 		{
 			Name: "aws_apigatewayv2_api.websocket",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Requests (first 1B message transfers)",
-					PriceHash:        "a05bc87146da4c5fb7e1f26842932733-9feb253daec90eea89ff2b27827298c1",
-					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
-				},
-				{
-					Name:             "Requests (over 1B message transfers)",
+					Name:             "Messages (first 1B)",
 					PriceHash:        "a05bc87146da4c5fb7e1f26842932733-9feb253daec90eea89ff2b27827298c1",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},

--- a/internal/providers/terraform/aws/apigatewayv2_api_test.go
+++ b/internal/providers/terraform/aws/apigatewayv2_api_test.go
@@ -1,0 +1,60 @@
+package aws_test
+
+import (
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+	"testing"
+)
+
+func TestApiGatewayv2Api(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+        resource "aws_apigatewayv2_api" "http" {
+          name          = "test-http-api"
+          protocol_type = "HTTP" 
+        }
+
+        resource "aws_apigatewayv2_api" "websocket" {
+          name          = "test-websocket-api"
+          protocol_type = "WEBSOCKET"
+        }`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_apigatewayv2_api.http",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Requests (first 300m)",
+					PriceHash:        "af24853fd5a2d7b09b6c998c68aae0fb-4a9dfd3965ffcbab75845ead7a27fd47",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+				{
+					Name:             "Requests (over 300m)",
+					PriceHash:        "af24853fd5a2d7b09b6c998c68aae0fb-4a9dfd3965ffcbab75845ead7a27fd47",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+			},
+		},
+		{
+			Name: "aws_apigatewayv2_api.websocket",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Requests (first 1B message transfers)",
+					PriceHash:        "a05bc87146da4c5fb7e1f26842932733-9feb253daec90eea89ff2b27827298c1",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+				{
+					Name:             "Requests (over 1B message transfers)",
+					PriceHash:        "a05bc87146da4c5fb7e1f26842932733-9feb253daec90eea89ff2b27827298c1",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/apigatewayv2_api_test.go
+++ b/internal/providers/terraform/aws/apigatewayv2_api_test.go
@@ -28,7 +28,7 @@ func TestApiGatewayv2Api(t *testing.T) {
 			Name: "aws_apigatewayv2_api.http",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Requests (first 300m)",
+					Name:             "Requests (first 300M)",
 					PriceHash:        "af24853fd5a2d7b09b6c998c68aae0fb-4a9dfd3965ffcbab75845ead7a27fd47",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},

--- a/internal/providers/terraform/aws/free_resources.go
+++ b/internal/providers/terraform/aws/free_resources.go
@@ -130,6 +130,19 @@ var (
 		"aws_load_balancer_listener_policy",
 		"aws_load_balancer_policy",
 
+		// API Gateway v2 HTTP & Websocket API.
+		"aws_apigatewayv2_api_mapping",
+		"aws_apigatewayv2_authorizer",
+		"aws_apigatewayv2_deployment",
+		"aws_apigatewayv2_domain_name",
+		"aws_apigatewayv2_integration",
+		"aws_apigatewayv2_integration_response",
+		"aws_apigatewayv2_model",
+		"aws_apigatewayv2_route",
+		"aws_apigatewayv2_route_response",
+		"aws_apigatewayv2_stage",
+		"aws_apigatewayv2_vpc_link",
+
 		// Others (sorted alphabetically)
 		"aws_rds_cluster",
 		"aws_ecs_cluster",

--- a/internal/providers/terraform/aws/free_resources.go
+++ b/internal/providers/terraform/aws/free_resources.go
@@ -143,7 +143,7 @@ var (
 		"aws_apigatewayv2_stage",
 		"aws_apigatewayv2_vpc_link",
 
-    // API Gateway Rest APIs
+		// API Gateway Rest APIs
 		"aws_api_gateway_account",
 		"aws_api_gateway_api_key",
 		"aws_api_gateway_authorizer",

--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -3,6 +3,7 @@ package aws
 import "github.com/infracost/infracost/internal/schema"
 
 var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
+	GetApiGatewayv2ApiRegistryItem(),
 	GetAutoscalingGroupRegistryItem(),
 	GetDBInstanceRegistryItem(),
 	GetDMSRegistryItem(),

--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -5,7 +5,7 @@ import "github.com/infracost/infracost/internal/schema"
 var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAPIGatewayRestAPIRegistryItem(),
 	GetAPIGatewayStageRegistryItem(),
-  GetAPIGatewayv2ApiRegistryItem(),
+	GetAPIGatewayv2ApiRegistryItem(),
 	GetAutoscalingGroupRegistryItem(),
 	GetDBInstanceRegistryItem(),
 	GetDMSRegistryItem(),

--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -3,7 +3,7 @@ package aws
 import "github.com/infracost/infracost/internal/schema"
 
 var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
-	GetApiGatewayv2ApiRegistryItem(),
+	GetAPIGatewayv2ApiRegistryItem(),
 	GetAutoscalingGroupRegistryItem(),
 	GetDBInstanceRegistryItem(),
 	GetDMSRegistryItem(),


### PR DESCRIPTION
**Objective**:

Adds support for ```api_gatewayv2_api```

**Example output:**

```
 NAME                                      MONTHLY QTY  UNIT      PRICE  HOURLY COST  MONTHLY COST  

  aws_apigatewayv2_api.http                                                                          
  ├─ Requests (first 300m)                      1000000  requests  1e-06       0.0014        1.0000  
  └─ Requests (over 300m)                             0  requests  9e-07       0.0000        0.0000  
  Total                                                                        0.0014        1.0000  
                                                                                                     
  aws_apigatewayv2_api.websocket                                                                     
  ├─ Requests (first 1B message transfers)   1000000000  requests  1e-06       1.3699     1000.0000  
  └─ Requests (over 1B message transfers)             0  requests  8e-07       0.0000        0.0000  
  Total                                                                        1.3699     1000.0000  
                                                                                                     
  OVERALL TOTAL                                                                1.3712     1001.0000  


```

**Pricing details:**

The aws_apigatewayv2_api provides 4 pricing components described in https://aws.amazon.com/api-gateway/pricing/. This adds support for the API gateway HTTP API & WebSocket API. 