### PR TITLE
chore: reorder Dockerfile instruction to minimize image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ WORKDIR /app
 COPY . .
 RUN make deps
 RUN NO_DIRTY=true make build
+RUN chmod +x /app/build/infracost
 
 # Application
 FROM alpine:3.13 as app
@@ -51,6 +52,5 @@ COPY scripts /scripts
 COPY --from=builder /usr/bin/terraform* /usr/bin/
 COPY --from=builder /usr/bin/terragrunt /usr/bin/
 COPY --from=builder /app/build/infracost /usr/bin/
-RUN chmod +x /usr/bin/infracost
 
 ENTRYPOINT [ "infracost" ]


### PR DESCRIPTION
Change the file permision in the builder stage, save an image layer and
the duplicated file caused by permission change.

Result as below, saved the size of `infracost` the binary itself(about 16MB):

```
REPOSITORY      TAG        IMAGE ID         CREATED              SIZE
infracost       after      0a932e916231     3 minutes ago        638MB
infracost       before     37edb87395bb     8 minutes ago        654MB
```