### PR TITLE
fix(aws): instance types for t3 were matching t3a too

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,8 @@ func getInfracostEnv() string {
 				return "bitbucket"
 			} else if strings.HasPrefix(k, "JENKINS_") {
 				return "jenkins"
+			} else if strings.HasPrefix(k, "CONCOURSE_") {
+				return "concourse"
 			}
 		}
 		if IsTruthy(os.Getenv("CI")) {

--- a/internal/providers/terraform/aws/eks_node_group.go
+++ b/internal/providers/terraform/aws/eks_node_group.go
@@ -118,7 +118,7 @@ func eksCPUCreditsCostComponent(d *schema.ResourceData, region string, desiredSi
 			ProductFamily: strPtr("CPU Credits"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "operatingSystem", Value: strPtr("Linux")},
-				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/CPUCredits:%s/", prefix))},
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/CPUCredits:%s$/", prefix))},
 			},
 		},
 	}

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -161,7 +161,7 @@ func cpuCreditsCostComponent(d *schema.ResourceData) *schema.CostComponent {
 			ProductFamily: strPtr("CPU Credits"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "operatingSystem", Value: strPtr("Linux")},
-				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/CPUCredits:%s/", prefix))},
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/CPUCredits:%s$/", prefix))},
 			},
 		},
 	}


### PR DESCRIPTION
this should fix these:
```
=== RUN   TestAutoscalingGroup_launchConfiguration_cpuCredits
time="2020-11-28T17:38:03Z" level=warning msg="Multiple products found for aws_launch_configuration.lc1 CPU credits, using the first product"
TestEKSNodeGroup_default
time="2020-11-28T17:38:37Z" level=warning msg="Multiple products found for aws_launch_template.lt1 CPU credits, using the first product"
TestInstance_cpuCredits
time="2020-11-28T17:40:22Z" level=warning msg="Multiple products found for aws_eks_node_group.example CPU credits, using the first product"
```