### PR TITLE
AWS CodeBuild support

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -36,6 +36,9 @@ resource_usage:
     monthly_data_ingested_gb: 1000 # Data ingested by CloudWatch logs per month in GB.
     monthly_data_scanned_gb: 200   # Data scanned by CloudWatch logs insights per month in GB.
 
+  aws_codebuild_project.my_project: #
+    monthly_build_minutes: 10000
+
   aws_data_transfer.my_region:
     region: us-east-1                           # Region the data transfer is originating from.
     monthly_intra_region_gb: 1000               # Data transferred between availability zones in the region.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -36,8 +36,8 @@ resource_usage:
     monthly_data_ingested_gb: 1000 # Data ingested by CloudWatch logs per month in GB.
     monthly_data_scanned_gb: 200   # Data scanned by CloudWatch logs insights per month in GB.
 
-  aws_codebuild_project.my_project: #
-    monthly_build_minutes: 10000
+  aws_codebuild_project.my_project: 
+    monthly_build_mins: 10000 # Total duration of builds during the month in minutes. Each build is rounded up to the nearest minute.
 
   aws_data_transfer.my_region:
     region: us-east-1                           # Region the data transfer is originating from.

--- a/internal/providers/terraform/aws/codebuild_project.go
+++ b/internal/providers/terraform/aws/codebuild_project.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"fmt"
+
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
 )
@@ -40,7 +42,7 @@ func NewCodebuildProject(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 		Name: d.Address,
 		CostComponents: []*schema.CostComponent{
 			{
-				Name:            "CodeBuild instance",
+				Name:            fmt.Sprintf("CodeBuild instance (%s)", usageType),
 				Unit:            "minutes",
 				UnitMultiplier:  1,
 				MonthlyQuantity: decimalPtr(decimal.NewFromInt(monthlyBuildMinutes)),

--- a/internal/providers/terraform/aws/codebuild_project.go
+++ b/internal/providers/terraform/aws/codebuild_project.go
@@ -1,0 +1,97 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetCodebuildProjectRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_codebuild_project",
+		RFunc: NewCodebuildProject,
+	}
+}
+
+func NewCodebuildProject(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+
+	environmentComputeType := d.Get("environment.0.compute_type").String()
+	environmentType := d.Get("environment.0.type").String()
+
+	var monthlyBuildMinutes int64
+	if u != nil && u.Get("monthly_build_minutes").Exists() {
+		monthlyBuildMinutes = u.Get("monthly_build_minutes").Int()
+	}
+
+	if environmentComputeType == "BUILD_GENERAL1_SMALL" {
+		if monthlyBuildMinutes <= 100 {
+			return &schema.Resource{
+				NoPrice:   true,
+				IsSkipped: true,
+			}
+		} else {
+			monthlyBuildMinutes -= 100
+		}
+	}
+
+	usageType := SetUsageType(environmentComputeType, environmentType)
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:            "CodeBuild instance",
+				Unit:            "minutes",
+				UnitMultiplier:  1,
+				MonthlyQuantity: decimalPtr(decimal.NewFromInt(monthlyBuildMinutes)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("aws"),
+					Region:        strPtr(region),
+					Service:       strPtr("CodeBuild"),
+					ProductFamily: strPtr("Compute"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "usagetype", Value: strPtr(usageType)},
+					},
+				},
+			},
+		},
+	}
+}
+
+func SetUsageType(environmentComputeType string, environmentType string) string {
+	usageTypeTemplate := "USE1-Build-Min:"
+	environmentType = SetValidEnvironmentType(environmentType)
+	environmentComputeType = SetValidEnvironmentComputeType(environmentComputeType)
+
+	return usageTypeTemplate + environmentType + environmentComputeType
+}
+
+func SetValidEnvironmentType(environmentType string) string {
+	switch environmentType {
+	case "LINUX_CONTAINER":
+		return "Linux"
+	case "LINUX_GPU_CONTAINER":
+		return "LinuxGPU"
+	case "ARM_CONTAINER":
+		return "ARM"
+	case "WINDOWS_SERVER_2019_CONTAINER":
+		return "Windows"
+	default:
+		return ""
+	}
+}
+
+func SetValidEnvironmentComputeType(computeType string) string {
+	switch computeType {
+	case "BUILD_GENERAL1_SMALL":
+		return ":g1.small"
+	case "BUILD_GENERAL1_MEDIUM":
+		return ":g1.medium"
+	case "BUILD_GENERAL1_LARGE":
+		return ":g1.large"
+	case "BUILD_GENERAL1_2XLARGE":
+		return ":g1.2xlarge"
+	default:
+		return ""
+	}
+}

