### PR TITLE
feat(google): Add support for Google Memorystore Redis

### DIFF
--- a/internal/providers/terraform/google/redis_instance.go
+++ b/internal/providers/terraform/google/redis_instance.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
@@ -43,7 +44,7 @@ func NewRedisInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 	}
 
 	description := fmt.Sprintf("/Redis Capacity %s %s/", serviceTier, capacityTier)
-	name := fmt.Sprintf("Redis instance (%s, %s)", serviceTier, capacityTier)
+	name := fmt.Sprintf("Redis instance (%s, %s)", strings.ToLower(serviceTier), capacityTier)
 
 	return &schema.Resource{
 		Name: d.Address,

--- a/internal/providers/terraform/google/redis_instance.go
+++ b/internal/providers/terraform/google/redis_instance.go
@@ -1,0 +1,68 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetRedisInstanceRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "google_redis_instance",
+		RFunc: NewRedisInstance,
+	}
+}
+
+func NewRedisInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+	serviceTier := "Basic"
+
+	var tierMapping = map[string]string{
+		"BASIC":       "Basic",
+		"STANDARD_HA": "Standard",
+	}
+
+	if d.Get("tier").Exists() {
+		serviceTier = tierMapping[d.Get("tier").String()]
+	}
+
+	var memorySize = d.Get("memory_size_gb").Int()
+	var capacityTier string
+
+	if memorySize >= 1 && memorySize <= 4 {
+		capacityTier = "M1"
+	} else if memorySize >= 5 && memorySize <= 10 {
+		capacityTier = "M2"
+	} else if memorySize >= 11 && memorySize <= 35 {
+		capacityTier = "M3"
+	} else if memorySize >= 36 && memorySize <= 100 {
+		capacityTier = "M4"
+	} else {
+		capacityTier = "M5"
+	}
+
+	description := fmt.Sprintf("/Redis Capacity %s %s/", serviceTier, capacityTier)
+	name := fmt.Sprintf("Redis instance (%s, %s)", serviceTier, capacityTier)
+
+	return &schema.Resource{
+		Name: d.Address,
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:           name,
+				Unit:           "GB-hours",
+				UnitMultiplier: 1,
+				HourlyQuantity: decimalPtr(decimal.NewFromInt(memorySize)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr(region),
+					Service:       strPtr("Cloud Memorystore for Redis"),
+					ProductFamily: strPtr("ApplicationServices"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "description", ValueRegex: strPtr(description)},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/google/redis_instance_test.go
+++ b/internal/providers/terraform/google/redis_instance_test.go
@@ -1,0 +1,167 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+)
+
+func TestRedisInstance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "google_redis_instance" "basic_m1" {
+			name           = "memory-cache"
+			memory_size_gb = 1
+		}
+		resource "google_redis_instance" "basic_m2" {
+			name           = "memory-cache"
+			memory_size_gb = 5
+		}
+		resource "google_redis_instance" "basic_m3" {
+			name           = "memory-cache"
+			memory_size_gb = 25
+		}
+		resource "google_redis_instance" "basic_m4" {
+			name           = "memory-cache"
+			memory_size_gb = 45
+		}
+		resource "google_redis_instance" "basic_m5" {
+			name           = "memory-cache"
+			memory_size_gb = 105
+		}
+		resource "google_redis_instance" "standard_m1" {
+			name           = "memory-cache"
+			memory_size_gb = 1
+			tier           = "STANDARD_HA"
+		}
+		resource "google_redis_instance" "standard_m2" {
+			name           = "memory-cache"
+			memory_size_gb = 5
+			tier           = "STANDARD_HA"
+		}
+		resource "google_redis_instance" "standard_m3" {
+			name           = "memory-cache"
+			memory_size_gb = 25
+			tier           = "STANDARD_HA"
+		}
+		resource "google_redis_instance" "standard_m4" {
+			name           = "memory-cache"
+			memory_size_gb = 45
+			tier           = "STANDARD_HA"
+		}
+		resource "google_redis_instance" "standard_m5" {
+			name           = "memory-cache"
+			memory_size_gb = 105
+			tier           = "STANDARD_HA"
+		}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_redis_instance.basic_m1",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Basic, M1)",
+					PriceHash:        "5c7ff4d6f6712e1e460103e0cb9467d1-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "google_redis_instance.basic_m2",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Basic, M2)",
+					PriceHash:        "bed41390d56b4d59fe5cbc2b6051371a-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(5)),
+				},
+			},
+		},
+		{
+			Name: "google_redis_instance.basic_m3",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Basic, M3)",
+					PriceHash:        "28740eefcf78c4ce991763088cf3de93-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(25)),
+				},
+			},
+		},
+		{
+			Name: "google_redis_instance.basic_m4",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Basic, M4)",
+					PriceHash:        "3e0d21d45d10db22a6009467b753c4df-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(45)),
+				},
+			},
+		},
+		{
+			Name: "google_redis_instance.basic_m5",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Basic, M5)",
+					PriceHash:        "fda7bbba7cc4bd925b2a06d2e300e418-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(105)),
+				},
+			},
+		},
+		{
+			Name: "google_redis_instance.standard_m1",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Standard, M1)",
+					PriceHash:        "3c7262dff6304711007dcad84ac1b239-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "google_redis_instance.standard_m2",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Standard, M2)",
+					PriceHash:        "cd37c015d896f8dafa4e8646fe757e14-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(5)),
+				},
+			},
+		},
+		{
+			Name: "google_redis_instance.standard_m3",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Standard, M3)",
+					PriceHash:        "1869a4d41adeb44fe54ba09c8876da85-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(25)),
+				},
+			},
+		},
+		{
+			Name: "google_redis_instance.standard_m4",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Standard, M4)",
+					PriceHash:        "d3585ce32c14a89ea37b61e29142f180-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(45)),
+				},
+			},
+		},
+		{
+			Name: "google_redis_instance.standard_m5",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Redis instance (Standard, M5)",
+					PriceHash:        "74db16786f927d999730e152f6320d7d-e400b4debea1ba77ad9bec422eeaf576",
+					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(105)),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}

