### PR TITLE
feat: add gp3 support

### DIFF
--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -29,6 +29,12 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 				device_name = "xvdf"
 				volume_size = 10
 			}
+
+			ebs_block_device {
+				device_name = "xvdg"
+				volume_type = "gp3"
+				volume_size = 10
+			}
 		}
 
 		resource "aws_autoscaling_group" "asg1" {
@@ -73,6 +79,16 @@ func TestAutoscalingGroup_launchConfiguration(t *testing.T) {
 								{
 									Name:             "General Purpose SSD storage (gp2)",
 									PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
+									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
+								},
+							},
+						},
+						{
+							Name: "ebs_block_device[1]",
+							CostComponentChecks: []testutil.CostComponentCheck{
+								{
+									Name:             "General Purpose SSD storage (gp3)",
+									PriceHash:        "b7a83d535d47fcfd1be68ec37f046b3d-ee3dd7e4624338037ca6fea0933a662f",
 									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
 								},
 							},

--- a/internal/providers/terraform/aws/ebs_volume.go
+++ b/internal/providers/terraform/aws/ebs_volume.go
@@ -59,6 +59,8 @@ func ebsVolumeCostComponents(region string, volumeAPIName string, gbVal decimal.
 		name = "Throughput Optimized HDD storage (st1)"
 	case "sc1":
 		name = "Cold HDD storage (sc1)"
+	case "gp3":
+		name = "General Purpose SSD storage (gp3)"
 	default:
 		name = "General Purpose SSD storage (gp2)"
 	}

--- a/internal/providers/terraform/aws/ebs_volume_test.go
+++ b/internal/providers/terraform/aws/ebs_volume_test.go
@@ -158,7 +158,7 @@ func TestEBSVolume_GP3(t *testing.T) {
 				{
 					Name:             "General Purpose SSD storage (gp3)",
 					PriceHash:        "b7a83d535d47fcfd1be68ec37f046b3d-ee3dd7e4624338037ca6fea0933a662f",
-					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(40)),
 				},
 			},
 		},

--- a/internal/providers/terraform/aws/ebs_volume_test.go
+++ b/internal/providers/terraform/aws/ebs_volume_test.go
@@ -134,3 +134,35 @@ func TestEBSVolume(t *testing.T) {
 
 	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
 }
+
+func TestEBSVolume_GP3(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "aws_ebs_volume" "gp3" {
+		availability_zone = "us-west-2a"
+		size              = 40
+		type = "gp3"
+		
+		tags = {
+			Name = "HelloWorld"
+		}
+	}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_ebs_volume.gp3",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "General Purpose SSD storage (gp3)",
+					PriceHash:        "b7a83d535d47fcfd1be68ec37f046b3d-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -48,6 +48,12 @@ func TestInstance(t *testing.T) {
 				volume_size = 40
 				iops        = 1000
 			}
+
+			ebs_block_device {
+				device_name = "xvdj"
+				volume_type = "gp3"
+				volume_size = 20
+			}
 		}`
 
 	resourceChecks := []testutil.ResourceCheck{
@@ -118,6 +124,16 @@ func TestInstance(t *testing.T) {
 							Name:            "Provisioned IOPS",
 							PriceHash:       "d5c5e1fb9b8ded55c336f6ae87aa2c3b-9c483347596633f8cf3ab7fdd5502b78",
 							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
+						},
+					},
+				},
+				{
+					Name: "ebs_block_device[4]",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "General Purpose SSD storage (gp3)",
+							PriceHash:       "b7a83d535d47fcfd1be68ec37f046b3d-ee3dd7e4624338037ca6fea0933a662f",
+							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
 						},
 					},
 				},


### PR DESCRIPTION
Fix #296 

List of gp2 occurrences (all might not need change):
- [x] `CONTRIBUTING.md`
- [x] `autoscaling_group_test.go`
- [x] `dms.go`
- [x] `dms_test..go`
- [x] `ebs_snapshot_test.go`
- [x] `ebs_snapshot_copy_test.go`
- [x] `ebs_volume.go`
- [x] `ebs_volume_test.go`
- [x] `eks_node_group.go`
- [x] `eks_node_group_test.go`
- [x] `elasticsearch_domain.go`
- [x] `elasticsearch_domain_test.go`
- [x] `instance.go`
- [x] `instance_test.go`
- [x] `msk_cluster.go`