### PR TITLE
fix(aws): Use EC2 Transit Gateway's region for the attachments

### DIFF
--- a/internal/providers/terraform/aws/ec2_transit_gateway_peering_attachment.go
+++ b/internal/providers/terraform/aws/ec2_transit_gateway_peering_attachment.go
@@ -8,11 +8,18 @@ func GetEC2TransitGatewayPeeringAttachmentRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_ec2_transit_gateway_peering_attachment",
 		RFunc: NewEC2TransitGatewayPeeringAttachment,
+		ReferenceAttributes: []string{
+			"transit_gateway_id",
+		},
 	}
 }
 
 func NewEC2TransitGatewayPeeringAttachment(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := d.Get("region").String()
+	transitGatewayRefs := d.References("transit_gateway_id")
+	if len(transitGatewayRefs) > 0 {
+		region = transitGatewayRefs[0].Get("region").String()
+	}
 
 	return &schema.Resource{
 		Name: d.Address,

--- a/internal/providers/terraform/aws/ec2_transit_gateway_vpc_attachment.go
+++ b/internal/providers/terraform/aws/ec2_transit_gateway_vpc_attachment.go
@@ -10,11 +10,18 @@ func GetEC2TransitGatewayVpcAttachmentRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_ec2_transit_gateway_vpc_attachment",
 		RFunc: NewEC2TransitGatewayVpcAttachment,
+		ReferenceAttributes: []string{
+			"transit_gateway_id",
+		},
 	}
 }
 
 func NewEC2TransitGatewayVpcAttachment(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := d.Get("region").String()
+	transitGatewayRefs := d.References("transit_gateway_id")
+	if len(transitGatewayRefs) > 0 {
+		region = transitGatewayRefs[0].Get("region").String()
+	}
 
 	var gbDataProcessed *decimal.Decimal
 

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -131,7 +131,7 @@ func parseResourceData(providerConf, planVals gjson.Result, conf gjson.Result, v
 
 		// Otherwise use region from the provider conf
 		if region == "" {
-			region = providerRegion(providerConf, vars, t, resConf)
+			region = providerRegion(addr, providerConf, vars, t, resConf)
 		}
 
 		v = schema.AddRawValue(v, "region", region)
@@ -184,7 +184,7 @@ func resourceRegion(resourceType string, v gjson.Result) string {
 	return strings.Split(v.Get(arnAttr).String(), ":")[3]
 }
 
-func providerRegion(providerConf gjson.Result, vars gjson.Result, resourceType string, resConf gjson.Result) string {
+func providerRegion(addr string, providerConf gjson.Result, vars gjson.Result, resourceType string, resConf gjson.Result) string {
 	var region string
 
 	providerKey := parseProviderKey(resConf)
@@ -204,7 +204,7 @@ func providerRegion(providerConf gjson.Result, vars gjson.Result, resourceType s
 			region = defaultProviderRegions[providerPrefix]
 
 			if region != "" {
-				log.Debugf("Falling back to default region (%s) for %s", region, resConf.Get("address").String())
+				log.Debugf("Falling back to default region (%s) for %s", region, addr)
 			}
 		}
 	}


### PR DESCRIPTION
These resources don't return an ARN from the AWS API so we can't tell the region, but we can get it from their transit gateway