### PR TITLE
feat(google): add support for Google SQL

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -396,7 +396,7 @@ resource_usage:
     monthly_message_data_tb: 7.416 # Monthly amount of message data published to the topic in TB.
 
   google_sql_database_instance.my_instance:
-    monthly_backup_gb: 1000 # Total size of backups per month
+    backup_storage_gb: 1000 # Amount of backup storage in GB.
     
   google_storage_bucket.my_storage_bucket:
     storage_gb: 150                   # Total size of bucket in GB.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -394,6 +394,9 @@ resource_usage:
 
   google_pubsub_topic.my_topic:
     monthly_message_data_tb: 7.416 # Monthly amount of message data published to the topic in TB.
+
+  google_sql_database_instance.my_instance:
+    monthly_backup_gb: 1000 # Total size of backups per month
     
   google_storage_bucket.my_storage_bucket:
     storage_gb: 150                   # Total size of bucket in GB.

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -29,6 +29,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetPubSubSubscriptionRegistryItem(),
 	GetPubSubTopicRegistryItem(),
 	GetRedisInstanceRegistryItem(),
+	GetSQLInstanceRegistryItem(),
 	GetStorageBucketRegistryItem(),
 }
 
@@ -140,6 +141,9 @@ var FreeResources []string = []string{
 	"google_service_account_iam_member",
 	"google_service_account_iam_policy",
 	"google_service_account_key",
+	"google_sql_database",
+	"google_sql_ssl_cert",
+	"google_sql_user",
 	"google_storage_bucket_access_control",
 	"google_storage_bucket_acl",
 	"google_storage_bucket_iam_binding",

--- a/internal/providers/terraform/google/sql_database_instance.go
+++ b/internal/providers/terraform/google/sql_database_instance.go
@@ -178,11 +178,11 @@ func SQLServerTierNameToDescriptionRegex(tier, licenseType string, isSharedInsta
 }
 
 func SQLInstanceStorage(region string, dbType SQLInstanceDBType, availabilityType, diskType string, diskSizeGB int64) *schema.CostComponent {
-	storageTypeHumanReadableNames := map[string]string{
+	diskTypeHumanReadableNames := map[string]string{
 		"PD_SSD": "SSD",
 		"PD_HDD": "HDD",
 	}
-	storageTypeAPIResourceGroup := map[string]string{
+	diskTypeAPIResourceGroup := map[string]string{
 		"PD_SSD": "SSD",
 		"PD_HDD": "PDStandard",
 	}
@@ -196,7 +196,7 @@ func SQLInstanceStorage(region string, dbType SQLInstanceDBType, availabilityTyp
 		SQLServer:  "SQL Server",
 	}
 	cost := &schema.CostComponent{
-		Name:            fmt.Sprintf("Storage (%s)", storageTypeHumanReadableNames[diskType]),
+		Name:            fmt.Sprintf("Storage (%s)", diskTypeHumanReadableNames[diskType]),
 		Unit:            "GB-months",
 		UnitMultiplier:  1,
 		MonthlyQuantity: decimalPtr(decimal.NewFromInt(diskSizeGB)),
@@ -205,7 +205,7 @@ func SQLInstanceStorage(region string, dbType SQLInstanceDBType, availabilityTyp
 			Region:     strPtr(region),
 			Service:    strPtr("Cloud SQL"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "resourceGroup", Value: strPtr(storageTypeAPIResourceGroup[diskType])},
+				{Key: "resourceGroup", Value: strPtr(diskTypeAPIResourceGroup[diskType])},
 				{Key: "description", ValueRegex: strPtr(fmt.Sprintf("/%s: %s/", dbTypeNames[dbType], availabilityTypeNames[availabilityType]))},
 			},
 		},

--- a/internal/providers/terraform/google/sql_database_instance.go
+++ b/internal/providers/terraform/google/sql_database_instance.go
@@ -28,7 +28,7 @@ func GetSQLInstanceRegistryItem() *schema.RegistryItem {
 func NewSQLInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	name := d.Address
 	tier := d.Get("settings.0").Get("tier").String()
-	availabilityType := d.Get("settings.0").Get("availabilityType").String()
+	availabilityType := d.Get("settings.0").Get("availability_type").String()
 	region := d.Get("region").String()
 	dbVersion := d.Get("database_version").String()
 	dbType := SQLInstanceDBVersionToDBType(dbVersion)

--- a/internal/providers/terraform/google/sql_database_instance.go
+++ b/internal/providers/terraform/google/sql_database_instance.go
@@ -1,0 +1,105 @@
+package google
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+	log "github.com/sirupsen/logrus"
+)
+
+type SQLInstanceDBType int
+
+const (
+	MySQL SQLInstanceDBType = iota
+	PostgreSQL
+	SQLServer
+)
+
+func GetSQLInstanceRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:                "google_sql_database_instance",
+		RFunc:               NewSQLInstance,
+		ReferenceAttributes: []string{},
+	}
+}
+
+func NewSQLInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	name := d.Address
+	tier := d.Get("settings.0").Get("tier").String()
+	availabilityType := d.Get("settings.0").Get("availabilityType").String()
+	region := d.Get("region").String()
+	dbVersion := d.Get("database_version").String()
+	dbType := SQLInstanceDBVersionToDBType(dbVersion)
+	return &schema.Resource{
+		Name: name,
+		CostComponents: []*schema.CostComponent{
+			SharedSQLInstance(name, tier, availabilityType, dbType, region),
+		},
+	}
+}
+
+func SharedSQLInstance(name, tier, availabilityType string, DBType SQLInstanceDBType, region string) *schema.CostComponent {
+	cost := &schema.CostComponent{
+		Name: "Instance pricing",
+	}
+	resourceGroup := SQLInstanceTierToResourceGroup(tier)
+	if resourceGroup == "" {
+		log.Debugf("No tier resource group for sql instance %s", name)
+		return cost
+	}
+	descriptionRegex := SQLInstanceAvTypeDBtoDescriptionRegex(availabilityType, DBType)
+	cost = &schema.CostComponent{
+		Name:           "Instance pricing",
+		Unit:           "seconds",
+		UnitMultiplier: 1,
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("gcp"),
+			Region:     strPtr(region),
+			Service:    strPtr("Cloud SQL"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "resourceGroup", Value: strPtr(resourceGroup)},
+				{Key: "description", ValueRegex: strPtr(descriptionRegex)},
+			},
+		},
+	}
+	return cost
+}
+
+func SQLInstanceDBVersionToDBType(dbVersion string) SQLInstanceDBType {
+	if strings.Contains(dbVersion, "POSTGRES") {
+		return PostgreSQL
+	} else if strings.Contains(dbVersion, "MYSQL") {
+		return MySQL
+	} else if strings.Contains(dbVersion, "SQLSERVER") {
+		return SQLServer
+	} else {
+		return MySQL
+	}
+}
+
+func SQLInstanceTierToResourceGroup(tier string) string {
+	data := map[string]string{
+		"db-f1-micro": "SQLGen2InstancesF1Micro",
+		"db-g1-small": "SQLGen2InstancesF1Small",
+	}
+	return data[tier]
+}
+
+func SQLInstanceAvTypeDBtoDescriptionRegex(availabilityType string, DBType SQLInstanceDBType) string {
+	dbTypeNames := map[SQLInstanceDBType]string{
+		MySQL:      "MySQL",
+		PostgreSQL: "PostgreSQL",
+		SQLServer:  "SQL Server",
+	}
+	availabilityTypeNames := map[string]string{
+		"REGIONAL": "Regional",
+		"ZONAL":    "Zonal",
+	}
+	dbType := dbTypeNames[DBType]
+	avType := availabilityTypeNames[availabilityType]
+	description := fmt.Sprintf("/%s: %s/", dbType, avType)
+	return description
+}

