### PR TITLE
feat(aws): Adds support for EFS.

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -65,13 +65,10 @@ resource_usage:
     storage_gb: 1 # Total size of ECR repository in GB.
 
   aws_efs_file_system.my_file_system:
-    storage_gb: 230
-    infrequent_access_storage_gb: 100
-
-  aws_efs_file_system.ia_access:
-    storage_gb: 230 # Monthly EFS standard storage in GB on EFS volume
-    infrequent_access_storage_gb: 100  # Monthly EFS infrequent access storage in GB in.
-    infrequent_access_requests_gb: 100 # Monthly access requests in GB for both read & write requests.
+    storage_gb: 230 # Monthly EFS standard storage in GB.
+    infrequent_access_storage_gb: 100 # Monthly amount in GB that is used within IA Storage tier.
+    infrequent_access_read_requests_gb: 50 # Monthly access requests in GB for reading of data.
+    infrequent_access_write_requests_gb: 100 # Monthly access requests in GB for both writing of data.
 
   aws_instance.windows_instance:
     operating_system: windows # Override the operating system of the instance, can be: windows, suse, rhel.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -65,10 +65,10 @@ resource_usage:
     storage_gb: 1 # Total size of ECR repository in GB.
 
   aws_efs_file_system.my_file_system:
-    storage_gb: 230 # Monthly EFS standard storage in GB.
-    infrequent_access_storage_gb: 100 # Monthly amount in GB that is used within IA Storage tier.
-    infrequent_access_read_requests_gb: 50 # Monthly access requests in GB for reading of data.
-    infrequent_access_write_requests_gb: 100 # Monthly access requests in GB for both writing of data.
+    storage_gb: 230                         # Total storage for Standard class in GB.
+    infrequent_access_storage_gb: 100       # Total storage for Infrequent Access class in GB.
+    monthly_infrequent_access_read_gb: 50   # Monthly infrequent access read requests in GB.
+    monthly_infrequent_access_write_gb: 100 # Monthly infrequent access write requests in GB.
 
   aws_instance.windows_instance:
     operating_system: windows # Override the operating system of the instance, can be: windows, suse, rhel.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -64,6 +64,15 @@ resource_usage:
   aws_ecr_repository.my_repository:
     storage_gb: 1 # Total size of ECR repository in GB.
 
+  aws_efs_file_system.my_file_system:
+    storage_gb: 230
+    infrequent_access_storage_gb: 100
+
+  aws_efs_file_system.ia_access:
+    storage_gb: 230 # Monthly EFS standard storage in GB on EFS volume
+    infrequent_access_storage_gb: 100  # Monthly EFS infrequent access storage in GB in.
+    infrequent_access_requests_gb: 100 # Monthly access requests in GB for both read & write requests.
+
   aws_instance.windows_instance:
     operating_system: windows # Override the operating system of the instance, can be: windows, suse, rhel.
 

--- a/internal/providers/terraform/aws/efs_file_system.go
+++ b/internal/providers/terraform/aws/efs_file_system.go
@@ -66,9 +66,14 @@ func NewEFSFileSystem(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 			infrequentAccessGbStorage = decimalPtr(decimal.NewFromFloat(u.Get("infrequent_access_storage_gb").Float()))
 		}
 
