### PR TITLE
Add support for Google PubSub resources

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -148,3 +148,11 @@ resource_usage:
   #
   google_dns_record_set.my_record_set:
     monthly_queries:  1000000 # Estimated monthly DNS queries.
+
+  google_pubsub_topic.my_topic:
+    monthly_messages:        2592000 # Monthly number of messages published to the topic.
+    message_size_kb:         1024    # Average size of messages in KB.
+    subscriptions:           1       # Number of subscriptions to the topic.
+    message_retention_days:  7       # Number of days to retain acknowledged messages.
+    snapshot_retention_days: 7       # Number of days to retain snapshots.
+    monthly_snapshots:       3       # Monthly total number of snapshots for all subscriptions.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -150,9 +150,9 @@ resource_usage:
     monthly_queries:  1000000 # Estimated monthly DNS queries.
 
   google_pubsub_topic.my_topic:
-    monthly_messages:        2592000 # Monthly number of messages published to the topic.
-    message_size_kb:         1024    # Average size of messages in KB.
-    subscriptions:           1       # Number of subscriptions to the topic.
-    message_retention_days:  7       # Number of days to retain acknowledged messages.
-    snapshot_retention_days: 7       # Number of days to retain snapshots.
-    monthly_snapshots:       3       # Monthly total number of snapshots for all subscriptions.
+    monthly_message_data_tb: 7.416 # Monthly amount of message data published to the topic in TB.
+
+  google_pubsub_subscription.my_subscription:
+    monthly_message_data_tb: 7.416 # Monthly amount of message data pulled by the subscription in TB.
+    storage_gb: 605                # Storage for retaining acknowledged messages in GB.
+    snapshot_storage_gb: 70.6      # Snapshot storage for unacknowledged messages in GB.

