### PR TITLE
fix(terraform): parse region from values if exists

### DIFF
--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -184,6 +184,12 @@ func resourceRegion(resourceType string, v gjson.Result) string {
 		return ""
 	}
 
+	// If a region key exists in the values use that
+	if v.Get("region").String() != "" {
+		return v.Get("region").String()
+	}
+
+	// Otherwise try and parse the ARN from the values
 	arnAttr, ok := arnAttributeMap[resourceType]
 	if !ok {
 		arnAttr = "arn"


### PR DESCRIPTION
S3 buckets ARNs look like `arn:aws:s3:::bucket1` so they don't include a region key. In this case S3 buckets also pass a "region" value in the response so we can parse that out and use it as the region.