--- a/internal/providers/terraform/google/redis_instance_test.go
+++ b/internal/providers/terraform/google/redis_instance_test.go
@@ -66,7 +66,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.basic_m1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Basic, M1)",
+					Name:             "Redis instance (basic, M1)",
 					PriceHash:        "5c7ff4d6f6712e1e460103e0cb9467d1-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -76,7 +76,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.basic_m2",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Basic, M2)",
+					Name:             "Redis instance (basic, M2)",
 					PriceHash:        "bed41390d56b4d59fe5cbc2b6051371a-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(5)),
 				},
@@ -86,7 +86,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.basic_m3",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Basic, M3)",
+					Name:             "Redis instance (basic, M3)",
 					PriceHash:        "28740eefcf78c4ce991763088cf3de93-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(25)),
 				},
@@ -96,7 +96,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.basic_m4",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Basic, M4)",
+					Name:             "Redis instance (basic, M4)",
 					PriceHash:        "3e0d21d45d10db22a6009467b753c4df-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(45)),
 				},
@@ -106,7 +106,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.basic_m5",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Basic, M5)",
+					Name:             "Redis instance (basic, M5)",
 					PriceHash:        "fda7bbba7cc4bd925b2a06d2e300e418-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(105)),
 				},
@@ -116,7 +116,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.standard_m1",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Standard, M1)",
+					Name:             "Redis instance (standard, M1)",
 					PriceHash:        "3c7262dff6304711007dcad84ac1b239-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
@@ -126,7 +126,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.standard_m2",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Standard, M2)",
+					Name:             "Redis instance (standard, M2)",
 					PriceHash:        "cd37c015d896f8dafa4e8646fe757e14-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(5)),
 				},
@@ -136,7 +136,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.standard_m3",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Standard, M3)",
+					Name:             "Redis instance (standard, M3)",
 					PriceHash:        "1869a4d41adeb44fe54ba09c8876da85-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(25)),
 				},
@@ -146,7 +146,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.standard_m4",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Standard, M4)",
+					Name:             "Redis instance (standard, M4)",
 					PriceHash:        "d3585ce32c14a89ea37b61e29142f180-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(45)),
 				},
@@ -156,7 +156,7 @@ func TestRedisInstance(t *testing.T) {
 			Name: "google_redis_instance.standard_m5",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:             "Redis instance (Standard, M5)",
+					Name:             "Redis instance (standard, M5)",
 					PriceHash:        "74db16786f927d999730e152f6320d7d-e400b4debea1ba77ad9bec422eeaf576",
 					MonthlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(105)),
 				},

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -27,6 +27,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetMonitoringItem(),
 	GetPubSubSubscriptionRegistryItem(),
 	GetPubSubTopicRegistryItem(),
+	GetRedisInstanceRegistryItem(),
 	GetStorageBucketRegistryItem(),
 }
 


### PR DESCRIPTION
Issue #439 

Output example: 

```
  NAME                                          MONTHLY QTY  UNIT      PRICE   HOURLY COST  MONTHLY COST
  google_redis_instance.cache                                                                             
  └─ Redis instance (Standard, M3)                   14,600  GB-hours  0.0460       0.9200      671.6000  
  Total                                                                             0.9200      671.6000 
  
    google_redis_instance.cache                                                                             
  └─ Redis instance (Basic, M2)                       7,300  GB-hours  0.0270       0.2700      197.1000  
  Total                                                                             0.2700      197.1000
```