### PR TITLE
feat(azure): azurerm_app_service_certificate_binding

### DIFF
--- a/internal/providers/terraform/azure/app_service_certificate_binding.go
+++ b/internal/providers/terraform/azure/app_service_certificate_binding.go
@@ -1,0 +1,59 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetAzureRMAppServiceCertificateBindingRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_app_service_certificate_binding",
+		RFunc: NewAzureRMAppServiceCertificateBinding,
+	}
+}
+
+func NewAzureRMAppServiceCertificateBinding(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+
+	var sslType string
+	sslState := d.Get("ssl_state").String()
+
+	// The two approved values are IpBasedEnabled or SniEnabled
+	sslState = strings.ToUpper(sslState)[0:2]
+
+	if sslState == "IP" {
+		sslType = "IP"
+	} else {
+		sslType = "SNI"
+	}
+
+	var instanceCount int64 = 1
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name:            "IP SSL certificate",
+			Unit:            "months",
+			UnitMultiplier:  1,
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(instanceCount)),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("azure"),
+				Region:        strPtr("Global"),
+				Service:       strPtr("Azure App Service"),
+				ProductFamily: strPtr("Compute"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "skuName", Value: strPtr(fmt.Sprintf("%s SSL", sslType))},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/providers/terraform/azure/app_service_certificate_binding.go
+++ b/internal/providers/terraform/azure/app_service_certificate_binding.go
@@ -27,6 +27,12 @@ func NewAzureRMAppServiceCertificateBinding(d *schema.ResourceData, u *schema.Us
 		sslType = "IP"
 	} else {
 		sslType = "SNI"
+
+		// returning directly since SNI is currently defined as free in the Azure cost page
+		return &schema.Resource{
+			NoPrice:   true,
+			IsSkipped: true,
+		}
 	}
 
 	var instanceCount int64 = 1

