### PR TITLE
feat(aws): Adds support for AWS MSK

### DIFF
--- a/internal/providers/terraform/aws/free_resources.go
+++ b/internal/providers/terraform/aws/free_resources.go
@@ -109,6 +109,7 @@ var (
 		"aws_lightsail_key_pair",
 		"aws_lightsail_static_ip",
 		"aws_lightsail_static_ip_attachment",
+		"aws_msk_configuration",
 		"aws_rds_cluster",
 		"aws_rds_cluster_endpoint",
 		"aws_rds_cluster_parameter_group",

--- a/internal/providers/terraform/aws/msk_cluster.go
+++ b/internal/providers/terraform/aws/msk_cluster.go
@@ -35,7 +35,7 @@ func NewMskCluster(d *schema.ResourceData, u *schema.ResourceData) *schema.Resou
 					Service:       strPtr("AmazonMSK"),
 					ProductFamily: strPtr("Managed Streaming for Apache Kafka (MSK)"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/", instanceType))},
+						{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", instanceType))},
 						{Key: "locationType", Value: strPtr("AWS Region")},
 					},
 				},

--- a/internal/providers/terraform/aws/msk_cluster.go
+++ b/internal/providers/terraform/aws/msk_cluster.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
-	"strings"
 )
 
 func GetMSKClusterRegistryItem() *schema.RegistryItem {

--- a/internal/providers/terraform/aws/msk_cluster.go
+++ b/internal/providers/terraform/aws/msk_cluster.go
@@ -18,7 +18,7 @@ func NewMskCluster(d *schema.ResourceData, u *schema.ResourceData) *schema.Resou
 	region := d.Get("region").String()
 
 	brokerNodes := decimal.NewFromInt(d.Get("number_of_broker_nodes").Int())
-	instanceType := strings.ReplaceAll(d.Get("broker_node_group_info.0.instance_type").String(), "kafka", "Kafka")
+	instanceType := d.Get("broker_node_group_info.0.instance_type").String()
 	ebsVolumeSize := decimal.NewFromInt(d.Get("broker_node_group_info.0.ebs_volume_size").Int()).Mul(brokerNodes)
 
 	return &schema.Resource{

--- a/internal/providers/terraform/aws/msk_cluster.go
+++ b/internal/providers/terraform/aws/msk_cluster.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+	"strings"
+)
+
+func GetMSKClusterRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_msk_cluster",
+		RFunc: NewMskCluster,
+	}
+}
+
+func NewMskCluster(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	region := d.Get("region").String()
+
+	brokerNodes := decimal.NewFromInt(d.Get("number_of_broker_nodes").Int())
+	brokerInstance := d.Get("broker_node_group_info.0.instance_type").String()
+	ebsVolumeSize := decimal.NewFromInt(d.Get("broker_node_group_info.0.ebs_volume_size").Int()).Mul(brokerNodes)
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:           fmt.Sprintf("MSK (broker instance, %s)", brokerInstance),
+				Unit:           "hours",
+				UnitMultiplier: 1,
+				HourlyQuantity: &brokerNodes,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("aws"),
+					Region:        strPtr(region),
+					Service:       strPtr("AmazonMSK"),
+					ProductFamily: strPtr("Managed Streaming for Apache Kafka (MSK)"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "computeFamily", ValueRegex: strPtr(fmt.Sprintf("/%s/", strings.SplitN(brokerInstance, ".", 2)[1]))},
+					},
+				},
+			},
+			{
+				Name:            "MSK storage",
+				Unit:            "GB-months",
+				UnitMultiplier:  1,
+				MonthlyQuantity: decimalPtr(ebsVolumeSize),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("aws"),
+					Region:        strPtr(region),
+					Service:       strPtr("AmazonMSK"),
+					ProductFamily: strPtr("Managed Streaming for Apache Kafka (MSK)"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "storageFamily", Value: strPtr("GP2")},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/aws/msk_cluster_test.go
+++ b/internal/providers/terraform/aws/msk_cluster_test.go
@@ -1,0 +1,73 @@
+package aws_test
+
+import (
+    "github.com/infracost/infracost/internal/providers/terraform/tftest"
+    "github.com/infracost/infracost/internal/testutil"
+    "github.com/shopspring/decimal"
+    "testing"
+)
+
+func TestMSKCluster(t *testing.T) {
+    if testing.Short() {
+        t.Skip("skipping test in short mode")
+    }
+
+    tf := `
+       resource "aws_msk_cluster" "cluster-2-nodes" {
+           cluster_name = "cluster-2-nodes"
+           kafka_version = "2.4.1"
+           number_of_broker_nodes = 2
+           broker_node_group_info {
+             client_subnets = []
+             ebs_volume_size = 500
+             instance_type = "kafka.t3.small"
+             security_groups = []
+           }
+       }
+
+       resource "aws_msk_cluster" "cluster-4-nodes" {
+           cluster_name = "cluster-4-nodes"
+           kafka_version = "2.4.1"
+           number_of_broker_nodes = 4
+           broker_node_group_info {
+             client_subnets = []
+             ebs_volume_size = 1000
+             instance_type = "kafka.m5.24xlarge"
+             security_groups = []
+           }
+       }
+`
+    resourceChecks := []testutil.ResourceCheck{
+        {
+            Name: "aws_msk_cluster.cluster-2-nodes",
+            CostComponentChecks: []testutil.CostComponentCheck{
+                {
+                    Name:             "MSK (broker instance, kafka.t3.small)",
+                    PriceHash:        "7384559214ca7695916562cfcdf52adf-1fb365d8a0bc1f462690ec9d444f380c",
+                    MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+                },
+                {
+                    Name:             "MSK storage",
+                    PriceHash:        "c051f24392b78290de9613ef486ba264-ee3dd7e4624338037ca6fea0933a662f",
+                    MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
+                },
+            },
+        },        {
+            Name: "aws_msk_cluster.cluster-4-nodes",
+            CostComponentChecks: []testutil.CostComponentCheck{
+                {
+                    Name:             "MSK (broker instance, kafka.m5.24xlarge)",
+                    PriceHash:        "9cc7cb79c34e4c7812d98da6dcdc8411-1fb365d8a0bc1f462690ec9d444f380c",
+                    MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
+                },
+                {
+                    Name:             "MSK storage",
+                    PriceHash:        "c051f24392b78290de9613ef486ba264-ee3dd7e4624338037ca6fea0933a662f",
+                    MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(4000)),
+                },
+            },
+        },
+    }
+
+    tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/msk_cluster_test.go
+++ b/internal/providers/terraform/aws/msk_cluster_test.go
@@ -42,7 +42,7 @@ func TestMSKCluster(t *testing.T) {
 			Name: "aws_msk_cluster.cluster-2-nodes",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Instance (Kafka.t3.small)",
+					Name:             "Instance (kafka.t3.small)",
 					PriceHash:        "7384559214ca7695916562cfcdf52adf-1fb365d8a0bc1f462690ec9d444f380c",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 				},

--- a/internal/providers/terraform/aws/msk_cluster_test.go
+++ b/internal/providers/terraform/aws/msk_cluster_test.go
@@ -1,18 +1,18 @@
 package aws_test
 
 import (
-    "github.com/infracost/infracost/internal/providers/terraform/tftest"
-    "github.com/infracost/infracost/internal/testutil"
-    "github.com/shopspring/decimal"
-    "testing"
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+	"testing"
 )
 
 func TestMSKCluster(t *testing.T) {
-    if testing.Short() {
-        t.Skip("skipping test in short mode")
-    }
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
-    tf := `
+	tf := `
        resource "aws_msk_cluster" "cluster-2-nodes" {
            cluster_name = "cluster-2-nodes"
            kafka_version = "2.4.1"
@@ -37,37 +37,37 @@ func TestMSKCluster(t *testing.T) {
            }
        }
 `
-    resourceChecks := []testutil.ResourceCheck{
-        {
-            Name: "aws_msk_cluster.cluster-2-nodes",
-            CostComponentChecks: []testutil.CostComponentCheck{
-                {
-                    Name:             "MSK (broker instance, kafka.t3.small)",
-                    PriceHash:        "7384559214ca7695916562cfcdf52adf-1fb365d8a0bc1f462690ec9d444f380c",
-                    MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
-                },
-                {
-                    Name:             "MSK storage",
-                    PriceHash:        "c051f24392b78290de9613ef486ba264-ee3dd7e4624338037ca6fea0933a662f",
-                    MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
-                },
-            },
-        },        {
-            Name: "aws_msk_cluster.cluster-4-nodes",
-            CostComponentChecks: []testutil.CostComponentCheck{
-                {
-                    Name:             "MSK (broker instance, kafka.m5.24xlarge)",
-                    PriceHash:        "9cc7cb79c34e4c7812d98da6dcdc8411-1fb365d8a0bc1f462690ec9d444f380c",
-                    MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
-                },
-                {
-                    Name:             "MSK storage",
-                    PriceHash:        "c051f24392b78290de9613ef486ba264-ee3dd7e4624338037ca6fea0933a662f",
-                    MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(4000)),
-                },
-            },
-        },
-    }
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_msk_cluster.cluster-2-nodes",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "MSK (broker instance, kafka.t3.small)",
+					PriceHash:        "7384559214ca7695916562cfcdf52adf-1fb365d8a0bc1f462690ec9d444f380c",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+				},
+				{
+					Name:             "MSK storage",
+					PriceHash:        "c051f24392b78290de9613ef486ba264-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
+				},
+			},
+		}, {
+			Name: "aws_msk_cluster.cluster-4-nodes",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "MSK (broker instance, kafka.m5.24xlarge)",
+					PriceHash:        "9cc7cb79c34e4c7812d98da6dcdc8411-1fb365d8a0bc1f462690ec9d444f380c",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
+				},
+				{
+					Name:             "MSK storage",
+					PriceHash:        "c051f24392b78290de9613ef486ba264-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(4000)),
+				},
+			},
+		},
+	}
 
-    tftest.ResourceTests(t, tf, resourceChecks)
+	tftest.ResourceTests(t, tf, resourceChecks)
 }

--- a/internal/providers/terraform/aws/msk_cluster_test.go
+++ b/internal/providers/terraform/aws/msk_cluster_test.go
@@ -56,7 +56,7 @@ func TestMSKCluster(t *testing.T) {
 			Name: "aws_msk_cluster.cluster-4-nodes",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Instance (Kafka.m5.24xlarge)",
+					Name:             "Instance (kafka.m5.24xlarge)",
 					PriceHash:        "9cc7cb79c34e4c7812d98da6dcdc8411-1fb365d8a0bc1f462690ec9d444f380c",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
 				},

--- a/internal/providers/terraform/aws/msk_cluster_test.go
+++ b/internal/providers/terraform/aws/msk_cluster_test.go
@@ -42,12 +42,12 @@ func TestMSKCluster(t *testing.T) {
 			Name: "aws_msk_cluster.cluster-2-nodes",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "MSK (broker instance, kafka.t3.small)",
+					Name:             "Instance (Kafka.t3.small)",
 					PriceHash:        "7384559214ca7695916562cfcdf52adf-1fb365d8a0bc1f462690ec9d444f380c",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 				},
 				{
-					Name:             "MSK storage",
+					Name:             "Storage",
 					PriceHash:        "c051f24392b78290de9613ef486ba264-ee3dd7e4624338037ca6fea0933a662f",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
 				},
@@ -56,12 +56,12 @@ func TestMSKCluster(t *testing.T) {
 			Name: "aws_msk_cluster.cluster-4-nodes",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "MSK (broker instance, kafka.m5.24xlarge)",
+					Name:             "Instance (Kafka.m5.24xlarge)",
 					PriceHash:        "9cc7cb79c34e4c7812d98da6dcdc8411-1fb365d8a0bc1f462690ec9d444f380c",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
 				},
 				{
-					Name:             "MSK storage",
+					Name:             "Storage",
 					PriceHash:        "c051f24392b78290de9613ef486ba264-ee3dd7e4624338037ca6fea0933a662f",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(4000)),
 				},

--- a/internal/providers/terraform/aws/resource_registry.go
+++ b/internal/providers/terraform/aws/resource_registry.go
@@ -22,6 +22,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetLambdaFunctionRegistryItem(),
 	GetLBRegistryItem(),
 	GetLightsailInstanceRegistryItem(),
+	GetMSKClusterRegistryItem(),
 	GetALBRegistryItem(),
 	GetNATGatewayRegistryItem(),
 	GetRDSClusterInstanceRegistryItem(),


### PR DESCRIPTION
**Objective**:

Adds support for ```msk_cluster```

** Closes ** #205 

**Example output:**

```
NAME                                      MONTHLY QTY  UNIT       PRICE   HOURLY COST  MONTHLY COST  

  aws_msk_cluster.test                                                                                 
  ├─ MSK (broker instance, kafka.t3.small)        2,920  hours      0.0456       0.1824      133.1520  
  └─ MSK storage                                  4,000  GB-months  0.1000       0.5479      400.0000  
  Total                                                                          0.7303      533.1520  
                                                                                                       
  OVERALL TOTAL (USD)                                                            0.7303      533.1520  


```

**Pricing details:**

The Amazon MSK service provides 2 pricing components described in https://aws.amazon.com/msk/pricing/. This adds support for the Amazon MSK Clusters.  