### PR TITLE
feat(aws): Refactored CPU credits to use usage file.

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -50,9 +50,9 @@ resource_usage:
     reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: no_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
-    # Only used when T2 credit_specification is set to unlimited or T3 & T4 instance types are used within a launch template,  or T3 & T4 instance types in a launch configuration.
-    monthly_cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
-    virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
+    # Only applicable when T2 credit_specification is set to unlimited or T3 & T4 instance types are used within a launch template,  or T3 & T4 instance types are used in a launch configuration.
+    monthly_cpu_credit_hrs: 350 # Number of hours in the month where the instance is expected to burst.
+    virtual_cpu_count: 2 # Number of the vCPUs for the instance type.
 
   aws_cloudwatch_event_bus.my_events:
     monthly_custom_events: 1000000            # Monthly custom events published. Each 64 KB chunk of payload is billed as 1 event.
@@ -142,9 +142,9 @@ resource_usage:
     reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: partial_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
-    # Only used for T3 & T4 instance types or if you specify a t2 instance with a launch template.
-    monthly_cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
-    virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
+    # Only applicable for T3 & T4 instance types or if you specify a t2 instance within a launch template.
+    monthly_cpu_credit_hrs: 350 # Number of hours in the month where the instance is expected to burst.
+    virtual_cpu_count: 2 # Number of the vCPUs for the instance type.
 
   aws_elasticache_cluster.my_redis_snapshot:
     snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB.
@@ -158,8 +158,8 @@ resource_usage:
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: all_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
     # Can be used with T2 / T3 & T4 Instance types. T2 requires credit_specification to be unlimited.
-    monthly_cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
-    virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
+    monthly_cpu_credit_hrs: 350 # Number of hours in the month where the instance is expected to burst.
+    virtual_cpu_count: 2 # Number of the vCPUs for the instance type.
 
   aws_fsx_windows_file_system.my_system:
     backup_storage_gb: 10000 # Total storage used for backups in GB.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -51,7 +51,7 @@ resource_usage:
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: no_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
     # Only used when T2 credit_specification is set to unlimited or T3 & T4 instance types are used within a launch template,  or T3 & T4 instance types in a launch configuration.
-    cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
+    monthly_cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
     virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
 
   aws_cloudwatch_event_bus.my_events:
@@ -95,7 +95,7 @@ resource_usage:
   aws_docdb_cluster_instance.my_db:
     data_storage_gb: 1000         # Total storage for cluster in GB.
     monthly_io_request: 100000000 # Monthly number of input/output requests for cluster.
-    monthly_cpu_credit_hours: 100 # Monthly CPU credits used over the instance baseline in vCPU-hours, only applicable for T3 instances.
+    monthly_cpu_credit_hrs: 100 # Monthly CPU credits used over the instance baseline in vCPU-hours, only applicable for T3 instances.
 
   aws_docdb_cluster_snapshot.my_snapshot:
     backup_storage_gb: 10000      # Amount of backup storage that is in excess of 100% of the storage size for the cluster in GB.
@@ -143,7 +143,7 @@ resource_usage:
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: partial_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
     # Only used for T3 & T4 instance types or if you specify a t2 instance with a launch template.
-    cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
+    monthly_cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
     virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
 
   aws_elasticache_cluster.my_redis_snapshot:
@@ -158,7 +158,7 @@ resource_usage:
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: all_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
     # Can be used with T2 / T3 & T4 Instance types. T2 requires credit_specification to be unlimited.
-    cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
+    monthly_cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
     virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
 
   aws_fsx_windows_file_system.my_system:
@@ -191,7 +191,7 @@ resource_usage:
 
   # These settings only apply when using t3 instance types.
   aws_rds_cluster_instance.my_cluster:
-    cpu_credit_hrs: 24   # Number of hours in a month, where you expect to burst the baseline credit balance of a "t3" instance type.
+    monthly_cpu_credit_hrs: 24   # Number of hours in a month, where you expect to burst the baseline credit balance of a "t3" instance type.
     virtual_cpu_count: 2 # Number of virtual CPUs allocated to your "t3" instance type. Currently instances with 2 vCPUs are available.
 
   aws_redshift_cluster.with_usage:

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -19,9 +19,9 @@ resource_usage:
   # (e.g. `this[0]`) and `[*]` are specified for a resource, only the array element's usage
   # will be applied to that resource. This enables you to define default values using `[*]`
   # and override specific elements using their index.
-  # 
-  # Example: 
-  # 
+  #
+  # Example:
+  #
   # aws_cloudwatch_log_group.my_log_group[*]:
   #   storage_gb: 1000
   #   monthly_data_ingested_gb: 1000
@@ -50,11 +50,14 @@ resource_usage:
     reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: no_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
+    # Only used when T2 credit_specification is set to unlimited or T3 & T4 instance types are used within a launch template,  or T3 & T4 instance types in a launch configuration.
+    cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
+    virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
 
   aws_cloudwatch_event_bus.my_events:
     monthly_custom_events: 1000000            # Monthly custom events published. Each 64 KB chunk of payload is billed as 1 event.
     monthly_third_party_events: 2000000       # Monthly third-party and cross-account events published. Each 64 KB chunk of payload is billed as 1 event.
