### PR TITLE
chore(deps): install unzip instead of zip package in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV HOME /app
 ENV CGO_ENABLED 0
 
 # Install Packages
-RUN apt-get update -q && apt-get -y install zip jq
+RUN apt-get update -q && apt-get -y install unzip jq
 
 # Install latest of each Terraform version after 0.12 as we don't support versions before that
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.30 0.13.6 ${DEFAULT_TERRAFORM_VERSION}" && \


### PR DESCRIPTION
`zip` is actually not needed in the Dockerfile, but install `zip` by default will also install the suggested `unzip` package, so that the later commands can use `unzip` without a problem, but `zip` really doesn't need to be installed here 😄 

This will help to speed up the builder stage a little bit 😀 