### PR TITLE
fix(flags): fix -o flag deprecation

### DIFF
--- a/cmd/infracost/default.go
+++ b/cmd/infracost/default.go
@@ -52,10 +52,11 @@ func defaultCmd(cfg *config.Config) *cli.Command {
 			Hidden: true,
 		},
 		&cli.StringFlag{
-			Name:   "output",
-			Usage:  "Output format: json, table, html",
-			Value:  "table",
-			Hidden: true,
+			Name:    "output",
+			Aliases: []string{"o"},
+			Usage:   "Output format: json, table, html",
+			Value:   "table",
+			Hidden:  true,
 		},
 	}
 


### PR DESCRIPTION
Shows the following output:

```
Flag --tfdir is deprecated and will be removed in v0.8.0. Please use --terraform-dir.

Flag --output/-o is deprecated and will be removed in v0.8.0. Please use --format.
```