-		var infrequentAccessGbRequests *decimal.Decimal
-		if u != nil && u.Get("infrequent_access_requests_gb").Exists() {
-			infrequentAccessGbRequests = decimalPtr(decimal.NewFromFloat(u.Get("infrequent_access_requests_gb").Float()))
+		var infrequentAccessReadGbRequests *decimal.Decimal
+		if u != nil && u.Get("infrequent_access_read_requests_gb").Exists() {
+			infrequentAccessReadGbRequests = decimalPtr(decimal.NewFromFloat(u.Get("infrequent_access_read_requests_gb").Float()))
+		}
+
+		var infrequentAccessWriteGbRequests *decimal.Decimal
+		if u != nil && u.Get("infrequent_access_write_requests_gb").Exists() {
+			infrequentAccessWriteGbRequests = decimalPtr(decimal.NewFromFloat(u.Get("infrequent_access_write_requests_gb").Float()))
 		}
 
 		costComponents = append(costComponents, &schema.CostComponent{
@@ -88,10 +93,26 @@ func NewEFSFileSystem(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		})
 
 		costComponents = append(costComponents, &schema.CostComponent{
-			Name:            "Requests (infrequent access)",
+			Name:            "Requests (infrequent access - read)",
 			Unit:            "GB",
 			UnitMultiplier:  1,
-			MonthlyQuantity: infrequentAccessGbRequests,
+			MonthlyQuantity: infrequentAccessReadGbRequests,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonEFS"),
+				ProductFamily: strPtr("Storage"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "accessType", Value: strPtr("Read")},
+				},
+			},
+		})
+
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            "Requests (infrequent access - write)",
+			Unit:            "GB",
+			UnitMultiplier:  1,
+			MonthlyQuantity: infrequentAccessWriteGbRequests,
 			ProductFilter: &schema.ProductFilter{
 				VendorName:    strPtr("aws"),
 				Region:        strPtr(region),

--- a/internal/providers/terraform/aws/efs_file_system.go
+++ b/internal/providers/terraform/aws/efs_file_system.go
@@ -67,13 +67,13 @@ func NewEFSFileSystem(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		}
 
 		var infrequentAccessReadGbRequests *decimal.Decimal
-		if u != nil && u.Get("infrequent_access_read_requests_gb").Exists() {
-			infrequentAccessReadGbRequests = decimalPtr(decimal.NewFromFloat(u.Get("infrequent_access_read_requests_gb").Float()))
+		if u != nil && u.Get("monthly_infrequent_access_read_gb").Exists() {
+			infrequentAccessReadGbRequests = decimalPtr(decimal.NewFromFloat(u.Get("monthly_infrequent_access_read_gb").Float()))
 		}
 
 		var infrequentAccessWriteGbRequests *decimal.Decimal
-		if u != nil && u.Get("infrequent_access_write_requests_gb").Exists() {
-			infrequentAccessWriteGbRequests = decimalPtr(decimal.NewFromFloat(u.Get("infrequent_access_write_requests_gb").Float()))
+		if u != nil && u.Get("monthly_infrequent_access_write_gb").Exists() {
+			infrequentAccessWriteGbRequests = decimalPtr(decimal.NewFromFloat(u.Get("monthly_infrequent_access_write_gb").Float()))
 		}
 
 		costComponents = append(costComponents, &schema.CostComponent{
@@ -93,7 +93,7 @@ func NewEFSFileSystem(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		})
 
 		costComponents = append(costComponents, &schema.CostComponent{
-			Name:            "Requests (infrequent access - read)",
+			Name:            "Read requests (infrequent access)",
 			Unit:            "GB",
 			UnitMultiplier:  1,
 			MonthlyQuantity: infrequentAccessReadGbRequests,
@@ -109,7 +109,7 @@ func NewEFSFileSystem(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		})
 
 		costComponents = append(costComponents, &schema.CostComponent{
-			Name:            "Requests (infrequent access - write)",
+			Name:            "Write requests (infrequent access)",
 			Unit:            "GB",
 			UnitMultiplier:  1,
 			MonthlyQuantity: infrequentAccessWriteGbRequests,

--- a/internal/providers/terraform/aws/efs_file_system.go
+++ b/internal/providers/terraform/aws/efs_file_system.go
@@ -1,0 +1,123 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+	"github.com/tidwall/gjson"
+)
+
+func GetEFSFileSystemRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_efs_file_system",
+		RFunc: NewEFSFileSystem,
+	}
+}
+
+func NewEFSFileSystem(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+
+	costComponents := make([]*schema.CostComponent, 0)
+
+	var gbStorage *decimal.Decimal
+	if u != nil && u.Get("storage_gb").Exists() {
+		gbStorage = decimalPtr(decimal.NewFromFloat(u.Get("storage_gb").Float()))
+	}
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Storage (standard)",
+		Unit:            "GB-months",
+		UnitMultiplier:  1,
+		MonthlyQuantity: gbStorage,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEFS"),
+			ProductFamily: strPtr("Storage"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr("/-TimedStorage-ByteHrs/")},
+			},
+		},
+	})
+
+	if d.Get("provisioned_throughput_in_mibps").Exists() && d.Get("provisioned_throughput_in_mibps").Type != gjson.Null {
+		throughput := decimal.NewFromFloat(d.Get("provisioned_throughput_in_mibps").Float())
+		provisionedThroughput := calculateProvisionedThroughput(gbStorage, throughput)
+
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            "Provisioned throughput",
+			Unit:            "MBps-months",
+			UnitMultiplier:  1,
+			MonthlyQuantity: decimalPtr(provisionedThroughput),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonEFS"),
+				ProductFamily: strPtr("Provisioned Throughput"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/ProvisionedTP-MiBpsHrs/")},
+				},
+			},
+		})
+	}
+
+	if len(d.Get("lifecycle_policy").Array()) > 0 {
+		var infrequentAccessGbStorage *decimal.Decimal
+		if u != nil && u.Get("infrequent_access_storage_gb").Exists() {
+			infrequentAccessGbStorage = decimalPtr(decimal.NewFromFloat(u.Get("infrequent_access_storage_gb").Float()))
+		}
+
+		var infrequentAccessGbRequests *decimal.Decimal
+		if u != nil && u.Get("infrequent_access_requests_gb").Exists() {
+			infrequentAccessGbRequests = decimalPtr(decimal.NewFromFloat(u.Get("infrequent_access_requests_gb").Float()))
+		}
+
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            "Storage (infrequent access)",
+			Unit:            "GB-months",
+			UnitMultiplier:  1,
+			MonthlyQuantity: infrequentAccessGbStorage,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonEFS"),
+				ProductFamily: strPtr("Storage"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr("/-IATimedStorage-ByteHrs/")},
+				},
+			},
+		})
+
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            "Requests (infrequent access)",
+			Unit:            "GB",
+			UnitMultiplier:  1,
+			MonthlyQuantity: infrequentAccessGbRequests,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonEFS"),
+				ProductFamily: strPtr("Storage"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "accessType", Value: strPtr("Write")},
+				},
+			},
+		})
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}
+
+func calculateProvisionedThroughput(gbStorage *decimal.Decimal, throughput decimal.Decimal) decimal.Decimal {
+	defaultThroughput := gbStorage.Mul(decimal.NewFromInt(730).Div(decimal.NewFromInt(20).Mul(decimal.NewFromInt(1))))
+	totalProvisionedThroughput := throughput.Mul(decimal.NewFromInt(730))
+	totalBillableProvisionedThroughput := totalProvisionedThroughput.Sub(defaultThroughput).Div(decimal.NewFromInt(730))
+
+	if totalBillableProvisionedThroughput.IsPositive() {
+		return totalBillableProvisionedThroughput
+	}
+
+	return decimal.Zero
+}

