### PR TITLE
Revert "chore: darwin-arm64 binaries"

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,7 +31,6 @@ jobs:
             ./build/infracost-linux-amd64.tar.gz
             ./build/infracost-windows-amd64.tar.gz
             ./build/infracost-darwin-amd64.tar.gz
-            ./build/infracost-darwin-arm64.tar.gz
             ./docs/generated/docs.tar.gz
 
       - name: Build and push Docker images

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ linux:
 
 darwin:
 	env GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY)-darwin-amd64 $(PKG)
-	env GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY)-darwin-arm64 $(PKG)
 
 build_all: build windows linux darwin docs
 
@@ -44,7 +43,6 @@ release: build_all
 	cd build; tar -czf $(BINARY)-windows-amd64.tar.gz $(BINARY)-windows-amd64
 	cd build; tar -czf $(BINARY)-linux-amd64.tar.gz $(BINARY)-linux-amd64
 	cd build; tar -czf $(BINARY)-darwin-amd64.tar.gz $(BINARY)-darwin-amd64
-	cd build; tar -czf $(BINARY)-darwin-arm64.tar.gz $(BINARY)-darwin-arm64
 	cd docs/generated; tar -czvf docs.tar.gz *.md
 
 install_provider:


### PR DESCRIPTION
Reverts infracost/infracost#287

darwin-arm64 binaries should wait until golang 1.16 release