### PR TITLE
Add Azure VM scale sets

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -442,7 +442,12 @@ resource_usage:
   azurerm_linux_virtual_machine.my_linux_vm:
     os_disk:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
-  
+
+  azurerm_linux_virtual_machine_scale_set.standard_f2:
+    instances: 10 # Override the number of instances in the scale set.
+    os_disk:
+      monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB per instance in the scale set.
+
   azurerm_managed_disk.my_disk:
     monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
   
@@ -450,4 +455,7 @@ resource_usage:
     os_disk:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 
-
+  azurerm_windows_virtual_machine_scale_set.basic_a2:
+    instances: 10 # Override the number of instances in the scale set.
+    os_disk:
+      monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB per instance in the scale set.

--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -25,6 +25,11 @@ func NewAzureRMLinuxVirtualMachine(d *schema.ResourceData, u *schema.UsageData) 
 	instanceType := d.Get("size").String()
 
 	costComponents := []*schema.CostComponent{linuxVirtualMachineCostComponent(region, instanceType)}
+
+	if d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool() {
+		costComponents = append(costComponents, ultraSSDReservationCostComponent(region))
+	}
+
 	subResources := make([]*schema.Resource, 0)
 
 	osDisk := osDiskSubResource(region, d, u)

--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -22,8 +22,9 @@ func GetAzureRMLinuxVirtualMachineRegistryItem() *schema.RegistryItem {
 
 func NewAzureRMLinuxVirtualMachine(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := d.Get("location").String()
+	instanceType := d.Get("size").String()
 
-	costComponents := []*schema.CostComponent{linuxVirtualMachineCostComponent(d)}
+	costComponents := []*schema.CostComponent{linuxVirtualMachineCostComponent(region, instanceType)}
 	subResources := make([]*schema.Resource, 0)
 
 	osDisk := osDiskSubResource(region, d, u)
@@ -38,18 +39,16 @@ func NewAzureRMLinuxVirtualMachine(d *schema.ResourceData, u *schema.UsageData) 
 	}
 }
 