--- a/internal/providers/terraform/aws/codebuild_project.go
+++ b/internal/providers/terraform/aws/codebuild_project.go
@@ -31,9 +31,8 @@ func NewCodebuildProject(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 				NoPrice:   true,
 				IsSkipped: true,
 			}
-		} else {
-			monthlyBuildMinutes -= 100
 		}
+		monthlyBuildMinutes -= 100
 	}
 
 	usageType := SetUsageType(environmentComputeType, environmentType)

--- a/internal/providers/terraform/aws/codebuild_project_test.go
+++ b/internal/providers/terraform/aws/codebuild_project_test.go
@@ -46,7 +46,7 @@ func TestCodebuildProject(t *testing.T) {
 			Name: "aws_codebuild_project.my_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance",
+					Name:             "CodeBuild instance (USE1-Build-Min:Linux:g1.medium)",
 					PriceHash:        "a26b218d7a04b4de7dc49fc899fcbf7f-a62d9273fef0987b8d1b9a67a508acdc",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
@@ -179,7 +179,7 @@ func TestCodebuildProject_usage(t *testing.T) {
 			Name: "aws_codebuild_project.my_small_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance",
+					Name:             "CodeBuild instance (USE1-Build-Min:Linux:g1.small)",
 					PriceHash:        "78647b140df3f8c5350ab75213cac828-a62d9273fef0987b8d1b9a67a508acdc",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(1000 - 100)),
 				},
@@ -189,7 +189,7 @@ func TestCodebuildProject_usage(t *testing.T) {
 			Name: "aws_codebuild_project.my_medium_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance",
+					Name:             "CodeBuild instance (USE1-Build-Min:Linux:g1.medium)",
 					PriceHash:        "a26b218d7a04b4de7dc49fc899fcbf7f-a62d9273fef0987b8d1b9a67a508acdc",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(10000)),
 				},
@@ -199,7 +199,7 @@ func TestCodebuildProject_usage(t *testing.T) {
 			Name: "aws_codebuild_project.my_large_linux_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance",
+					Name:             "CodeBuild instance (USE1-Build-Min:Linux:g1.large)",
 					PriceHash:        "05233b2fb94a8929a2bc26c8a4000b1c-a62d9273fef0987b8d1b9a67a508acdc",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(100000)),
 				},
@@ -209,7 +209,7 @@ func TestCodebuildProject_usage(t *testing.T) {
 			Name: "aws_codebuild_project.my_large_windows_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance",
+					Name:             "CodeBuild instance (USE1-Build-Min:Windows:g1.large)",
 					PriceHash:        "a5080472369b82f5143a4c9a5b1381ee-a62d9273fef0987b8d1b9a67a508acdc",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(100000)),
 				},