--- a/internal/providers/terraform/google/pubsub_subscription.go
+++ b/internal/providers/terraform/google/pubsub_subscription.go
@@ -1,0 +1,89 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetPubSubSubscriptionRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "google_pubsub_subscription",
+		RFunc: NewPubSubSubscription,
+	}
+}
+
+func NewPubSubSubscription(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	var messageDataTB, storageGB, snapshotStorageGB *decimal.Decimal
+
+	if u != nil {
+		if u.Get("monthly_message_data_tb").Exists() {
+			messageDataTB = decimalPtr(decimal.NewFromFloat(u.Get("monthly_message_data_tb").Float()))
+		}
+		if u.Get("storage_gb").Exists() {
+			storageGB = decimalPtr(decimal.NewFromFloat(u.Get("storage_gb").Float()))
+		}
+		if u.Get("snapshot_storage_gb").Exists() {
+			snapshotStorageGB = decimalPtr(decimal.NewFromFloat(u.Get("snapshot_storage_gb").Float()))
+		}
+	}
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:            "Message delivery data",
+				Unit:            "TiB",
+				UnitMultiplier:  1,
+				MonthlyQuantity: messageDataTB,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr("global"),
+					Service:       strPtr("Cloud Pub/Sub"),
+					ProductFamily: strPtr("ApplicationServices"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", Value: strPtr("Message Delivery Basic")},
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					EndUsageAmount: strPtr(""),
+				},
+			},
+			{
+				Name:            "Retained acknowledged message storage",
+				Unit:            "GiB-months",
+				UnitMultiplier:  1,
+				MonthlyQuantity: storageGB,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr("global"),
+					Service:       strPtr("Cloud Pub/Sub"),
+					ProductFamily: strPtr("ApplicationServices"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", Value: strPtr("Subscriptions retained acknowledged messages")},
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					EndUsageAmount: strPtr(""),
+				},
+			},
+			{
+				Name:            "Snapshot message backlog storage",
+				Unit:            "GiB-months",
+				UnitMultiplier:  1,
+				MonthlyQuantity: snapshotStorageGB,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr("global"),
+					Service:       strPtr("Cloud Pub/Sub"),
+					ProductFamily: strPtr("ApplicationServices"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", Value: strPtr("Snapshots message backlog")},
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					EndUsageAmount: strPtr(""),
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/google/pubsub_subscription_test.go
+++ b/internal/providers/terraform/google/pubsub_subscription_test.go
@@ -1,0 +1,92 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+)
+
+func TestPubSubSubscription(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "google_pubsub_subscription" "my_subscription" {
+			name  = "example-subscription"
+			topic = "my_topic"
+		}
+	`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_pubsub_subscription.my_subscription",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Message delivery data",
+					PriceHash:        "cd1eba29e63e40fed467ba3eb7c5a6e6-a17de3a1a22680d865c82275b34c9d21",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+				{
+					Name:             "Retained acknowledged message storage",
+					PriceHash:        "2f872d150153ed13eee94c2bbcc2b69f-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+				{
+					Name:             "Snapshot message backlog storage",
+					PriceHash:        "c70f49a01dcd455baf39b999e45961d3-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestPubSubSubscription_usage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "google_pubsub_subscription" "my_subscription" {
+			name  = "example-subscription"
+			topic = "my_topic"
+		}
+	`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"google_pubsub_subscription.my_subscription": map[string]interface{}{
+			"monthly_message_data_tb": 10,
+			"storage_gb":              20,
+			"snapshot_storage_gb":     30,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_pubsub_subscription.my_subscription",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Message delivery data",
+					PriceHash:        "cd1eba29e63e40fed467ba3eb7c5a6e6-a17de3a1a22680d865c82275b34c9d21",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:             "Retained acknowledged message storage",
+					PriceHash:        "2f872d150153ed13eee94c2bbcc2b69f-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
+				},
+				{
+					Name:             "Snapshot message backlog storage",
+					PriceHash:        "c70f49a01dcd455baf39b999e45961d3-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(30)),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/google/pubsub_topic.go
+++ b/internal/providers/terraform/google/pubsub_topic.go
@@ -13,96 +13,27 @@ func GetPubSubTopicRegistryItem() *schema.RegistryItem {
 }
 
 func NewPubSubTopic(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	var messageDeliveryTB, storageGB, snapshotStorageGB *decimal.Decimal
+	var messageDataTB *decimal.Decimal
 
-	var monthlyMessages, messageSizeKB, subscriptions, messageRetentionDays, snapshotRetentionDays, monthlySnapshots *int64
-	if u != nil {
-		if u.Get("monthly_messages").Exists() {
-			monthlyMessages = int64Ptr(u.Get("monthly_messages").Int())
-		}
-		if u.Get("message_size_kb").Exists() {
-			messageSizeKB = int64Ptr(u.Get("message_size_kb").Int())
-		}
-		if u.Get("subscriptions").Exists() {
-			subscriptions = int64Ptr(u.Get("subscriptions").Int())
-		}
-		if u.Get("message_retention_days").Exists() {
-			messageRetentionDays = int64Ptr(u.Get("message_retention_days").Int())
-		}
-		if u.Get("snapshot_retention_days").Exists() {
-			snapshotRetentionDays = int64Ptr(u.Get("snapshot_retention_days").Int())
-		}
-		if u.Get("monthly_snapshots").Exists() {
-			monthlySnapshots = int64Ptr(u.Get("monthly_snapshots").Int())
-		}
-	}
-
-	if monthlyMessages != nil && messageSizeKB != nil && subscriptions != nil {
-		// Add 1 to subscriptions for the publishing, convert to TiB, subtract 0.01 as the first 10GB is free
-		messageDeliveryTB = decimalPtr(decimal.NewFromInt(*monthlyMessages * *messageSizeKB * (*subscriptions + 1)).Div(decimal.NewFromInt(1024 * 1024 * 1024)).Sub(decimal.NewFromFloat(0.01)))
-	}
-
-	if monthlyMessages != nil && messageSizeKB != nil && subscriptions != nil && messageRetentionDays != nil {
-		storageGB = decimalPtr(decimal.NewFromInt(*monthlyMessages * *messageSizeKB * *subscriptions * *messageRetentionDays).Div(decimal.NewFromInt(30 * 1024 * 1024)))
-	}
-
-	if monthlyMessages != nil && messageSizeKB != nil && subscriptions != nil && snapshotRetentionDays != nil && monthlySnapshots != nil {
-		// Needs work
-		snapshotStorageGB = decimalPtr(decimal.NewFromFloat(
-			0.5 * float64(*monthlySnapshots) * float64(*snapshotRetentionDays) * float64(*monthlyMessages/30) * float64(*messageSizeKB)).Div(decimal.NewFromInt(1024 * 1024)))
+	if u != nil && u.Get("monthly_message_data_tb").Exists() {
+		messageDataTB = decimalPtr(decimal.NewFromFloat(u.Get("monthly_message_data_tb").Float()))
 	}
 
 	return &schema.Resource{
 		Name: d.Address,
 		CostComponents: []*schema.CostComponent{
 			{
-				Name:            "Message delivery (publish)",
+				Name:            "Message ingestion data",
 				Unit:            "TiB",
 				UnitMultiplier:  1,
-				MonthlyQuantity: messageDeliveryTB,
+				MonthlyQuantity: messageDataTB,
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("gcp"),
 					Region:        strPtr("global"),
 					Service:       strPtr("Cloud Pub/Sub"),
 					ProductFamily: strPtr("ApplicationServices"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "description", Value: strPtr("Message Delivery Basic")}, // cd1eba29e63e40fed467ba3eb7c5a6e6-a17de3a1a22680d865c82275b34c9d21
-					},
-				},
-				PriceFilter: &schema.PriceFilter{
-					EndUsageAmount: strPtr(""),
-				},
-			},
-			{
-				Name:            "Storage",
-				Unit:            "GiB-months",
-				UnitMultiplier:  1,
-				MonthlyQuantity: storageGB,
-				ProductFilter: &schema.ProductFilter{
-					VendorName:    strPtr("gcp"),
-					Region:        strPtr("global"),
-					Service:       strPtr("Cloud Pub/Sub"),
-					ProductFamily: strPtr("ApplicationServices"),
-					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "description", Value: strPtr("Subscriptions retained acknowledged messages")}, // 2f872d150153ed13eee94c2bbcc2b69f-57bc5d148491a8381abaccb21ca6b4e9
-					},
-				},
-				PriceFilter: &schema.PriceFilter{
-					EndUsageAmount: strPtr(""),
-				},
-			},
-			{
-				Name:            "Snapshot storage",
-				Unit:            "GiB-months",
-				UnitMultiplier:  1,
-				MonthlyQuantity: snapshotStorageGB,
-				ProductFilter: &schema.ProductFilter{
-					VendorName:    strPtr("gcp"),
-					Region:        strPtr("global"),
-					Service:       strPtr("Cloud Pub/Sub"),
-					ProductFamily: strPtr("ApplicationServices"),
-					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "description", Value: strPtr("Snapshots message backlog")}, // c70f49a01dcd455baf39b999e45961d3-57bc5d148491a8381abaccb21ca6b4e9
+						{Key: "description", Value: strPtr("Message Delivery Basic")},
 					},
 				},
 				PriceFilter: &schema.PriceFilter{

--- a/internal/providers/terraform/google/pubsub_topic.go
+++ b/internal/providers/terraform/google/pubsub_topic.go
@@ -1,0 +1,114 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetPubSubTopicRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "google_pubsub_topic",
+		RFunc: NewPubSubTopic,
+	}
+}
+
+func NewPubSubTopic(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	var messageDeliveryTB, storageGB, snapshotStorageGB *decimal.Decimal
+
+	var monthlyMessages, messageSizeKB, subscriptions, messageRetentionDays, snapshotRetentionDays, monthlySnapshots *int64
+	if u != nil {
+		if u.Get("monthly_messages").Exists() {
+			monthlyMessages = int64Ptr(u.Get("monthly_messages").Int())
+		}
+		if u.Get("message_size_kb").Exists() {
+			messageSizeKB = int64Ptr(u.Get("message_size_kb").Int())
+		}
+		if u.Get("subscriptions").Exists() {
+			subscriptions = int64Ptr(u.Get("subscriptions").Int())
+		}
+		if u.Get("message_retention_days").Exists() {
+			messageRetentionDays = int64Ptr(u.Get("message_retention_days").Int())
+		}
+		if u.Get("snapshot_retention_days").Exists() {
+			snapshotRetentionDays = int64Ptr(u.Get("snapshot_retention_days").Int())
+		}
+		if u.Get("monthly_snapshots").Exists() {
+			monthlySnapshots = int64Ptr(u.Get("monthly_snapshots").Int())
+		}
+	}
+
+	if monthlyMessages != nil && messageSizeKB != nil && subscriptions != nil {
+		// Add 1 to subscriptions for the publishing, convert to TiB, subtract 0.01 as the first 10GB is free
+		messageDeliveryTB = decimalPtr(decimal.NewFromInt(*monthlyMessages * *messageSizeKB * (*subscriptions + 1)).Div(decimal.NewFromInt(1024 * 1024 * 1024)).Sub(decimal.NewFromFloat(0.01)))
+	}
+
+	if monthlyMessages != nil && messageSizeKB != nil && subscriptions != nil && messageRetentionDays != nil {
+		storageGB = decimalPtr(decimal.NewFromInt(*monthlyMessages * *messageSizeKB * *subscriptions * *messageRetentionDays).Div(decimal.NewFromInt(30 * 1024 * 1024)))
+	}
+
+	if monthlyMessages != nil && messageSizeKB != nil && subscriptions != nil && snapshotRetentionDays != nil && monthlySnapshots != nil {
+		// Needs work
+		snapshotStorageGB = decimalPtr(decimal.NewFromFloat(
+			0.5 * float64(*monthlySnapshots) * float64(*snapshotRetentionDays) * float64(*monthlyMessages/30) * float64(*messageSizeKB)).Div(decimal.NewFromInt(1024 * 1024)))
+	}
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:            "Message delivery (publish)",
+				Unit:            "TiB",
+				UnitMultiplier:  1,
+				MonthlyQuantity: messageDeliveryTB,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr("global"),
+					Service:       strPtr("Cloud Pub/Sub"),
+					ProductFamily: strPtr("ApplicationServices"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", Value: strPtr("Message Delivery Basic")}, // cd1eba29e63e40fed467ba3eb7c5a6e6-a17de3a1a22680d865c82275b34c9d21
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					EndUsageAmount: strPtr(""),
+				},
+			},
+			{
+				Name:            "Storage",
+				Unit:            "GiB-months",
+				UnitMultiplier:  1,
+				MonthlyQuantity: storageGB,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr("global"),
+					Service:       strPtr("Cloud Pub/Sub"),
+					ProductFamily: strPtr("ApplicationServices"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", Value: strPtr("Subscriptions retained acknowledged messages")}, // 2f872d150153ed13eee94c2bbcc2b69f-57bc5d148491a8381abaccb21ca6b4e9
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					EndUsageAmount: strPtr(""),
+				},
+			},
+			{
+				Name:            "Snapshot storage",
+				Unit:            "GiB-months",
+				UnitMultiplier:  1,
+				MonthlyQuantity: snapshotStorageGB,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr("global"),
+					Service:       strPtr("Cloud Pub/Sub"),
+					ProductFamily: strPtr("ApplicationServices"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", Value: strPtr("Snapshots message backlog")}, // c70f49a01dcd455baf39b999e45961d3-57bc5d148491a8381abaccb21ca6b4e9
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					EndUsageAmount: strPtr(""),
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/google/pubsub_topic_test.go
+++ b/internal/providers/terraform/google/pubsub_topic_test.go
@@ -1,0 +1,68 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+)
+
+func TestPubSubTopic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "google_pubsub_topic" "my_topic" {
+			name = "example-topic"
+		}
+	`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_pubsub_topic.my_topic",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Message ingestion data",
+					PriceHash:        "cd1eba29e63e40fed467ba3eb7c5a6e6-a17de3a1a22680d865c82275b34c9d21",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestPubSubTopic_usage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "google_pubsub_topic" "my_topic" {
+			name = "example-topic"
+		}
+	`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"google_pubsub_topic.my_topic": map[string]interface{}{
+			"monthly_message_data_tb": 10,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_pubsub_topic.my_topic",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Message ingestion data",
+					PriceHash:        "cd1eba29e63e40fed467ba3eb7c5a6e6-a17de3a1a22680d865c82275b34c9d21",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -11,6 +11,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetComputeGlobalAddressRegistryItem(),
 	GetDNSManagedZoneRegistryItem(),
 	GetDNSRecordSetRegistryItem(),
+	GetPubSubTopicRegistryItem(),
 }
 
 // FreeResources grouped alphabetically
@@ -72,6 +73,12 @@ var FreeResources []string = []string{
 	"google_project_organization_policy",
 	"google_project_service",
 	"google_project_service_identity",
+	"google_pubsub_subscription_iam_binding",
+	"google_pubsub_subscription_iam_member",
+	"google_pubsub_subscription_iam_policy",
+	"google_pubsub_topic_iam_binding",
+	"google_pubsub_topic_iam_member",
+	"google_pubsub_topic_iam_policy",
 	"google_service_account",
 	"google_service_account_iam_binding",
 	"google_service_account_iam_member",

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -11,6 +11,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetComputeGlobalAddressRegistryItem(),
 	GetDNSManagedZoneRegistryItem(),
 	GetDNSRecordSetRegistryItem(),
+	GetPubSubSubscriptionRegistryItem(),
 	GetPubSubTopicRegistryItem(),
 }
 

--- a/internal/providers/terraform/google/util.go
+++ b/internal/providers/terraform/google/util.go
@@ -16,10 +16,6 @@ func decimalPtr(d decimal.Decimal) *decimal.Decimal {
 	return &d
 }
 
-func int64Ptr(i int64) *int64 {
-	return &i
-}
-
 func zoneToRegion(zone string) string {
 	s := strings.Split(zone, "-")
 	return strings.Join(s[:len(s)-1], "-")

--- a/internal/providers/terraform/google/util.go
+++ b/internal/providers/terraform/google/util.go
@@ -16,6 +16,10 @@ func decimalPtr(d decimal.Decimal) *decimal.Decimal {
 	return &d
 }
 
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
 func zoneToRegion(zone string) string {
 	s := strings.Split(zone, "-")
 	return strings.Join(s[:len(s)-1], "-")


### PR DESCRIPTION
Google pubsub has 1 price that applies for both the ingestion and delivery of messages. I show the same price with a slightly different name in the subscription and topic resources. I only show the retained and snapshot prices in the subscription as they apply on a per-subscription basis so it seems best to only show them there.

```
  NAME                                          MONTHLY QTY  UNIT         PRICE    HOURLY COST  MONTHLY COST
  google_pubsub_subscription.my_subscription
  ├─ Message delivery data                            7.416  TiB          40.0000       0.4064      296.6400
  ├─ Retained acknowledged message storage              605  GiB-months    0.2700       0.2238      163.3500
  └─ Snapshot message backlog storage                  70.6  GiB-months    0.2700       0.0261       19.0620
  Total                                                                                 0.6562      479.0520

  google_pubsub_topic.my_topic
  └─ Message ingestion data                           7.416  TiB          40.0000       0.4064      296.6400
  Total                                                                                 0.4064      296.6400
```

My initial attempt (see first commit) went down a rabbit hole of trying to model the costs using message sizes, retention windows etc but it got too complicated, and might confuse users who want to enter values based on their last week/month's usage data.