### PR TITLE
fix(terraform): fix typo in non-windows terraform CLI config file

### DIFF
--- a/internal/providers/terraform/cloud.go
+++ b/internal/providers/terraform/cloud.go
@@ -160,7 +160,7 @@ func defaultConfFile() string {
 		return filepath.Join(os.Getenv("APPDATA"), "terraform.rc")
 	}
 
-	p, _ := homedir.Expand("~/.terraform.rc")
+	p, _ := homedir.Expand("~/.terraformrc")
 	return p
 }
 


### PR DESCRIPTION
See https://www.terraform.io/docs/commands/cli-config.html and https://github.com/hashicorp/setup-terraform/blob/master/lib/setup-terraform.js#L92