--- a/internal/providers/terraform/aws/codebuild_project_test.go
+++ b/internal/providers/terraform/aws/codebuild_project_test.go
@@ -1,0 +1,221 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestCodebuildProject(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_codebuild_project" "my_project" {
+			name           = "test-project-cache"
+  		description    = "test_codebuild_project_cache"
+			
+			service_role = ""
+
+			artifacts {
+				type = "NO_ARTIFACTS"
+			}
+
+			environment {
+				compute_type                = "BUILD_GENERAL1_MEDIUM"
+				image                       = "aws/codebuild/standard:1.0"
+				type                        = "LINUX_CONTAINER"
+				image_pull_credentials_type = "CODEBUILD"
+			}
+
+			source {
+				type            = "GITHUB"
+				location        = ""
+				git_clone_depth = 1
+			}
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_codebuild_project.my_project",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "CodeBuild instance",
+					PriceHash:        "a26b218d7a04b4de7dc49fc899fcbf7f-a62d9273fef0987b8d1b9a67a508acdc",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestCodebuildProject_usage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_codebuild_project" "my_small_project" {
+			name           = "test-project-cache"
+			description    = "test_codebuild_project_cache"
+			
+			service_role = ""
+
+			artifacts {
+				type = "NO_ARTIFACTS"
+			}
+
+			environment {
+				compute_type                = "BUILD_GENERAL1_SMALL"
+				image                       = "aws/codebuild/standard:1.0"
+				type                        = "LINUX_CONTAINER"
+				image_pull_credentials_type = "CODEBUILD"
+			}
+
+			source {
+				type            = "GITHUB"
+				location        = ""
+				git_clone_depth = 1
+			}
+		}
+
+		resource "aws_codebuild_project" "my_medium_project" {
+			name           = "test-project-cache"
+  		description    = "test_codebuild_project_cache"
+			
+			service_role = ""
+
+			artifacts {
+				type = "NO_ARTIFACTS"
+			}
+
+			environment {
+				compute_type                = "BUILD_GENERAL1_MEDIUM"
+				image                       = "aws/codebuild/standard:1.0"
+				type                        = "LINUX_CONTAINER"
+				image_pull_credentials_type = "CODEBUILD"
+			}
+
+			source {
+				type            = "GITHUB"
+				location        = ""
+				git_clone_depth = 1
+			}
+		}
+
+		resource "aws_codebuild_project" "my_large_linux_project" {
+			name           = "test-project-cache"
+  		description    = "test_codebuild_project_cache"
+			
+			service_role = ""
+
+			artifacts {
+				type = "NO_ARTIFACTS"
+			}
+
+			environment {
+				compute_type                = "BUILD_GENERAL1_LARGE"
+				image                       = "aws/codebuild/standard:1.0"
+				type                        = "LINUX_CONTAINER"
+				image_pull_credentials_type = "CODEBUILD"
+			}
+
+			source {
+				type            = "GITHUB"
+				location        = ""
+				git_clone_depth = 1
+			}
+		}
+		
+		resource "aws_codebuild_project" "my_large_windows_project" {
+			name           = "test-project-cache"
+  		description    = "test_codebuild_project_cache"
+			
+			service_role = ""
+
+			artifacts {
+				type = "NO_ARTIFACTS"
+			}
+
+			environment {
+				compute_type                = "BUILD_GENERAL1_LARGE"
+				image                       = "aws/codebuild/standard:1.0"
+				type                        = "WINDOWS_SERVER_2019_CONTAINER"
+				image_pull_credentials_type = "CODEBUILD"
+			}
+
+			source {
+				type            = "GITHUB"
+				location        = ""
+				git_clone_depth = 1
+			}
+		}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_codebuild_project.my_small_project": map[string]interface{}{
+			"monthly_build_minutes": 1000,
+		},
+		"aws_codebuild_project.my_medium_project": map[string]interface{}{
+			"monthly_build_minutes": 10000,
+		},
+		"aws_codebuild_project.my_large_linux_project": map[string]interface{}{
+			"monthly_build_minutes": 100000,
+		},
+		"aws_codebuild_project.my_large_windows_project": map[string]interface{}{
+			"monthly_build_minutes": 100000,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_codebuild_project.my_small_project",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "CodeBuild instance",
+					PriceHash:        "78647b140df3f8c5350ab75213cac828-a62d9273fef0987b8d1b9a67a508acdc",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(1000 - 100)),
+				},
+			},
+		},
+		{
+			Name: "aws_codebuild_project.my_medium_project",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "CodeBuild instance",
+					PriceHash:        "a26b218d7a04b4de7dc49fc899fcbf7f-a62d9273fef0987b8d1b9a67a508acdc",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(10000)),
+				},
+			},
+		},
+		{
+			Name: "aws_codebuild_project.my_large_linux_project",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "CodeBuild instance",
+					PriceHash:        "05233b2fb94a8929a2bc26c8a4000b1c-a62d9273fef0987b8d1b9a67a508acdc",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(100000)),
+				},
+			},
+		},
+		{
+			Name: "aws_codebuild_project.my_large_windows_project",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "CodeBuild instance",
+					PriceHash:        "a5080472369b82f5143a4c9a5b1381ee-a62d9273fef0987b8d1b9a67a508acdc",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(100000)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/aws/codebuild_project_test.go
+++ b/internal/providers/terraform/aws/codebuild_project_test.go
@@ -46,7 +46,7 @@ func TestCodebuildProject(t *testing.T) {
 			Name: "aws_codebuild_project.my_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance (USE1-Build-Min:Linux:g1.medium)",
+					Name:             "Linux (general1.medium)",
 					PriceHash:        "a26b218d7a04b4de7dc49fc899fcbf7f-a62d9273fef0987b8d1b9a67a508acdc",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
@@ -161,16 +161,16 @@ func TestCodebuildProject_usage(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_codebuild_project.my_small_project": map[string]interface{}{
-			"monthly_build_minutes": 1000,
+			"monthly_build_mins": 1000,
 		},
 		"aws_codebuild_project.my_medium_project": map[string]interface{}{
-			"monthly_build_minutes": 10000,
+			"monthly_build_mins": 10000,
 		},
 		"aws_codebuild_project.my_large_linux_project": map[string]interface{}{
-			"monthly_build_minutes": 100000,
+			"monthly_build_mins": 100000,
 		},
 		"aws_codebuild_project.my_large_windows_project": map[string]interface{}{
-			"monthly_build_minutes": 100000,
+			"monthly_build_mins": 100000,
 		},
 	})
 
