### PR TITLE
feat(aws): Adds support for Cloudwatch dashboards & metric alarms.  

### DIFF
--- a/internal/providers/terraform/aws/cloudwatch_dashboard.go
+++ b/internal/providers/terraform/aws/cloudwatch_dashboard.go
@@ -18,7 +18,7 @@ func NewCloudwatchDashboard(d *schema.ResourceData, u *schema.ResourceData) *sch
 		CostComponents: []*schema.CostComponent{
 			{
 				Name:            "Dashboard",
-				Unit:            "monthly",
+				Unit:            "months",
 				UnitMultiplier:  1,
 				MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 				ProductFilter: &schema.ProductFilter{

--- a/internal/providers/terraform/aws/cloudwatch_dashboard.go
+++ b/internal/providers/terraform/aws/cloudwatch_dashboard.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetCloudwatchDashboardRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_cloudwatch_dashboard",
+		RFunc: NewCloudwatchDashboard,
+	}
+}
+
+func NewCloudwatchDashboard(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:            "Dashboard",
+				Unit:            "monthly",
+				UnitMultiplier:  1,
+				MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("aws"),
+					Service:       strPtr("AmazonCloudWatch"),
+					ProductFamily: strPtr("Dashboard"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "usagetype", Value: strPtr("DashboardsUsageHour")},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/aws/cloudwatch_dashboard_test.go
+++ b/internal/providers/terraform/aws/cloudwatch_dashboard_test.go
@@ -1,0 +1,76 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestCloudwatchDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+        resource "aws_cloudwatch_dashboard" "dashboard" {
+          dashboard_name = "my-testing-dashboard"
+        
+          dashboard_body = <<EOF
+        {
+          "widgets": [
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [
+                    "AWS/EC2",
+                    "CPUUtilization",
+                    "InstanceId",
+                    "i-012345"
+                  ]
+                ],
+                "period": 300,
+                "stat": "Average",
+                "region": "us-east-1",
+                "title": "EC2 Instance CPU"
+              }
+            },
+            {
+              "type": "text",
+              "x": 0,
+              "y": 7,
+              "width": 3,
+              "height": 3,
+              "properties": {
+                "markdown": "Hello world"
+              }
+            }
+          ]
+        }
+        EOF
+        }
+`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_cloudwatch_dashboard.dashboard",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Dashboard",
+					PriceHash:        "0d9249c99a5605c643f4505314d483f7-e5d57ccffe964e509c0afb79efbe1987",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/cloudwatch_log_group.go
+++ b/internal/providers/terraform/aws/cloudwatch_log_group.go
@@ -17,25 +17,18 @@ func NewCloudwatchLogGroup(d *schema.ResourceData, u *schema.ResourceData) *sche
 
 	var gbDataIngestion *decimal.Decimal
 	var gbDataStorage *decimal.Decimal
-	var gbDataAnalyzed *decimal.Decimal
-	var gbDataAnalyzedQueries int64
+	var gbDataScanned *decimal.Decimal
 
-	if u != nil && u.Get("data_ingestion.0.value").Exists() {
-		gbDataIngestion = decimalPtr(decimal.NewFromFloat(u.Get("data_ingestion.0.value").Float()))
+	if u != nil && u.Get("monthly_gb_data_ingestion.0.value").Exists() {
+		gbDataIngestion = decimalPtr(decimal.NewFromFloat(u.Get("monthly_gb_data_ingestion.0.value").Float()))
 	}
 
-	if u != nil && u.Get("data_storage.0.value").Exists() {
-		gbDataStorage = decimalPtr(decimal.NewFromFloat(u.Get("data_storage.0.value").Float()))
+	if u != nil && u.Get("monthly_gb_data_storage.0.value").Exists() {
+		gbDataStorage = decimalPtr(decimal.NewFromFloat(u.Get("monthly_gb_data_storage.0.value").Float()))
 	}
 
-	if u != nil && u.Get("data_analyzed.0.value").Exists() {
-		gbDataAnalyzed = decimalPtr(decimal.NewFromFloat(u.Get("data_analyzed.0.value").Float()))
-	}
-
-	gbDataAnalyzedQueries = 1
-
-	if u != nil && u.Get("data_queries.0.value").Exists() {
-		gbDataAnalyzedQueries = u.Get("data_queries.0.value").Int()
+	if u != nil && u.Get("monthly_gb_data_scanned.0.value").Exists() {
+		gbDataScanned = decimalPtr(decimal.NewFromFloat(u.Get("monthly_gb_data_scanned.0.value").Float()))
 	}
 
 	return &schema.Resource{
@@ -74,8 +67,8 @@ func NewCloudwatchLogGroup(d *schema.ResourceData, u *schema.ResourceData) *sche
 			{
 				Name:            "Insights queries data scanned",
 				Unit:            "GB",
-				UnitMultiplier:  int(gbDataAnalyzedQueries),
-				MonthlyQuantity: gbDataAnalyzed,
+				UnitMultiplier:  1,
+				MonthlyQuantity: gbDataScanned,
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("aws"),
 					Region:        strPtr(region),

--- a/internal/providers/terraform/aws/cloudwatch_log_group.go
+++ b/internal/providers/terraform/aws/cloudwatch_log_group.go
@@ -1,0 +1,95 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetCloudwatchLogGroupItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_cloudwatch_log_group",
+		RFunc: NewCloudwatchLogGroup,
+	}
+}
+
+func NewCloudwatchLogGroup(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	region := d.Get("region").String()
+
+	var gbDataAnalzyedQueries int64
+
+	gbDataIngestion := decimal.NewFromInt(0)
+	gbDataStorage := decimal.NewFromInt(0)
+	gbDataAnalzyed := decimal.NewFromInt(0)
+
+	if u != nil && u.Get("data_ingestion.0.value").Exists() {
+		gbDataIngestion = decimal.NewFromInt(u.Get("data_ingestion.0.value").Int())
+	}
+
+	if u != nil && u.Get("data_storage.0.value").Exists() {
+		gbDataStorage = decimal.NewFromInt(u.Get("data_storage.0.value").Int())
+	}
+
+	if u != nil && u.Get("data_analyzed.0.value").Exists() {
+		gbDataAnalzyed = decimal.NewFromInt(u.Get("data_analyzed.0.value").Int())
+	}
+
+	if u != nil && u.Get("data_queries.0.value").Exists() {
+		gbDataAnalzyedQueries = u.Get("data_queries.0.value").Int()
+	}
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name:            "Collect (Data Ingestion)",
+			Unit:            "GB",
+			UnitMultiplier:  1,
+			MonthlyQuantity: decimalPtr(gbDataIngestion),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonCloudWatch"),
+				ProductFamily: strPtr("Data Payload"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/-DataProcessing-Bytes/")},
+				},
+			},
+		},
+		{
+			Name:            "Store (Archival)",
+			Unit:            "GB",
+			UnitMultiplier:  1,
+			MonthlyQuantity: decimalPtr(gbDataStorage),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonCloudWatch"),
+				ProductFamily: strPtr("Storage Snapshot"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/-TimedStorage-ByteHrs/")},
+				},
+			},
+		},
+	}
+
+	if gbDataAnalzyedQueries > 0 && gbDataAnalzyed.GreaterThan(decimal.NewFromInt(0)) {
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            "Analyze (Logs insights queries)",
+			Unit:            "GB-scanned",
+			UnitMultiplier:  int(gbDataAnalzyedQueries),
+			MonthlyQuantity: decimalPtr(gbDataAnalzyed),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonCloudWatch"),
+				ProductFamily: strPtr("Data Payload"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/-DataScanned-Bytes/")},
+				},
+			},
+		})
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/providers/terraform/aws/cloudwatch_log_group_test.go
+++ b/internal/providers/terraform/aws/cloudwatch_log_group_test.go
@@ -3,7 +3,6 @@ package aws_test
 import (
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
 	"github.com/infracost/infracost/internal/testutil"
-	"github.com/shopspring/decimal"
 	"testing"
 )
 
@@ -22,14 +21,19 @@ func TestCloudwatchLogGroup(t *testing.T) {
 			Name: "aws_cloudwatch_log_group.logs",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Collect (Data Ingestion)",
+					Name:             "Data ingestion",
 					PriceHash:        "4c00b8e26729863d2cc1f1a2d824dcf0-b1ae3861dc57e2db217fa83a7420374f",
-					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 				{
-					Name:             "Store (Archival)",
+					Name:             "Archival Storage",
 					PriceHash:        "af1a1c7a3c3f5fc6e72de0ba26dcf55e-ee3dd7e4624338037ca6fea0933a662f",
-					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+				{
+					Name:             "Insights queries data scanned",
+					PriceHash:        "e4d44a4a02daffd13cd87e63d67f30a5-b1ae3861dc57e2db217fa83a7420374f",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/cloudwatch_log_group_test.go
+++ b/internal/providers/terraform/aws/cloudwatch_log_group_test.go
@@ -1,39 +1,39 @@
 package aws_test
 
 import (
-    "github.com/infracost/infracost/internal/providers/terraform/tftest"
-    "github.com/infracost/infracost/internal/testutil"
-    "github.com/shopspring/decimal"
-    "testing"
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+	"testing"
 )
 
 func TestCloudwatchLogGroup(t *testing.T) {
-    if testing.Short() {
-        t.Skip("skipping test in short mode")
-    }
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 
-    tf := `
+	tf := `
         resource "aws_cloudwatch_log_group" "logs" {
           name              = "log-group"
         }`
 