-    monthly_archive_processing_gb: 100        # Monthly archive event processing in GB. 
+    monthly_archive_processing_gb: 100        # Monthly archive event processing in GB.
     archive_storage_gb: 200                   # Archive storage used for event replay in GB.
     monthly_schema_discovery_events: 1000000  # Monthly events ingested for schema discovery. Each 8 KB chunk of payload is billed as 1 event.
 
@@ -63,9 +66,9 @@ resource_usage:
     monthly_data_ingested_gb: 1000 # Monthly data ingested by CloudWatch logs in GB.
     monthly_data_scanned_gb: 200   # Monthly data scanned by CloudWatch logs insights in GB.
 
-  aws_codebuild_project.my_project: 
+  aws_codebuild_project.my_project:
     monthly_build_mins: 10000 # Monthly total duration of builds in minutes. Each build is rounded up to the nearest minute.
-    
+
   aws_config_config_rule.my_config:
     monthly_rule_evaluations: 1000000 # Monthly config rule evaluations.
 
@@ -92,10 +95,7 @@ resource_usage:
   aws_docdb_cluster_instance.my_db:
     data_storage_gb: 1000         # Total storage for cluster in GB.
     monthly_io_request: 100000000 # Monthly number of input/output requests for cluster.
-    monthly_cpu_credit_hours: 100 # Monthly CPU credits used over the instance baseline in vCPU-hours, only applicable for T3 instances. 
-    
-  aws_docdb_cluster.my_cluster:
-    backup_storage_gb: 10000      # Amount of backup storage that is in excess of 100% of the storage size for the cluster in GB.
+    monthly_cpu_credit_hours: 100 # Monthly CPU credits used over the instance baseline in vCPU-hours, only applicable for T3 instances.
 
   aws_docdb_cluster_snapshot.my_snapshot:
     backup_storage_gb: 10000      # Amount of backup storage that is in excess of 100% of the storage size for the cluster in GB.
@@ -142,9 +142,12 @@ resource_usage:
     reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: partial_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
+    # Only used for T3 & T4 instance types or if you specify a t2 instance with a launch template.
+    cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
+    virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
 
   aws_elasticache_cluster.my_redis_snapshot:
-    snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB. 
+    snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB.
 
   aws_elb.my_elb:
     monthly_data_processed_gb: 10000 # Monthly data processed by a Classic Load Balancer in GB.
@@ -154,6 +157,9 @@ resource_usage:
     reserved_instance_type: standard # Offering class for Reserved Instances. Can be: convertible, standard.
     reserved_instance_term: 1_year # Term for Reserved Instances. Can be: 1_year, 3_year.
     reserved_instance_payment_option: all_upfront # Payment option for Reserved Instances. Can be: no_upfront, partial_upfront, all_upfront.
+    # Can be used with T2 / T3 & T4 Instance types. T2 requires credit_specification to be unlimited.
+    cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
+    virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
 
   aws_fsx_windows_file_system.my_system:
     backup_storage_gb: 10000 # Total storage used for backups in GB.
@@ -354,7 +360,7 @@ resource_usage:
     monthly_encryption_requests: 100000 # Monthly number of field level encryption requests.
     monthly_log_lines: 5000000          # Monthly number of real-time log lines.
     custom_ssl_certificates: 3          # Number of dedicated IP custom SSL certificates.
-  
+
   #
   # Terraform GCP resources
   #
@@ -388,10 +394,10 @@ resource_usage:
       australia: 250       # Australia.
 
 
-  google_compute_image.my_image: 
+  google_compute_image.my_image:
     storage_gb: 1000 # Total size of image storage in GB.
 
-  google_compute_machine_image.my_machine_image: 
+  google_compute_machine_image.my_machine_image:
     storage_gb: 1000 # Total size of machine image storage in GB.
 
   google_compute_snapshot.my_snapshot:
@@ -442,7 +448,7 @@ resource_usage:
 
   google_sql_database_instance.my_instance:
     backup_storage_gb: 1000 # Amount of backup storage in GB.
-    
+
   google_storage_bucket.my_storage_bucket:
     storage_gb: 150                   # Total size of bucket in GB.
     monthly_class_a_operations: 40000 # Monthly number of class A operations (object adds, bucket/object list).
@@ -478,7 +484,7 @@ resource_usage:
 
   azurerm_postgresql_server.my_server:
     additional_backup_storage_gb: 3000 # Additional consumption of backup storage in GB.
-  
+
   azurerm_windows_virtual_machine.my_windows_vm:
     os_disk:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.

--- a/internal/providers/terraform/aws/autoscaling_group.go
+++ b/internal/providers/terraform/aws/autoscaling_group.go
@@ -116,7 +116,7 @@ func newLaunchConfiguration(name string, d *schema.ResourceData, u *schema.Usage
 		costComponents = append(costComponents, detailedMonitoringCostComponent(d))
 	}
 
