### PR TITLE
feat(output): add skipped resources message to report

### DIFF
--- a/cmd/infracost/default.go
+++ b/cmd/infracost/default.go
@@ -54,13 +54,18 @@ func defaultCmd() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "show-skipped",
-				Usage: "Show unsupported resources, some of which might be free",
+				Usage: "Show unsupported resources, some of which might be free (only for table and HTML output)",
 				Value: false,
 			},
 		},
 		Action: func(c *cli.Context) error {
 			if err := checkAPIKey(); err != nil {
 				return err
+			}
+
+			if c.String("output") == "json" && c.Bool("show-skipped") {
+				msg := color.YellowString("The --show-skipped option is not needed with JSON output as that always includes them\n")
+				fmt.Fprint(os.Stderr, msg)
 			}
 
 			provider := terraform.New()
@@ -104,7 +109,7 @@ func defaultCmd() *cli.Command {
 
 			schema.SortResources(resources)
 
-			r := output.ToOutputFormat(resources, c)
+			r := output.ToOutputFormat(resources)
 			var (
 				b   []byte
 				out string
@@ -114,10 +119,10 @@ func defaultCmd() *cli.Command {
 				b, err = output.ToJSON(r)
 				out = string(b)
 			case "html":
-				b, err = output.ToHTML(r)
+				b, err = output.ToHTML(r, c)
 				out = string(b)
 			default:
-				b, err = output.ToTable(r)
+				b, err = output.ToTable(r, c)
 				out = fmt.Sprintf("\n%s", string(b))
 			}
 

--- a/cmd/infracost/report.go
+++ b/cmd/infracost/report.go
@@ -3,8 +3,10 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/infracost/infracost/internal/output"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
@@ -29,15 +31,25 @@ EXAMPLES:
 				Usage:   "Output format (json, table, html)",
 				Value:   "table",
 			},
+			&cli.BoolFlag{
+				Name:  "show-skipped",
+				Usage: "Show unsupported resources, some of which might be free (only for table and HTML output)",
+				Value: false,
+			},
 		},
 		Action: func(c *cli.Context) error {
+			if c.String("output") == "json" && c.Bool("show-skipped") {
+				msg := color.YellowString("The --show-skipped option is not needed with JSON output as that always includes them\n")
+				fmt.Fprint(os.Stderr, msg)
+			}
+
 			files := make([]string, 0)
 
 			for i := 0; i < c.Args().Len(); i++ {
 				files = append(files, c.Args().Get(i))
 			}
 
-			jsons := make([]output.Root, len(files))
+			jsons := make([]output.Root, 0, len(files))
 			for _, f := range files {
 				data, err := ioutil.ReadFile(f)
 				if err != nil {
@@ -62,9 +74,9 @@ EXAMPLES:
 			case "json":
 				b, err = output.ToJSON(combined)
 			case "html":
-				b, err = output.ToHTML(combined)
+				b, err = output.ToHTML(combined, c)
 			default:
-				b, err = output.ToTable(combined)
+				b, err = output.ToTable(combined, c)
 			}
 			if err != nil {
 				return err

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -10,7 +10,6 @@ import (
 	"github.com/infracost/infracost/internal/providers/terraform"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
-	"github.com/urfave/cli/v2"
 )
 
 type Root struct {
@@ -18,7 +17,7 @@ type Root struct {
 	TotalHourlyCost  *decimal.Decimal `json:"totalHourlyCost"`
 	TotalMonthlyCost *decimal.Decimal `json:"totalMonthlyCost"`
 	TimeGenerated    time.Time        `json:"timeGenerated"`
-	Warnings         []string         `json:"warnings"`
+	ResourceSummary  *ResourceSummary `json:"resourceSummary"`
 }
 
 type CostComponent struct {
@@ -37,6 +36,20 @@ type Resource struct {
 	MonthlyCost    *decimal.Decimal `json:"monthlyCost"`
 	CostComponents []CostComponent  `json:"costComponents,omitempty"`
 	SubResources   []Resource       `json:"subresources,omitempty"`
+}
+
+type ResourceSummary struct {
+	SupportedCounts   *map[string]int `json:"supportedCounts,omitempty"`
+	UnsupportedCounts *map[string]int `json:"unsupportedCounts,omitempty"`
+	TotalSupported    *int            `json:"totalSupported,omitempty"`
+	TotalUnsupported  *int            `json:"totalUnsupported,omitempty"`
+	TotalNoPrice      *int            `json:"totalNoPrice,omitempty"`
+	Total             *int            `json:"total,omitempty"`
+}
+
+type ResourceSummaryOptions struct {
+	IncludeUnsupportedProviders bool
+	OnlyFields                  []string
 }
 
 func outputResource(r *schema.Resource) Resource {
@@ -68,7 +81,7 @@ func outputResource(r *schema.Resource) Resource {
 	}
 }
 
-func ToOutputFormat(resources []*schema.Resource, c *cli.Context) Root {
+func ToOutputFormat(resources []*schema.Resource) Root {
 	arr := make([]Resource, 0, len(resources))
 
 	var totalHourlyCost *decimal.Decimal
@@ -101,11 +114,9 @@ func ToOutputFormat(resources []*schema.Resource, c *cli.Context) Root {
 		TotalHourlyCost:  totalHourlyCost,
 		TotalMonthlyCost: totalMonthlyCost,
 		TimeGenerated:    time.Now(),
-	}
-
-	msg := skippedResourcesMessage(resources, c.Bool("show-skipped"))
-	if msg != "" {
-		out.Warnings = append(out.Warnings, msg)
+		ResourceSummary: BuildResourceSummary(resources, ResourceSummaryOptions{
+			OnlyFields: []string{"UnsupportedCounts"},
+		}),
 	}
 
 	return out
@@ -122,8 +133,10 @@ func Combine(outs ...Root) Root {
 
 	var totalHourlyCost *decimal.Decimal
 	var totalMonthlyCost *decimal.Decimal
+	summaries := make([]*ResourceSummary, 0, len(outs))
 
 	for _, o := range outs {
+
 		combined.Resources = append(combined.Resources, o.Resources...)
 
 		if o.TotalHourlyCost != nil {
@@ -140,58 +153,172 @@ func Combine(outs ...Root) Root {
 
 			totalMonthlyCost = decimalPtr(totalMonthlyCost.Add(*o.TotalMonthlyCost))
 		}
+
+		summaries = append(summaries, o.ResourceSummary)
 	}
 
-	sortResources(combined)
+	combined.sortResources()
 
 	combined.TotalHourlyCost = totalHourlyCost
 	combined.TotalMonthlyCost = totalMonthlyCost
 	combined.TimeGenerated = time.Now()
+	combined.ResourceSummary = combinedResourceSummaries(summaries)
 
 	return combined
 }
 
-func sortResources(out Root) {
-	sort.Slice(out.Resources, func(i, j int) bool {
-		return out.Resources[i].Name < out.Resources[j].Name
+func (r *Root) sortResources() {
+	sort.Slice(r.Resources, func(i, j int) bool {
+		return r.Resources[i].Name < r.Resources[j].Name
 	})
 }
 
-func skippedResourcesMessage(resources []*schema.Resource, showDetails bool) string {
-	summary := schema.GenerateResourceSummary(resources)
-	if summary.TotalUnsupported == 0 {
+func (r *Root) unsupportedResourcesMessage(showSkipped bool) string {
+	if r.ResourceSummary.UnsupportedCounts == nil || len(*r.ResourceSummary.UnsupportedCounts) == 0 {
 		return ""
 	}
 
-	supportedTypeCount := 0
-	for rType := range summary.UnsupportedCounts {
-		if terraform.HasSupportedProvider(rType) {
-			supportedTypeCount++
+	unsupportedTypeCount := len(*r.ResourceSummary.UnsupportedCounts)
+
+	unsupportedMsg := "resource types couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)"
+	if unsupportedTypeCount == 1 {
+		unsupportedMsg = "resource type couldn't be estimated as Infracost doesn't support it yet (https://www.infracost.io/docs/supported_resources)"
+	}
+
+	showSkippedMsg := ", re-run with --show-skipped to see the list"
+	if showSkipped {
+		showSkippedMsg = ""
+	}
+
+	msg := fmt.Sprintf("%d %s %s.\n%s",
+		unsupportedTypeCount,
+		unsupportedMsg,
+		showSkippedMsg,
+		"We're continually adding new resources, please email hello@infracost.io if you'd like us to prioritize your list.",
+	)
+
+	if showSkipped {
+		for t, c := range *r.ResourceSummary.UnsupportedCounts {
+			msg += fmt.Sprintf("\n%d x %s", c, t)
 		}
 	}
 
-	message := fmt.Sprintf("%d resource types couldn't be estimated as Infracost doesn't support them yet (https://www.infracost.io/docs/supported_resources)", supportedTypeCount)
-	if supportedTypeCount == 1 {
-		message = "1 resource type couldn't be estimated as Infracost doesn't support it yet (https://www.infracost.io/docs/supported_resources)"
-	}
+	return msg
+}
 
-	if showDetails {
-		message += ".\n"
-	} else {
-		message += ", re-run with --show-skipped to see the list.\n"
-	}
+func BuildResourceSummary(resources []*schema.Resource, opts ResourceSummaryOptions) *ResourceSummary {
+	supportedCounts := make(map[string]int)
+	unsupportedCounts := make(map[string]int)
+	totalSupported := 0
+	totalUnsupported := 0
+	totalNoPrice := 0
 
-	message += "We're continually adding new resources, please email hello@infracost.io if you'd like us to prioritize your list."
+	for _, r := range resources {
+		if !opts.IncludeUnsupportedProviders && !terraform.HasSupportedProvider(r.ResourceType) {
+			continue
+		}
 
-	if showDetails {
-		for rType, count := range summary.UnsupportedCounts {
-			if terraform.HasSupportedProvider(rType) {
-				message += fmt.Sprintf("\n%d x %s", count, rType)
+		if r.NoPrice {
+			totalNoPrice++
+		} else if r.IsSkipped {
+			totalUnsupported++
+			if _, ok := unsupportedCounts[r.ResourceType]; !ok {
+				unsupportedCounts[r.ResourceType] = 0
 			}
+			unsupportedCounts[r.ResourceType]++
+		} else {
+			totalSupported++
+			if _, ok := supportedCounts[r.ResourceType]; !ok {
+				supportedCounts[r.ResourceType] = 0
+			}
+			supportedCounts[r.ResourceType]++
 		}
 	}
 
-	return message
+	total := len(resources)
+
+	s := &ResourceSummary{}
+
+	if len(opts.OnlyFields) == 0 || contains(opts.OnlyFields, "SupportedCounts") {
+		s.SupportedCounts = &supportedCounts
+	}
+	if len(opts.OnlyFields) == 0 || contains(opts.OnlyFields, "UnsupportedCounts") {
+		s.UnsupportedCounts = &unsupportedCounts
+	}
+	if len(opts.OnlyFields) == 0 || contains(opts.OnlyFields, "TotalSupported") {
+		s.TotalSupported = &totalSupported
+	}
+	if len(opts.OnlyFields) == 0 || contains(opts.OnlyFields, "TotalUnsupported") {
+		s.TotalUnsupported = &totalUnsupported
+	}
+	if len(opts.OnlyFields) == 0 || contains(opts.OnlyFields, "TotalNoPrice") {
+		s.TotalNoPrice = &totalNoPrice
+	}
+	if len(opts.OnlyFields) == 0 || contains(opts.OnlyFields, "Total") {
+		s.Total = &total
+	}
+
+	return s
+}
+
+func combinedResourceSummaries(summaries []*ResourceSummary) *ResourceSummary {
+	combined := &ResourceSummary{}
+
+	for _, s := range summaries {
+		if s == nil {
+			continue
+		}
+
+		combined.SupportedCounts = combineCounts(combined.SupportedCounts, s.SupportedCounts)
+		combined.UnsupportedCounts = combineCounts(combined.UnsupportedCounts, s.UnsupportedCounts)
+		combined.TotalSupported = addIntPtrs(combined.TotalSupported, s.TotalSupported)
+		combined.TotalUnsupported = addIntPtrs(combined.TotalUnsupported, s.TotalUnsupported)
+		combined.TotalNoPrice = addIntPtrs(combined.TotalNoPrice, s.TotalNoPrice)
+		combined.Total = addIntPtrs(combined.Total, s.Total)
+	}
+
+	return combined
+}
+
+func combineCounts(c1 *map[string]int, c2 *map[string]int) *map[string]int {
+	if c1 == nil && c2 == nil {
+		return nil
+	}
+
+	res := make(map[string]int)
+
+	if c1 != nil {
+		for k, v := range *c1 {
+			res[k] = v
+		}
+	}
+
+	if c2 != nil {
+		for k, v := range *c2 {
+			res[k] += v
+		}
+	}
+
+	return &res
+}
+
+func addIntPtrs(i1 *int, i2 *int) *int {
+	if i1 == nil && i2 == nil {
+		return nil
+	}
+
+	val1 := 0
+	if i1 != nil {
+		val1 = *i1
+	}
+
+	val2 := 0
+	if i2 != nil {
+		val2 = *i2
+	}
+
+	res := val1 + val2
+	return &res
 }
 
 func formatAmount(d decimal.Decimal) string {
@@ -216,6 +343,15 @@ func formatQuantity(q *decimal.Decimal) string {
 	}
 	f, _ := q.Float64()
 	return humanize.CommafWithDigits(f, 4)
+}
+
+func contains(arr []string, e string) bool {
+	for _, a := range arr {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }
 
 func decimalPtr(d decimal.Decimal) *decimal.Decimal {

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 
 	"github.com/infracost/infracost/internal/config"
-
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
 )
 
-func ToTable(out Root) ([]byte, error) {
+func ToTable(out Root, c *cli.Context) ([]byte, error) {
 	var buf bytes.Buffer
 	bufw := bufio.NewWriter(&buf)
 
@@ -60,13 +60,12 @@ func ToTable(out Root) ([]byte, error) {
 
 	t.Render()
 
-	if len(out.Warnings) > 0 {
-		for _, w := range out.Warnings {
-			_, err := bufw.WriteString(fmt.Sprintf("\n%s", w))
-			if err != nil {
-				// The error here would just mean the output is shortened, so no need to return an error to the user in this case
-				log.Errorf("Error writing warning message: %v", err.Error())
-			}
+	msg := out.unsupportedResourcesMessage(c.Bool("show-skipped"))
+	if msg != "" {
+		_, err := bufw.WriteString(fmt.Sprintf("\n%s", msg))
+		if err != nil {
+			// The error here would just mean the output is shortened, so no need to return an error to the user in this case
+			log.Errorf("Error writing unsupported resources message: %v", err.Error())
 		}
 	}
 

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -33,6 +33,10 @@ a {
   width: 8rem;
 }
 
+.warnings {
+  margin-top: 1.5rem;
+}
+
 table {
   border-collapse: collapse;
   border: 1px solid #6b7280;
@@ -131,7 +135,7 @@ iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
         </li>
         <li>
           <span class="label">Time generated:</span>
-          <span class="value">{{.TimeGenerated | date "2006-01-02 15:04:05 MST"}}</span>
+          <span class="value">{{.Root.TimeGenerated | date "2006-01-02 15:04:05 MST"}}</span>
         </li>
       </ul>
     </div>
@@ -146,7 +150,7 @@ iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
         <th class="monthly-cost">Monthly cost</th>
       </thead>
       <tbody>
-        {{range .Resources}}
+        {{range .Root.Resources}}
           {{template "resourceRows" dict "Resource" . "Indent" 0}}
         {{end}}
         <tr class="spacer"><td colspan="6"></td></tr>
@@ -155,10 +159,14 @@ iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
           <td class="monthly-quantity"></td>
           <td class="unit"></td>
           <td class="price"></td>
-          <td class="hourly-cost">{{.TotalHourlyCost | formatCost}}</td>
-          <td class="monthly-cost">{{.TotalMonthlyCost | formatCost}}</td>
+          <td class="hourly-cost">{{.Root.TotalHourlyCost | formatCost}}</td>
+          <td class="monthly-cost">{{.Root.TotalMonthlyCost | formatCost}}</td>
         </tr>
       </tbody>
     </table>
+
+    <div class="warnings">
+      <p>{{.UnsupportedResourcesMessage | replaceNewLines}}</p>
+    </div>
   </body>
 </html>`

--- a/internal/prices/query.go
+++ b/internal/prices/query.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/output"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/pkg/errors"
 
@@ -159,10 +160,12 @@ func (q *GraphQLQueryRunner) ReportSummary(resources []*schema.Resource) {
 
 	url := fmt.Sprintf("%s/report", q.baseURL)
 
-	summary := schema.GenerateResourceSummary(resources)
+	summary := output.BuildResourceSummary(resources, output.ResourceSummaryOptions{
+		IncludeUnsupportedProviders: true,
+	})
 
 	j := struct {
-		ResourceSummary *schema.ResourceSummary `json:"resourceSummary"`
+		ResourceSummary *output.ResourceSummary `json:"resourceSummary"`
 	}{
 		ResourceSummary: summary,
 	}

--- a/internal/schema/resource.go
+++ b/internal/schema/resource.go
@@ -22,15 +22,6 @@ type Resource struct {
 	ResourceType   string
 }
 
-type ResourceSummary struct {
-	SupportedCounts   map[string]int `json:"supportedCounts"`
-	UnsupportedCounts map[string]int `json:"unsupportedCounts"`
-	TotalSupported    int            `json:"totalSupported"`
-	TotalUnsupported  int            `json:"totalUnsupported"`
-	TotalNoPrice      int            `json:"totalNoPrice"`
-	Total             int            `json:"total"`
-}
-
 func CalculateCosts(resources []*Resource) {
 	for _, r := range resources {
 		r.CalculateCosts()
@@ -102,41 +93,6 @@ func SortResources(resources []*Resource) {
 	sort.Slice(resources, func(i, j int) bool {
 		return resources[i].Name < resources[j].Name
 	})
-}
-
-func GenerateResourceSummary(resources []*Resource) *ResourceSummary {
-	supportedCounts := make(map[string]int)
-	unsupportedCounts := make(map[string]int)
-	totalSupported := 0
-	totalUnsupported := 0
-	totalNoPrice := 0
-
-	for _, r := range resources {
-		if r.NoPrice {
-			totalNoPrice++
-		} else if r.IsSkipped {
-			totalUnsupported++
-			if _, ok := unsupportedCounts[r.ResourceType]; !ok {
-				unsupportedCounts[r.ResourceType] = 0
-			}
-			unsupportedCounts[r.ResourceType]++
-		} else {
-			totalSupported++
-			if _, ok := supportedCounts[r.ResourceType]; !ok {
-				supportedCounts[r.ResourceType] = 0
-			}
-			supportedCounts[r.ResourceType]++
-		}
-	}
-
-	return &ResourceSummary{
-		SupportedCounts:   supportedCounts,
-		UnsupportedCounts: unsupportedCounts,
-		TotalSupported:    totalSupported,
-		TotalUnsupported:  totalUnsupported,
-		TotalNoPrice:      totalNoPrice,
-		Total:             len(resources),
-	}
 }
 
 func MultiplyQuantities(resource *Resource, multiplier decimal.Decimal) {


### PR DESCRIPTION
This also updates the JSON output to show the unsupported resources in a structured format, e.g.
```json
  "resourceSummary": {
    "unsupportedCounts": {
      "aws_simpledb_domain": 3,
      "aws_docdb_cluster": 1
    }
  }
```