### PR TITLE
docs: update readme to be shorter and clearer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,58 @@ The overall process for contributing to Infracost is:
 3. Send a pull request with the proposed change (don't forget to run `make lint` and `make fmt` first). Please include unit and integration tests where applicable. We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 4. We'll review your change and provide feedback.
 
+## Development
+
+Install Go dependencies:
+```sh
+make deps
+```
+
+Install latest version of terraform-provider-infracost. If you want to use a local development version, see [this](#using-a-local-version-of-terraform-provider-infracost)
+```sh
+make install_provider
+```
+
+Get an API key.
+```sh
+make run ARGS="register"
+```
+Alternatively checkout and run the [cloud-pricing-api](https://github.com/infracost/cloud-pricing-api) and set the `INFRACOST_PRICING_API_ENDPOINT` environment variable to point to it.
+
+Add the API key to your `.env.local` file:
+```
+cat <<EOF >> .env.local
+INFRACOST_API_KEY=XXX
+EOF
+```
+
+Run the code:
+```sh
+make run ARGS="--tfdir examples/terraform"
+```
+
+Run all tests:
+```sh
+make test
+```
+
+Exclude integration tests:
+```sh
+make test ARGS="-v -short"
+```
+
+Build:
+```sh
+make build
+```
+
+If you want to work on the [terraform-provider-infracost repository](https://github.com/infracost/terraform-provider-infracost), you can install the local version in your `~/.terraform.d/plugins` directory by:
+```sh
+# fork/clone the repo
+cd terraform-provider-infracost
+make install
+```
+
 ## Adding new resources
 
 ### Quickstart AWS
@@ -83,7 +135,7 @@ Finally create a temporary terraform file to test your resource and run (no need
 make run ARGS="--tfdir my_new_terraform/"
 ```
 
-### Overview
+### Detailed notes
 
 When adding your first resource, we recommend you look at one of the existing resources to see how it's done, for example, check the [nat_gateway.go](internal/providers/terraform/aws/nat_gateway.go) resource. You can then review the [price_explorer](scripts/price_explorer/README.md) scripts that help you find various pricing service filters, and something called a "priceHash" that you need for writing integration tests.
 

--- a/README.md
+++ b/README.md
@@ -1,66 +1,39 @@
 <a href="https://www.infracost.io"><img src="https://raw.githubusercontent.com/infracost/infracost/master/assets/logo.svg" width=320 alt="Infracost logo" /></a>
 
-<a href="https://www.infracost.io/docs/"><img alt="Docs" src="https://img.shields.io/badge/docs-blue"/></a>
 <a href="https://www.infracost.io/community-chat"><img alt="Community Slack channel" src="https://img.shields.io/badge/chat-Slack-%234a154b"/></a>
+<a href="https://www.infracost.io/docs/"><img alt="Docs" src="https://img.shields.io/badge/docs-blue"/></a>
 <a href="https://github.com/infracost/infracost/actions?query=workflow%3AGo+branch%3Amaster"><img alt="Build Status" src="https://img.shields.io/github/workflow/status/infracost/infracost/Go/master"/></a>
 <a href="https://hub.docker.com/r/infracost/infracost/tags"><img alt="Docker Image" src="https://img.shields.io/docker/cloud/build/infracost/infracost"/></a>
 <a href="https://twitter.com/intent/tweet?text=Get%20cost%20estimates%20for%20cloud%20infrastructure%20in%20pull%20requests!&url=https://www.infracost.io&hashtags=cloud,cost,aws,IaC,terraform"><img alt="Tweet" src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"/></a>
 
-Infracost shows hourly and monthly cost estimates for a Terraform project. This helps developers, DevOps et al. quickly see the cost breakdown and compare different deployment options upfront.
+Infracost shows cloud cost estimates for a Terraform project. It helps developers, devops and others to quickly see the cost breakdown and compare different options upfront.
 
 <img src="https://raw.githubusercontent.com/infracost/infracost/master/assets/screenshot.png" width=600 alt="Example Infracost output" />
 
-## Table of Contents
-
-**Checkout the [docs site](https://www.infracost.io/docs/) for additional usage options.**
-
-* [Installation](#installation)
-* [Usage](#usage-methods)
-* [CI/CD integrations](https://www.infracost.io/docs/integrations)
-* [Supported clouds and resources](https://www.infracost.io/docs/supported_resources/)
-* [Development](#development)
-* [Contributing (we'll pay you!)](#contributing)
-
-<!-- NOTE: When updated also update https://github.com/infracost/docs/blob/master/docs/getting_started.md#installation with the same content -->
 ## Installation
 
 1. Download and install the latest Infracost release
 
-    Linux:
-    ```sh
-    curl -s -L https://github.com/infracost/infracost/releases/latest/download/infracost-linux-amd64.tar.gz | tar xz -C /tmp && \
-    sudo mv /tmp/infracost-linux-amd64 /usr/local/bin/infracost
-    ```
-
-    macOS (Homebrew):
+    macOS Homebrew:
     ```sh
     brew install infracost
     ```
 
-    macOS (manual):
+    Linux/macOS manual:
     ```sh
-    curl -s -L https://github.com/infracost/infracost/releases/latest/download/infracost-darwin-amd64.tar.gz | tar xz -C /tmp && \
-    sudo mv /tmp/infracost-darwin-amd64 /usr/local/bin/infracost
+    os=$(uname | tr [:upper:] [:lower:])
+    curl -s -L https://github.com/infracost/infracost/releases/latest/download/infracost-$os-amd64.tar.gz | tar xz -C /tmp && \
+    sudo mv /tmp/infracost-$os-amd64 /usr/local/bin/infracost
     ```
 
-    Docker:
-    ```sh
-    docker pull infracost/infracost
-    docker run --rm \
-      -e INFRACOST_API_KEY=see_following_step_on_how_to_get_this \
-      -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-      -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-      -v $PWD/:/code/ infracost/infracost --tfdir /code/
-      # add other required flags for infracost or envs for Terraform
-    ```
+    Docker and Windows users see [here](https://www.infracost.io/docs/#installation).
 
-2.	Use our free hosted Cloud Pricing API by registering for an API key:
+2.	Use our free Cloud Pricing API by registering for an API key:
     ```sh
     infracost register
     ```
 
-    The `INFRACOST_API_KEY` environment variable can be used to set the API key in CI systems.
-    If you prefer, you can run your own [pricing API](https://www.infracost.io/docs/faq/#can-i-run-my-own-pricing-api).
+    If you prefer, you can run your own [Cloud Pricing API](https://www.infracost.io/docs/faq/#can-i-run-my-own-pricing-api).
 
 3.  Run `infracost` using our example Terraform project to see how it works. You can also play with the `main.tf` file in the example:
 
@@ -69,6 +42,8 @@ Infracost shows hourly and monthly cost estimates for a Terraform project. This 
     infracost --tfdir example-terraform/aws
     ```
 
+Please **watch** this repo for new releases as we add new cloud resources every week or so.
+
 ## Basic usage
 
 There are [4 usage methods](https://www.infracost.io/docs/#usage-methods) for Infracost depending on your use-case. The following is the default method. Point to the Terraform directory using `--tfdir` and pass any required Terraform flags using `--tfflags`. Internally Infracost runs Terraform `init`, `plan` and `show`; `init` requires cloud credentials to be set, e.g. via the usual `AWS_ACCESS_KEY_ID` environment variables. This method works with remote state too.
@@ -76,73 +51,27 @@ There are [4 usage methods](https://www.infracost.io/docs/#usage-methods) for In
   infracost --tfdir /path/to/code --tfflags "-var-file=myvars.tfvars"
   ```
 
-The [Infracost GitHub Action](https://www.infracost.io/docs/integrations#github-action), [GitLab CI template](https://www.infracost.io/docs/integrations#gitlab-ci) or [CircleCI Orb](https://www.infracost.io/docs/integrations#circleci) can be used to automatically add a PR comment showing the cost estimate `diff` between a pull/merge request and the master branch.
+Checkout the [docs site](https://www.infracost.io/docs/) for additional usage options, including notes for [Terragrunt](https://www.infracost.io/docs/#terragrunt-users) and [Terraform Cloud](https://www.infracost.io/docs/#terraform-cloud-users) users.
+
+## CI/CD integrations
+
+The [Infracost GitHub Action](https://www.infracost.io/docs/integrations#github-action), [GitLab CI template](https://www.infracost.io/docs/integrations#gitlab-ci) or [CircleCI Orb](https://www.infracost.io/docs/integrations#circleci) can be used to automatically add a comment showing the cost estimate `diff` between a pull/merge request and the master branch. If you run into any issues with CI/CD integrations, please join our [community Slack channel](https://www.infracost.io/community-chat), we'd be happy to guide you through it.
 
 <img src="https://raw.githubusercontent.com/infracost/infracost-gh-action/master/screenshot.png" width=600 alt="Example infracost diff usage" />
 
-## Development
+## Supported clouds and resources
 
-Install Go dependencies:
-```sh
-make deps
-```
+Infracost supports over [50 AWS and Google resources](https://www.infracost.io/docs/supported_resources/), Azure is [planned](https://github.com/infracost/infracost/issues/64). The quickest way to find out if your Terraform resources are supported is to run Infracost with the `--show-skipped` option. This shows the unsupported resources, some of which might be free.
 
-Install latest version of terraform-provider-infracost. If you want to use a local development version, see [this](#using-a-local-version-of-terraform-provider-infracost)
-```sh
-make install_provider
-```
-
-Get an API key.
-```sh
-make run ARGS="register"
-```
-Alternatively checkout and run the [cloud-pricing-api](https://github.com/infracost/cloud-pricing-api) and set the `INFRACOST_PRICING_API_ENDPOINT` environment variable to point to it.
-
-Add the API key to your `.env.local` file:
-```
-cat <<EOF >> .env.local
-INFRACOST_API_KEY=XXX
-EOF
-```
-
-Run the code:
-```sh
-make run ARGS="--tfdir examples/terraform"
-```
-
-Run all tests:
-```sh
-make test
-```
-
-Exclude integration tests:
-```sh
-make test ARGS="-v -short"
-```
-
-Build:
-```sh
-make build
-```
-
-### Using a local version of terraform-provider-infracost
-
-To use a local development version of terraform-provider-infracost
-
-1. Fork/clone the [terraform-provider-infracost repository](https://github.com/infracost/terraform-provider-infracost)
-
-2. Inside the directory that you cloned the repository run the following to install the local version in your `~/.terraform.d/plugins` directory:
-  ```sh
-  make install
-  ```
+See [this page](https://www.infracost.io/docs/usage_based_resources) for details on cost estimation of usage-based resources.
 
 ## Contributing
 
-Pull requests are welcome! For more info, see the [CONTRIBUTING](CONTRIBUTING.md) file. For major changes, please open an issue first to discuss what you would like to change.
+Issues and pull requests are welcome! For development details, see the [CONTRIBUTING](CONTRIBUTING.md) file. For major changes, please open an issue first to discuss what you would like to change.
 
 [Join our community Slack channel](https://www.infracost.io/community-chat), we are a friendly bunch and happy to help you get started :)
 
-We're looking for people to help us add new AWS and Google resources and are willing to pay for that. Please direct-message Ali Khajeh-Hosseini on our community Slack channel to find out more!
+We're looking for people to help us add new AWS and Google resources and are willing to pay for it. Please direct-message Ali Khajeh-Hosseini on our community Slack channel to find out more.
 
 ## License
 


### PR DESCRIPTION
1. Merge macOS/Linux install steps
2. Link to docker and windows
2. Move development details to contributing page
3. Inline CI/CD and supported resources sections