### PR TITLE
feat(azure): add azurerm_app_service_certificate_order

### DIFF
--- a/internal/providers/terraform/azure/app_service_certificate_order.go
+++ b/internal/providers/terraform/azure/app_service_certificate_order.go
@@ -1,0 +1,56 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/schema"
+
+	"github.com/shopspring/decimal"
+)
+
+func GetAzureRMAppServiceCertificateOrderRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_app_service_certificate_order",
+		RFunc: NewAzureRMAppServiceCertificateOrder,
+	}
+}
+
+func NewAzureRMAppServiceCertificateOrder(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := "Global"
+	if strings.HasPrefix(region, "usgov") {
+		region = "US Gov"
+	}
+
+	productType := "Standard"
+	if d.Get("product_type").Exists() {
+		productType = d.Get("product_type").String()
+	}
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name:           fmt.Sprintf("SSL certificate (%s)", productType),
+			Unit:           "years",
+			UnitMultiplier: 1,
+			// Convert yearly price to monthly
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1).Div(decimal.NewFromInt(12))),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("azure"),
+				Region:        strPtr(region),
+				Service:       strPtr("Azure App Service"),
+				ProductFamily: strPtr("Compute"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "skuName", ValueRegex: strPtr(fmt.Sprintf("/%s SSL - 1 Year/i", productType))},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/providers/terraform/azure/app_service_certificate_order_test.go
+++ b/internal/providers/terraform/azure/app_service_certificate_order_test.go
@@ -1,0 +1,59 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureRMAppServiceCertificateOrder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "azurerm_app_service_certificate_order" "standard_cert" {
+			name                = "example-cert-order"
+			resource_group_name = "fake"
+			location            = "global"
+			distinguished_name  = "CN=example.com"
+		}
+
+		resource "azurerm_app_service_certificate_order" "wildcard_cert" {
+			name                = "example-cert-order"
+			resource_group_name = "fake"
+			location            = "global"
+			distinguished_name  = "CN=example.com"
+			product_type        = "Wildcard"
+		}		
+	`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "azurerm_app_service_certificate_order.standard_cert",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "SSL certificate (Standard)",
+					PriceHash:        "4e8a819ae89e667ac4c8e5a86c983d49-e1f24f9fc7676b8cc310519e3f060f1d",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1).Div(decimal.NewFromInt(12))),
+				},
+			},
+		},
+		{
+			Name: "azurerm_app_service_certificate_order.wildcard_cert",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "SSL certificate (Wildcard)",
+					PriceHash:        "6ec315d71563d4fc7369d88c8869765f-e1f24f9fc7676b8cc310519e3f060f1d",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1).Div(decimal.NewFromInt(12))),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -3,6 +3,7 @@ package azure
 import "github.com/infracost/infracost/internal/schema"
 
 var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
+	GetAzureRMAppServiceCertificateOrderRegistryItem(),
 	GetAzureRMLinuxVirtualMachineRegistryItem(),
 	GetAzureRMManagedDiskRegistryItem(),
 	GetAzureRMWindowsVirtualMachineRegistryItem(),


### PR DESCRIPTION
**Objective**:

Add support for `azurerm_app_service_certificate_order`. Fixes https://github.com/infracost/infracost/issues/570

Example output without usage-file:
```
Running "infracost breakdown --path ." against a main.tf with:
resource "azurerm_app_service_certificate_order" "example" {
  name                = "example-cert-order"
  resource_group_name = "fake"
  location            = "usgovtexas"
  distinguished_name  = "CN=example.com"
  product_type        = "wildcard"
}


 Name                                           Quantity  Unit   Monthly Cost

 azurerm_app_service_certificate_order.example
 └─ SSL certificate (wildcard)                    0.0833  years        $25.00

 PROJECT TOTAL                                                         $25.00

Example output with usage-file:
(same as above)
```

**Pricing details**:

The Azure pricing page mentioned that the non-Gov cloud and Gov-cloud prices are the same but the Azure pricing API had different prices for those so I went with the Azure pricing API. Please let me know if I should change that.

**Status**:

- [x] Added to resource_registry.go
- [x] Added resource file
- [x] Added integration tests
- Added unit tests if applicable - Not applicable

**Issues**:

    None

**Useful links**:

    Pricing: https://azure.microsoft.com/en-gb/pricing/details/app-service/windows/
    Terraform: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_certificate_order
