### PR TITLE
Add 'post_condition' arg in CI script

### DIFF
--- a/scripts/ci/diff.sh
+++ b/scripts/ci/diff.sh
@@ -28,7 +28,24 @@ process_args () {
   path=${path:-$terraform_dir}
   terraform_plan_flags=${terraform_plan_flags:-$tfflags}
 
+  # Validate post_condition
+  if ! echo "$post_condition" | jq empty; then
+    echo "Error: post_condition contains invalid JSON"
+  fi
+
   # Set defaults
+  if [ ! -z "$percentage_threshold" ] && [ ! -z "$post_condition" ]; then
+    echo "Warning: percentage_threshold is deprecated, using post_condition instead"
+  elif [ ! -z "$percentage_threshold" ]; then
+    post_condition="{\"percentage_threshold\": $percentage_threshold}"
+    echo "Warning: percentage_threshold is deprecated and will be removed in v0.9.0, please use post_condition='{\"percentage_threshold\": \"0\"}'"
+  else
+    post_condition=${post_condition:-'{"has_diff": true}'}
+  fi
+  if [ ! -z "$post_condition" ] && [ "$(echo "$post_condition" | jq '.percentage_threshold')" != "null" ]; then
+    percentage_threshold=$(echo "$post_condition" | jq -r '.percentage_threshold')
+  fi
+  percentage_threshold=${percentage_threshold:-0}
   INFRACOST_BINARY=${INFRACOST_BINARY:-infracost}
 
   # Export as it's used by infracost, not this script
@@ -192,6 +209,10 @@ post_to_bitbucket () {
   fi
 }
 
+cleanup () {
+  rm -f infracost_breakdown.json infracost_breakdown_cmd infracost_output_cmd
+}
+
 # MAIN
 
 process_args "$@"
@@ -226,33 +247,24 @@ if [ $(echo "$past_total_monthly_cost <= 0" | bc -l) = 1 ] && [ $(echo "$total_m
   percent=0
 fi
 
-if [ -n "$percentage_threshold" ] && [ -n "$post_condition" ]; then
-  echo "Warning: The percentage_threshold parameter is deprecated, using post_condition instead"
-elif [ -n "$percentage_threshold" ]; then
-  echo -e "Warning: The percentage_threshold parameter is deprecated and will be removed in v0.9.0, please use post_condition='{\042percentage_threshold\042:\042 2\042}'"
-fi 
-
-if [ $(echo $post_condition | jq '.percentage_threshold') != null ]; then
-  percentage_threshold=$(echo $post_condition | jq '.percentage_threshold')
-  percentage_threshold=$(echo "${percentage_threshold//'"'}")
-fi
-
 absolute_percent=$(echo $percent | tr -d -)
 diff_resources=$(jq '[.projects[].diff.resources[]] | add' infracost_breakdown.json)
 
-if [ "$(echo "$post_condition" | jq '.always')" = $(echo '"true"') ]; then
-  echo "Comment is posted as set always param"
-elif [ $(echo "$post_condition" | jq '.has_diff') = $(echo '"true"') ] && [ -n "$diff_resources" ]; then
-  echo "Comment is posted as set has_diff param"
-elif [ $(echo "$post_condition" | jq '.has_diff') = $(echo '"true"') ] && [ $diff_resources == null ]; then
-  echo "Comment not posted as there are no diff"
+if [ "$(echo "$post_condition" | jq '.always')" = "true" ]; then
+  echo "Posting comment as post_condition is set to always"
+elif [ "$(echo "$post_condition" | jq '.has_diff')" = "true" ] && [ "$diff_resources" = "null" ]; then
+  echo "Not posting comment as post_condition is set to has_diff but there is no diff"
+  cleanup
   exit 0
+elif [ "$(echo "$post_condition" | jq '.has_diff')" = "true" ] && [ -n "$diff_resources" ]; then
+  echo "Posting comment as post_condition is set to has_diff and there is a diff"
 elif [ -z "$percent" ]; then
-  echo "Diff percentage is empty"
+  echo "Posting comment as percentage diff is empty"
 elif [ $(echo "$absolute_percent > $percentage_threshold" | bc -l) = 1 ]; then
-  echo "Diff ($absolute_percent%) is greater than the percentage threshold ($percentage_threshold%)."
+  echo "Posting comment as percentage diff ($absolute_percent%) is greater than the percentage threshold ($percentage_threshold%)."
 else
-  echo "Comment not posted as diff ($absolute_percent%) is less than or equal to percentage threshold ($percentage_threshold%)."
+  echo "Not posting comment as percentage diff ($absolute_percent%) is less than or equal to percentage threshold ($percentage_threshold%)."
+  cleanup
   exit 0
 fi
 
@@ -268,4 +280,4 @@ elif [ ! -z "$BITBUCKET_PIPELINES" ]; then
   post_to_bitbucket
 fi
 
-exit
+cleanup


### PR DESCRIPTION
Part of [Issue](https://github.com/infracost/infracost-gh-action/issues/22)

New argument: post_condition
Could be:
post_condition:'{"always":"true"}' - always post comments
post_condition:'{"has_diff":"true"}' - post comments if it has output
post_condition:'{"percentage_threshold":"2"}' - post comment if absolute_percent more than percentage_threshold