-    resourceChecks := []testutil.ResourceCheck{
-        {
-            Name: "aws_cloudwatch_log_group.logs",
-            CostComponentChecks: []testutil.CostComponentCheck{
-                {
-                    Name:             "Collect (Data Ingestion)",
-                    PriceHash:        "4c00b8e26729863d2cc1f1a2d824dcf0-b1ae3861dc57e2db217fa83a7420374f",
-                    MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
-                },
-                {
-                    Name:             "Store (Archival)",
-                    PriceHash:        "af1a1c7a3c3f5fc6e72de0ba26dcf55e-ee3dd7e4624338037ca6fea0933a662f",
-                    MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
-                },
-            },
-        },
-    }
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_cloudwatch_log_group.logs",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Collect (Data Ingestion)",
+					PriceHash:        "4c00b8e26729863d2cc1f1a2d824dcf0-b1ae3861dc57e2db217fa83a7420374f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+				{
+					Name:             "Store (Archival)",
+					PriceHash:        "af1a1c7a3c3f5fc6e72de0ba26dcf55e-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+			},
+		},
+	}
 
-    tftest.ResourceTests(t, tf, resourceChecks)
+	tftest.ResourceTests(t, tf, resourceChecks)
 }

--- a/internal/providers/terraform/aws/cloudwatch_log_group_test.go
+++ b/internal/providers/terraform/aws/cloudwatch_log_group_test.go
@@ -1,0 +1,39 @@
+package aws_test
+
+import (
+    "github.com/infracost/infracost/internal/providers/terraform/tftest"
+    "github.com/infracost/infracost/internal/testutil"
+    "github.com/shopspring/decimal"
+    "testing"
+)
+
+func TestCloudwatchLogGroup(t *testing.T) {
+    if testing.Short() {
+        t.Skip("skipping test in short mode")
+    }
+
+    tf := `
+        resource "aws_cloudwatch_log_group" "logs" {
+          name              = "log-group"
+        }`
+
+    resourceChecks := []testutil.ResourceCheck{
+        {
+            Name: "aws_cloudwatch_log_group.logs",
+            CostComponentChecks: []testutil.CostComponentCheck{
+                {
+                    Name:             "Collect (Data Ingestion)",
+                    PriceHash:        "4c00b8e26729863d2cc1f1a2d824dcf0-b1ae3861dc57e2db217fa83a7420374f",
+                    MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+                },
+                {
+                    Name:             "Store (Archival)",
+                    PriceHash:        "af1a1c7a3c3f5fc6e72de0ba26dcf55e-ee3dd7e4624338037ca6fea0933a662f",
+                    MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+                },
+            },
+        },
+    }
+
+    tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/cloudwatch_metric_alarm.go
+++ b/internal/providers/terraform/aws/cloudwatch_metric_alarm.go
@@ -57,7 +57,7 @@ func cloudWatchMetricQuery(d *schema.ResourceData, region string, costComponentU
 
 	for _, metric := range d.Get("metric_query.#.metric").Array() {
 		if len(metric.Array()) > 0 {
-			metricCount += 1
+			metricCount++
 		}
 	}
 

--- a/internal/providers/terraform/aws/cloudwatch_metric_alarm.go
+++ b/internal/providers/terraform/aws/cloudwatch_metric_alarm.go
@@ -1,0 +1,112 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetCloudwatchMetricAlarmRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_cloudwatch_metric_alarm",
+		RFunc: NewCloudwatchMetricAlarm,
+	}
+}
+
+func NewCloudwatchMetricAlarm(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	region := d.Get("region").String()
+	costComponents := make([]*schema.CostComponent, 0)
+
+	if len(d.Get("metric_query").Array()) > 0 {
+		costComponents = append(costComponents, cloudWatchMetricQuery(d, region))
+	} else {
+		costComponents = append(costComponents, cloudWatchMetricName(d, region))
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}
+
+func cloudwatchMetricAlarmCostComponent(name string, region string, alarmType string, quantity decimal.Decimal) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            name,
+		Unit:            "alarm",
+		UnitMultiplier:  1,
+		MonthlyQuantity: decimalPtr(quantity),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonCloudWatch"),
+			ProductFamily: strPtr("Alarm"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "alarmType", Value: strPtr(alarmType)},
+			},
+		},
+	}
+}
+
+func cloudWatchMetricQuery(d *schema.ResourceData, region string) *schema.CostComponent {
+	var quantity decimal.Decimal
+	var name string
+	var alarmType string
+
+	var anomalyDetection string
+
+	quantity = decimal.NewFromInt(1)
+
+	if checkAnomlyDetection(d) {
+		quantity = decimal.NewFromInt(3)
+		anomalyDetection = " anomaly detection"
+	}
+
+	for _, query := range d.Get("metric_query").Array() {
+		if !query.Get("metric").Exists() {
+			continue
+		}
+
+		for _, m := range query.Get("metric").Array() {
+			if m.Get("period").Exists() {
+				if calcMetricResolution(decimal.NewFromInt(m.Get("period").Int())) {
+					name = fmt.Sprintf("%s%s", "Standard resolution", anomalyDetection)
+					alarmType = "Standard"
+				} else {
+					name = fmt.Sprintf("%s%s", "High resolution", anomalyDetection)
+					alarmType = "High Resolution"
+				}
+
+				return cloudwatchMetricAlarmCostComponent(name, region, alarmType, quantity)
+			}
+		}
+	}
+
+	return nil
+}
+
+func cloudWatchMetricName(d *schema.ResourceData, region string) *schema.CostComponent {
+	var name string
+	var alarmType string
+
+	if calcMetricResolution(decimal.NewFromInt(d.Get("period").Int())) {
+		name = "Standard resolution"
+		alarmType = "Standard"
+	} else {
+		name = "High resolution"
+		alarmType = "High Resolution"
+	}
+
+	return cloudwatchMetricAlarmCostComponent(name, region, alarmType, decimal.NewFromInt(1))
+}
+
+func calcMetricResolution(metricPeriod decimal.Decimal) bool {
+	return metricPeriod.Div(decimal.NewFromInt(60)).GreaterThanOrEqual(decimal.NewFromInt(1))
+}
+
+func checkAnomlyDetection(d *schema.ResourceData) bool {
+	switch d.Get("comparison_operator").String() {
+	case "LessThanLowerOrGreaterThanUpperThreshold", "LessThanLowerThreshold", "GreaterThanUpperThreshold":
+		return true
+	}
+	return false
+}

