### PR TITLE
feat(aws): Adds basic SNS support

### DIFF
--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -171,6 +171,11 @@ var FreeResources []string = []string{
 	"aws_s3_bucket_policy",
 	"aws_s3_bucket_public_access_block",
 
+	// AWS SNS
+	"aws_sns_platform_application",
+	"aws_sns_sms_preferences",
+	"aws_sns_topic_policy",
+
 	// AWS VPC
 	"aws_customer_gateway",
 	"aws_default_network_acl",

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -33,6 +33,8 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetS3BucketRegistryItem(),
 	GetS3BucketAnalyticsConfigurationRegistryItem(),
 	GetS3BucketInventoryRegistryItem(),
+	GetSNSTopicRegistryItem(),
+	GetSNSTopicSubscriptionRegistryItem(),
 	GetSQSQueueRegistryItem(),
 	GetNewEKSNodeGroupItem(),
 	GetNewEKSFargateProfileItem(),

--- a/internal/providers/terraform/aws/sns_topic_subscription.go
+++ b/internal/providers/terraform/aws/sns_topic_subscription.go
@@ -1,0 +1,68 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/infracost/infracost/internal/schema"
+
+	"github.com/shopspring/decimal"
+)
+
+func GetSNSTopicSubscriptionRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_sns_topic_subscription",
+		RFunc: NewSnsTopicSubscription,
+		Notes: []string{
+			"SMS & Mobile push not yet supported.",
+		},
+	}
+}
+
+func NewSnsTopicSubscription(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
+	region := d.Get("region").String()
+
+	var endpointType string
+	var freeTier string
+
+	requestSize := decimal.NewFromInt(64)
+	if u != nil && u.Get("request_size.0.value").Exists() {
+		requestSize = decimal.NewFromFloat(u.Get("request_size.0.value").Float())
+	}
+
+	var requests *decimal.Decimal
+	if u != nil && u.Get("monthly_requests.0.value").Exists() {
+		monthlyRequests := decimal.NewFromInt(u.Get("monthly_requests.0.value").Int())
+		requests = decimalPtr(calculateRequests(requestSize, monthlyRequests))
+	}
+
+	switch d.Get("protocol").String() {
+	case "http", "https":
+		endpointType = "HTTP"
+		freeTier = "100000"
+	default:
+		return nil
+	}
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:            fmt.Sprintf("%s notifications", endpointType),
+				Unit:            "notifications",
+				UnitMultiplier:  1000000,
+				MonthlyQuantity: requests,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("aws"),
+					Region:        strPtr(region),
+					Service:       strPtr("AmazonSNS"),
+					ProductFamily: strPtr("Message Delivery"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "endpointType", Value: strPtr(endpointType)},
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					StartUsageAmount: strPtr(freeTier),
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/aws/sns_topic_subscription.go
+++ b/internal/providers/terraform/aws/sns_topic_subscription.go
@@ -12,7 +12,7 @@ func GetSNSTopicSubscriptionRegistryItem() *schema.RegistryItem {
 		Name:  "aws_sns_topic_subscription",
 		RFunc: NewSnsTopicSubscription,
 		Notes: []string{
-			"SMS & Mobile push not yet supported.",
+			"SMS and mobile push not yet supported.",
 		},
 	}
 }

--- a/internal/providers/terraform/aws/sns_topic_subscription_test.go
+++ b/internal/providers/terraform/aws/sns_topic_subscription_test.go
@@ -15,7 +15,7 @@ func TestSNSTopicSubscriptionFunction(t *testing.T) {
 
 	tf := `
         resource "aws_sns_topic_subscription" "http" {
-          endpoint = "some-dummy-outpoint"
+          endpoint = "some-dummy-endpoint"
           protocol = "http"
           topic_arn = "aws_sns_topic.topic.arn"
         }

--- a/internal/providers/terraform/aws/sns_topic_subscription_test.go
+++ b/internal/providers/terraform/aws/sns_topic_subscription_test.go
@@ -1,0 +1,38 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestSNSTopicSubscriptionFunction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+        resource "aws_sns_topic_subscription" "http" {
+          endpoint = "some-dummy-outpoint"
+          protocol = "http"
+          topic_arn = "aws_sns_topic.topic.arn"
+        }
+`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_sns_topic_subscription.http",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "HTTP notifications",
+					PriceHash:        "0b289a170f868cdf934546d365df8097-3a73d6a2c60c01675dc5432bc383db67",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/sns_topic_test.go
+++ b/internal/providers/terraform/aws/sns_topic_test.go
@@ -1,0 +1,35 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestSQSTopicFunction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+        resource "aws_sns_topic" "topic" {
+            name = "my-standard-queue"
+        }`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_sns_topic.topic",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Requests",
+					PriceHash:        "33cb108100e772bb071322e9b4736e98-4a9dfd3965ffcbab75845ead7a27fd47",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}


### PR DESCRIPTION
**Objective**:

Adds support for `sns_topic` & `sns_topic_subscription`

** Closes ** #229 

**Example output:**

```
 NAME                             MONTHLY QTY  UNIT              PRICE   HOURLY COST  MONTHLY COST  

  aws_sns_topic.this                                                                                 
  └─ Requests                                -  1M requests       0.5000            -             -  
  Total                                                                             -             -  
                                                                                                     
  aws_sns_topic_subscription.this                                                                    
  └─ HTTP notifications                      -  1M notifications  0.6000            -             -  
  Total                                                                             -             -  
                                                                                                     
  OVERALL TOTAL (USD)                                                          0.0000        0.0000  

```

**Note**:
TF currently doesn't provide support SES, SNS FIFO is currently not supported in TF & there's an outstanding PR open here hashicorp/terraform-provider-aws#15805.


