### PR TITLE
feat(aws): add support for AWS EC2 RI prices

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -46,6 +46,7 @@ resource_usage:
 
   aws_autoscaling_group.my_asg:
     instances: 15 # Number of instances in the autoscaling group.
+    operating_system: linux # Override the operating system of the instance, can be: linux, windows, suse, rhel.
     reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: no_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
@@ -137,6 +138,7 @@ resource_usage:
     monthly_infrequent_access_write_gb: 100 # Monthly infrequent access write requests in GB.
 
   aws_eks_node_group.my_instance:
+    operating_system: linux # Override the operating system of the instance, can be: linux, windows, suse, rhel.
     reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: partial_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -44,6 +44,12 @@ resource_usage:
     message_size_kb: 32               # Average size of the messages sent to the Websocket API Gateway in KB. Messages are metered in 32 KB increments, maximum size is 128KB.
     monthly_connection_mins: 10000000 # Monthly total connection minutes to Websockets.
 
+  aws_autoscaling_group.my_asg:
+    instances: 15 # Number of instances in the autoscaling group.
+    reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
+    reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
+    reserved_instance_payment_option: no_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
+
   aws_cloudwatch_event_bus.my_events:
     monthly_custom_events: 1000000            # Monthly custom events published. Each 64 KB chunk of payload is billed as 1 event.
     monthly_third_party_events: 2000000       # Monthly third-party and cross-account events published. Each 64 KB chunk of payload is billed as 1 event.
@@ -130,14 +136,22 @@ resource_usage:
     monthly_infrequent_access_read_gb: 50   # Monthly infrequent access read requests in GB.
     monthly_infrequent_access_write_gb: 100 # Monthly infrequent access write requests in GB.
 
+  aws_eks_node_group.my_instance:
+    reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
+    reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
+    reserved_instance_payment_option: partial_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
+
   aws_elasticache_cluster.my_redis_snapshot:
     snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB. 
 
   aws_elb.my_elb:
     monthly_data_processed_gb: 10000 # Monthly data processed by a Classic Load Balancer in GB.
 
-  aws_instance.windows_instance:
+  aws_instance.my_instance:
     operating_system: linux # Override the operating system of the instance, can be: linux, windows, suse, rhel.
+    reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
+    reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
+    reserved_instance_payment_option: all_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
 
   aws_fsx_windows_file_system.my_system:
     backup_storage_gb: 10000 # Total storage used for backups in GB.
@@ -332,9 +346,6 @@ resource_usage:
     monthly_encryption_requests: 100000 # Monthly number of field level encryption requests.
     monthly_log_lines: 5000000          # Monthly number of real-time log lines.
     custom_ssl_certificates: 3          # Number of dedicated IP custom SSL certificates.
-
-  aws_autoscaling_group.my_asg:
-    instances: 15 # Number of instances in the autoscaling group.
   
   #
   # Terraform GCP resources

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -979,3 +979,87 @@ func TestAutoscalingGroup_overrideUsageData(t *testing.T) {
 
 	tftest.ResourceTests(t, tf, usage, resourceChecks)
 }
