### PR TITLE
fix(vpc_endpoint): Fix bug with counting interfaces. 

### DIFF
--- a/internal/providers/terraform/aws/vpc_endpoint.go
+++ b/internal/providers/terraform/aws/vpc_endpoint.go
@@ -20,11 +20,17 @@ func NewVpcEndpoint(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 
 	vpcEndpointType := "Gateway"
 
+	vpcEndpointInterfaces := 1
+
 	var endpointHours string
 	var endpointBytes string
 
 	if d.Get("vpc_endpoint_type").Exists() {
 		vpcEndpointType = d.Get("vpc_endpoint_type").String()
+	}
+
+	if len(d.Get("subnet_ids").Array()) > 1 {
+		vpcEndpointInterfaces = len(d.Get("subnet_ids").Array())
 	}
 
 	// Gateway endpoints don't have a cost associated with them
@@ -53,7 +59,7 @@ func NewVpcEndpoint(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 				Name:           fmt.Sprintf("%s endpoint", vpcEndpointType),
 				Unit:           "hours",
 				UnitMultiplier: 1,
-				HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+				HourlyQuantity: decimalPtr(decimal.NewFromInt(int64(vpcEndpointInterfaces))),
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("aws"),
 					Region:        strPtr(region),

--- a/internal/providers/terraform/aws/vpc_endpoint_test.go
+++ b/internal/providers/terraform/aws/vpc_endpoint_test.go
@@ -26,7 +26,18 @@ func TestVpcEndpoint(t *testing.T) {
             service_name = "com.amazonaws.region.ec2"
             vpc_id = "vpc-123456"
             vpc_endpoint_type = "GatewayLoadBalancer"
-		}`
+		}
+
+		resource "aws_vpc_endpoint" "multiple_interfaces" {
+			service_name = "com.amazonaws.region.ec2"
+			vpc_id = "vpc-123456"
+			vpc_endpoint_type = "Interface"
+			subnet_ids = [
+				"subnet-123456",
+    			"subnet-654321"
+			]
+		}
+`
 
 	resourceChecks := []testutil.ResourceCheck{
 		{
@@ -55,6 +66,21 @@ func TestVpcEndpoint(t *testing.T) {
 				{
 					Name:            "Data processed",
 					PriceHash:       "88513e1fd2a2e28b7ae752a813e771eb-b1ae3861dc57e2db217fa83a7420374f",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "aws_vpc_endpoint.multiple_interfaces",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Interface endpoint",
+					PriceHash:       "ef7fb85cbd68a47968dd294f49ed3517-d2c98780d7b6e36641b521f1f8145c6f",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+				},
+				{
+					Name:            "Data processed",
+					PriceHash:       "5fb8d7a651606fc4214684873291830f-b1ae3861dc57e2db217fa83a7420374f",
 					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},

--- a/internal/providers/terraform/aws/vpc_endpoint_test.go
+++ b/internal/providers/terraform/aws/vpc_endpoint_test.go
@@ -17,15 +17,15 @@ func TestVpcEndpoint(t *testing.T) {
 
 	tf := `
 		resource "aws_vpc_endpoint" "interface" {
-            service_name = "com.amazonaws.region.ec2"
-            vpc_id = "vpc-123456"
-            vpc_endpoint_type = "Interface"
+			service_name = "com.amazonaws.region.ec2"
+			vpc_id = "vpc-123456"
+			vpc_endpoint_type = "Interface"
 		}
 
 		resource "aws_vpc_endpoint" "gateway_loadbalancer" {
-            service_name = "com.amazonaws.region.ec2"
-            vpc_id = "vpc-123456"
-            vpc_endpoint_type = "GatewayLoadBalancer"
+			service_name = "com.amazonaws.region.ec2"
+			vpc_id = "vpc-123456"
+			vpc_endpoint_type = "GatewayLoadBalancer"
 		}
 
 		resource "aws_vpc_endpoint" "multiple_interfaces" {
@@ -34,7 +34,7 @@ func TestVpcEndpoint(t *testing.T) {
 			vpc_endpoint_type = "Interface"
 			subnet_ids = [
 				"subnet-123456",
-    			"subnet-654321"
+				"subnet-654321"
 			]
 		}
 `


### PR DESCRIPTION
VPC endpoints can create multiple interfaces across subnets. The initial implementation missed this and didn't check to see if the optional TF resource specified ``subnet_ids``. I've updated the tests to cater for this. 

fixes #327 

output from when two subnets are specified.  

```
 ✔ Running terraform init
  ✔ Running terraform plan
  ✔ Running terraform show
  ✔ Calculating cost estimate

  NAME                   MONTHLY QTY  UNIT   PRICE   HOURLY COST  MONTHLY COST

  aws_vpc_endpoint.this
  ├─ Interface endpoint        1,460  hours  0.0100       0.0200       14.6000
  └─ Data processed                -  GB     0.0100            -             -
  Total                                                   0.0200       14.6000

  OVERALL TOTAL (USD)                                     0.0200       14.6000
```