### PR TITLE
chore: darwin-arm64 binaries

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,6 +31,7 @@ jobs:
             ./build/infracost-linux-amd64.tar.gz
             ./build/infracost-windows-amd64.tar.gz
             ./build/infracost-darwin-amd64.tar.gz
+            ./build/infracost-darwin-arm64.tar.gz
             ./docs/generated/docs.tar.gz
 
       - name: Build and push Docker images

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ linux:
 
 darwin:
 	env GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY)-darwin-amd64 $(PKG)
+	env GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY)-darwin-arm64 $(PKG)
 
 build_all: build windows linux darwin docs
 
@@ -43,6 +44,7 @@ release: build_all
 	cd build; tar -czf $(BINARY)-windows-amd64.tar.gz $(BINARY)-windows-amd64
 	cd build; tar -czf $(BINARY)-linux-amd64.tar.gz $(BINARY)-linux-amd64
 	cd build; tar -czf $(BINARY)-darwin-amd64.tar.gz $(BINARY)-darwin-amd64
+	cd build; tar -czf $(BINARY)-darwin-arm64.tar.gz $(BINARY)-darwin-arm64
 	cd docs/generated; tar -czvf docs.tar.gz *.md
 
 install_provider:


### PR DESCRIPTION
Saves a few watt-hours for people using the CLI with newer Mac hardware.