--- a/internal/providers/terraform/azure/app_service_certificate_binding.go
+++ b/internal/providers/terraform/azure/app_service_certificate_binding.go
@@ -26,8 +26,6 @@ func NewAzureRMAppServiceCertificateBinding(d *schema.ResourceData, u *schema.Us
 	if sslState == "IP" {
 		sslType = "IP"
 	} else {
-		sslType = "SNI"
-
 		// returning directly since SNI is currently defined as free in the Azure cost page
 		return &schema.Resource{
 			NoPrice:   true,

--- a/internal/providers/terraform/azure/app_service_certificate_binding_test.go
+++ b/internal/providers/terraform/azure/app_service_certificate_binding_test.go
@@ -27,7 +27,6 @@ func TestAzureRMAppServiceCertificateBinding(t *testing.T) {
 			certificate_id      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Web/certificates/example.example.com"
 			ssl_state           = "SniEnabled"
 		}
-
 	`
 
 	resourceChecks := []testutil.ResourceCheck{
@@ -36,21 +35,23 @@ func TestAzureRMAppServiceCertificateBinding(t *testing.T) {
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
 					Name:             "IP SSL certificate",
-					PriceHash:        "68c00672510a2df4195138186bb1f81b-e285791b6e6926c07354b58a33e7ecf4",
+					PriceHash:        "9aaa15fe7dc8302f9046d95ba081c50a-e285791b6e6926c07354b58a33e7ecf4",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 			},
 		},
-		{
-			Name: "azurerm_app_service_certificate_binding.sni_ssl",
-			CostComponentChecks: []testutil.CostComponentCheck{
-				{
-					Name:             "IP SSL certificate",
-					PriceHash:        "582bbeaa3646b991abbdaf03f885f7b8-e285791b6e6926c07354b58a33e7ecf4",
-					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+		/*
+			{
+				Name: "azurerm_app_service_certificate_binding.sni_ssl",
+				CostComponentChecks: []testutil.CostComponentCheck{
+					{
+						Name:             "IP SSL certificate",
+						PriceHash:        "582bbeaa3646b991abbdaf03f885f7b8-e285791b6e6926c07354b58a33e7ecf4",
+						MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					},
 				},
 			},
-		},
+		*/
 	}
 
 	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)

--- a/internal/providers/terraform/azure/app_service_certificate_binding_test.go
+++ b/internal/providers/terraform/azure/app_service_certificate_binding_test.go
@@ -40,18 +40,6 @@ func TestAzureRMAppServiceCertificateBinding(t *testing.T) {
 				},
 			},
 		},
-		/*
-			{
-				Name: "azurerm_app_service_certificate_binding.sni_ssl",
-				CostComponentChecks: []testutil.CostComponentCheck{
-					{
-						Name:             "IP SSL certificate",
-						PriceHash:        "582bbeaa3646b991abbdaf03f885f7b8-e285791b6e6926c07354b58a33e7ecf4",
-						MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
-					},
-				},
-			},
-		*/
 	}
 
 	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)

--- a/internal/providers/terraform/azure/app_service_certificate_binding_test.go
+++ b/internal/providers/terraform/azure/app_service_certificate_binding_test.go
@@ -1,0 +1,57 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureRMAppServiceCertificateBinding(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+		resource "azurerm_app_service_certificate_binding" "ip_ssl" {
+			hostname_binding_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Web/sites/mywebappfake/hostNameBindings/example.example.com"
+			certificate_id      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Web/certificates/example.example.com"
+			ssl_state           = "IpBasedEnabled"
+		}
+
+		resource "azurerm_app_service_certificate_binding" "sni_ssl" {
+			hostname_binding_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Web/sites/mywebappfake/hostNameBindings/example.example.com"
+			certificate_id      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Web/certificates/example.example.com"
+			ssl_state           = "SniEnabled"
+		}
+
+	`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "azurerm_app_service_certificate_binding.ip_ssl",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "IP SSL certificate",
+					PriceHash:        "68c00672510a2df4195138186bb1f81b-e285791b6e6926c07354b58a33e7ecf4",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+		{
+			Name: "azurerm_app_service_certificate_binding.sni_ssl",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "IP SSL certificate",
+					PriceHash:        "582bbeaa3646b991abbdaf03f885f7b8-e285791b6e6926c07354b58a33e7ecf4",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -3,6 +3,7 @@ package azure
 import "github.com/infracost/infracost/internal/schema"
 
 var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
+	GetAzureRMAppServiceCertificateBindingRegistryItem(),
 	GetAzureRMAppServiceCertificateOrderRegistryItem(),
 	GetAzureRMLinuxVirtualMachineRegistryItem(),
 	GetAzureRMLinuxVirtualMachineScaleSetRegistryItem(),


### PR DESCRIPTION
Solves https://github.com/infracost/infracost/issues/596

**Objective:**

Add support for aws_docdb_cluster_instance.

**Example output without usage-file:**

```
Project: examples/terraform

 Name                                                Quantity  Unit    Monthly Cost 
                                                                                    
 azurerm_app_service_certificate_binding.ipexample                                  
 └─ IP SSL certificate                                      1  months        $39.00 
                                                                                    
 azurerm_app_service_certificate_binding.sniexample                                 
 └─ IP SSL certificate                                      1  months         $9.00 
                                                                                    
 PROJECT TOTAL                                                               $48.00 

Example output with usage-file: N/A
```
**Pricing details:**
I updated the issue with a question: https://github.com/infracost/infracost/issues/596#issuecomment-826371951, according to the azure price page the SNI option should be free of charged, but in the database i can see a 9$ cost. Let's keep the discussion in the issue. Hopefully I'm wrong :)

**Status:**

- [x]  dded to resource_registry.go
- [x]   Added resource file
- [x]  Added integration tests
- [x]  Added unit tests if applicable - Not applicable

**Issues:**

The azurerm_app_service_certificate_binding resource don't take in any region.
Due to that I use the Global as a hard coded value in the resource.

**Useful links:**
Pricing: https://azure.microsoft.com/en-gb/pricing/details/app-service/
Terraform: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_certificate_binding#certificate_id