--- a/internal/providers/terraform/aws/efs_file_system_test.go
+++ b/internal/providers/terraform/aws/efs_file_system_test.go
@@ -52,9 +52,9 @@ func TestNewEFSFileSystemIAStorage(t *testing.T) {
 	`
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_efs_file_system.ia_storage": map[string]interface{}{
-			"storage_gb":                    230,
-			"infrequent_access_storage_gb":  100,
-			"infrequent_access_read_requests_gb": 50,
+			"storage_gb":                          230,
+			"infrequent_access_storage_gb":        100,
+			"infrequent_access_read_requests_gb":  50,
 			"infrequent_access_write_requests_gb": 100,
 		},
 	})

--- a/internal/providers/terraform/aws/efs_file_system_test.go
+++ b/internal/providers/terraform/aws/efs_file_system_test.go
@@ -54,7 +54,8 @@ func TestNewEFSFileSystemIAStorage(t *testing.T) {
 		"aws_efs_file_system.ia_storage": map[string]interface{}{
 			"storage_gb":                    230,
 			"infrequent_access_storage_gb":  100,
-			"infrequent_access_requests_gb": 100,
+			"infrequent_access_read_requests_gb": 50,
+			"infrequent_access_write_requests_gb": 100,
 		},
 	})
 
@@ -73,9 +74,14 @@ func TestNewEFSFileSystemIAStorage(t *testing.T) {
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
 				},
 				{
-					Name:             "Requests (infrequent access)",
+					Name:             "Requests (infrequent access - write)",
 					PriceHash:        "86d91c810b14b77cac328f9fcd26459b-b1ae3861dc57e2db217fa83a7420374f",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
+				},
+				{
+					Name:             "Requests (infrequent access - read)",
+					PriceHash:        "5560def6568a03a8cb3d474a588867ce-b1ae3861dc57e2db217fa83a7420374f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(50)),
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/efs_file_system_test.go
+++ b/internal/providers/terraform/aws/efs_file_system_test.go
@@ -1,0 +1,123 @@
+package aws_test
+
+import (
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+	"testing"
+)
+
+func TestNewEFSFileSystemStandardStorage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_efs_file_system" "standard_storage" {}
+	`
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_efs_file_system.standard_storage": map[string]interface{}{
+			"storage_gb": 230,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_efs_file_system.standard_storage",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage (standard)",
+					PriceHash:        "032f12a61bc85ad77fd0e9fd5c1e6e3c-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(230)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}
+
+func TestNewEFSFileSystemIAStorage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_efs_file_system" "ia_storage" {
+			lifecycle_policy {
+				transition_to_ia = "AFTER_7_DAYS"
+			}
+		}
+	`
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_efs_file_system.ia_storage": map[string]interface{}{
+			"storage_gb":                    230,
+			"infrequent_access_storage_gb":  100,
+			"infrequent_access_requests_gb": 100,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_efs_file_system.ia_storage",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage (standard)",
+					PriceHash:        "032f12a61bc85ad77fd0e9fd5c1e6e3c-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(230)),
+				},
+				{
+					Name:             "Storage (infrequent access)",
+					PriceHash:        "05a47659d1d78c2d60de3f9165b10a42-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
+				},
+				{
+					Name:             "Requests (infrequent access)",
+					PriceHash:        "86d91c810b14b77cac328f9fcd26459b-b1ae3861dc57e2db217fa83a7420374f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}
+
+func TestNewEFSFileSystemProvisionedThroughput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_efs_file_system" "provisioned" {
+			provisioned_throughput_in_mibps = 100
+			throughput_mode = "provisioned"
+		}
+	`
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_efs_file_system.provisioned": map[string]interface{}{
+			"storage_gb": 230,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_efs_file_system.provisioned",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage (standard)",
+					PriceHash:        "032f12a61bc85ad77fd0e9fd5c1e6e3c-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(230)),
+				},
+				{
+					Name:             "Provisioned throughput",
+					PriceHash:        "41da10cb418495b3e0848200857f2d4d-8191dc82cee9b89717087e447a40abbd",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromFloat((100*730 - (230.00*730)/20*1) / 730)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/aws/efs_file_system_test.go
+++ b/internal/providers/terraform/aws/efs_file_system_test.go
@@ -1,11 +1,12 @@
 package aws_test
 
 import (
+	"testing"
+
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/infracost/infracost/internal/testutil"
 	"github.com/shopspring/decimal"
-	"testing"
 )
 
 func TestNewEFSFileSystemStandardStorage(t *testing.T) {
@@ -52,10 +53,10 @@ func TestNewEFSFileSystemIAStorage(t *testing.T) {
 	`
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_efs_file_system.ia_storage": map[string]interface{}{
-			"storage_gb":                          230,
-			"infrequent_access_storage_gb":        100,
-			"infrequent_access_read_requests_gb":  50,
-			"infrequent_access_write_requests_gb": 100,
+			"storage_gb":                         230,
+			"infrequent_access_storage_gb":       100,
+			"monthly_infrequent_access_read_gb":  50,
+			"monthly_infrequent_access_write_gb": 100,
 		},
 	})
 
@@ -74,12 +75,12 @@ func TestNewEFSFileSystemIAStorage(t *testing.T) {
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
 				},
 				{
-					Name:             "Requests (infrequent access - write)",
+					Name:             "Write requests (infrequent access)",
 					PriceHash:        "86d91c810b14b77cac328f9fcd26459b-b1ae3861dc57e2db217fa83a7420374f",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
 				},
 				{
-					Name:             "Requests (infrequent access - read)",
+					Name:             "Read requests (infrequent access)",
 					PriceHash:        "5560def6568a03a8cb3d474a588867ce-b1ae3861dc57e2db217fa83a7420374f",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(50)),
 				},

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -30,6 +30,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetEC2TransitGatewayVpcAttachmentRegistryItem(),
 	GetECRRegistryItem(),
 	GetECSServiceRegistryItem(),
+	GetEFSFileSystemRegistryItem(),
 	GetEIPRegistryItem(),
 	GetElastiCacheClusterItem(),
 	GetElastiCacheReplicationGroupItem(),


### PR DESCRIPTION
Objective: closes #388 

```
 aws_efs_file_system.ia_access                                                                              
  ├─ Storage (standard)                                 230  GB-months    0.3300       0.1040       75.9000  
  ├─ Storage (infrequent access)                        100  GB-months    0.0250       0.0034        2.5000  
  └─ Requests (infrequent access)                       100  GB           0.0110       0.0015        1.1000  
  Total                                                                                0.1089       79.5000  
                                                                                                             
  aws_efs_file_system.my_file_system                                                                         
  ├─ Storage (standard)                                 230  GB-months    0.3300       0.1040       75.9000  
  └─ Provisioned throughput                           90.51  MBps-months  6.6000       0.8183      597.3660  
  Total                                                                                0.9223      673.2660  
                                                                                                             
  OVERALL TOTAL (USD)                                                                  1.6339    1,192.7660  

```

This currently supports fixed quantities when using IA storage access, also ``Requests``  to access data on the IA tier are whole and are the total amount of read / write requests.


