### PR TITLE
feat(google): add Cloud DNS resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,10 @@ The following notes are general guidelines, please leave a comment in your pull 
 
 - count: do not include the count in the Infracost name. Terraform's `count` replicates a resource in `plan.json` file. If something like `desired_count` or other cost-related count parameter is included in the `plan.json` file, do use count when calculating the HourlyQuantity/MonthlyQuantity so each line-item in the Infracost output shows the total price/cost for that line-item.
 
-- units: use plural, e.g. hours, requests, GB-months, GB (already plural). For a "unit per something", use singular per time unit, e.g. use Per GB per hour. Where it makes sense, instead of "API calls" use "API requests" or "requests" for better consistency.
+- units:
+  - use plural, e.g. hours, months, requests, GB-months, GB (already plural). For a "unit per something", use singular per time unit, e.g. use Per GB per hour. Where it makes sense, instead of "API calls" use "API requests" or "requests" for better consistency.
+
+  - for things where the Terraform resource represents 1 unit, e.g. an `aws_instance`, an `aws_secretsmanager_secret` and a `google_dns_managed_zone`, the units should be months (or hours if that makes more sense). For everything else, the units should be whatever is being charged for, e.g. queries, requests.
 
 - unit multiplier: when adding a `costComponent`, set the `UnitMultiplier` to 1 unless the price is for a large number, e.g. set it to `1000000` if the price should be shown "per 1M requests" in the output.
 
@@ -187,7 +190,7 @@ The following notes are general guidelines, please leave a comment in your pull 
 
 - storage type: if applicable, include the storage type in brackets in lower case, e.g. `General purpose storage (gp2)`.
 
-- upper/lower case: cost component names should start with a capital letter and use capital letters for acronyms, for example, `General purpose storage (gp2)` and `Provisioned IOPS storage`.
+- upper/lower case: cost component names should start with a capital letter and use capital letters for acronyms, unless the acronym refers to a type used by the cloud vendor, for example, `General purpose storage (gp2)` (as `gp2` is a type used by AWS) and `Provisioned IOPS storage`.
 
 - unnecessary words: drop the following words from cost component names if the cloud vendor's pricing webpage shows them: "Rate" "Volumes", "SSD", "HDD"
 
@@ -212,7 +215,9 @@ The following notes are general guidelines, please leave a comment in your pull 
 	}
 	```
 
-## Releasing steps
+## Release steps
+
+@alikhajeh1 and @aliscott rotate release responsibilities between them.
 
 1. In [here](https://github.com/infracost/infracost/actions), click on the "Go" build for the master branch, click on Build, expand Test, then use the "Search logs" box to find any line that has "Multiple products found", "No products found for" or "No prices found for". Update the resource files in question to fix these error, often it's because the price filters need to be adjusted to only return 1 result.
 2. In the infracost repo, run `git tag vx.y.z && git push origin vx.y.z`
@@ -222,4 +227,4 @@ The following notes are general guidelines, please leave a comment in your pull 
 6. Update the docs repo with any required changes and supported resources.
 7. Close addressed issues and tag anyone who liked/commented in them to tell them it's live in version X.
 
-If a new flag/feature is added that requires CI support, update the 9 repos mentioned in https://github.com/infracost/infracost/tree/master/scripts/ci#infracost-ci-scripts. For the GitHub Action, a new tag is needed and the release should be published on the GitHub Marketplace. For the CircleCI orb, the readme mentions the commit prefix that triggers releases to the CircleCI orb marketplace.
+If a new flag/feature is added that requires CI support, update the 9 repos mentioned [here](https://github.com/infracost/infracost/tree/master/scripts/ci#infracost-ci-scripts). For the GitHub Action, a new tag is needed and the release should be published on the GitHub Marketplace. For the CircleCI orb, the readme mentions the commit prefix that triggers releases to the CircleCI orb marketplace.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -4,6 +4,10 @@
 # See https://github.com/infracost/infracost/blob/master/infracost-usage-example.yml for available options.
 version: v0.1
 resource_usage:
+
+  #
+  # Terraform AWS resources
+  #
   aws_api_gateway_rest_api.my_rest_api:
     monthly_requests:  100000000 # Estimated monthly requests to the Rest API Gateway.
 
@@ -138,3 +142,9 @@ resource_usage:
     monthly_encryption_requests: 100000 # Estimated number of field level encryption requests per month.
     monthly_log_lines: 5000000          # Estimated number of real-time log lines per month.
     monthly_custom_ssl_certificates: 3  # Estimated number of dedicated IP custom SSL certificates per month.
+
+  #
+  # Terraform GCP resources
+  #
+  google_dns_record_set.my_record_set:
+    monthly_queries:  1000000 # Estimated monthly DNS queries.

--- a/internal/providers/terraform/aws/secretsmanager_secret.go
+++ b/internal/providers/terraform/aws/secretsmanager_secret.go
@@ -26,7 +26,7 @@ func NewSecretsManagerSecret(d *schema.ResourceData, u *schema.UsageData) *schem
 		CostComponents: []*schema.CostComponent{
 			{
 				Name:            "Secret",
-				Unit:            "secrets",
+				Unit:            "months",
 				UnitMultiplier:  1,
 				MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 				ProductFilter: &schema.ProductFilter{

--- a/internal/providers/terraform/google/dns_managed_zone.go
+++ b/internal/providers/terraform/google/dns_managed_zone.go
@@ -1,0 +1,39 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetDNSManagedZoneRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "google_dns_managed_zone",
+		RFunc: NewDNSManagedZone,
+	}
+}
+
+func NewDNSManagedZone(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:            "Managed zone",
+				Unit:            "months",
+				UnitMultiplier:  1,
+				MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr("global"),
+					Service:       strPtr("Cloud DNS"),
+					ProductFamily: strPtr("Network"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", Value: strPtr("ManagedZone")},
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					StartUsageAmount: strPtr("0"),
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/google/dns_managed_zone_test.go
+++ b/internal/providers/terraform/google/dns_managed_zone_test.go
@@ -1,0 +1,37 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+)
+
+func TestDNSManagedZone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "google_dns_managed_zone" "zone" {
+			name        = "example"
+			dns_name    = "example-123.com."
+		}
+	`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_dns_managed_zone.zone",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Managed zone",
+					PriceHash:        "ab8fb71420449113cb43ba3a1a381b24-beb6f6e797864c7d03c4cb4301c625b4",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}

