### PR TITLE
fix(flags): Adding no-color support to report

### DIFF
--- a/cmd/infracost/default.go
+++ b/cmd/infracost/default.go
@@ -185,6 +185,7 @@ func loadDefaultCmdFlags(cfg *config.Config, c *cli.Context) error {
 	if hasOutputFlags {
 		outputCfg.Format = c.String("format")
 		outputCfg.ShowSkipped = c.Bool("show-skipped")
+		outputCfg.NoColor = c.Bool("no-color")
 	}
 
 	return nil
@@ -309,7 +310,7 @@ func defaultMain(cfg *config.Config) error {
 
 		opts := output.Options{
 			ShowSkipped: outputCfg.ShowSkipped,
-			NoColor:     cfg.NoColor,
+			NoColor:     outputCfg.NoColor,
 		}
 
 		var (

--- a/cmd/infracost/report.go
+++ b/cmd/infracost/report.go
@@ -32,6 +32,11 @@ func reportCmd(cfg *config.Config) *cli.Command {
 			Usage: "Show unsupported resources, some of which might be free. Only for table and HTML output",
 			Value: false,
 		},
+		&cli.BoolFlag{
+			Name:  "no-color",
+			Usage: "Turn off colored output",
+			Value: false,
+		},
 	)
 
 	return &cli.Command{
@@ -81,7 +86,7 @@ EXAMPLES:
 
 			opts := output.Options{
 				ShowSkipped: c.Bool("show-skipped"),
-				NoColor:     cfg.NoColor,
+				NoColor:     c.Bool("no-color"),
 				GroupKey:    "filename",
 				GroupLabel:  "File",
 			}
@@ -91,6 +96,7 @@ EXAMPLES:
 			outputCfg := &config.Output{
 				Format:      c.String("format"),
 				ShowSkipped: c.Bool("show-skipped"),
+				NoColor:     c.Bool("no-color"),
 			}
 
 			var (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type Output struct {
 	Format      string   `yaml:"format,omitempty" ignored:"true"`
 	Columns     []string `yaml:"columns,omitempty" ignored:"true"`
 	ShowSkipped bool     `yaml:"show_skipped,omitempty" ignored:"true"`
+	NoColor     bool     `yaml:"no_color,omitempty" ignored:"true"`
 	Path        string   `yaml:"path,omitempty" ignored:"true"`
 }
 


### PR DESCRIPTION
`--no-color` flag on `infracost report` returns the following error:

```
flag provided but not defined: -no-color
```

This fixes an issue with the configuration option to behave like `--show-skipped`.