--- a/internal/providers/terraform/aws/cloudwatch_metric_alarm_internal_test.go
+++ b/internal/providers/terraform/aws/cloudwatch_metric_alarm_internal_test.go
@@ -1,0 +1,25 @@
+package aws
+
+import (
+    "testing"
+
+    "github.com/shopspring/decimal"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestCloudwatchMetricResolution(t *testing.T) {
+    tests := []struct{
+        inputValue decimal.Decimal
+        expected bool
+    }{
+        {decimal.NewFromInt(60), true},
+        {decimal.NewFromInt(120), true},
+        {decimal.NewFromInt(30), false},
+        {decimal.NewFromInt(10), false},
+    }
+
+    for _, test := range tests {
+        actual := calcMetricResolution(test.inputValue)
+        assert.Equal(t, test.expected, actual)
+    }
+}

--- a/internal/providers/terraform/aws/cloudwatch_metric_alarm_internal_test.go
+++ b/internal/providers/terraform/aws/cloudwatch_metric_alarm_internal_test.go
@@ -1,25 +1,25 @@
 package aws
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/shopspring/decimal"
-    "github.com/stretchr/testify/assert"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCloudwatchMetricResolution(t *testing.T) {
-    tests := []struct{
-        inputValue decimal.Decimal
-        expected bool
-    }{
-        {decimal.NewFromInt(60), true},
-        {decimal.NewFromInt(120), true},
-        {decimal.NewFromInt(30), false},
-        {decimal.NewFromInt(10), false},
-    }
+	tests := []struct {
+		inputValue decimal.Decimal
+		expected   bool
+	}{
+		{decimal.NewFromInt(60), true},
+		{decimal.NewFromInt(120), true},
+		{decimal.NewFromInt(30), false},
+		{decimal.NewFromInt(10), false},
+	}
 
-    for _, test := range tests {
-        actual := calcMetricResolution(test.inputValue)
-        assert.Equal(t, test.expected, actual)
-    }
+	for _, test := range tests {
+		actual := calcMetricResolution(test.inputValue)
+		assert.Equal(t, test.expected, actual)
+	}
 }

--- a/internal/providers/terraform/aws/cloudwatch_metric_alarm_test.go
+++ b/internal/providers/terraform/aws/cloudwatch_metric_alarm_test.go
@@ -1,0 +1,168 @@
+package aws_test
+
+import (
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+	"testing"
+)
+
+func TestCloudWatchMetricAlarm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+        resource "aws_cloudwatch_metric_alarm" "standard" {
+          alarm_name                = "terraform-test-alarm"
+          comparison_operator       = "GreaterThanOrEqualToThreshold"
+          evaluation_periods        = "2"
+          metric_name               = "CPUUtilization"
+          namespace                 = "AWS/EC2"
+          period                    = "120"
+          statistic                 = "Average"
+          threshold                 = "80"
+          alarm_description         = "This metric monitors ec2 cpu utilization"
+          insufficient_data_actions = []
+        }
+
+        resource "aws_cloudwatch_metric_alarm" "high" {
+          alarm_name                = "terraform-test-alarm"
+          comparison_operator       = "GreaterThanOrEqualToThreshold"
+          evaluation_periods        = "1"
+          metric_name               = "CPUUtilization"
+          namespace                 = "AWS/EC2"
+          period                    = "10"
+          statistic                 = "Average"
+          threshold                 = "80"
+          alarm_description         = "This metric monitors ec2 cpu utilization"
+          insufficient_data_actions = []
+        }
+
+         resource "aws_cloudwatch_metric_alarm" "expression" {
+           alarm_name                = "terraform-test-expression"
+           comparison_operator       = "GreaterThanOrEqualToThreshold"
+           evaluation_periods        = "2"
+           threshold                 = "10"
+           alarm_description         = "Request error rate has exceeded 10%"
+           insufficient_data_actions = []
+         
+           metric_query {
+             id          = "e1"
+             expression  = "m2/m1*100"
+             label       = "Error Rate"
+             return_data = "true"
+           }
+         
+           metric_query {
+             id = "m1"
+         
+             metric {
+               metric_name = "RequestCount"
+               namespace   = "AWS/ApplicationELB"
+               period      = "120"
+               stat        = "Sum"
+               unit        = "Count"
+         
+               dimensions = {
+                 LoadBalancer = "app/web"
+               }
+             }
+           }
+         
+           metric_query {
+             id = "m2"
+         
+             metric {
+               metric_name = "HTTPCode_ELB_5XX_Count"
+               namespace   = "AWS/ApplicationELB"
+               period      = "120"
+               stat        = "Sum"
+               unit        = "Count"
+         
+               dimensions = {
+                 LoadBalancer = "app/web"
+               }
+             }
+           }
+         }
+
+         resource "aws_cloudwatch_metric_alarm" "anomaly_detection" {
+           alarm_name                = "terraform-test-foobar"
+           comparison_operator       = "GreaterThanUpperThreshold"
+           evaluation_periods        = "2"
+           threshold_metric_id       = "e1"
+           alarm_description         = "This metric monitors ec2 cpu utilization"
+           insufficient_data_actions = []
+         
+           metric_query {
+             id          = "e1"
+             expression  = "ANOMALY_DETECTION_BAND(m1)"
+             label       = "CPUUtilization (Expected)"
+             return_data = "true"
+           }
+         
+           metric_query {
+             id          = "m1"
+             return_data = "true"
+             metric {
+               metric_name = "CPUUtilization"
+               namespace   = "AWS/EC2"
+               period      = "30"
+               stat        = "Average"
+               unit        = "Count"
+         
+               dimensions = {
+                 InstanceId = "i-abc123"
+               }
+             }
+           }
+         }
+
+`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_cloudwatch_metric_alarm.standard",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Standard resolution",
+					PriceHash:        "a84a546af7ac086f8ba1e9e80712d14e-062aaa56dee17578c258c2b52f349952",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "aws_cloudwatch_metric_alarm.high",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "High resolution",
+					PriceHash:        "2909875a1b2145747d5ee321e71aeaf1-062aaa56dee17578c258c2b52f349952",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "aws_cloudwatch_metric_alarm.expression",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Standard resolution",
+					PriceHash:        "a84a546af7ac086f8ba1e9e80712d14e-062aaa56dee17578c258c2b52f349952",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "aws_cloudwatch_metric_alarm.anomaly_detection",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "High resolution anomaly detection",
+					PriceHash:        "2909875a1b2145747d5ee321e71aeaf1-062aaa56dee17578c258c2b52f349952",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(3)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/cloudwatch_metric_alarm_test.go
+++ b/internal/providers/terraform/aws/cloudwatch_metric_alarm_test.go
@@ -148,7 +148,7 @@ func TestCloudWatchMetricAlarm(t *testing.T) {
 				{
 					Name:             "Standard resolution",
 					PriceHash:        "a84a546af7ac086f8ba1e9e80712d14e-062aaa56dee17578c258c2b52f349952",
-					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -8,6 +8,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAPIGatewayv2ApiRegistryItem(),
 	GetAutoscalingGroupRegistryItem(),
 	GetCloudwatchDashboardRegistryItem(),
+	GetCloudwatchLogGroupItem(),
 	GetCloudwatchMetricAlarmRegistryItem(),
 	GetDBInstanceRegistryItem(),
 	GetDMSRegistryItem(),
@@ -81,7 +82,6 @@ var FreeResources []string = []string{
 	// AWS Cloudwatch
 	"aws_cloudwatch_log_destination",
 	"aws_cloudwatch_log_destination_policy",
-	"aws_cloudwatch_log_group",
 	"aws_cloudwatch_log_metric_filter",
 	"aws_cloudwatch_log_resource_policy",
 	"aws_cloudwatch_log_stream",

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -7,6 +7,8 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAPIGatewayStageRegistryItem(),
 	GetAPIGatewayv2ApiRegistryItem(),
 	GetAutoscalingGroupRegistryItem(),
+	GetCloudwatchDashboardRegistryItem(),
+	GetCloudwatchMetricAlarmRegistryItem(),
 	GetDBInstanceRegistryItem(),
 	GetDMSRegistryItem(),
 	GetDocDBClusterInstanceRegistryItem(),
@@ -75,6 +77,15 @@ var FreeResources []string = []string{
 	"aws_apigatewayv2_route_response",
 	"aws_apigatewayv2_stage",
 	"aws_apigatewayv2_vpc_link",
+
+	// AWS Cloudwatch
+	"aws_cloudwatch_log_destination",
+	"aws_cloudwatch_log_destination_policy",
+	"aws_cloudwatch_log_group",
+	"aws_cloudwatch_log_metric_filter",
+	"aws_cloudwatch_log_resource_policy",
+	"aws_cloudwatch_log_stream",
+	"aws_cloudwatch_log_subscription_filter",
 
 	// AWS Elastic Load Balancing
 	"aws_alb_listener",


### PR DESCRIPTION
**Objective**:

Adds support for cloudwatch_dashboard & cloudwatch_metric_alarm.

** Closes ** #54 

**Example output**: 

```
NAME                                              MONTHLY QTY  UNIT     PRICE   HOURLY COST  MONTHLY COST  

  aws_cloudwatch_dashboard.main                                                                              
  └─ Dashboard                                                1  monthly  3.0000       0.0041        3.0000  
  Total                                                                                0.0041        3.0000  
                                                                                                             
  aws_cloudwatch_metric_alarm.expression                                                                     
  └─ Standard resolution                                      1  alarm    0.1000       0.0001        0.1000  
  Total                                                                                0.0001        0.1000  
                                                                                                             
  aws_cloudwatch_metric_alarm.high                                                                           
  └─ High resolution                                          1  alarm    0.3000       0.0004        0.3000  
  Total                                                                                0.0004        0.3000  
                                                                                                             
  aws_cloudwatch_metric_alarm.standard                                                                       
  └─ Standard resolution                                      1  alarm    0.1000       0.0001        0.1000  
  Total                                                                                0.0001        0.1000  
                                                                                                             
  aws_cloudwatch_metric_alarm.xx_anomaly_detection                                                           
  └─ Standard resolution anomaly detection                    3  alarm    0.1000       0.0004        0.3000  
  Total                                                                                0.0004        0.3000  
                                                                                                             
  OVERALL TOTAL (USD)                                                                  0.0052        3.8000  
```
**Pricing details**:
The Cloudwatch service provides a single pricing component for dashboards & 5 pricing components for alarms. Composite alarms are not currently supported by terraform. Pricing details describe here https://aws.amazon.com/cloudwatch/pricing/
