### PR TITLE
fix: handle modules appearing in resource names

### DIFF
--- a/internal/usage/usage_file.go
+++ b/internal/usage/usage_file.go
@@ -66,7 +66,9 @@ func syncResourcesUsage(resources []*schema.Resource, usageSchema map[string][]*
 	syncedResourceUsage := make(map[string]interface{})
 	for _, resource := range resources {
 		resourceName := resource.Name
-		resourceTypeName := strings.Split(resourceName, ".")[0]
+		resourceTypeNames := strings.Split(resourceName, ".")
+		// This handles module names appearing in the resourceName too
+		resourceTypeName := resourceTypeNames[len(resourceTypeNames)-2]
 		resourceUSchema, ok := usageSchema[resourceTypeName]
 		if !ok {
 			continue


### PR DESCRIPTION
Fixes #557

FYI I tested the sync feature working with TF sub-resources as well as resources such as aws_cloudfront_distribution that have nested blocks in our usage-file. 