--- a/internal/providers/terraform/google/dns_record_set.go
+++ b/internal/providers/terraform/google/dns_record_set.go
@@ -1,0 +1,45 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetDNSRecordSetRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "google_dns_record_set",
+		RFunc: NewDNSRecordSet,
+	}
+}
+
+func NewDNSRecordSet(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	var monthlyQueries *decimal.Decimal
+
+	if u != nil && u.Get("monthly_queries").Exists() {
+		monthlyQueries = decimalPtr(decimal.NewFromInt(u.Get("monthly_queries").Int()))
+	}
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:            "Queries",
+				Unit:            "queries",
+				UnitMultiplier:  1000000,
+				MonthlyQuantity: monthlyQueries,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr("global"),
+					Service:       strPtr("Cloud DNS"),
+					ProductFamily: strPtr("Network"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", Value: strPtr("DNS Query (port 53)")},
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					StartUsageAmount: strPtr("0"),
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/google/dns_record_set_test.go
+++ b/internal/providers/terraform/google/dns_record_set_test.go
@@ -1,0 +1,76 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+)
+
+func TestDNSRecordSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "google_dns_record_set" "frontend" {
+			name = "frontend.123"
+			type = "A"
+			ttl  = 300
+			rrdatas = ["123.123.123.123]"]
+			managed_zone = "zone"
+		}		
+	`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_dns_record_set.frontend",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Queries",
+					PriceHash:        "eceb1d425e4ccbafe3a6d1bdc3b7c93a-d1b3ead1ad60245fc548d1764c127c05",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestDNSRecordSet_usage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "google_dns_record_set" "frontend" {
+			name = "frontend.123"
+			type = "A"
+			ttl  = 300
+			rrdatas = ["123.123.123.123]"]
+			managed_zone = "zone"
+		}		
+	`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"google_dns_record_set.frontend": map[string]interface{}{
+			"monthly_queries": 100000,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_dns_record_set.frontend",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Queries",
+					PriceHash:        "eceb1d425e4ccbafe3a6d1bdc3b7c93a-d1b3ead1ad60245fc548d1764c127c05",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100000)),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -9,6 +9,8 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetComputeInstanceRegistryItem(),
 	GetComputeAddressRegistryItem(),
 	GetComputeGlobalAddressRegistryItem(),
+	GetDNSManagedZoneRegistryItem(),
+	GetDNSRecordSetRegistryItem(),
 }
 
 // FreeResources grouped alphabetically
@@ -36,6 +38,9 @@ var FreeResources []string = []string{
 	"google_compute_network_endpoint_group",
 	"google_compute_network_peering",
 	"google_compute_network_peering_routes_config",
+	"google_compute_organization_security_policy",
+	"google_compute_organization_security_policy_association",
+	"google_compute_organization_security_policy_rule",
 	"google_compute_project_default_network_tier",
 	"google_compute_project_metadata",
 	"google_compute_project_metadata_item",
@@ -56,6 +61,23 @@ var FreeResources []string = []string{
 	"google_compute_subnetwork",
 	"google_compute_subnetwork_iam",
 	"google_compute_url_map",
+	"google_dns_policy",
+	"google_project",
+	"google_project_default_service_accounts",
+	"google_project_iam_audit_config",
+	"google_project_iam_binding",
+	"google_project_iam_custom_role",
+	"google_project_iam_member",
+	"google_project_iam_policy",
+	"google_project_organization_policy",
+	"google_project_service",
+	"google_project_service_identity",
+	"google_service_account",
+	"google_service_account_iam_binding",
+	"google_service_account_iam_member",
+	"google_service_account_iam_policy",
+	"google_service_account_key",
+	"google_usage_export_bucket",
 }
 
 var UsageOnlyResources []string = []string{}
@@ -111,11 +133,7 @@ var UsageOnlyResources []string = []string{}
 // google_compute_interconnect_attachment
 //
 // Others:
-// google_compute_organization_security_policy
-// google_compute_organization_security_policy_association
-// google_compute_organization_security_policy_rule
 // google_compute_region_disk_resource_policy_attachment
 // google_compute_reservation
 // google_compute_resource_policy
 // google_compute_security_policy
-// google_usage_export_bucket


### PR DESCRIPTION
Closes https://github.com/infracost/infracost/issues/254 and https://github.com/infracost/infracost/issues/253
Also adds other free google resources and fixes a typo in aws_secretsmanager_secret

Example output:
```
  NAME                                               MONTHLY QTY  UNIT        PRICE   HOURLY COST  MONTHLY COST

  google_dns_managed_zone.example_zone
  └─ Managed zone                                              1  months      0.2000       0.0003        0.2000
  Total                                                                                    0.0003        0.2000

  google_dns_record_set.frontend
  └─ Queries                                                   1  1M queries  0.4000       0.0005        0.4000
  Total                                                                                    0.0005        0.4000

  OVERALL TOTAL (USD)                                                                      0.8079      589.8000
```