+
+func TestAutoscalingGroup_reserved(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "aws_launch_configuration" "lc1" {
+		image_id      = "fake_ami"
+		instance_type = "t3.medium"
+
+		root_block_device {
+			volume_size = 10
+		}
+
+		ebs_block_device {
+			device_name = "xvdf"
+			volume_size = 10
+		}
+
+		ebs_block_device {
+			device_name = "xvdg"
+			volume_type = "gp3"
+			volume_size = 10
+		}
+	}
+
+	resource "aws_autoscaling_group" "my_asg" {
+		launch_configuration = aws_launch_configuration.lc1.id
+		desired_capacity     = 1
+		max_size             = 1
+		min_size             = 1
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_autoscaling_group.my_asg": map[string]interface{}{
+			"reserved_instance_type":           "standard",
+			"reserved_instance_term":           "1_year",
+			"reserved_instance_payment_option": "no_upfront",
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.my_asg",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_configuration.lc1",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+							PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-354de5028123250997d97c05d011fe1c",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+						},
+						{
+							Name:      "EC2 detailed monitoring",
+							SkipCheck: true,
+						},
+						{
+							Name:      "CPU credits",
+							SkipCheck: true,
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
+							SkipCheck: true,
+						},
+						{
+							Name:      "ebs_block_device[0]",
+							SkipCheck: true,
+						},
+						{
+							Name:      "ebs_block_device[1]",
+							SkipCheck: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -989,21 +989,6 @@ func TestAutoscalingGroup_reserved(t *testing.T) {
 	resource "aws_launch_configuration" "lc1" {
 		image_id      = "fake_ami"
 		instance_type = "t3.medium"
-
-		root_block_device {
-			volume_size = 10
-		}
-
-		ebs_block_device {
-			device_name = "xvdf"
-			volume_size = 10
-		}
-
-		ebs_block_device {
-			device_name = "xvdg"
-			volume_type = "gp3"
-			volume_size = 10
-		}
 	}
 
 	resource "aws_autoscaling_group" "my_asg" {
@@ -1047,12 +1032,63 @@ func TestAutoscalingGroup_reserved(t *testing.T) {
 							Name:      "root_block_device",
 							SkipCheck: true,
 						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}
+
+func TestAutoscalingGroup_windows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "aws_launch_configuration" "lc1" {
+		image_id      = "fake_ami"
+		instance_type = "t3.medium"
+	}
+
+	resource "aws_autoscaling_group" "my_asg" {
+		launch_configuration = aws_launch_configuration.lc1.id
+		desired_capacity     = 1
+		max_size             = 1
+		min_size             = 1
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_autoscaling_group.my_asg": map[string]interface{}{
+			"operating_system": "windows",
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_autoscaling_group.my_asg",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_configuration.lc1",
+					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:      "ebs_block_device[0]",
+							Name:            "Instance usage (Windows, on-demand, t3.medium)",
+							PriceHash:       "e18ba69d4a34cb83afd75d29cc0535ff-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+						},
+						{
+							Name:      "EC2 detailed monitoring",
 							SkipCheck: true,
 						},
 						{
-							Name:      "ebs_block_device[1]",
+							Name:      "CPU credits",
+							SkipCheck: true,
+						},
+					},
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name:      "root_block_device",
 							SkipCheck: true,
 						},
 					},

--- a/internal/providers/terraform/aws/eks_node_group.go
+++ b/internal/providers/terraform/aws/eks_node_group.go
@@ -88,33 +88,32 @@ func eksComputeCostComponent(d *schema.ResourceData, u *schema.UsageData, region
 		}
 	}
 
-	if RIType == "" {
-		return &schema.CostComponent{
-			Name:           fmt.Sprintf("Instance usage (Linux/UNIX, %s, %s)", strings.Replace(purchaseOptionLabel, "_", "-", 1), instanceType),
-			Unit:           "hours",
-			UnitMultiplier: 1,
-			HourlyQuantity: decimalPtr(decimal.NewFromInt(desiredSize)),
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Region:        strPtr(region),
-				Service:       strPtr("AmazonEC2"),
-				ProductFamily: strPtr("Compute Instance"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "instanceType", Value: strPtr(instanceType)},
-					{Key: "operatingSystem", Value: strPtr("Linux")},
-					{Key: "preInstalledSw", Value: strPtr("NA")},
-					{Key: "tenancy", Value: strPtr("Shared")},
-					{Key: "capacitystatus", Value: strPtr("Used")},
-				},
-			},
-			PriceFilter: &schema.PriceFilter{
-				PurchaseOption: strPtr(purchaseOptionLabel),
-			},
-		}
-	} else {
+	if RIType != "" {
 		return reservedInstanceCostComponent(region, "Linux/UNIX", purchaseOptionLabel, RIType, RITerm, RIPaymentOption, "Shared", instanceType, "Linux", desiredSize)
 	}
 
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("Instance usage (Linux/UNIX, %s, %s)", strings.Replace(purchaseOptionLabel, "_", "-", 1), instanceType),
+		Unit:           "hours",
+		UnitMultiplier: 1,
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(desiredSize)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEC2"),
+			ProductFamily: strPtr("Compute Instance"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "instanceType", Value: strPtr(instanceType)},
+				{Key: "operatingSystem", Value: strPtr("Linux")},
+				{Key: "preInstalledSw", Value: strPtr("NA")},
+				{Key: "tenancy", Value: strPtr("Shared")},
+				{Key: "capacitystatus", Value: strPtr("Used")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr(purchaseOptionLabel),
+		},
+	}
 }
 
 func eksCPUCreditsCostComponent(d *schema.ResourceData, region string, desiredSize int64, instanceType string) *schema.CostComponent {

--- a/internal/providers/terraform/aws/eks_node_group.go
+++ b/internal/providers/terraform/aws/eks_node_group.go
@@ -23,6 +23,10 @@ func NewEKSNodeGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resour
 	region := d.Get("region").String()
 	scalingConfig := d.Get("scaling_config").Array()[0]
 	desiredSize := scalingConfig.Get("desired_size").Int()
+	purchaseOptionLabel := "on_demand"
+	if d.Get("capacity_type").String() != "" {
+		purchaseOptionLabel = strings.ToLower(d.Get("capacity_type").String())
+	}
 	instanceType := "t3.medium"
 	if len(d.Get("instance_types").Array()) > 0 {
 		// Only a single type is expected https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group#instance_types
@@ -55,7 +59,7 @@ func NewEKSNodeGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resour
 		}
 		subResources = append(subResources, lt)
 	} else {
-		costComponents = append(costComponents, eksComputeCostComponent(d, u, region, desiredSize, instanceType))
+		costComponents = append(costComponents, computeCostComponent(d, u, purchaseOptionLabel, instanceType, "Shared", desiredSize))
 		eksCPUCreditsCostComponent := eksCPUCreditsCostComponent(d, region, desiredSize, instanceType)
 		if eksCPUCreditsCostComponent != nil {
 			costComponents = append(costComponents, eksCPUCreditsCostComponent)
@@ -67,52 +71,6 @@ func NewEKSNodeGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resour
 		Name:           d.Address,
 		CostComponents: costComponents,
 		SubResources:   subResources,
-	}
-}
-
-func eksComputeCostComponent(d *schema.ResourceData, u *schema.UsageData, region string, desiredSize int64, instanceType string) *schema.CostComponent {
-	purchaseOptionLabel := "on_demand"
-	if d.Get("capacity_type").String() != "" {
-		purchaseOptionLabel = strings.ToLower(d.Get("capacity_type").String())
-	}
-
-	var RIType, RITerm, RIPaymentOption string
-	if u != nil && u.Get("reserved_instance_type").Exists() {
-		purchaseOptionLabel = "reserved"
-		RIType = u.Get("reserved_instance_type").String()
-		if u.Get("reserved_instance_term").Exists() {
-			RITerm = u.Get("reserved_instance_term").String()
-		}
-		if u.Get("reserved_instance_payment_option").Exists() {
-			RIPaymentOption = u.Get("reserved_instance_payment_option").String()
-		}
-	}
-
-	if RIType != "" {
-		return reservedInstanceCostComponent(region, "Linux/UNIX", purchaseOptionLabel, RIType, RITerm, RIPaymentOption, "Shared", instanceType, "Linux", desiredSize)
-	}
-
-	return &schema.CostComponent{
-		Name:           fmt.Sprintf("Instance usage (Linux/UNIX, %s, %s)", strings.Replace(purchaseOptionLabel, "_", "-", 1), instanceType),
-		Unit:           "hours",
-		UnitMultiplier: 1,
-		HourlyQuantity: decimalPtr(decimal.NewFromInt(desiredSize)),
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("aws"),
-			Region:        strPtr(region),
-			Service:       strPtr("AmazonEC2"),
-			ProductFamily: strPtr("Compute Instance"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "instanceType", Value: strPtr(instanceType)},
-				{Key: "operatingSystem", Value: strPtr("Linux")},
-				{Key: "preInstalledSw", Value: strPtr("NA")},
-				{Key: "tenancy", Value: strPtr("Shared")},
-				{Key: "capacitystatus", Value: strPtr("Used")},
-			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			PurchaseOption: strPtr(purchaseOptionLabel),
-		},
 	}
 }
 

