### PR TITLE
fix: update name of old env

### DIFF
--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -70,7 +70,7 @@ func (p *DirProvider) DisplayType() string {
 func (p *DirProvider) checks() error {
 	_, err := exec.LookPath(p.TerraformBinary)
 	if err != nil {
-		msg := fmt.Sprintf("Terraform binary \"%s\" could not be found.\nSet a custom Terraform binary in your Infracost config or using the environment variable TERRAFORM_BINARY.", p.TerraformBinary)
+		msg := fmt.Sprintf("Terraform binary \"%s\" could not be found.\nSet a custom Terraform binary in your Infracost config or using the environment variable INFRACOST_TERRAFORM_BINARY.", p.TerraformBinary)
 		return events.NewError(errors.Errorf(msg), "Terraform binary could not be found")
 	}
 


### PR DESCRIPTION
@aliscott feel free to close this PR if this code is meant to mention the old env name. A user using the latest infracost-atlantis integration saw this error, so I wondered if we should update this:
```
Error: Terraform binary "/usr/local/bin/terraform0.13.4" could not be found.
Set a custom Terraform binary in your Infracost config or using the environment variable TERRAFORM_BINARY.
```