--- a/internal/providers/terraform/google/sql_database_instance.go
+++ b/internal/providers/terraform/google/sql_database_instance.go
@@ -40,7 +40,7 @@ func NewSQLInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 	}
 }
 
-func SharedSQLInstance(name, tier, availabilityType string, DBType SQLInstanceDBType, region string) *schema.CostComponent {
+func SharedSQLInstance(name, tier, availabilityType string, dbType SQLInstanceDBType, region string) *schema.CostComponent {
 	cost := &schema.CostComponent{
 		Name: "Instance pricing",
 	}
@@ -49,7 +49,7 @@ func SharedSQLInstance(name, tier, availabilityType string, DBType SQLInstanceDB
 		log.Debugf("No tier resource group for sql instance %s", name)
 		return cost
 	}
-	descriptionRegex := SQLInstanceAvDBTypeToDescriptionRegex(availabilityType, DBType)
+	descriptionRegex := SQLInstanceAvDBTypeToDescriptionRegex(availabilityType, dbType)
 	cost = &schema.CostComponent{
 		Name:           "Instance pricing",
 		Unit:           "seconds",
@@ -88,7 +88,7 @@ func SQLInstanceTierToResourceGroup(tier string) string {
 	return data[tier]
 }
 
-func SQLInstanceAvDBTypeToDescriptionRegex(availabilityType string, DBType SQLInstanceDBType) string {
+func SQLInstanceAvDBTypeToDescriptionRegex(availabilityType string, dbType SQLInstanceDBType) string {
 	dbTypeNames := map[SQLInstanceDBType]string{
 		MySQL:      "MySQL",
 		PostgreSQL: "PostgreSQL",
@@ -98,8 +98,8 @@ func SQLInstanceAvDBTypeToDescriptionRegex(availabilityType string, DBType SQLIn
 		"REGIONAL": "Regional",
 		"ZONAL":    "Zonal",
 	}
-	dbType := dbTypeNames[DBType]
-	avType := availabilityTypeNames[availabilityType]
-	description := fmt.Sprintf("/%s: %s/", dbType, avType)
+	dbTypeString := dbTypeNames[dbType]
+	availabilityTypeString := availabilityTypeNames[availabilityType]
+	description := fmt.Sprintf("/%s: %s/", dbTypeString, availabilityTypeString)
 	return description
 }

--- a/internal/providers/terraform/google/sql_database_instance.go
+++ b/internal/providers/terraform/google/sql_database_instance.go
@@ -165,14 +165,6 @@ func sharedSQLInstance(tier, availabilityType string, dbType SQLInstanceDBType, 
 	}
 }
 
-func sqlCustomInstanceDescriptionRegex(availabilityType string, dbType SQLInstanceDBType, vCPU *decimal.Decimal, memory *decimal.Decimal) string {
-	dbTypeString := sqlInstanceTypeToDescriptionName(dbType)
-	availabilityTypeString := availabilityTypeDescName(availabilityType)
-
-	descriptionRegex := fmt.Sprintf("/%s: %s - %s vCPU %s %sGB RAM/", dbTypeString, availabilityTypeString, vCPU, `\+\`, memory)
-	return descriptionRegex
-}
-
 func sqlInstanceDBVersionToDBType(dbVersion string) SQLInstanceDBType {
 	if strings.Contains(dbVersion, "POSTGRES") {
 		return PostgreSQL
@@ -230,6 +222,10 @@ func sqlInstanceStorage(region string, dbType SQLInstanceDBType, availabilityTyp
 	diskTypeAPIResourceGroup := map[string]string{
 		"PD_SSD": "SSD",
 		"PD_HDD": "PDStandard",
+	}
+
+	if dbType == SQLServer {
+		diskType = "PD_SSD"
 	}
 
 	cost := &schema.CostComponent{

--- a/internal/providers/terraform/google/sql_database_instance.go
+++ b/internal/providers/terraform/google/sql_database_instance.go
@@ -49,7 +49,7 @@ func SharedSQLInstance(name, tier, availabilityType string, DBType SQLInstanceDB
 		log.Debugf("No tier resource group for sql instance %s", name)
 		return cost
 	}
-	descriptionRegex := SQLInstanceAvTypeDBtoDescriptionRegex(availabilityType, DBType)
+	descriptionRegex := SQLInstanceAvDBTypeToDescriptionRegex(availabilityType, DBType)
 	cost = &schema.CostComponent{
 		Name:           "Instance pricing",
 		Unit:           "seconds",
@@ -88,7 +88,7 @@ func SQLInstanceTierToResourceGroup(tier string) string {
 	return data[tier]
 }
 
-func SQLInstanceAvTypeDBtoDescriptionRegex(availabilityType string, DBType SQLInstanceDBType) string {
+func SQLInstanceAvDBTypeToDescriptionRegex(availabilityType string, DBType SQLInstanceDBType) string {
 	dbTypeNames := map[SQLInstanceDBType]string{
 		MySQL:      "MySQL",
 		PostgreSQL: "PostgreSQL",

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -1,4 +1,4 @@
-package google
+package google_test
 
 import (
 	"testing"

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -39,6 +39,7 @@ func TestNewSQLInstance(t *testing.T) {
 		
 			settings {
 				tier = "db-custom-16-61440"
+				availability_type = "REGIONAL"
 			}
 		}
 
@@ -60,6 +61,27 @@ func TestNewSQLInstance(t *testing.T) {
 			settings {
 				tier = "db-g1-small"
 				availability_type = "ZONAL"
+			}
+		}
+
+		resource "google_sql_database_instance" "micro_mysql_SSD_storage" {
+			name             = "master-instance"
+			database_version = "MYSQL_8_0"
+		
+			settings {
+				tier = "db-f1-micro"
+				availability_type = "ZONAL"
+			}
+		}
+
+		resource "google_sql_database_instance" "micro_mysql_HDD_storage" {
+			name             = "master-instance"
+			database_version = "MYSQL_8_0"
+		
+			settings {
+				tier = "db-f1-micro"
+				availability_type = "ZONAL"
+				disk_type = "PD_HDD"
 			}
 		}
 
@@ -96,6 +118,11 @@ func TestNewSQLInstance(t *testing.T) {
 					PriceHash:       "5cf7faa740d422ad2a42937d73517ba4-57bc5d148491a8381abaccb21ca6b4e9",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
 				},
+				{
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
 			},
 		},
 		{
@@ -117,9 +144,9 @@ func TestNewSQLInstance(t *testing.T) {
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
 				},
 				{
-					Name:            "SQL instance (db-custom-2-13312, zonal)",
-					PriceHash:       "896b2e1bfdcef6f44ba586aea1d0daa1-ef2cadbde566a742ff14834f883bcb8a",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},
 		},
@@ -127,24 +154,24 @@ func TestNewSQLInstance(t *testing.T) {
 			Name: "google_sql_database_instance.HA_custom_postgres",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "vCPUs (zonal)",
-					PriceHash:       "8ca4313075dce70bb4b2473b012ddb7c-ef2cadbde566a742ff14834f883bcb8a",
+					Name:            "vCPUs (regional)",
+					PriceHash:       "06aab83b7c71ff48fedf5b3e3b642901-ef2cadbde566a742ff14834f883bcb8a",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(16)),
 				},
 				{
-					Name:            "Memory (zonal)",
-					PriceHash:       "d2d3ec68f097b7a7c2302e33ef61b23d-e400b4debea1ba77ad9bec422eeaf576",
+					Name:            "Memory (regional)",
+					PriceHash:       "41ffc843143c058ef633c8f353d88b7e-e400b4debea1ba77ad9bec422eeaf576",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(60)),
 				},
 				{
-					Name:            "Storage (SSD, zonal)",
-					PriceHash:       "13d1eea521d50ece4069df73fab5e4fe-57bc5d148491a8381abaccb21ca6b4e9",
+					Name:            "Storage (SSD, regional)",
+					PriceHash:       "cb35b710d2bdb84771a140c1722c2bc2-57bc5d148491a8381abaccb21ca6b4e9",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
 				},
 				{
-					Name:            "SQL instance (db-custom-16-61440, zonal)",
-					PriceHash:       "350175da373d26dda5a9d4ddba8e37c9-ef2cadbde566a742ff14834f883bcb8a",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},
 		},
@@ -152,14 +179,19 @@ func TestNewSQLInstance(t *testing.T) {
 			Name: "google_sql_database_instance.HA_small_mysql",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
+					Name:            "SQL instance (db-g1-small, regional)",
+					PriceHash:       "cc7a2cc3b784c524185839fbbc426b4f-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
 					Name:            "Storage (SSD, regional)",
 					PriceHash:       "ac54437f3c0f733bc629b6cf667e2943-57bc5d148491a8381abaccb21ca6b4e9",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
 				},
 				{
-					Name:            "SQL instance (db-g1-small, regional)",
-					PriceHash:       "cc7a2cc3b784c524185839fbbc426b4f-ef2cadbde566a742ff14834f883bcb8a",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},
 		},
@@ -167,14 +199,59 @@ func TestNewSQLInstance(t *testing.T) {
 			Name: "google_sql_database_instance.small_mysql",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
+					Name:            "SQL instance (db-g1-small, zonal)",
+					PriceHash:       "107408a8d6858ac0ca4cecf164263aee-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
 					Name:            "Storage (SSD, zonal)",
 					PriceHash:       "e02fe49c6a08383eadddbc68669618d5-57bc5d148491a8381abaccb21ca6b4e9",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
 				},
 				{
-					Name:            "SQL instance (db-g1-small, zonal)",
-					PriceHash:       "107408a8d6858ac0ca4cecf164263aee-ef2cadbde566a742ff14834f883bcb8a",
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "google_sql_database_instance.micro_mysql_SSD_storage",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "SQL instance (db-f1-micro, zonal)",
+					PriceHash:       "6bb030d939a5b1f0ce8ed7d586be2530-ef2cadbde566a742ff14834f883bcb8a",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "Storage (SSD, zonal)",
+					PriceHash:       "e02fe49c6a08383eadddbc68669618d5-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "google_sql_database_instance.micro_mysql_HDD_storage",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "SQL instance (db-f1-micro, zonal)",
+					PriceHash:       "6bb030d939a5b1f0ce8ed7d586be2530-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "Storage (HDD, zonal)",
+					PriceHash:       "429861f2d4c06792bbbe2130eeaf0254-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},
 		},
@@ -197,9 +274,9 @@ func TestNewSQLInstance(t *testing.T) {
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(500)),
 				},
 				{
-					Name:            "SQL instance (db-custom-16-61440, regional)",
-					PriceHash:       "a1d8913462087d200ce33ea36a8ae5e1-ef2cadbde566a742ff14834f883bcb8a",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},
 			SubResourceChecks: []testutil.ResourceCheck{
@@ -220,11 +297,6 @@ func TestNewSQLInstance(t *testing.T) {
 							Name:            "Storage (SSD, zonal)",
 							PriceHash:       "13d1eea521d50ece4069df73fab5e4fe-57bc5d148491a8381abaccb21ca6b4e9",
 							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(500)),
-						},
-						{
-							Name:            "SQL instance (db-custom-16-61440, zonal)",
-							PriceHash:       "350175da373d26dda5a9d4ddba8e37c9-ef2cadbde566a742ff14834f883bcb8a",
-							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 						},
 					},
 				},

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -23,7 +23,7 @@ func TestNewSQLInstance_SharedInstance(t *testing.T) {
 	  resource "google_sql_database_instance" "my_sql_instance" {
 		name   = "my-database-instance"
 		region = "us-central1"
-		database_version = "POSTGRES_11"
+		database_version = "SQLSERVER_2017_ENTERPRISE"
 		settings {
 		  tier = "db-f1-micro"
 		  availability_type = "ZONAL"
@@ -41,8 +41,13 @@ func TestNewSQLInstance_SharedInstance(t *testing.T) {
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
 					Name:            "Instance pricing",
-					PriceHash:       "00652373a56ac9fb427a933a88235829-ef2cadbde566a742ff14834f883bcb8a",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					PriceHash:       "8c6410e6b05f87ffc7ee2268f2d7afc7-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "License (Enterprise)",
+					PriceHash:       "577c5d61a66cb3b7eaf6b405c1d5f785-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 			},
 		},

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -27,7 +27,7 @@ func TestNewSQLInstance_SharedInstance(t *testing.T) {
 		settings {
 		  tier = "db-f1-micro"
 		  availability_type = "ZONAL"
-		  disk_type = "PD_SDD"
+		  disk_type = "PD_SSD"
 		  disk_size = 50
 		}
 	  

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func TestNewSQLInstance_SharedInstance(t *testing.T) {
+func TestNewSQLInstance(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
@@ -22,32 +22,65 @@ func TestNewSQLInstance_SharedInstance(t *testing.T) {
 	  
 	  resource "google_sql_database_instance" "my_sql_instance" {
 		name   = "my-database-instance"
-		region = "us-central1"
 		database_version = "SQLSERVER_2017_ENTERPRISE"
 		settings {
 		  tier = "db-f1-micro"
 		  availability_type = "ZONAL"
-		  disk_type = "PD_SSD"
 		  disk_size = 50
 		}
-	  
-		deletion_protection  = "true"
-	  }	  
-	`
+	}	  
+		
+		resource "google_sql_database_instance" "custom_postgres" {
+			name             = "master-instance"
+			database_version = "POSTGRES_11"
+		
+			settings {
+				tier = "db-custom-2-13312"
+			}
+		}
 
-	usage := schema.NewEmptyUsageMap()
+		resource "google_sql_database_instance" "HA_custom_postgres" {
+			name             = "master-instance"
+			database_version = "POSTGRES_11"
+		
+			settings {
+				tier = "db-custom-16-61440"
+			}
+		}
+
+		resource "google_sql_database_instance" "HA_small_mysql" {
+			name             = "master-instance"
+			database_version = "MYSQL_8_0"
+		
+			settings {
+				tier = "db-g1-small"
+				availability_type = "REGIONAL"
+				disk_size = "100"
+			}
+		}
+
+		resource "google_sql_database_instance" "small_mysql" {
+			name             = "master-instance"
+			database_version = "MYSQL_8_0"
+		
+			settings {
+				tier = "db-g1-small"
+				availability_type = "ZONAL"
+			}
+		}
+	`
 
 	resourceChecks := []testutil.ResourceCheck{
 		{
 			Name: "google_sql_database_instance.my_sql_instance",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Instance pricing",
+					Name:            "SQL instance (SQL Server, db-f1-micro)",
 					PriceHash:       "8c6410e6b05f87ffc7ee2268f2d7afc7-ef2cadbde566a742ff14834f883bcb8a",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
-					Name:            "Storage (HDD)",
+					Name:            "Storage (SSD)",
 					PriceHash:       "5cf7faa740d422ad2a42937d73517ba4-57bc5d148491a8381abaccb21ca6b4e9",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(50)),
 				},
@@ -58,6 +91,134 @@ func TestNewSQLInstance_SharedInstance(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "google_sql_database_instance.custom_postgres",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "CPU Credits",
+					PriceHash:       "8ca4313075dce70bb4b2473b012ddb7c-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+				},
+				{
+					Name:            "Memory",
+					PriceHash:       "d2d3ec68f097b7a7c2302e33ef61b23d-e400b4debea1ba77ad9bec422eeaf576",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(13)),
+				},
+				{
+					Name:            "Storage (SSD)",
+					PriceHash:       "13d1eea521d50ece4069df73fab5e4fe-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "SQL instance (PostgreSQL, custom)",
+					PriceHash:       "896b2e1bfdcef6f44ba586aea1d0daa1-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "google_sql_database_instance.HA_custom_postgres",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "CPU Credits",
+					PriceHash:       "8ca4313075dce70bb4b2473b012ddb7c-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(16)),
+				},
+				{
+					Name:            "Memory",
+					PriceHash:       "d2d3ec68f097b7a7c2302e33ef61b23d-e400b4debea1ba77ad9bec422eeaf576",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(60)),
+				},
+				{
+					Name:            "Storage (SSD)",
+					PriceHash:       "13d1eea521d50ece4069df73fab5e4fe-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "SQL instance (PostgreSQL, custom)",
+					PriceHash:       "350175da373d26dda5a9d4ddba8e37c9-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "google_sql_database_instance.HA_small_mysql",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Storage (SSD)",
+					PriceHash:       "ac54437f3c0f733bc629b6cf667e2943-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
+				},
+				{
+					Name:            "SQL instance (MySQL, db-g1-small)",
+					PriceHash:       "cc7a2cc3b784c524185839fbbc426b4f-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "google_sql_database_instance.small_mysql",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Storage (SSD)",
+					PriceHash:       "e02fe49c6a08383eadddbc68669618d5-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "SQL instance (MySQL, db-g1-small)",
+					PriceHash:       "107408a8d6858ac0ca4cecf164263aee-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
 	}
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestNewSQLInstance_usage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "google_sql_database_instance" "small_mysql" {
+		name             = "master-instance"
+		database_version = "MYSQL_8_0"
+	
+		settings {
+			tier = "db-g1-small"
+			availability_type = "ZONAL"
+		}
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"google_sql_database_instance.small_mysql": map[string]interface{}{
+			"monthly_backup_gb": 100,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_sql_database_instance.small_mysql",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Storage (SSD)",
+					PriceHash:       "e02fe49c6a08383eadddbc68669618d5-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "SQL instance (MySQL, db-g1-small)",
+					PriceHash:       "107408a8d6858ac0ca4cecf164263aee-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
+				},
+			},
+		},
+	}
+
 	tftest.ResourceTests(t, tf, usage, resourceChecks)
 }

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -252,7 +252,7 @@ func TestNewSQLInstance_usage(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"google_sql_database_instance.small_mysql": map[string]interface{}{
-			"monthly_backup_gb": 100,
+			"backup_storage_gb": 100,
 		},
 	})
 
@@ -261,12 +261,12 @@ func TestNewSQLInstance_usage(t *testing.T) {
 			Name: "google_sql_database_instance.small_mysql",
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
-					Name:            "Storage (SSD)",
+					Name:            "Storage (SSD, zonal)",
 					PriceHash:       "e02fe49c6a08383eadddbc68669618d5-57bc5d148491a8381abaccb21ca6b4e9",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
 				},
 				{
-					Name:            "SQL instance (MySQL, db-g1-small)",
+					Name:            "SQL instance (db-g1-small, zonal)",
 					PriceHash:       "107408a8d6858ac0ca4cecf164263aee-ef2cadbde566a742ff14834f883bcb8a",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -1,0 +1,51 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+)
+
+func TestNewSQLInstance_SharedInstance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	  resource "google_sql_database" "database" {
+		name     = "my-database"
+		instance = google_sql_database_instance.my_sql_instance.name
+	  }
+	  
+	  resource "google_sql_database_instance" "my_sql_instance" {
+		name   = "my-database-instance"
+		region = "us-central1"
+		database_version = "POSTGRES_11"
+		settings {
+		  tier = "db-f1-micro"
+		  availability_type = "ZONAL"
+		}
+	  
+		deletion_protection  = "true"
+	  }	  
+	`
+
+	usage := schema.NewEmptyUsageMap()
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "google_sql_database_instance.my_sql_instance",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance pricing",
+					PriceHash:       "00652373a56ac9fb427a933a88235829-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+	}
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -85,6 +85,22 @@ func TestNewSQLInstance(t *testing.T) {
 			}
 		}
 
+		resource "google_sql_database_instance" "mysql_standard" {
+			name             = "master-instance"
+			database_version = "MYSQL_5_7"
+			settings {
+				tier = "db-n1-standard-32"
+			}
+		}
+
+		resource "google_sql_database_instance" "mysql_highmem" {
+			name             = "master-instance"
+			database_version = "MYSQL_5_7"
+			settings {
+				tier = "db-n1-highmem-8"
+			}
+		}
+
 		resource "google_sql_database_instance" "with_replica" {
 			name             = "master-instance"
 			database_version = "POSTGRES_11"
@@ -246,6 +262,46 @@ func TestNewSQLInstance(t *testing.T) {
 				{
 					Name:            "Storage (HDD, zonal)",
 					PriceHash:       "429861f2d4c06792bbbe2130eeaf0254-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "google_sql_database_instance.mysql_standard",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "SQL instance (db-n1-standard-32, zonal)",
+					PriceHash:       "de17b8ffd65878905c410bd12415ef9d-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "Storage (SSD, zonal)",
+					PriceHash:       "e02fe49c6a08383eadddbc68669618d5-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:            "Backups",
+					PriceHash:       "5d5ace3b30ea029049048c6fba8d6ce2-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "google_sql_database_instance.mysql_highmem",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "SQL instance (db-n1-highmem-8, zonal)",
+					PriceHash:       "ef3e0450278cba3131b44600dc6b9563-ef2cadbde566a742ff14834f883bcb8a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "Storage (SSD, zonal)",
+					PriceHash:       "e02fe49c6a08383eadddbc68669618d5-57bc5d148491a8381abaccb21ca6b4e9",
 					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
 				},
 				{

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -16,19 +16,19 @@ func TestNewSQLInstance(t *testing.T) {
 
 	tf := `
 	  resource "google_sql_database" "database" {
-		name     = "my-database"
-		instance = google_sql_database_instance.my_sql_instance.name
-	  }
-	  
-	  resource "google_sql_database_instance" "my_sql_instance" {
-		name   = "my-database-instance"
-		database_version = "SQLSERVER_2017_ENTERPRISE"
-		settings {
-		  tier = "db-f1-micro"
-		  availability_type = "ZONAL"
-		  disk_size = 50
-		}
-	}	  
+			name     = "my-database"
+			instance = google_sql_database_instance.my_sql_instance.name
+			}
+			
+			resource "google_sql_database_instance" "my_sql_instance" {
+			name   = "my-database-instance"
+			database_version = "SQLSERVER_2017_ENTERPRISE"
+			settings {
+				tier = "db-f1-micro"
+				availability_type = "ZONAL"
+				disk_size = 50
+			}
+		}	  
 		
 		resource "google_sql_database_instance" "custom_postgres" {
 			name             = "master-instance"

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -27,6 +27,8 @@ func TestNewSQLInstance_SharedInstance(t *testing.T) {
 		settings {
 		  tier = "db-f1-micro"
 		  availability_type = "ZONAL"
+		  disk_type = "PD_SDD"
+		  disk_size = 50
 		}
 	  
 		deletion_protection  = "true"
@@ -43,6 +45,11 @@ func TestNewSQLInstance_SharedInstance(t *testing.T) {
 					Name:            "Instance pricing",
 					PriceHash:       "8c6410e6b05f87ffc7ee2268f2d7afc7-ef2cadbde566a742ff14834f883bcb8a",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "Storage (HDD)",
+					PriceHash:       "5cf7faa740d422ad2a42937d73517ba4-57bc5d148491a8381abaccb21ca6b4e9",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(50)),
 				},
 				{
 					Name:            "License (Enterprise)",


### PR DESCRIPTION
Issue #386

Output example: 

```
  NAME                                          MONTHLY QTY  UNIT       PRICE   HOURLY COST  MONTHLY COST
  google_sql_database_instance.my_instance                                                                 
  ├─ vCPUs (regional)                                11,680  hours      0.0826       1.3216      964.7680  
  ├─ Memory (regional)                               43,800  GB         0.0140       0.8400      613.2000  
  ├─ Storage (SSD, regional)                            100  GB-months  0.3400       0.0466       34.0000  
  ├─ Backups                                          1,000  GB-months  0.0800       0.1096       80.0000  
  ├─ IP address (if unused)                             730  hours      0.0100       0.0100        7.3000  
  └─ Replica                                    
     ├─ vCPUs (zonal)                                11,680  hours      0.0413       0.6608      482.3840  
     ├─ Memory (zonal)                               43,800  GB         0.0070       0.4200      306.6000  
     └─ Storage (SSD, zonal)                            100  GB-months  0.1700       0.0233       17.0000  
  Total                                                                              3.4319    2,505.2520
```

```
  NAME                                          MONTHLY QTY  UNIT       PRICE   HOURLY COST  MONTHLY COST
  google_sql_database_instance.my_instance                                                                 
  ├─ SQL instance (db-n1-standard-32, zonal)            730  hours      2.1620       2.1620    1,578.2600  
  ├─ Storage (SSD, zonal)                                10  GB-months  0.1700       0.0023        1.7000  
  └─ Backups                                          1,000  GB-months  0.0800       0.1096       80.0000  
  Total                                                                              2.2739    1,659.9600 
```