--- a/internal/providers/terraform/aws/eks_node_group_test.go
+++ b/internal/providers/terraform/aws/eks_node_group_test.go
@@ -452,3 +452,56 @@ func TestEKSNodeGroup_spot(t *testing.T) {
 
 	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
 }
+
+func TestEKSNodeGroup_reserved(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "aws_eks_node_group" "reserved" {
+		cluster_name    = "test aws_eks_node_group"
+		node_group_name = "example"
+		node_role_arn   = "node_role_arn"
+		subnet_ids      = ["subnet_id"]
+
+		scaling_config {
+			desired_size = 1
+			max_size     = 1
+			min_size     = 1
+		}
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_eks_node_group.reserved": map[string]interface{}{
+			"reserved_instance_type":           "standard",
+			"reserved_instance_term":           "1_year",
+			"reserved_instance_payment_option": "no_upfront",
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_eks_node_group.reserved",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-354de5028123250997d97c05d011fe1c",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "CPU credits",
+					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Storage (general purpose SSD, gp2)",
+					PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/aws/eks_node_group_test.go
+++ b/internal/providers/terraform/aws/eks_node_group_test.go
@@ -505,3 +505,54 @@ func TestEKSNodeGroup_reserved(t *testing.T) {
 
 	tftest.ResourceTests(t, tf, usage, resourceChecks)
 }
+
+func TestEKSNodeGroup_windows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "aws_eks_node_group" "windows" {
+		cluster_name    = "test aws_eks_node_group"
+		node_group_name = "example"
+		node_role_arn   = "node_role_arn"
+		subnet_ids      = ["subnet_id"]
+
+		scaling_config {
+			desired_size = 1
+			max_size     = 1
+			min_size     = 1
+		}
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_eks_node_group.windows": map[string]interface{}{
+			"operating_system": "windows",
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_eks_node_group.windows",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Windows, on-demand, t3.medium)",
+					PriceHash:       "e18ba69d4a34cb83afd75d29cc0535ff-d2c98780d7b6e36641b521f1f8145c6f",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "CPU credits",
+					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Storage (general purpose SSD, gp2)",
+					PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -138,17 +138,17 @@ func computeCostComponent(d *schema.ResourceData, u *schema.UsageData, purchaseO
 func validateReserveInstanceParams(typeName, term, option string) (bool, string) {
 	validTypes := []string{"convertible", "standard"}
 	if !stringInSlice(validTypes, typeName) {
-		return false, fmt.Sprintf("Invalid reserved_instance_type value. Expected: convertible, standard. Got: %s", typeName)
+		return false, fmt.Sprintf("Invalid reserved_instance_type, ignoring reserved options. Expected: convertible, standard. Got: %s", typeName)
 	}
 
 	validTerms := []string{"1_year", "3_year"}
 	if !stringInSlice(validTerms, term) {
-		return false, fmt.Sprintf("Invalid reserved_instance_term value. Expected: 1_year, 3_year. Got: %s", term)
+		return false, fmt.Sprintf("Invalid reserved_instance_term, ignoring reserved options. Expected: 1_year, 3_year. Got: %s", term)
 	}
 
 	validOptions := []string{"no_upfront", "partial_upfront", "all_upfront"}
 	if !stringInSlice(validOptions, option) {
-		return false, fmt.Sprintf("Invalid reserved_instance_payment_option value. Expected: no_upfront, partial_upfront, all_upfront. Got: %s", option)
+		return false, fmt.Sprintf("Invalid reserved_instance_payment_option, ignoring reserved options. Expected: no_upfront, partial_upfront, all_upfront. Got: %s", option)
 	}
 
 	return true, ""

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -91,57 +91,57 @@ func computeCostComponent(d *schema.ResourceData, u *schema.UsageData, purchaseO
 		}
 	}
 
-	var RIType, RITerm, RIPaymentOption string
+	var reservedIType, reservedTerm, reservedPaymentOption string
 	if u != nil && u.Get("reserved_instance_type").Exists() {
 		purchaseOptionLabel = "reserved"
-		RIType = u.Get("reserved_instance_type").String()
+		reservedIType = u.Get("reserved_instance_type").String()
 		if u.Get("reserved_instance_term").Exists() {
-			RITerm = u.Get("reserved_instance_term").String()
+			reservedTerm = u.Get("reserved_instance_term").String()
 		}
 		if u.Get("reserved_instance_payment_option").Exists() {
-			RIPaymentOption = u.Get("reserved_instance_payment_option").String()
+			reservedPaymentOption = u.Get("reserved_instance_payment_option").String()
 		}
 	}
 
-	if RIType != "" {
-		return reservedInstanceCostComponent(region, osLabel, purchaseOptionLabel, RIType, RITerm, RIPaymentOption, tenancy, instanceType, operatingSystem, 1)
-	} else {
-		return &schema.CostComponent{
-			Name:           fmt.Sprintf("Instance usage (%s, %s, %s)", osLabel, purchaseOptionLabel, instanceType),
-			Unit:           "hours",
-			UnitMultiplier: 1,
-			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Region:        strPtr(region),
-				Service:       strPtr("AmazonEC2"),
-				ProductFamily: strPtr("Compute Instance"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "instanceType", Value: strPtr(instanceType)},
-					{Key: "tenancy", Value: strPtr(tenancy)},
-					{Key: "operatingSystem", Value: strPtr(operatingSystem)},
-					{Key: "preInstalledSw", Value: strPtr("NA")},
-					{Key: "capacitystatus", Value: strPtr("Used")},
-				},
+	if reservedIType != "" {
+		return reservedInstanceCostComponent(region, osLabel, purchaseOptionLabel, reservedIType, reservedTerm, reservedPaymentOption, tenancy, instanceType, operatingSystem, 1)
+	}
+
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("Instance usage (%s, %s, %s)", osLabel, purchaseOptionLabel, instanceType),
+		Unit:           "hours",
+		UnitMultiplier: 1,
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEC2"),
+			ProductFamily: strPtr("Compute Instance"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "instanceType", Value: strPtr(instanceType)},
+				{Key: "tenancy", Value: strPtr(tenancy)},
+				{Key: "operatingSystem", Value: strPtr(operatingSystem)},
+				{Key: "preInstalledSw", Value: strPtr("NA")},
+				{Key: "capacitystatus", Value: strPtr("Used")},
 			},
-			PriceFilter: &schema.PriceFilter{
-				PurchaseOption: &purchaseOption,
-			},
-		}
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: &purchaseOption,
+		},
 	}
 }
 