-	c := cpuCreditsCostComponent(d)
+	c := newCPUCredit(d, u)
 	if c != nil {
 		costComponents = append(costComponents, c)
 	}
@@ -158,9 +158,13 @@ func newLaunchTemplate(name string, d *schema.ResourceData, u *schema.UsageData,
 		costComponents = append(costComponents, c)
 	}
 
-	c := cpuCreditsCostComponent(d)
-	if c != nil {
-		costComponents = append(costComponents, c)
+	if d.Get("instance_type").Exists() && d.Get("instance_type").Type != gjson.Null {
+		if isInstanceBurstable(d.Get("instance_type").String(), []string{"t2.", "t3.", "t4."}) {
+			c := newCPUCredit(d, u)
+			if c != nil {
+				costComponents = append(costComponents, c)
+			}
+		}
 	}
 
 	subResources := make([]*schema.Resource, 0)

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -284,6 +284,13 @@ func TestAutoscalingGroup_launchConfiguration_cpuCredits(t *testing.T) {
 			min_size             = 1
 		}`
 
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_autoscaling_group.asg1": map[string]interface{}{
+			"cpu_credit_hrs":    200,
+			"virtual_cpu_count": 2,
+		},
+	})
+
 	resourceChecks := []testutil.ResourceCheck{
 		{
 			Name: "aws_autoscaling_group.asg1",
@@ -299,7 +306,7 @@ func TestAutoscalingGroup_launchConfiguration_cpuCredits(t *testing.T) {
 						{
 							Name:             "CPU credits",
 							PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-							MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(200 * 2 * 2)),
 						},
 					},
 					SubResourceChecks: []testutil.ResourceCheck{
@@ -313,7 +320,7 @@ func TestAutoscalingGroup_launchConfiguration_cpuCredits(t *testing.T) {
 		},
 	}
 
-	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
 }
 
 func TestAutoscalingGroup_launchTemplate(t *testing.T) {
@@ -701,7 +708,7 @@ func TestAutoscalingGroup_launchTemplate_cpuCredits(t *testing.T) {
 	tf := `
 		resource "aws_launch_template" "lt1" {
 			image_id          = "fake_ami"
-			instance_type     = "t3.medium"
+			instance_type     = "t3.large"
 		}
 
 		resource "aws_autoscaling_group" "asg1" {
@@ -713,6 +720,13 @@ func TestAutoscalingGroup_launchTemplate_cpuCredits(t *testing.T) {
 			min_size         = 1
 		}`
 
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_autoscaling_group.asg1": map[string]interface{}{
+			"cpu_credit_hrs":    350,
+			"virtual_cpu_count": 2,
+		},
+	})
+
 	resourceChecks := []testutil.ResourceCheck{
 		{
 			Name: "aws_autoscaling_group.asg1",
@@ -721,14 +735,14 @@ func TestAutoscalingGroup_launchTemplate_cpuCredits(t *testing.T) {
 					Name: "aws_launch_template.lt1",
 					CostComponentChecks: []testutil.CostComponentCheck{
 						{
-							Name:            "Instance usage (Linux/UNIX, on-demand, t3.medium)",
-							PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-d2c98780d7b6e36641b521f1f8145c6f",
+							Name:            "Instance usage (Linux/UNIX, on-demand, t3.large)",
+							PriceHash:       "3a45cd05e73384099c2ff360bdb74b74-d2c98780d7b6e36641b521f1f8145c6f",
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
 						},
 						{
 							Name:             "CPU credits",
 							PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-							MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2 * 350 * 2)),
 						},
 					},
 					SubResourceChecks: []testutil.ResourceCheck{
@@ -742,7 +756,7 @@ func TestAutoscalingGroup_launchTemplate_cpuCredits(t *testing.T) {
 		},
 	}
 
-	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
 }
 
 func TestAutoscalingGroup_mixedInstanceLaunchTemplate(t *testing.T) {

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -286,8 +286,8 @@ func TestAutoscalingGroup_launchConfiguration_cpuCredits(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_autoscaling_group.asg1": map[string]interface{}{
-			"cpu_credit_hrs":    200,
-			"virtual_cpu_count": 2,
+			"monthly_cpu_credit_hrs": 200,
+			"virtual_cpu_count":      2,
 		},
 	})
 
@@ -722,8 +722,8 @@ func TestAutoscalingGroup_launchTemplate_cpuCredits(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_autoscaling_group.asg1": map[string]interface{}{
-			"cpu_credit_hrs":    350,
-			"virtual_cpu_count": 2,
+			"monthly_cpu_credit_hrs": 350,
+			"virtual_cpu_count":      2,
 		},
 	})
 

--- a/internal/providers/terraform/aws/docdb_cluster_instance.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance.go
@@ -31,8 +31,8 @@ func NewDocDBClusterInstance(d *schema.ResourceData, u *schema.UsageData) *schem
 	}
 
 	var cpuCreditsT3 *decimal.Decimal
-	if u != nil && u.Get("monthly_cpu_credit_hours").Exists() {
-		cpuCreditsT3 = decimalPtr(decimal.NewFromInt(u.Get("monthly_cpu_credit_hours").Int()))
+	if u != nil && u.Get("monthly_cpu_credit_hrs").Exists() {
+		cpuCreditsT3 = decimalPtr(decimal.NewFromInt(u.Get("monthly_cpu_credit_hrs").Int()))
 	}
 
 	costComponents := []*schema.CostComponent{

--- a/internal/providers/terraform/aws/docdb_cluster_instance_test.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance_test.go
@@ -69,8 +69,8 @@ func TestNewDocDBClusterInstance_usage(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_docdb_cluster_instance.medium": map[string]interface{}{
-			"data_storage_gb":          1000,
-			"monthly_io_request":       10000000,
+			"data_storage_gb":        1000,
+			"monthly_io_request":     10000000,
 			"monthly_cpu_credit_hrs": 10,
 		},
 		"aws_docdb_cluster_instance.large": map[string]interface{}{

--- a/internal/providers/terraform/aws/docdb_cluster_instance_test.go
+++ b/internal/providers/terraform/aws/docdb_cluster_instance_test.go
@@ -71,7 +71,7 @@ func TestNewDocDBClusterInstance_usage(t *testing.T) {
 		"aws_docdb_cluster_instance.medium": map[string]interface{}{
 			"data_storage_gb":          1000,
 			"monthly_io_request":       10000000,
-			"monthly_cpu_credit_hours": 10,
+			"monthly_cpu_credit_hrs": 10,
 		},
 		"aws_docdb_cluster_instance.large": map[string]interface{}{
 			"data_storage_gb":    1000,

--- a/internal/providers/terraform/aws/eks_node_group.go
+++ b/internal/providers/terraform/aws/eks_node_group.go
@@ -53,8 +53,8 @@ func NewEKSNodeGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resour
 		var cpuCreditQuantity decimal.Decimal
 		if isInstanceBurstable(instanceType, []string{"t3", "t4"}) {
 			instanceCPUCreditHours := decimal.Zero
-			if u != nil && u.Get("cpu_credit_hrs").Exists() {
-				instanceCPUCreditHours = decimal.NewFromInt(u.Get("cpu_credit_hrs").Int())
+			if u != nil && u.Get("monthly_cpu_credit_hrs").Exists() {
+				instanceCPUCreditHours = decimal.NewFromInt(u.Get("monthly_cpu_credit_hrs").Int())
 			}
 
 			instanceVCPUCount := decimal.Zero

--- a/internal/providers/terraform/aws/eks_node_group_test.go
+++ b/internal/providers/terraform/aws/eks_node_group_test.go
@@ -17,7 +17,7 @@ func TestEKSNodeGroup_default(t *testing.T) {
 
 	tf := `
 	resource "aws_eks_node_group" "example" {
-		cluster_name    = "test aws_eks_node_group"
+		cluster_name    = "test_aws_eks_node_group"
 		node_group_name = "example"
 		node_role_arn   = "node_role_arn"
 		subnet_ids      = ["subnet_id"]
@@ -63,7 +63,7 @@ func TestEKSNodeGroup_defaultCpuCredits(t *testing.T) {
 
 	tf := `
 	resource "aws_eks_node_group" "example" {
-		cluster_name    = "test aws_eks_node_group"
+		cluster_name    = "test_aws_eks_node_group"
 		node_group_name = "example"
 		node_role_arn   = "node_role_arn"
 		subnet_ids      = ["subnet_id"]
@@ -77,8 +77,8 @@ func TestEKSNodeGroup_defaultCpuCredits(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_eks_node_group.example": map[string]interface{}{
-			"cpu_credit_hrs":    350,
-			"virtual_cpu_count": 2,
+			"monthly_cpu_credit_hrs": 350,
+			"virtual_cpu_count":      2,
 		},
 	})
 
@@ -116,7 +116,7 @@ func TestEKSNodeGroup_disk_size_instance_type(t *testing.T) {
 
 	tf := `
 	resource "aws_eks_node_group" "example" {
-		cluster_name    = "test aws_eks_node_group"
+		cluster_name    = "test_aws_eks_node_group"
 		node_group_name = "example"
 		instance_types  = ["t2.medium"]
 		node_role_arn   = "node_role_arn"
@@ -159,7 +159,7 @@ func TestEKSNodeGroup_launch_template(t *testing.T) {
 
 	tf := `
 	resource "aws_eks_node_group" "example_with_launch_template" {
-		cluster_name    = "test aws_eks_node_group"
+		cluster_name    = "test_aws_eks_node_group"
 		node_group_name = "example"
 		node_role_arn   = "node_role_arn"
 		subnet_ids      = ["subnet_id"]
@@ -313,7 +313,7 @@ func TestEKSNodeGroup_launch_template_by_name(t *testing.T) {
 
 	tf := `
 	resource "aws_eks_node_group" "example_with_launch_template" {
-		cluster_name    = "test aws_eks_node_group"
+		cluster_name    = "test_aws_eks_node_group"
 		node_group_name = "example"
 		node_role_arn   = "node_role_arn"
 		subnet_ids      = ["subnet_id"]
@@ -467,7 +467,7 @@ func TestEKSNodeGroup_with_instance_launch_template_without_instance(t *testing.
 
 	tf := `
 	resource "aws_eks_node_group" "example_with_launch_template" {
-		cluster_name    = "test aws_eks_node_group"
+		cluster_name    = "test_aws_eks_node_group"
 		node_group_name = "example"
 		node_role_arn   = "node_role_arn"
 		subnet_ids      = ["subnet_id"]
@@ -561,8 +561,8 @@ func TestEKSNodeGroup_with_instance_launch_template_without_instance(t *testing.
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_eks_node_group.example_with_launch_template": map[string]interface{}{
-			"cpu_credit_hrs":    350,
-			"virtual_cpu_count": 2,
+			"monthly_cpu_credit_hrs": 350,
+			"virtual_cpu_count":      2,
 		},
 	})
 
@@ -628,7 +628,7 @@ func TestEKSNodeGroup_spot(t *testing.T) {
 
 	tf := `
 	resource "aws_eks_node_group" "example" {
-		cluster_name    = "test aws_eks_node_group"
+		cluster_name    = "test_aws_eks_node_group"
 		node_group_name = "example"
 		node_role_arn   = "node_role_arn"
 		subnet_ids      = ["subnet_id"]
@@ -674,7 +674,7 @@ func TestEKSNodeGroup_reserved(t *testing.T) {
 
 	tf := `
 	resource "aws_eks_node_group" "reserved" {
-		cluster_name    = "test aws_eks_node_group"
+		cluster_name    = "test_aws_eks_node_group"
 		node_group_name = "example"
 		node_role_arn   = "node_role_arn"
 		subnet_ids      = ["subnet_id"]
@@ -691,7 +691,7 @@ func TestEKSNodeGroup_reserved(t *testing.T) {
 			"reserved_instance_type":           "standard",
 			"reserved_instance_term":           "1_year",
 			"reserved_instance_payment_option": "no_upfront",
-			"cpu_credit_hrs":                   350,
+			"monthly_cpu_credit_hrs":           350,
 			"virtual_cpu_count":                2,
 		},
 	})
@@ -729,7 +729,7 @@ func TestEKSNodeGroup_windows(t *testing.T) {
 
 	tf := `
 	resource "aws_eks_node_group" "windows" {
-		cluster_name    = "test aws_eks_node_group"
+		cluster_name    = "test_aws_eks_node_group"
 		node_group_name = "example"
 		node_role_arn   = "node_role_arn"
 		subnet_ids      = ["subnet_id"]
@@ -743,9 +743,9 @@ func TestEKSNodeGroup_windows(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_eks_node_group.windows": map[string]interface{}{
-			"operating_system":  "windows",
-			"cpu_credit_hrs":    100,
-			"virtual_cpu_count": 2,
+			"operating_system":       "windows",
+			"monthly_cpu_credit_hrs": 100,
+			"virtual_cpu_count":      2,
 		},
 	})
 

--- a/internal/providers/terraform/aws/eks_node_group_test.go
+++ b/internal/providers/terraform/aws/eks_node_group_test.go
@@ -41,7 +41,7 @@ func TestEKSNodeGroup_default(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",
@@ -94,7 +94,7 @@ func TestEKSNodeGroup_defaultCpuCredits(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2 * 350 * 3)),
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2 * 350 * 3)),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",
@@ -581,7 +581,7 @@ func TestEKSNodeGroup_with_instance_launch_template_without_instance(t *testing.
 						{
 							Name:            "CPU credits",
 							PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(350 * 2 * 3)),
+							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(350 * 2 * 3)),
 						},
 						{
 							Name:            "Inference accelerator (eia1.medium)",
@@ -653,7 +653,7 @@ func TestEKSNodeGroup_spot(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",
@@ -708,7 +708,7 @@ func TestEKSNodeGroup_reserved(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(350 * 2 * 1)),
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(350 * 2 * 1)),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",
@@ -761,7 +761,7 @@ func TestEKSNodeGroup_windows(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100 * 2 * 1)),
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100 * 2 * 1)),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",

--- a/internal/providers/terraform/aws/eks_node_group_test.go
+++ b/internal/providers/terraform/aws/eks_node_group_test.go
@@ -41,7 +41,7 @@ func TestEKSNodeGroup_default(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.Zero),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",
@@ -53,6 +53,59 @@ func TestEKSNodeGroup_default(t *testing.T) {
 	}
 
 	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+
+}
+
+func TestEKSNodeGroup_defaultCpuCredits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "aws_eks_node_group" "example" {
+		cluster_name    = "test aws_eks_node_group"
+		node_group_name = "example"
+		node_role_arn   = "node_role_arn"
+		subnet_ids      = ["subnet_id"]
+
+		scaling_config {
+			desired_size = 3
+			max_size     = 3
+			min_size     = 1
+		}
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_eks_node_group.example": map[string]interface{}{
+			"cpu_credit_hrs":    350,
+			"virtual_cpu_count": 2,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_eks_node_group.example",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Instance usage (Linux/UNIX, on-demand, t3.medium)",
+					PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-d2c98780d7b6e36641b521f1f8145c6f",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(3)),
+				},
+				{
+					Name:            "CPU credits",
+					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2 * 350 * 3)),
+				},
+				{
+					Name:             "Storage (general purpose SSD, gp2)",
+					PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(20)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
 
 }
 
@@ -407,6 +460,167 @@ func TestEKSNodeGroup_launch_template_by_name(t *testing.T) {
 
 }
 
+func TestEKSNodeGroup_with_instance_launch_template_without_instance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "aws_eks_node_group" "example_with_launch_template" {
+		cluster_name    = "test aws_eks_node_group"
+		node_group_name = "example"
+		node_role_arn   = "node_role_arn"
+		subnet_ids      = ["subnet_id"]
+
+		instance_types  = ["t3.medium"]
+
+		scaling_config {
+			desired_size = 3
+			max_size     = 1
+			min_size     = 1
+		}
+
+		launch_template {
+			id      = aws_launch_template.foo.id
+			version = "default_version"
+		}
+	}
+
+	resource "aws_launch_template" "foo" {
+		name = "foo"
+
+		block_device_mappings {
+			device_name = "/dev/sda1"
+
+			ebs {
+				volume_size = 20
+			}
+		}
+
+		capacity_reservation_specification {
+			capacity_reservation_preference = "open"
+		}
+
+		cpu_options {
+			core_count       = 4
+			threads_per_core = 2
+		}
+
+		credit_specification {
+			cpu_credits = "unlimited"
+		}
+
+		disable_api_termination = true
+
+		ebs_optimized = true
+
+		elastic_gpu_specifications {
+			type = "test"
+		}
+
+		elastic_inference_accelerator {
+			type = "eia1.medium"
+		}
+
+		iam_instance_profile {
+			name = "test"
+		}
+
+		image_id = "ami-test"
+
+		instance_initiated_shutdown_behavior = "terminate"
+
+		kernel_id = "test"
+
+		key_name = "test"
+
+		license_specification {
+			license_configuration_arn = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef"
+		}
+
+		metadata_options {
+			http_endpoint               = "enabled"
+			http_tokens                 = "required"
+			http_put_response_hop_limit = 1
+		}
+
+		network_interfaces {
+			associate_public_ip_address = true
+		}
+
+		placement {
+			availability_zone = "us-west-2a"
+		}
+
+		ram_disk_id = "test"
+
+		vpc_security_group_ids = ["example"]
+
+	}
+	`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"aws_eks_node_group.example_with_launch_template": map[string]interface{}{
+			"cpu_credit_hrs":    350,
+			"virtual_cpu_count": 2,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name: "aws_eks_node_group.example_with_launch_template",
+			SubResourceChecks: []testutil.ResourceCheck{
+				{
+					Name: "aws_launch_template.foo",
+					CostComponentChecks: []testutil.CostComponentCheck{
+						{
+							Name:            "Instance usage (Linux/UNIX, on-demand, t3.medium)",
+							PriceHash:       "c8faba8210cd512ccab6b71ca400f4de-d2c98780d7b6e36641b521f1f8145c6f",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(3)),
+						},
+						{
+							Name:            "CPU credits",
+							PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+							HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(350 * 2 * 3)),
+						},
+						{
+							Name:            "Inference accelerator (eia1.medium)",
+							PriceHash:       "3a42dad03b09f630bdba373e7ed51c0f-66d0d770bee368b4f2a8f2f597eeb417",
+							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(3)),
+						},
+					},
+
+					SubResourceChecks: []testutil.ResourceCheck{
+						{
+							Name: "root_block_device",
+							CostComponentChecks: []testutil.CostComponentCheck{
+								{
+									Name:             "Storage (general purpose SSD, gp2)",
+									PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
+									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(24)),
+								},
+							},
+						},
+						{
+							Name: "block_device_mapping[0]",
+							CostComponentChecks: []testutil.CostComponentCheck{
+								{
+									Name:             "Storage (general purpose SSD, gp2)",
+									PriceHash:        "efa8e70ebe004d2e9527fd30d50d09b2-ee3dd7e4624338037ca6fea0933a662f",
+									MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(60)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+
+}
+
 func TestEKSNodeGroup_spot(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
@@ -439,7 +653,7 @@ func TestEKSNodeGroup_spot(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",
@@ -477,6 +691,8 @@ func TestEKSNodeGroup_reserved(t *testing.T) {
 			"reserved_instance_type":           "standard",
 			"reserved_instance_term":           "1_year",
 			"reserved_instance_payment_option": "no_upfront",
+			"cpu_credit_hrs":                   350,
+			"virtual_cpu_count":                2,
 		},
 	})
 
@@ -492,7 +708,7 @@ func TestEKSNodeGroup_reserved(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(350 * 2 * 1)),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",
@@ -528,6 +744,8 @@ func TestEKSNodeGroup_windows(t *testing.T) {
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_eks_node_group.windows": map[string]interface{}{
 			"operating_system": "windows",
+			"cpu_credit_hrs": 100,
+			"virtual_cpu_count": 2,
 		},
 	})
 
@@ -543,7 +761,7 @@ func TestEKSNodeGroup_windows(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100 * 2 * 1)),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",

--- a/internal/providers/terraform/aws/eks_node_group_test.go
+++ b/internal/providers/terraform/aws/eks_node_group_test.go
@@ -41,7 +41,7 @@ func TestEKSNodeGroup_default(t *testing.T) {
 				{
 					Name:            "CPU credits",
 					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
-					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.Zero),
+					HourlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 				{
 					Name:             "Storage (general purpose SSD, gp2)",

--- a/internal/providers/terraform/aws/eks_node_group_test.go
+++ b/internal/providers/terraform/aws/eks_node_group_test.go
@@ -39,8 +39,8 @@ func TestEKSNodeGroup_default(t *testing.T) {
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
-					Name:            "CPU credits",
-					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					Name:             "CPU credits",
+					PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 				{
@@ -92,8 +92,8 @@ func TestEKSNodeGroup_defaultCpuCredits(t *testing.T) {
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(3)),
 				},
 				{
-					Name:            "CPU credits",
-					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					Name:             "CPU credits",
+					PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(2 * 350 * 3)),
 				},
 				{
@@ -579,8 +579,8 @@ func TestEKSNodeGroup_with_instance_launch_template_without_instance(t *testing.
 							HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(3)),
 						},
 						{
-							Name:            "CPU credits",
-							PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+							Name:             "CPU credits",
+							PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
 							MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(350 * 2 * 3)),
 						},
 						{
@@ -651,8 +651,8 @@ func TestEKSNodeGroup_spot(t *testing.T) {
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
-					Name:            "CPU credits",
-					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					Name:             "CPU credits",
+					PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.Zero),
 				},
 				{
@@ -706,8 +706,8 @@ func TestEKSNodeGroup_reserved(t *testing.T) {
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
-					Name:            "CPU credits",
-					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					Name:             "CPU credits",
+					PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(350 * 2 * 1)),
 				},
 				{
@@ -743,8 +743,8 @@ func TestEKSNodeGroup_windows(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_eks_node_group.windows": map[string]interface{}{
-			"operating_system": "windows",
-			"cpu_credit_hrs": 100,
+			"operating_system":  "windows",
+			"cpu_credit_hrs":    100,
 			"virtual_cpu_count": 2,
 		},
 	})
@@ -759,8 +759,8 @@ func TestEKSNodeGroup_windows(t *testing.T) {
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
-					Name:            "CPU credits",
-					PriceHash:       "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
+					Name:             "CPU credits",
+					PriceHash:        "ccdf11d8e4c0267d78a19b6663a566c1-e8e892be2fbd1c8f42fd6761ad8977d8",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100 * 2 * 1)),
 				},
 				{

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -49,9 +49,12 @@ func NewInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	if d.Get("monitoring").Bool() {
 		costComponents = append(costComponents, detailedMonitoringCostComponent(d))
 	}
-	c := cpuCreditsCostComponent(d)
-	if c != nil {
-		costComponents = append(costComponents, c)
+
+	if isInstanceBurstable(d.Get("instance_type").String(), []string{"t2.", "t3.", "t4."}) {
+		c := newCPUCredit(d, u)
+		if c != nil {
+			costComponents = append(costComponents, c)
+		}
 	}
 
 	return &schema.Resource{
@@ -238,7 +241,35 @@ func detailedMonitoringCostComponent(d *schema.ResourceData) *schema.CostCompone
 	}
 }
 
-func cpuCreditsCostComponent(d *schema.ResourceData) *schema.CostComponent {
+func cpuCreditsCostComponent(region string, vCPUCount decimal.Decimal, prefix string) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "CPU credits",
+		Unit:            "vCPU-hours",
+		UnitMultiplier:  1,
+		MonthlyQuantity: &vCPUCount,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonEC2"),
+			ProductFamily: strPtr("CPU Credits"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "operatingSystem", Value: strPtr("Linux")},
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/CPUCredits:%s$/", prefix))},
+			},
+		},
+	}
+}
+
+func isInstanceBurstable(instanceType string, burstableInstanceTypes []string) bool {
+	for _, instance := range burstableInstanceTypes {
+		if strings.HasPrefix(instanceType, instance) {
+			return true
+		}
+	}
+	return false
+}
+
+func newCPUCredit(d *schema.ResourceData, u *schema.UsageData) *schema.CostComponent {
 	region := d.Get("region").String()
 	instanceType := d.Get("instance_type").String()
 
@@ -253,21 +284,19 @@ func cpuCreditsCostComponent(d *schema.ResourceData) *schema.CostComponent {
 
 	prefix := strings.SplitN(instanceType, ".", 2)[0]
 
-	return &schema.CostComponent{
-		Name:           "CPU credits",
-		Unit:           "vCPU-hours",
-		UnitMultiplier: 1,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("aws"),
-			Region:        strPtr(region),
-			Service:       strPtr("AmazonEC2"),
-			ProductFamily: strPtr("CPU Credits"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "operatingSystem", Value: strPtr("Linux")},
-				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/CPUCredits:%s$/", prefix))},
-			},
-		},
+	instanceCPUCreditHours := decimal.Zero
+	if u != nil && u.Get("cpu_credit_hrs").Exists() {
+		instanceCPUCreditHours = decimal.NewFromInt(u.Get("cpu_credit_hrs").Int())
 	}
+
+	instanceVCPUCount := decimal.Zero
+	if u != nil && u.Get("virtual_cpu_count").Exists() {
+		instanceVCPUCount = decimal.NewFromInt(u.Get("virtual_cpu_count").Int())
+	}
+
+	cpuCreditQuantity := instanceVCPUCount.Mul(instanceCPUCreditHours)
+
+	return cpuCreditsCostComponent(region, cpuCreditQuantity, prefix)
 }
 
 func newRootBlockDevice(d gjson.Result, region string) *schema.Resource {

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -285,8 +285,8 @@ func newCPUCredit(d *schema.ResourceData, u *schema.UsageData) *schema.CostCompo
 	prefix := strings.SplitN(instanceType, ".", 2)[0]
 
 	instanceCPUCreditHours := decimal.Zero
-	if u != nil && u.Get("cpu_credit_hrs").Exists() {
-		instanceCPUCreditHours = decimal.NewFromInt(u.Get("cpu_credit_hrs").Int())
+	if u != nil && u.Get("monthly_cpu_credit_hrs").Exists() {
+		instanceCPUCreditHours = decimal.NewFromInt(u.Get("monthly_cpu_credit_hrs").Int())
 	}
 
 	instanceVCPUCount := decimal.Zero

--- a/internal/providers/terraform/aws/instance_test.go
+++ b/internal/providers/terraform/aws/instance_test.go
@@ -233,16 +233,16 @@ func TestInstance_cpuCredits(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_instance.t3_default": map[string]interface{}{
-			"cpu_credit_hrs":    0,
-			"virtual_cpu_count": 2,
+			"monthly_cpu_credit_hrs": 0,
+			"virtual_cpu_count":      2,
 		},
 		"aws_instance.t3_unlimited": map[string]interface{}{
-			"cpu_credit_hrs":    730,
-			"virtual_cpu_count": 2,
+			"monthly_cpu_credit_hrs": 730,
+			"virtual_cpu_count":      2,
 		},
 		"aws_instance.t2_unlimited": map[string]interface{}{
-			"cpu_credit_hrs":    300,
-			"virtual_cpu_count": 2,
+			"monthly_cpu_credit_hrs": 300,
+			"virtual_cpu_count":      2,
 		},
 	})
 

--- a/internal/providers/terraform/aws/rds_cluster_instance.go
+++ b/internal/providers/terraform/aws/rds_cluster_instance.go
@@ -51,8 +51,8 @@ func NewRDSClusterInstance(d *schema.ResourceData, u *schema.UsageData) *schema.
 
 	if strings.HasPrefix(instanceType, "db.t3") {
 		instanceCPUCreditHours := decimal.Zero
-		if u != nil && u.Get("cpu_credit_hrs").Exists() {
-			instanceCPUCreditHours = decimal.NewFromInt(u.Get("cpu_credit_hrs").Int())
+		if u != nil && u.Get("monthly_cpu_credit_hrs").Exists() {
+			instanceCPUCreditHours = decimal.NewFromInt(u.Get("monthly_cpu_credit_hrs").Int())
 		}
 
 		instanceVCPUCount := decimal.Zero

--- a/internal/providers/terraform/aws/rds_cluster_instance_test.go
+++ b/internal/providers/terraform/aws/rds_cluster_instance_test.go
@@ -77,7 +77,7 @@ func TestRDSClusterT3Instances(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_rds_cluster_instance.cluster_instance": map[string]interface{}{
-			"cpu_credit_hrs":    24,
+			"monthly_cpu_credit_hrs":    24,
 			"virtual_cpu_count": 2,
 		},
 	})

--- a/internal/providers/terraform/aws/rds_cluster_instance_test.go
+++ b/internal/providers/terraform/aws/rds_cluster_instance_test.go
@@ -77,8 +77,8 @@ func TestRDSClusterT3Instances(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_rds_cluster_instance.cluster_instance": map[string]interface{}{
-			"monthly_cpu_credit_hrs":    24,
-			"virtual_cpu_count": 2,
+			"monthly_cpu_credit_hrs": 24,
+			"virtual_cpu_count":      2,
 		},
 	})
 


### PR DESCRIPTION
fixes #554 

Allows usage data to be provided for the following resources.

`aws_autoscaling_group` both `aws_launch_configurations` & `aws_launch_templates`
`aws_eks_node_group`
`aws_instance`

The following values can now be added to your usage file, to estimate EC2 CPU credit usage over a given month. 

```yaml
cpu_credit_hrs: 350 # Number of hours in the month where you expect to burst the instance
virtual_cpu_count: 2 # Number of vCPUs that the instance type as.
```