### PR TITLE
feat(aws): Added support for VPC Endpoint(s)

### DIFF
--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -42,6 +42,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetNewEKSClusterItem(),
 	GetNewKMSKeyRegistryItem(),
 	GetNewKMSExternalKeyRegistryItem(),
+	GetVpcEndpointRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/aws/vpc_endpoint.go
+++ b/internal/providers/terraform/aws/vpc_endpoint.go
@@ -49,7 +49,7 @@ func NewVpcEndpoint(d *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 		Name: d.Address,
 		CostComponents: []*schema.CostComponent{
 			{
-				Name:           fmt.Sprintf("VPC %s endpoint", vpcEndpointType),
+				Name:           fmt.Sprintf("%s endpoint", vpcEndpointType),
 				Unit:           "hours",
 				UnitMultiplier: 1,
 				HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),

--- a/internal/providers/terraform/aws/vpc_endpoint.go
+++ b/internal/providers/terraform/aws/vpc_endpoint.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"github.com/infracost/infracost/internal/schema"
 
 	"github.com/shopspring/decimal"
@@ -16,6 +17,29 @@ func GetVpcEndpointRegistryItem() *schema.RegistryItem {
 func NewVpcEndpoint(d *schema.ResourceData, u *schema.ResourceData) *schema.Resource {
 	region := d.Get("region").String()
 
+	vpcEndpointType := "Gateway"
+
+	var endpointHours string
+	var endpointBytes string
+
+	if d.Get("vpc_endpoint_type").Exists() {
+		vpcEndpointType = d.Get("vpc_endpoint_type").String()
+	}
+
+	// Gateway endpoints don't have a cost associated with them
+	if vpcEndpointType == "Gateway" {
+		return nil
+	}
+
+	switch vpcEndpointType {
+	case "Interface":
+		endpointHours = "VpcEndpoint-Hours"
+		endpointBytes = "VpcEndpoint-Bytes"
+	case "GatewayLoadBalancer":
+		endpointHours = "VpcEndpoint-GWLBE-Hours"
+		endpointBytes = "VpcEndpoint-GWLBE-Bytes"
+	}
+
 	var gbDataProcessed *decimal.Decimal
 	if u != nil && u.Get("monthly_gb_data_processed.0.value").Exists() {
 		gbDataProcessed = decimalPtr(decimal.NewFromFloat(u.Get("monthly_gb_data_processed.0.value").Float()))
@@ -25,7 +49,7 @@ func NewVpcEndpoint(d *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 		Name: d.Address,
 		CostComponents: []*schema.CostComponent{
 			{
-				Name:           "VPC endpoint",
+				Name:           fmt.Sprintf("VPC %s endpoint", vpcEndpointType),
 				Unit:           "hours",
 				UnitMultiplier: 1,
 				HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
@@ -35,7 +59,7 @@ func NewVpcEndpoint(d *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 					Service:       strPtr("AmazonVPC"),
 					ProductFamily: strPtr("VpcEndpoint"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "usagetype", ValueRegex: strPtr("/VpcEndpoint-Hours/")},
+						{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/", endpointHours))},
 					},
 				},
 			},
@@ -50,7 +74,7 @@ func NewVpcEndpoint(d *schema.ResourceData, u *schema.ResourceData) *schema.Reso
 					Service:       strPtr("AmazonVPC"),
 					ProductFamily: strPtr("VpcEndpoint"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "usagetype", ValueRegex: strPtr("/VpcEndpoint-Bytes/")},
+						{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/", endpointBytes))},
 					},
 				},
 			},

--- a/internal/providers/terraform/aws/vpc_endpoint_test.go
+++ b/internal/providers/terraform/aws/vpc_endpoint_test.go
@@ -48,7 +48,7 @@ func TestVpcEndpoint(t *testing.T) {
 			Name: "aws_vpc_endpoint.gateway_loadbalancer",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "VPC GatewayLoadBalancer endpoint",
+					Name:            "GatewayLoadBalancer endpoint",
 					PriceHash:       "223b69fb3326be912fd0d30333e8dc50-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},

--- a/internal/providers/terraform/aws/vpc_endpoint_test.go
+++ b/internal/providers/terraform/aws/vpc_endpoint_test.go
@@ -33,7 +33,7 @@ func TestVpcEndpoint(t *testing.T) {
 			Name: "aws_vpc_endpoint.interface",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "VPC Interface endpoint",
+					Name:            "Interface endpoint",
 					PriceHash:       "ef7fb85cbd68a47968dd294f49ed3517-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},

--- a/internal/providers/terraform/aws/vpc_endpoint_test.go
+++ b/internal/providers/terraform/aws/vpc_endpoint_test.go
@@ -1,0 +1,43 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestVpcEndpoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_vpc_endpoint" "endpoint" {
+            service_name = "com.amazonaws.region.ec2"
+            vpc_id = "vpc-123456"
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_vpc_endpoint.endpoint",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "VPC endpoint",
+					PriceHash:       "ef7fb85cbd68a47968dd294f49ed3517-d2c98780d7b6e36641b521f1f8145c6f",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "Data processed",
+					PriceHash:       "5fb8d7a651606fc4214684873291830f-b1ae3861dc57e2db217fa83a7420374f",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, resourceChecks)
+}

--- a/internal/providers/terraform/aws/vpc_endpoint_test.go
+++ b/internal/providers/terraform/aws/vpc_endpoint_test.go
@@ -16,23 +16,45 @@ func TestVpcEndpoint(t *testing.T) {
 	}
 
 	tf := `
-		resource "aws_vpc_endpoint" "endpoint" {
+		resource "aws_vpc_endpoint" "interface" {
             service_name = "com.amazonaws.region.ec2"
             vpc_id = "vpc-123456"
+            vpc_endpoint_type = "Interface"
+		}
+
+		resource "aws_vpc_endpoint" "gateway_loadbalancer" {
+            service_name = "com.amazonaws.region.ec2"
+            vpc_id = "vpc-123456"
+            vpc_endpoint_type = "GatewayLoadBalancer"
 		}`
 
 	resourceChecks := []testutil.ResourceCheck{
 		{
-			Name: "aws_vpc_endpoint.endpoint",
+			Name: "aws_vpc_endpoint.interface",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "VPC endpoint",
+					Name:            "VPC Interface endpoint",
 					PriceHash:       "ef7fb85cbd68a47968dd294f49ed3517-d2c98780d7b6e36641b521f1f8145c6f",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
 					Name:            "Data processed",
 					PriceHash:       "5fb8d7a651606fc4214684873291830f-b1ae3861dc57e2db217fa83a7420374f",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "aws_vpc_endpoint.gateway_loadbalancer",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "VPC GatewayLoadBalancer endpoint",
+					PriceHash:       "223b69fb3326be912fd0d30333e8dc50-d2c98780d7b6e36641b521f1f8145c6f",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "Data processed",
+					PriceHash:       "88513e1fd2a2e28b7ae752a813e771eb-b1ae3861dc57e2db217fa83a7420374f",
 					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},


### PR DESCRIPTION
**Objective**:

Adds support for `vpc_endpoint` 

** Partially Closes ** #191  

**Example output:**

```
WWWWWWWWWWWWWWWWWWWWWW
  NAME                                 MONTHLY QTY  UNIT   PRICE   HOURLY COST  MONTHLY COST  
WWWWWWWWWWWWWWWWWWWWWWWWWWW
  aws_vpc_endpoint.endpoint                                                                   
  ├─ VPC Interface endpoint                    730  hours  0.0110       0.0110        8.0300  
  └─ Data processed                              -  GB     0.0100            -             -  
  Total                                                                 0.0110        8.0300  
                                                                                              
  aws_vpc_endpoint.gw                                                                         
  ├─ VPC GatewayLoadBalancer endpoint          730  hours  0.0112       0.0112        8.1760  
  └─ Data processed                              -  GB     0.0035            -             -  
  Total                                                                 0.0112        8.1760  
                                                                                              
  OVERALL TOTAL (USD)                                                   0.0222       16.2060  
WWWWWWWWWWWWWWWWWWWWWWWWWWW


```