-func reservedInstanceCostComponent(region, osLabel, purchaseOptionLabel, RIType, RITerm, RIPaymentOption, tenancy, instanceType, operatingSystem string, count int64) *schema.CostComponent {
-	RITermName := map[string]string{
+func reservedInstanceCostComponent(region, osLabel, purchaseOptionLabel, reservedType, reservedTerm, reservedPaymentOption, tenancy, instanceType, operatingSystem string, count int64) *schema.CostComponent {
+	reservedTermName := map[string]string{
 		"1_year": "1yr",
 		"3_year": "3yr",
-	}[RITerm]
+	}[reservedTerm]
 
-	RIPaymentOptionName := map[string]string{
+	reservedPaymentOptionName := map[string]string{
 		"no_upfront":      "No Upfront",
 		"partial_upfront": "Partial Upfront",
 		"all_upfront":     "All Upfront",
-	}[RIPaymentOption]
+	}[reservedPaymentOption]
 
 	return &schema.CostComponent{
 		Name:           fmt.Sprintf("Instance usage (%s, %s, %s)", osLabel, purchaseOptionLabel, instanceType),
@@ -163,9 +163,9 @@ func reservedInstanceCostComponent(region, osLabel, purchaseOptionLabel, RIType,
 		},
 		PriceFilter: &schema.PriceFilter{
 			StartUsageAmount:   strPtr("0"),
-			TermOfferingClass:  &RIType,
-			TermLength:         &RITermName,
-			TermPurchaseOption: &RIPaymentOptionName,
+			TermOfferingClass:  &reservedType,
+			TermLength:         &reservedTermName,
+			TermPurchaseOption: &reservedPaymentOptionName,
 		},
 	}
 }

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -423,3 +423,368 @@ func TestInstance_ec2DetailedMonitoring(t *testing.T) {
 
 	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
 }
+
+func TestInstance_RIPrices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "aws_instance" "std_1yr_no_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "std_3yr_no_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "std_1yr_partial_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "std_3yr_partial_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "std_1yr_all_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "std_3yr_all_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+
+		resource "aws_instance" "cnvr_1yr_no_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "cnvr_3yr_no_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "cnvr_1yr_partial_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "cnvr_3yr_partial_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "cnvr_1yr_all_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}
+		resource "aws_instance" "cnvr_3yr_all_upfront" {
+			ami           = "fake_ami"
+			instance_type = "t3.medium"
+		}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_instance.std_1yr_no_upfront": map[string]interface{}{
+			"reserved_instance_type":           "standard",
+			"reserved_instance_term":           "1_year",
+			"reserved_instance_payment_option": "no_upfront",
+		},
+		"aws_instance.std_3yr_no_upfront": map[string]interface{}{
+			"reserved_instance_type":           "standard",
+			"reserved_instance_term":           "3_year",
+			"reserved_instance_payment_option": "no_upfront",
+		},
+		"aws_instance.std_1yr_partial_upfront": map[string]interface{}{
+			"reserved_instance_type":           "standard",
+			"reserved_instance_term":           "1_year",
+			"reserved_instance_payment_option": "partial_upfront",
+		},
+		"aws_instance.std_3yr_partial_upfront": map[string]interface{}{
+			"reserved_instance_type":           "standard",
+			"reserved_instance_term":           "3_year",
+			"reserved_instance_payment_option": "partial_upfront",
+		},
+		"aws_instance.std_1yr_all_upfront": map[string]interface{}{
+			"reserved_instance_type":           "standard",
+			"reserved_instance_term":           "1_year",
+			"reserved_instance_payment_option": "all_upfront",
+		},
+		"aws_instance.std_3yr_all_upfront": map[string]interface{}{
+			"reserved_instance_type":           "standard",
+			"reserved_instance_term":           "3_year",
+			"reserved_instance_payment_option": "all_upfront",
+		},
+		"aws_instance.cnvr_1yr_no_upfront": map[string]interface{}{
+			"reserved_instance_type":           "convertible",
+			"reserved_instance_term":           "1_year",
+			"reserved_instance_payment_option": "no_upfront",
+		},
+		"aws_instance.cnvr_3yr_no_upfront": map[string]interface{}{
+			"reserved_instance_type":           "convertible",
+			"reserved_instance_term":           "3_year",
+			"reserved_instance_payment_option": "no_upfront",
+		},
+		"aws_instance.cnvr_1yr_partial_upfront": map[string]interface{}{
+			"reserved_instance_type":           "convertible",
+			"reserved_instance_term":           "1_year",
+			"reserved_instance_payment_option": "partial_upfront",
+		},
+		"aws_instance.cnvr_3yr_partial_upfront": map[string]interface{}{
+			"reserved_instance_type":           "convertible",
+			"reserved_instance_term":           "3_year",
+			"reserved_instance_payment_option": "partial_upfront",
+		},
+		"aws_instance.cnvr_1yr_all_upfront": map[string]interface{}{
+			"reserved_instance_type":           "convertible",
+			"reserved_instance_term":           "1_year",
+			"reserved_instance_payment_option": "all_upfront",
+		},
+		"aws_instance.cnvr_3yr_all_upfront": map[string]interface{}{
+			"reserved_instance_type":           "convertible",
+			"reserved_instance_term":           "3_year",
+			"reserved_instance_payment_option": "all_upfront",
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_instance.std_1yr_no_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-354de5028123250997d97c05d011fe1c",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.std_3yr_no_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-eacbcf31b049c055c292e5f56fbe6f38",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.std_1yr_partial_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-1b51d9b46826b8797099f7cfdfcdf299",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.std_3yr_partial_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-bf59b46c8f98c6a49405f768bfa8b60a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.std_1yr_all_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-0b517bfa356310108e91658d6759b4d5",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.std_3yr_all_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-4c69aedc693029aad69299aaef81901a",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.cnvr_1yr_no_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-db82ffe7b4996cd80e13db57284de443",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.cnvr_3yr_no_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-9252443b383d5d512783a5b68e9a901f",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.cnvr_1yr_partial_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-39830253d678995796c122c70b428e1b",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.cnvr_3yr_partial_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-99d3f32d59d2381ad0a77075299b58e6",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.cnvr_1yr_all_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-a0fcfdebef129d176f42bb38df23dad9",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+		{
+			Name: "aws_instance.cnvr_3yr_all_upfront",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, reserved, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-4a6714faa3f991aee5551b21d785b47c",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:      "CPU credits",
+					SkipCheck: true,
+				},
+			},
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name:      "root_block_device",
+					SkipCheck: true,
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/aws/util.go
+++ b/internal/providers/terraform/aws/util.go
@@ -11,3 +11,12 @@ func strPtr(s string) *string {
 func decimalPtr(d decimal.Decimal) *decimal.Decimal {
 	return &d
 }
+
+func stringInSlice(slice []string, s string) bool {
+	for _, b := range slice {
+		if b == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Issue #529 

Output examples:

```
 Name                                                         Quantity  Unit            Monthly Cost 
                                                                                                     
 aws_autoscaling_group.my_asg                                                                        
 └─ aws_launch_configuration.lc1                                                                     
    ├─ Instance usage (Linux/UNIX, reserved, t3.medium)         10,950  hours                $285.80 
    ├─ EC2 detailed monitoring                                     105  metrics               $31.50 
    ├─ CPU credits                                       Cost depends on usage: $0.05 per vCPU-hours 
    ├─ root_block_device                                                                             
    │  └─ Storage (general purpose SSD, gp2)                       150  GB-months             $15.00 
    ├─ ebs_block_device[0]                                                                           
    │  └─ Storage (general purpose SSD, gp2)                       150  GB-months             $15.00 
    └─ ebs_block_device[1]                                                                           
       └─ Storage (general purpose SSD, gp3)                       150  GB-months             $12.00 
                                                                                                                                                                                        
 aws_eks_node_group.my_instance                                                                      
 ├─ Instance usage (Linux/UNIX, reserved, t3.medium)               730  hours                  $9.05 
 ├─ CPU credits                                                    730  vCPU-hours            $36.50 
 └─ Storage (general purpose SSD, gp2)                              20  GB-months              $2.00 
                                                                                                     
 aws_instance.my_instance                                                                            
 ├─ Instance usage (Linux/UNIX, reserved, t3.medium)               730  hours                  $0.00 
 ├─ CPU credits                                          Cost depends on usage: $0.05 per vCPU-hours 
 └─ root_block_device                                                                                
    └─ Storage (general purpose SSD, gp2)                            8  GB-months              $0.80 
                                                                                                     
```

aws_instance has `reserved_instance_payment_option: all_upfront` usage-option, so it has $0.00 Monthly Cost