### PR TITLE
Add support for Google Compute Router NAT

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -141,6 +141,10 @@ resource_usage:
   #
   # Terraform GCP resources
   #
+  google_compute_router_nat.my_nat:
+    assigned_vms: 4                 # Number of VM instances assigned to the NAT gateway
+    monthly_data_processed_gb: 1000 # Data processed (ingress and egress) by the NAT gateway per month in GB
+
   google_container_cluster.my_cluster:
     nodes: 4    # Node count per zone for the default node pool
     node_pool[0]:

--- a/internal/providers/terraform/google/compute_router_nat.go
+++ b/internal/providers/terraform/google/compute_router_nat.go
@@ -1,0 +1,66 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetComputeRouterNATRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "google_compute_router_nat",
+		RFunc: NewComputeRouterNAT,
+	}
+}
+
+func NewComputeRouterNAT(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+
+	var assignedVMs int64
+	if u != nil && u.Get("assigned_vms").Exists() {
+		assignedVMs = u.Get("assigned_vms").Int()
+		if assignedVMs > 32 {
+			assignedVMs = 32
+		}
+	}
+
+	var dataProcessedGB *decimal.Decimal
+	if u != nil && u.Get("monthly_data_processed_gb").Exists() {
+		dataProcessedGB = decimalPtr(decimal.NewFromFloat(u.Get("monthly_data_processed_gb").Float()))
+	}
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:           "Assigned VMs (first 32)",
+				Unit:           "VM-hours",
+				UnitMultiplier: 1,
+				HourlyQuantity: decimalPtr(decimal.NewFromInt(assignedVMs)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr(region),
+					Service:       strPtr("Compute Engine"),
+					ProductFamily: strPtr("Network"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", ValueRegex: strPtr("/NAT Gateway: Uptime charge/")},
+					},
+				},
+			},
+			{
+				Name:            "Data processed",
+				Unit:            "GB",
+				UnitMultiplier:  1,
+				MonthlyQuantity: dataProcessedGB,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr(region),
+					Service:       strPtr("Compute Engine"),
+					ProductFamily: strPtr("Network"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", ValueRegex: strPtr("/NAT Gateway: Data processing charge/")},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/google/compute_router_nat_test.go
+++ b/internal/providers/terraform/google/compute_router_nat_test.go
@@ -1,0 +1,79 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+)
+
+func TestComputeRouterNAT(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "google_compute_router_nat" "nat" {
+			name   = "example"
+			router = "example-router"
+			region = "us-central1"
+			nat_ip_allocate_option = "MANUAL_ONLY"
+			source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+		}
+
+		resource "google_compute_router_nat" "over_32_vms" {
+			name   = "example-over-32-vms"
+			router = "example-router"
+			region = "us-central1"
+			nat_ip_allocate_option = "MANUAL_ONLY"
+			source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+		}
+	`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"google_compute_router_nat.nat": map[string]interface{}{
+			"assigned_vms":              4,
+			"monthly_data_processed_gb": 1000,
+		},
+		"google_compute_router_nat.over_32_vms": map[string]interface{}{
+			"assigned_vms":              32,
+			"monthly_data_processed_gb": 1000,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_compute_router_nat.nat",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Assigned VMs (first 32)",
+					PriceHash:       "0d11cd10fb408a6cd1c7978fd45dfe0f-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
+				},
+				{
+					Name:             "Data processed",
+					PriceHash:        "b9cdd27fb02db0c665ae0620ebf299ac-8012a4febcd0213911ed09e53341a976",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
+				},
+			},
+		},
+		{
+			Name: "google_compute_router_nat.over_32_vms",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Assigned VMs (first 32)",
+					PriceHash:       "0d11cd10fb408a6cd1c7978fd45dfe0f-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(32)),
+				},
+				{
+					Name:             "Data processed",
+					PriceHash:        "b9cdd27fb02db0c665ae0620ebf299ac-8012a4febcd0213911ed09e53341a976",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -3,12 +3,13 @@ package google
 import "github.com/infracost/infracost/internal/schema"
 
 var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
+	GetComputeAddressRegistryItem(),
 	GetComputeDiskRegistryItem(),
+	GetComputeGlobalAddressRegistryItem(),
 	GetComputeImageRegistryItem(),
 	GetComputeSnapshotRegistryItem(),
 	GetComputeInstanceRegistryItem(),
-	GetComputeAddressRegistryItem(),
-	GetComputeGlobalAddressRegistryItem(),
+	GetComputeRouterNATRegistryItem(),
 	GetContainerClusterRegistryItem(),
 	GetContainerNodePoolRegistryItem(),
 	GetDNSManagedZoneRegistryItem(),


### PR DESCRIPTION
Google Compute Router NAT has two prices - one per assigned VM and one for data processed.
For the assigned VM price, once the VM count reaches 32 then the price does not increase further.

Terraform resource: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat

Pricing page: https://cloud.google.com/nat/pricing

Example:
```
  google_compute_router_nat.my_nat
  ├─ Per assigned VM (up to 32)                          4  VMs          0.0014        8e-06        0.0056
  └─ Data processed                                  1,000  GB           0.0450       0.0616       45.0000
  Total                                                                               0.0617       45.0056
```