### PR TITLE
feat(google): Add support for Google Compute Image

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -324,6 +324,12 @@ resource_usage:
   google_container_node_pool.my_node_pool:
     nodes: 4 # Node count per zone for the node pool
 
+  google_compute_image.my_image: 
+    storage_gb: 1000 # Total size of image storage in GB.
+
+  google_compute_machine_image.my_machine_image: 
+    storage_gb: 1000 # Total size of machine image storage in GB.
+
   google_dns_record_set.my_record_set:
     monthly_queries:  1000000 # Monthly DNS queries.
 

--- a/internal/providers/terraform/google/compute_image_test.go
+++ b/internal/providers/terraform/google/compute_image_test.go
@@ -1,0 +1,159 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestComputeImage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "google_compute_image" "empty" {
+		name = "example-image"
+	}
+	
+	resource "google_compute_disk" "disk" {
+		name  = "test-disk"
+		size = 1000
+	}
+
+	resource "google_compute_image" "image" {
+		name = "image_source_image"
+		disk_size_gb = 100
+	}
+
+	resource "google_compute_snapshot" "snapshot" {
+		name = "snapshot_source_disk"
+		source_disk = google_compute_disk.disk.self_link
+	}
+
+	resource "google_compute_image" "with_disk_size" {
+		name = "example-image"
+		disk_size_gb = 500
+	}
+	
+	resource "google_compute_image" "with_source_disk" {
+		name = "example-image"
+		source_disk = google_compute_disk.disk.self_link
+	}
+
+	resource "google_compute_image" "with_source_image" {
+		name = "example-image"
+		source_image = google_compute_image.image.self_link
+	}
+
+	resource "google_compute_image" "with_source_snapshot" {
+		name = "example-image"
+		source_snapshot = google_compute_snapshot.snapshot.self_link
+	}
+	
+	`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name:      "google_compute_disk.disk",
+			SkipCheck: true,
+		},
+		{
+			Name:      "google_compute_image.image",
+			SkipCheck: true,
+		},
+		{
+			Name:      "google_compute_snapshot.snapshot",
+			SkipCheck: true,
+		},
+		{
+			Name: "google_compute_image.empty",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage",
+					PriceHash:        "1ab5c2278934b99f51df9f4ed5f3a1ec-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "google_compute_image.with_disk_size",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage",
+					PriceHash:        "1ab5c2278934b99f51df9f4ed5f3a1ec-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(500)),
+				},
+			},
+		},
+		{
+			Name: "google_compute_image.with_source_disk",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage",
+					PriceHash:        "1ab5c2278934b99f51df9f4ed5f3a1ec-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
+				},
+			},
+		},
+		{
+			Name: "google_compute_image.with_source_image",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage",
+					PriceHash:        "1ab5c2278934b99f51df9f4ed5f3a1ec-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
+				},
+			},
+		},
+		{
+			Name: "google_compute_image.with_source_snapshot",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage",
+					PriceHash:        "1ab5c2278934b99f51df9f4ed5f3a1ec-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestComputeImage_usage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "google_compute_image" "empty" {
+		name = "example-image"
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"google_compute_image.empty": map[string]interface{}{
+			"storage_gb": 100,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_compute_image.empty",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage",
+					PriceHash:        "1ab5c2278934b99f51df9f4ed5f3a1ec-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/google/compute_machine_image.go
+++ b/internal/providers/terraform/google/compute_machine_image.go
@@ -1,0 +1,28 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetComputeMachineImageRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "google_compute_machine_image",
+		RFunc: NewComputeMachineImage,
+	}
+}
+
+func NewComputeMachineImage(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+	description := "Storage Machine Image"
+
+	var storageSize *decimal.Decimal
+	if u != nil && u.Get("storage_gb").Exists() {
+		storageSize = decimalPtr(decimal.NewFromInt(u.Get("storage_gb").Int()))
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: storageImage(region, description, storageSize),
+	}
+}

--- a/internal/providers/terraform/google/compute_machine_image_test.go
+++ b/internal/providers/terraform/google/compute_machine_image_test.go
@@ -1,0 +1,113 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+
+	"github.com/shopspring/decimal"
+)
+
+func TestComputeMachineImage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "google_compute_instance" "vm" {
+		name         = "vm"
+		machine_type = "e2-medium"
+	
+		boot_disk {
+			initialize_params {
+				image = "fake"
+			}
+		}
+	
+		network_interface {
+			network = "fake"
+		}
+	}
+	
+	resource "google_compute_machine_image" "image" {
+		provider     		= "google-beta"
+		name            = "image"
+		source_instance = google_compute_instance.vm.self_link
+	}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name:      "google_compute_instance.vm",
+			SkipCheck: true,
+		},
+		{
+			Name: "google_compute_machine_image.image",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage",
+					PriceHash:        "26be44612e84631670a69db241945bfb-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestComputeMachineImage_usage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "google_compute_instance" "vm" {
+		name         = "vm"
+		machine_type = "e2-medium"
+		zone         = "us-central1-a"
+	
+		boot_disk {
+			initialize_params {
+				image = "fake"
+			}
+		}
+	
+		network_interface {
+			network = "fake"
+		}
+	}
+	
+	resource "google_compute_machine_image" "image" {
+		provider 				= "google-beta"
+		name            = "image"
+		source_instance = google_compute_instance.vm.self_link
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"google_compute_machine_image.image": map[string]interface{}{
+			"storage_gb": 100,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name:      "google_compute_instance.vm",
+			SkipCheck: true,
+		},
+		{
+			Name: "google_compute_machine_image.image",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Storage",
+					PriceHash:        "26be44612e84631670a69db241945bfb-57bc5d148491a8381abaccb21ca6b4e9",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -10,6 +10,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetComputeImageRegistryItem(),
 	GetComputeSnapshotRegistryItem(),
 	GetComputeInstanceRegistryItem(),
+	GetComputeMachineImageRegistryItem(),
 	GetComputeRouterNATRegistryItem(),
 	GetContainerClusterRegistryItem(),
 	GetContainerNodePoolRegistryItem(),

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -46,6 +46,11 @@ var tfProviders = `
 		credentials = "{\"type\":\"service_account\"}"
 		region = "us-central1"
 	}
+
+	provider "google-beta" {
+		credentials = "{\"type\":\"service_account\"}"
+		region = "us-central1"
+	}
 `
 
 var (


### PR DESCRIPTION
Issue #437 

With output: 

```
  NAME                                           MONTHLY QTY  UNIT       PRICE   HOURLY COST  MONTHLY COST
  google_compute_image.my_image                                                                             
  └─ Storage                                             100  GB-months  0.0500       0.0068        5.0000  
  Total                                                                               0.0068        5.0000

  google_compute_machine_image.my_machine_image                                                             
  └─ Storage                                           1,000  GB-months  0.0500       0.0685       50.0000  
  Total                                                                               0.0685       50.0000 
```

Without output: 

```
  NAME                                           MONTHLY QTY  UNIT       PRICE   HOURLY COST  MONTHLY COST
  google_compute_image.example                                                                             
  └─ Storage                                              -  GB-months  0.0500            -             -  
  Total                                                                                   -             -

  google_compute_machine_image.image                                                                        
  └─ Storage                                               -  GB-months  0.0500            -             -  
  Total                                                                                    -             -
```