@@ -179,9 +179,9 @@ func TestCodebuildProject_usage(t *testing.T) {
 			Name: "aws_codebuild_project.my_small_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance (USE1-Build-Min:Linux:g1.small)",
+					Name:             "Linux (general1.small)",
 					PriceHash:        "78647b140df3f8c5350ab75213cac828-a62d9273fef0987b8d1b9a67a508acdc",
-					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(1000 - 100)),
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(1000)),
 				},
 			},
 		},
@@ -189,7 +189,7 @@ func TestCodebuildProject_usage(t *testing.T) {
 			Name: "aws_codebuild_project.my_medium_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance (USE1-Build-Min:Linux:g1.medium)",
+					Name:             "Linux (general1.medium)",
 					PriceHash:        "a26b218d7a04b4de7dc49fc899fcbf7f-a62d9273fef0987b8d1b9a67a508acdc",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(10000)),
 				},
@@ -199,7 +199,7 @@ func TestCodebuildProject_usage(t *testing.T) {
 			Name: "aws_codebuild_project.my_large_linux_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance (USE1-Build-Min:Linux:g1.large)",
+					Name:             "Linux (general1.large)",
 					PriceHash:        "05233b2fb94a8929a2bc26c8a4000b1c-a62d9273fef0987b8d1b9a67a508acdc",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(100000)),
 				},
@@ -209,7 +209,7 @@ func TestCodebuildProject_usage(t *testing.T) {
 			Name: "aws_codebuild_project.my_large_windows_project",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "CodeBuild instance (USE1-Build-Min:Windows:g1.large)",
+					Name:             "Windows (general1.large)",
 					PriceHash:        "a5080472369b82f5143a4c9a5b1381ee-a62d9273fef0987b8d1b9a67a508acdc",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat(100000)),
 				},

--- a/internal/providers/terraform/aws/codebuild_project_test.go
+++ b/internal/providers/terraform/aws/codebuild_project_test.go
@@ -48,7 +48,7 @@ func TestCodebuildProject(t *testing.T) {
 				{
 					Name:             "Linux (general1.medium)",
 					PriceHash:        "a26b218d7a04b4de7dc49fc899fcbf7f-a62d9273fef0987b8d1b9a67a508acdc",
-					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -13,6 +13,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetCloudwatchDashboardRegistryItem(),
 	GetCloudwatchLogGroupItem(),
 	GetCloudwatchMetricAlarmRegistryItem(),
+	GetCodebuildProjectRegistryItem(),
 	GetDataTransferRegistryItem(),
 	GetDBInstanceRegistryItem(),
 	GetDMSRegistryItem(),
@@ -118,6 +119,11 @@ var FreeResources []string = []string{
 	"aws_cloudwatch_log_resource_policy",
 	"aws_cloudwatch_log_stream",
 	"aws_cloudwatch_log_subscription_filter",
+
+	// AWS CodeBuild
+	"aws_codebuild_report_group",
+	"aws_codebuild_source_credential",
+	"aws_codebuild_webhook",
 
 	// AWS ECR
 	"aws_ecr_lifecycle_policy",


### PR DESCRIPTION
Issue #193  

```
NAME                                          MONTHLY QTY  UNIT     PRICE   HOURLY COST  MONTHLY COST  

aws_codebuild_project.my_project                                                                       
└─ Linux (general1.2xlarge)                        10,000  minutes  0.2500       3.4247    2,500.0000  
Total                                                                            3.4247    2,500.0000 
```


When user wants to use this resource, Amazon requires fields such as "BUILD_GENERAL1_SMALL" and "LINUX_CONTAINER" for "Compute Type" and "Type" in the environment. But when we requesting the price of CodeBuild, it does not allow transferring the environment.type - this is the reason why I had to create and use the usagetype attribute.