-func linuxVirtualMachineCostComponent(d *schema.ResourceData) *schema.CostComponent {
-	region := d.Get("location").String()
-	size := d.Get("size").String()
+func linuxVirtualMachineCostComponent(region string, instanceType string) *schema.CostComponent {
 	purchaseOption := "Consumption"
 	purchaseOptionLabel := "pay as you go"
 
 	productNameRe := "/Virtual Machines .* Series$/"
-	if strings.HasPrefix(size, "Basic_") {
+	if strings.HasPrefix(instanceType, "Basic_") {
 		productNameRe = "/Virtual Machines .* Series Basic$/"
 	}
 
-	skuName := parseVMSKUName(size)
+	skuName := parseVMSKUName(instanceType)
 
 	return &schema.CostComponent{
 		Name:           fmt.Sprintf("Instance usage (%s, %s)", purchaseOptionLabel, skuName),
@@ -62,7 +61,7 @@ func linuxVirtualMachineCostComponent(d *schema.ResourceData) *schema.CostCompon
 			Service:       strPtr("Virtual Machines"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "armSkuName", Value: strPtr(size)},
+				{Key: "armSkuName", Value: strPtr(instanceType)},
 				{Key: "productName", ValueRegex: strPtr(productNameRe)},
 				{Key: "skuName", Value: strPtr(skuName)},
 			},

--- a/internal/providers/terraform/azure/linux_virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine_scale_set.go
@@ -20,6 +20,10 @@ func NewAzureRMLinuxVirtualMachineScaleSet(d *schema.ResourceData, u *schema.Usa
 	costComponents := []*schema.CostComponent{linuxVirtualMachineCostComponent(region, instanceType)}
 	subResources := make([]*schema.Resource, 0)
 
+	if d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool() {
+		costComponents = append(costComponents, ultraSSDReservationCostComponent(region))
+	}
+
 	osDisk := osDiskSubResource(region, d, u)
 	if osDisk != nil {
 		subResources = append(subResources, osDisk)

--- a/internal/providers/terraform/azure/linux_virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine_scale_set.go
@@ -1,0 +1,42 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+	"github.com/tidwall/gjson"
+)
+
+func GetAzureRMLinuxVirtualMachineScaleSetRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_linux_virtual_machine_scale_set",
+		RFunc: NewAzureRMLinuxVirtualMachineScaleSet,
+	}
+}
+
+func NewAzureRMLinuxVirtualMachineScaleSet(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("location").String()
+	instanceType := d.Get("sku").String()
+
+	costComponents := []*schema.CostComponent{linuxVirtualMachineCostComponent(region, instanceType)}
+	subResources := make([]*schema.Resource, 0)
+
+	osDisk := osDiskSubResource(region, d, u)
+	if osDisk != nil {
+		subResources = append(subResources, osDisk)
+	}
+
+	instanceCount := decimal.NewFromInt(d.Get("instances").Int())
+	if u != nil && u.Get("instances").Type != gjson.Null {
+		instanceCount = decimal.NewFromInt(u.Get("instances").Int())
+	}
+
+	r := &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+		SubResources:   subResources,
+	}
+
+	schema.MultiplyQuantities(r, instanceCount)
+
+	return r
+}

--- a/internal/providers/terraform/azure/linux_virtual_machine_scale_set_test.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine_scale_set_test.go
@@ -1,0 +1,152 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureRMLinuxVirtualMachineScaleSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "azurerm_linux_virtual_machine_scale_set" "basic_a2" {
+			name                = "basic_a2"
+			resource_group_name = "fake_resource_group"
+			location            = "eastus"
+			instances           = 3
+
+			sku            = "Basic_A2"
+			admin_username = "fakeuser"
+			admin_password = "fakepass"
+
+			network_interface {
+				name    = "example"
+				primary = true
+		
+				ip_configuration {
+					name      = "internal"
+					primary   = true
+					subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/subnets/fakesubnet"
+				}
+			}
+
+			os_disk {
+				caching              = "ReadWrite"
+				storage_account_type = "Standard_LRS"
+			}
+
+			source_image_reference {
+				publisher = "Canonical"
+				offer     = "UbuntuServer"
+				sku       = "16.04-LTS"
+				version   = "latest"
+			}
+		}
+
+		resource "azurerm_linux_virtual_machine_scale_set" "basic_a2_usage" {
+			name                = "basic_a2"
+			resource_group_name = "fake_resource_group"
+			location            = "eastus"
+			instances           = 3
+
+			sku            = "Basic_A2"
+			admin_username = "fakeuser"
+			admin_password = "fakepass"
+
+			network_interface {
+				name    = "example"
+				primary = true
+		
+				ip_configuration {
+					name      = "internal"
+					primary   = true
+					subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/subnets/fakesubnet"
+				}
+			}
+
+			os_disk {
+				caching              = "ReadWrite"
+				storage_account_type = "Standard_LRS"
+			}
+
+			source_image_reference {
+				publisher = "Canonical"
+				offer     = "UbuntuServer"
+				sku       = "16.04-LTS"
+				version   = "latest"
+			}
+		}
+	`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"azurerm_linux_virtual_machine_scale_set.basic_a2_usage": map[string]interface{}{
+			"instances": 4,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "azurerm_linux_virtual_machine_scale_set.basic_a2",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (pay as you go, A2)",
+					PriceHash:       "4a86d8e93f2661b5e00bbd43d589f6a9-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(3)),
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "os_disk",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:             "Storage (S4)",
+							PriceHash:        "c972de114a273694e428f2fd1f5fad35-e285791b6e6926c07354b58a33e7ecf4",
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(3)),
+						},
+						{
+							Name:             "Disk operations",
+							PriceHash:        "bde05feab07ea46abc6317ffd45fca54-49c37505210dfd1c98233191a87608bd",
+							MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "azurerm_linux_virtual_machine_scale_set.basic_a2_usage",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (pay as you go, A2)",
+					PriceHash:       "4a86d8e93f2661b5e00bbd43d589f6a9-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "os_disk",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:             "Storage (S4)",
+							PriceHash:        "c972de114a273694e428f2fd1f5fad35-e285791b6e6926c07354b58a33e7ecf4",
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(4)),
+						},
+						{
+							Name:             "Disk operations",
+							PriceHash:        "bde05feab07ea46abc6317ffd45fca54-49c37505210dfd1c98233191a87608bd",
+							MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/azure/linux_virtual_machine_test.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine_test.go
@@ -94,6 +94,36 @@ func TestAzureRMLinuxVirtualMachine(t *testing.T) {
 				version   = "latest"
 			}
 		}
+		
+		resource "azurerm_linux_virtual_machine" "standard_a2_ultra_enabled" {
+			name                = "standard_a2_ultra_enabled"
+			resource_group_name = "fake_resource_group"
+			location            = "eastus"
+
+			size           = "Standard_A2_v2"
+			admin_username = "fakeuser"
+			admin_password = "fakepass"
+
+			network_interface_ids = [
+				"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic",
+			]
+
+			os_disk {
+				caching              = "ReadWrite"
+				storage_account_type = "StandardSSD_LRS"
+			}
+			
+			additional_capabilities {
+				ultra_ssd_enabled = true
+			}
+
+			source_image_reference {
+				publisher = "Canonical"
+				offer     = "UbuntuServer"
+				sku       = "16.04-LTS"
+				version   = "latest"
+			}
+		}
 	`
 
 	usage := schema.NewUsageMap(map[string]interface{}{
@@ -176,6 +206,26 @@ func TestAzureRMLinuxVirtualMachine(t *testing.T) {
 							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 					},
+				},
+			},
+		},
+		{
+			Name: "azurerm_linux_virtual_machine.standard_a2_ultra_enabled",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:      "Instance usage (pay as you go, A2 v2)",
+					SkipCheck: true,
+				},
+				{
+					Name:             "Ultra disk reservation (if unattached)",
+					PriceHash:        "cdb969dd2d88d468c7842c5a42c07050-c1baecc1e3a89596af672fd42fe001bf",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "os_disk",
+					SkipCheck: true,
 				},
 			},
 		},

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -4,8 +4,10 @@ import "github.com/infracost/infracost/internal/schema"
 
 var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMLinuxVirtualMachineRegistryItem(),
+	GetAzureRMLinuxVirtualMachineScaleSetRegistryItem(),
 	GetAzureRMManagedDiskRegistryItem(),
 	GetAzureRMWindowsVirtualMachineRegistryItem(),
+	GetAzureRMWindowsVirtualMachineScaleSetRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/virtual_machine.go
+++ b/internal/providers/terraform/azure/virtual_machine.go
@@ -15,6 +15,29 @@ func parseVMSKUName(instanceType string) string {
 	return s
 }
 
+func ultraSSDReservationCostComponent(region string) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:           "Ultra disk reservation (if unattached)",
+		Unit:           "vCPU-hours",
+		UnitMultiplier: 1,
+		HourlyQuantity: nil,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(region),
+			Service:       strPtr("Storage"),
+			ProductFamily: strPtr("Storage"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Ultra Disks")},
+				{Key: "skuName", Value: strPtr("Ultra LRS")},
+				{Key: "meterName", Value: strPtr("Reservation per vCPU Provisioned")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	}
+}
+
 func osDiskSubResource(region string, d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	if len(d.Get("os_disk").Array()) == 0 {
 		return nil

--- a/internal/providers/terraform/azure/virtual_machine.go
+++ b/internal/providers/terraform/azure/virtual_machine.go
@@ -7,9 +7,9 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// Parse from Terraform size value to Azure instance type value.
-func parseVMSKUName(size string) string {
-	s := strings.ReplaceAll(size, "Standard_", "")
+// Parse from instance type value to Azure SKU name.
+func parseVMSKUName(instanceType string) string {
+	s := strings.ReplaceAll(instanceType, "Standard_", "")
 	s = strings.ReplaceAll(s, "Basic_", "")
 	s = strings.ReplaceAll(s, "_", " ")
 	return s

--- a/internal/providers/terraform/azure/windows_virtual_machine.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine.go
@@ -21,8 +21,10 @@ func GetAzureRMWindowsVirtualMachineRegistryItem() *schema.RegistryItem {
 
 func NewAzureRMWindowsVirtualMachine(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := d.Get("location").String()
+	instanceType := d.Get("size").String()
+	licenseType := d.Get("license_type").String()
 
-	costComponents := []*schema.CostComponent{windowsVirtualMachineCostComponent(d)}
+	costComponents := []*schema.CostComponent{windowsVirtualMachineCostComponent(region, instanceType, licenseType)}
 	subResources := make([]*schema.Resource, 0)
 
 	osDisk := osDiskSubResource(region, d, u)
@@ -37,25 +39,22 @@ func NewAzureRMWindowsVirtualMachine(d *schema.ResourceData, u *schema.UsageData
 	}
 }
 
-func windowsVirtualMachineCostComponent(d *schema.ResourceData) *schema.CostComponent {
-	region := d.Get("location").String()
-	size := d.Get("size").String()
+func windowsVirtualMachineCostComponent(region string, instanceType string, licenseType string) *schema.CostComponent {
 	purchaseOption := "Consumption"
 	purchaseOptionLabel := "pay as you go"
 
 	productNameRe := "/Virtual Machines .* Series Windows$/"
-	if strings.HasPrefix(size, "Basic_") {
+	if strings.HasPrefix(instanceType, "Basic_") {
 		productNameRe = "/Virtual Machines .* Series Basic Windows$/"
 	}
 
 	// Handle Azure Hybrid Benefit
-	licenseType := d.Get("license_type").String()
 	if licenseType == "Windows_Client" || licenseType == "Windows_Server" {
 		purchaseOption = "DevTestConsumption"
 		purchaseOptionLabel = "hybrid benefit"
 	}
 
-	skuName := parseVMSKUName(size)
+	skuName := parseVMSKUName(instanceType)
 
 	return &schema.CostComponent{
 		Name:           fmt.Sprintf("Instance usage (%s, %s)", purchaseOptionLabel, skuName),
@@ -68,7 +67,7 @@ func windowsVirtualMachineCostComponent(d *schema.ResourceData) *schema.CostComp
 			Service:       strPtr("Virtual Machines"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "armSkuName", Value: strPtr(size)},
+				{Key: "armSkuName", Value: strPtr(instanceType)},
 				{Key: "productName", ValueRegex: strPtr(productNameRe)},
 				{Key: "skuName", Value: strPtr(skuName)},
 			},

--- a/internal/providers/terraform/azure/windows_virtual_machine.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine.go
@@ -25,6 +25,11 @@ func NewAzureRMWindowsVirtualMachine(d *schema.ResourceData, u *schema.UsageData
 	licenseType := d.Get("license_type").String()
 
 	costComponents := []*schema.CostComponent{windowsVirtualMachineCostComponent(region, instanceType, licenseType)}
+
+	if d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool() {
+		costComponents = append(costComponents, ultraSSDReservationCostComponent(region))
+	}
+
 	subResources := make([]*schema.Resource, 0)
 
 	osDisk := osDiskSubResource(region, d, u)

--- a/internal/providers/terraform/azure/windows_virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine_scale_set.go
@@ -1,0 +1,43 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+	"github.com/tidwall/gjson"
+)
+
+func GetAzureRMWindowsVirtualMachineScaleSetRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_windows_virtual_machine_scale_set",
+		RFunc: NewAzureRMWindowsVirtualMachineScaleSet,
+	}
+}
+
+func NewAzureRMWindowsVirtualMachineScaleSet(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("location").String()
+	instanceType := d.Get("sku").String()
+	licenseType := d.Get("license_type").String()
+
+	costComponents := []*schema.CostComponent{windowsVirtualMachineCostComponent(region, instanceType, licenseType)}
+	subResources := make([]*schema.Resource, 0)
+
+	osDisk := osDiskSubResource(region, d, u)
+	if osDisk != nil {
+		subResources = append(subResources, osDisk)
+	}
+
+	instanceCount := decimal.NewFromInt(d.Get("instances").Int())
+	if u != nil && u.Get("instances").Type != gjson.Null {
+		instanceCount = decimal.NewFromInt(u.Get("instances").Int())
+	}
+
+	r := &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+		SubResources:   subResources,
+	}
+
+	schema.MultiplyQuantities(r, instanceCount)
+
+	return r
+}

--- a/internal/providers/terraform/azure/windows_virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine_scale_set.go
@@ -19,6 +19,11 @@ func NewAzureRMWindowsVirtualMachineScaleSet(d *schema.ResourceData, u *schema.U
 	licenseType := d.Get("license_type").String()
 
 	costComponents := []*schema.CostComponent{windowsVirtualMachineCostComponent(region, instanceType, licenseType)}
+
+	if d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool() {
+		costComponents = append(costComponents, ultraSSDReservationCostComponent(region))
+	}
+
 	subResources := make([]*schema.Resource, 0)
 
 	osDisk := osDiskSubResource(region, d, u)

--- a/internal/providers/terraform/azure/windows_virtual_machine_scale_set_test.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine_scale_set_test.go
@@ -1,0 +1,152 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureRMWindowsVirtualMachineScaleSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "azurerm_windows_virtual_machine_scale_set" "basic_a2" {
+			name                = "basic_a2"
+			resource_group_name = "fake_resource_group"
+			location            = "eastus"
+			instances           = 3
+
+			sku            = "Basic_A2"
+			admin_username = "fakeuser"
+			admin_password = "fakepass"
+
+			network_interface {
+				name    = "example"
+				primary = true
+		
+				ip_configuration {
+					name      = "internal"
+					primary   = true
+					subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/subnets/fakesubnet"
+				}
+			}
+
+			os_disk {
+				caching              = "ReadWrite"
+				storage_account_type = "Standard_LRS"
+			}
+
+			source_image_reference {
+				publisher = "MicrosoftWindowsServer"
+				offer     = "WindowsServer"
+				sku       = "2016-Datacenter"
+				version   = "latest"
+			}
+		}
+
+		resource "azurerm_windows_virtual_machine_scale_set" "basic_a2_usage" {
+			name                = "basic_a2"
+			resource_group_name = "fake_resource_group"
+			location            = "eastus"
+			instances           = 3
+
+			sku            = "Basic_A2"
+			admin_username = "fakeuser"
+			admin_password = "fakepass"
+
+			network_interface {
+				name    = "example"
+				primary = true
+		
+				ip_configuration {
+					name      = "internal"
+					primary   = true
+					subnet_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/subnets/fakesubnet"
+				}
+			}
+
+			os_disk {
+				caching              = "ReadWrite"
+				storage_account_type = "Standard_LRS"
+			}
+
+			source_image_reference {
+				publisher = "MicrosoftWindowsServer"
+				offer     = "WindowsServer"
+				sku       = "2016-Datacenter"
+				version   = "latest"
+			}
+		}
+	`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"azurerm_windows_virtual_machine_scale_set.basic_a2_usage": map[string]interface{}{
+			"instances": 4,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "azurerm_windows_virtual_machine_scale_set.basic_a2",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (pay as you go, A2)",
+					PriceHash:       "571360f185f641494606f9489a2f7141-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(3)),
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "os_disk",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:             "Storage (S4)",
+							PriceHash:        "c972de114a273694e428f2fd1f5fad35-e285791b6e6926c07354b58a33e7ecf4",
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(3)),
+						},
+						{
+							Name:             "Disk operations",
+							PriceHash:        "bde05feab07ea46abc6317ffd45fca54-49c37505210dfd1c98233191a87608bd",
+							MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "azurerm_windows_virtual_machine_scale_set.basic_a2_usage",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (pay as you go, A2)",
+					PriceHash:       "571360f185f641494606f9489a2f7141-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "os_disk",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:             "Storage (S4)",
+							PriceHash:        "c972de114a273694e428f2fd1f5fad35-e285791b6e6926c07354b58a33e7ecf4",
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(4)),
+						},
+						{
+							Name:             "Disk operations",
+							PriceHash:        "bde05feab07ea46abc6317ffd45fca54-49c37505210dfd1c98233191a87608bd",
+							MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/azure/windows_virtual_machine_test.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine_test.go
@@ -123,6 +123,36 @@ func TestAzureRMWindowsVirtualMachine(t *testing.T) {
 				version   = "latest"
 			}
 		}
+		
+		resource "azurerm_windows_virtual_machine" "standard_a2_ultra_enabled" {
+			name                = "standard_a2_ultra_enabled"
+			resource_group_name = "fake_resource_group"
+			location            = "eastus"
+
+			size           = "Standard_A2_v2"
+			admin_username = "fakeuser"
+			admin_password = "fakepass"
+
+			network_interface_ids = [
+				"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic",
+			]
+
+			os_disk {
+				caching              = "ReadWrite"
+				storage_account_type = "StandardSSD_LRS"
+			}
+			
+			additional_capabilities {
+				ultra_ssd_enabled = true
+			}
+
+			source_image_reference {
+				publisher = "MicrosoftWindowsServer"
+				offer     = "WindowsServer"
+				sku       = "2016-Datacenter"
+				version   = "latest"
+			}
+		}
 	`
 
 	usage := schema.NewUsageMap(map[string]interface{}{
@@ -215,6 +245,26 @@ func TestAzureRMWindowsVirtualMachine(t *testing.T) {
 					Name:            "Instance usage (hybrid benefit, D2 v4)",
 					PriceHash:       "188638135dbae0493714883d684fc65a-cfd8f218a181c17d03a5e84e38767fcc",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "os_disk",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "azurerm_windows_virtual_machine.standard_a2_ultra_enabled",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:      "Instance usage (pay as you go, A2 v2)",
+					SkipCheck: true,
+				},
+				{
+					Name:             "Ultra disk reservation (if unattached)",
+					PriceHash:        "cdb969dd2d88d468c7842c5a42c07050-c1baecc1e3a89596af672fd42fe001bf",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
 				},
 			},
 			SubResourceChecks: []testutil.ResourceCheck{


### PR DESCRIPTION
**Without usage:**
```
 Name                                                        Quantity  Unit                Monthly Cost

 azurerm_linux_virtual_machine_scale_set.standard_f2
 ├─ Instance usage (pay as you go, F2)                          1,460  hours                    $144.54
 ├─ Ultra disk reservation (if unattached)            Cost depends on usage: $0.006 per vCPU-hours
 └─ os_disk
    ├─ Storage (S4)                                                 2  months                     $3.07
    └─ Disk operations                                Cost depends on usage: $0.0005 per 10k operations

 azurerm_windows_virtual_machine_scale_set.basic_a2
 ├─ Instance usage (pay as you go, A2)                          2,190  hours                    $291.27
 └─ os_disk
    ├─ Storage (S4)                                                 3  months                     $4.61
    └─ Disk operations                                Cost depends on usage: $0.0005 per 10k operations
```

**With usage:**

```yml
  azurerm_linux_virtual_machine_scale_set.standard_f2:
    instances: 10 # Override the number of instances in the scale set.
    os_disk:
      monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB per instance in the scale set.

  azurerm_windows_virtual_machine_scale_set.basic_a2:
    instances: 10 # Override the number of instances in the scale set.
    os_disk:
      monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB per instance in the scale set.
```

```
 azurerm_linux_virtual_machine_scale_set.standard_f2
 ├─ Instance usage (pay as you go, F2)                          7,300  hours                    $722.70
 ├─ Ultra disk reservation (if unattached)            Cost depends on usage: $0.006 per vCPU-hours
 └─ os_disk
    ├─ Storage (S4)                                                10  months                    $15.36
    └─ Disk operations                                          2,000  10k operations             $1.00

 azurerm_windows_virtual_machine_scale_set.basic_a2
 ├─ Instance usage (pay as you go, A2)                          7,300  hours                    $970.90
 └─ os_disk
    ├─ Storage (S4)                                                10  months                    $15.36
    └─ Disk operations                                          2,000  10k operations             $1.00
```