### PR TITLE
Adding basic KMS resource

### DIFF
--- a/internal/providers/terraform/aws/kms_external_key.go
+++ b/internal/providers/terraform/aws/kms_external_key.go
@@ -1,0 +1,26 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func GetNewKMSExternalKeyRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_kms_external_key",
+		RFunc: NewKMSExternalKey,
+	}
+}
+
+func NewKMSExternalKey(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+
+	region := d.Get("region").String()
+
+	costComponents := []*schema.CostComponent{
+		CustomerMasterKeyCostComponent(region),
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -57,7 +57,7 @@ func appendRequestComponentsForSpec(costComponents []*schema.CostComponent, spec
 		"ECC_NIST_P384",
 		"ECC_NIST_P521",
 		"ECC_SECG_P256K1":
-		costComponents = append(costComponents, requestPriceComponent("Requests (Asymmetric)", region, "Asymmetric"))
+		costComponents = append(costComponents, requestPriceComponent("Requests (asymmetric)", region, "Asymmetric"))
 		return costComponents
 	}
 

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -15,7 +15,6 @@ func GetNewKMSKeyRegistryItem() *schema.RegistryItem {
 func NewKMSKey(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
 
 	region := d.Get("region").String()
-	cmkCount := int64(1)
 
 	costComponents := []*schema.CostComponent{
 		{

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -19,7 +19,7 @@ func NewKMSKey(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource 
 
 	costComponents := []*schema.CostComponent{
 		{
-			Name:            "CMK",
+			Name:            "Customer master key",
 			Unit:            "months",
 			UnitMultiplier:  1,
 			MonthlyQuantity: decimalPtr(decimal.NewFromInt(cmkCount)),

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -35,8 +35,32 @@ func NewKMSKey(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource 
 		},
 	}
 
+	costComponents = append(costComponents, requestPriceComponent("Requests", region, "All"))
+	costComponents = append(costComponents, requestPriceComponent("Requests (RSA 2048)", region, "Asymmetric-RSA_2048"))
+	costComponents = append(costComponents, requestPriceComponent("Requests (ECC GenerateDataKeyPair)", region, "GenerateDatakeyPair-ECC"))
+	costComponents = append(costComponents, requestPriceComponent("Requests (Asymmetric)", region, "Asymmetric"))
+	costComponents = append(costComponents, requestPriceComponent("Requests (RSA GenerateDataKeyPair)", region, "GenerateDatakeyPair-RSA"))
+
 	return &schema.Resource{
 		Name:           d.Address,
 		CostComponents: costComponents,
+	}
+}
+
+func requestPriceComponent(name string, region string, group string) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:           name,
+		Unit:           "requests",
+		UnitMultiplier: 10000,
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("aws"),
+			Region:     strPtr(region),
+			Service:    strPtr("awskms"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "group", ValueRegex: strPtr("/" + group + "/")},
+				{Key: "locationType", Value: strPtr("AWS Region")},
+				{Key: "usagetype", ValueRegex: strPtr("/KMS-Requests/")},
+			},
+		},
 	}
 }

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -62,7 +62,7 @@ func appendRequestComponentsForSpec(costComponents []*schema.CostComponent, spec
 	}
 
 	costComponents = append(costComponents, requestPriceComponent("Requests", region, "All"))
-	costComponents = append(costComponents, requestPriceComponent("Requests (ECC GenerateDataKeyPair)", region, "GenerateDatakeyPair-ECC"))
+	costComponents = append(costComponents, requestPriceComponent("ECC GenerateDataKeyPair requests", region, "GenerateDatakeyPair-ECC"))
 	costComponents = append(costComponents, requestPriceComponent("Requests (RSA GenerateDataKeyPair)", region, "GenerateDatakeyPair-ECC"))
 	return costComponents
 }

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -1,0 +1,42 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetKMSKeyRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_kms_key",
+		RFunc: NewKMSKey,
+	}
+}
+
+func NewKMSKey(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+
+	region := d.Get("region").String()
+	cmkCount := int64(1)
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name:            "CMK",
+			Unit:            "months",
+			UnitMultiplier:  1,
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(cmkCount)),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("awskms"),
+				ProductFamily: strPtr("Encryption Key"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/-KMS-Keys/")},
+				},
+			},
+		},
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -22,7 +22,7 @@ func NewKMSKey(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource 
 			Name:            "Customer master key",
 			Unit:            "months",
 			UnitMultiplier:  1,
-			MonthlyQuantity: decimalPtr(decimal.NewFromInt(cmkCount)),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 			ProductFilter: &schema.ProductFilter{
 				VendorName:    strPtr("aws"),
 				Region:        strPtr(region),

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -18,22 +18,7 @@ func NewKMSKey(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource 
 	spec := d.Get("customer_master_key_spec").String()
 
 	costComponents := []*schema.CostComponent{
-		{
-			Name:            "Customer master key",
-			Unit:            "months",
-			UnitMultiplier:  1,
-			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Region:        strPtr(region),
-				Service:       strPtr("awskms"),
-				ProductFamily: strPtr("Encryption Key"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "locationType", Value: strPtr("AWS Region")},
-					{Key: "usagetype", ValueRegex: strPtr("/KMS-Keys/")},
-				},
-			},
-		},
+		CustomerMasterKeyCostComponent(region),
 	}
 
 	costComponents = appendRequestComponentsForSpec(costComponents, spec, region)
@@ -41,6 +26,25 @@ func NewKMSKey(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource 
 	return &schema.Resource{
 		Name:           d.Address,
 		CostComponents: costComponents,
+	}
+}
+
+func CustomerMasterKeyCostComponent(region string) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Customer master key",
+		Unit:            "months",
+		UnitMultiplier:  1,
+		MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("awskms"),
+			ProductFamily: strPtr("Encryption Key"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "locationType", Value: strPtr("AWS Region")},
+				{Key: "usagetype", ValueRegex: strPtr("/KMS-Keys/")},
+			},
+		},
 	}
 }
 

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -63,7 +63,7 @@ func appendRequestComponentsForSpec(costComponents []*schema.CostComponent, spec
 
 	costComponents = append(costComponents, requestPriceComponent("Requests", region, "All"))
 	costComponents = append(costComponents, requestPriceComponent("ECC GenerateDataKeyPair requests", region, "GenerateDatakeyPair-ECC"))
-	costComponents = append(costComponents, requestPriceComponent("Requests (RSA GenerateDataKeyPair)", region, "GenerateDatakeyPair-ECC"))
+	costComponents = append(costComponents, requestPriceComponent("RSA GenerateDataKeyPair requests", region, "GenerateDatakeyPair-ECC"))
 	return costComponents
 }
 

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -28,7 +28,8 @@ func NewKMSKey(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource 
 				Service:       strPtr("awskms"),
 				ProductFamily: strPtr("Encryption Key"),
 				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "usagetype", ValueRegex: strPtr("/-KMS-Keys/")},
+					{Key: "locationType", Value: strPtr("AWS Region")},
+					{Key: "usagetype", ValueRegex: strPtr("/KMS-Keys/")},
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/kms_key.go
+++ b/internal/providers/terraform/aws/kms_key.go
@@ -5,7 +5,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func GetKMSKeyRegistryItem() *schema.RegistryItem {
+func GetNewKMSKeyRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_kms_key",
 		RFunc: NewKMSKey,

--- a/internal/providers/terraform/aws/kms_key_external_test.go
+++ b/internal/providers/terraform/aws/kms_key_external_test.go
@@ -1,0 +1,35 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestKMSExternalKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_kms_external_key" "kms" {}
+		`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_kms_external_key.kms",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Customer master key",
+					PriceHash:        "27f4c0ac50728e0b52e2eca6fae6c35b-8a6f8acec9da6fca443941d0cf1bfbef",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/kms_key_test.go
+++ b/internal/providers/terraform/aws/kms_key_test.go
@@ -1,0 +1,35 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestKMSKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_kms_key" "kms" {}
+		`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_kms_key.kms",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "CMK",
+					PriceHash:        "27f4c0ac50728e0b52e2eca6fae6c35b-8a6f8acec9da6fca443941d0cf1bfbef",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/kms_key_test.go
+++ b/internal/providers/terraform/aws/kms_key_test.go
@@ -23,9 +23,24 @@ func TestKMSKey(t *testing.T) {
 			Name: "aws_kms_key.kms",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CMK",
+					Name:             "Customer master key",
 					PriceHash:        "27f4c0ac50728e0b52e2eca6fae6c35b-8a6f8acec9da6fca443941d0cf1bfbef",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Requests",
+					PriceHash:        "7ee3fe8f4efd601e26775e1ebdf588d6-4a9dfd3965ffcbab75845ead7a27fd47",
+					MonthlyCostCheck: nil,
+				},
+				{
+					Name:             "Requests (ECC GenerateDataKeyPair)",
+					PriceHash:        "b283328d4a57675972284045c9343af0-4a9dfd3965ffcbab75845ead7a27fd47",
+					MonthlyCostCheck: nil,
+				},
+				{
+					Name:             "Requests (RSA GenerateDataKeyPair)",
+					PriceHash:        "b283328d4a57675972284045c9343af0-4a9dfd3965ffcbab75845ead7a27fd47",
+					MonthlyCostCheck: nil,
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/kms_key_test.go
+++ b/internal/providers/terraform/aws/kms_key_test.go
@@ -80,3 +80,35 @@ func TestKMSKey_RSA_2048(t *testing.T) {
 
 	tftest.ResourceTests(t, tf, resourceChecks)
 }
+
+func TestKMSKey_Asymmetric(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_kms_key" "kms" {
+			customer_master_key_spec = "RSA_3072"
+		}
+		`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_kms_key.kms",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Customer master key",
+					PriceHash:        "27f4c0ac50728e0b52e2eca6fae6c35b-8a6f8acec9da6fca443941d0cf1bfbef",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Requests (Asymmetric)",
+					PriceHash:        "e6c7bc01771a8886348e2727083eab1b-4a9dfd3965ffcbab75845ead7a27fd47",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/kms_key_test.go
+++ b/internal/providers/terraform/aws/kms_key_test.go
@@ -48,3 +48,35 @@ func TestKMSKey(t *testing.T) {
 
 	tftest.ResourceTests(t, tf, resourceChecks)
 }
+
+func TestKMSKey_RSA_2048(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_kms_key" "kms" {
+			customer_master_key_spec = "RSA_2048"
+		}
+		`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_kms_key.kms",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Customer master key",
+					PriceHash:        "27f4c0ac50728e0b52e2eca6fae6c35b-8a6f8acec9da6fca443941d0cf1bfbef",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Requests (RSA 2048)",
+					PriceHash:        "cf7b71f1cff51c5b2963048440c65ddc-4a9dfd3965ffcbab75845ead7a27fd47",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/kms_key_test.go
+++ b/internal/providers/terraform/aws/kms_key_test.go
@@ -33,12 +33,12 @@ func TestKMSKey(t *testing.T) {
 					MonthlyCostCheck: nil,
 				},
 				{
-					Name:             "Requests (ECC GenerateDataKeyPair)",
+					Name:             "ECC GenerateDataKeyPair requests",
 					PriceHash:        "b283328d4a57675972284045c9343af0-4a9dfd3965ffcbab75845ead7a27fd47",
 					MonthlyCostCheck: nil,
 				},
 				{
-					Name:             "Requests (RSA GenerateDataKeyPair)",
+					Name:             "RSA GenerateDataKeyPair requests",
 					PriceHash:        "b283328d4a57675972284045c9343af0-4a9dfd3965ffcbab75845ead7a27fd47",
 					MonthlyCostCheck: nil,
 				},
@@ -102,7 +102,7 @@ func TestKMSKey_Asymmetric(t *testing.T) {
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
-					Name:             "Requests (Asymmetric)",
+					Name:             "Requests (asymmetric)",
 					PriceHash:        "e6c7bc01771a8886348e2727083eab1b-4a9dfd3965ffcbab75845ead7a27fd47",
 					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -41,6 +41,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetNewEKSFargateProfileItem(),
 	GetNewEKSClusterItem(),
 	GetNewKMSKeyRegistryItem(),
+	GetNewKMSExternalKeyRegistryItem(),
 }
 
 // FreeResources grouped alphabetically
@@ -147,7 +148,6 @@ var FreeResources []string = []string{
 	// AWS KMS
 	"aws_kms_alias",
 	"aws_kms_ciphertext",
-	"aws_kms_external_key",
 	"aws_kms_grant",
 
 	// AWS Others

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -181,6 +181,12 @@ var FreeResources []string = []string{
 	"aws_s3_bucket_policy",
 	"aws_s3_bucket_public_access_block",
 
+	// AWS KMS
+	"aws_kms_alias",
+	"aws_kms_ciphertext",
+	"aws_kms_external_key",
+	"aws_kms_grant",
+
 	// AWS VPC
 	"aws_customer_gateway",
 	"aws_default_network_acl",

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -40,6 +40,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetNewEKSNodeGroupItem(),
 	GetNewEKSFargateProfileItem(),
 	GetNewEKSClusterItem(),
+	GetKMSKeyRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -40,7 +40,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetNewEKSNodeGroupItem(),
 	GetNewEKSFargateProfileItem(),
 	GetNewEKSClusterItem(),
-	GetKMSKeyRegistryItem(),
+	GetNewKMSKeyRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -144,6 +144,12 @@ var FreeResources []string = []string{
 	"aws_iam_user_policy_attachment",
 	"aws_iam_user_ssh_key",
 
+	// AWS KMS
+	"aws_kms_alias",
+	"aws_kms_ciphertext",
+	"aws_kms_external_key",
+	"aws_kms_grant",
+
 	// AWS Others
 	"aws_db_instance_role_association",
 	"aws_db_parameter_group",
@@ -180,12 +186,6 @@ var FreeResources []string = []string{
 	"aws_s3_bucket_ownership_controls",
 	"aws_s3_bucket_policy",
 	"aws_s3_bucket_public_access_block",
-
-	// AWS KMS
-	"aws_kms_alias",
-	"aws_kms_ciphertext",
-	"aws_kms_external_key",
-	"aws_kms_grant",
 
 	// AWS VPC
 	"aws_customer_gateway",


### PR DESCRIPTION
Fixes #213

Given a key definition:

```
resource "aws_kms_key" "kms" {}
```

Report the basic key usage:

```
 aws_kms_key.kms
  └─ CMK                                                1  months       1.0000       0.0014        1.0000
  Total                                                                              0.0014        1.0000
```

This PR does not cover cumulative costs incurred by yearly key rotation and does not cover key usage.