### PR TITLE
feat(azure): Add support for Azure MSSQL Database

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -474,8 +474,8 @@ resource_usage:
     additional_backup_storage_gb: 2000 # Additional consumption of backup storage in GB.
 
   azurerm_mssql_database.my_database:
-    vcore_hours: 600 # Number of used vCore-hours for serverless compute.
-    monthly_long_term_retention_storage_gb: 1000 # Number of GBs used by long-term retention backup storage.
+    monthly_vcore_hours: 600 # Monthly number of used vCore-hours for serverless compute.
+    long_term_retention_storage_gb: 1000 # Number of GBs used by long-term retention backup storage.
 
   azurerm_mysql_server.my_server:
     additional_backup_storage_gb: 2000 # Additional consumption of backup storage in GB.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -473,6 +473,10 @@ resource_usage:
   azurerm_mariadb_server.my_server:
     additional_backup_storage_gb: 2000 # Additional consumption of backup storage in GB.
 
+  azurerm_mssql_database.my_database:
+    vcore_hours: 600 # Number of used vCore-hours for serverless compute.
+    monthly_long_term_retention_storage_gb: 1000 # Number of GBs used by long-term retention backup storage.
+
   azurerm_mysql_server.my_server:
     additional_backup_storage_gb: 2000 # Additional consumption of backup storage in GB.
 

--- a/internal/providers/terraform/azure/mariadb_server.go
+++ b/internal/providers/terraform/azure/mariadb_server.go
@@ -46,7 +46,7 @@ func NewAzureMariaDBServer(d *schema.ResourceData, u *schema.UsageData) *schema.
 	productNameRegex := fmt.Sprintf("/%s - Compute %s/", tierName, family)
 	skuName := fmt.Sprintf("%s vCore", cores)
 
-	costComponents = append(costComponents, databaseComputeInstance(region, serviceName, sku, productNameRegex, skuName))
+	costComponents = append(costComponents, databaseComputeInstance(region, fmt.Sprintf("Compute (%s)", sku), serviceName, productNameRegex, skuName))
 
 	storageGB := d.Get("storage_mb").Int() / 1024
 
@@ -77,9 +77,9 @@ func NewAzureMariaDBServer(d *schema.ResourceData, u *schema.UsageData) *schema.
 	}
 }
 
-func databaseComputeInstance(region, serviceName, sku, productNameRegex, skuName string) *schema.CostComponent {
+func databaseComputeInstance(region, name, serviceName, productNameRegex, skuName string) *schema.CostComponent {
 	return &schema.CostComponent{
-		Name:           fmt.Sprintf("Compute (%s)", sku),
+		Name:           name,
 		Unit:           "hours",
 		UnitMultiplier: 1,
 		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
@@ -92,6 +92,9 @@ func databaseComputeInstance(region, serviceName, sku, productNameRegex, skuName
 				{Key: "productName", ValueRegex: strPtr(productNameRegex)},
 				{Key: "skuName", Value: strPtr(skuName)},
 			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
 		},
 	}
 }

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -2,9 +2,12 @@ package azure
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/infracost/infracost/internal/schema"
+	"github.com/pkg/errors"
+	"github.com/shopspring/decimal"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
@@ -13,65 +16,255 @@ func GetAzureMSSQLDatabaseRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "azurerm_mssql_database",
 		RFunc: NewAzureMSSQLDatabase,
+		ReferenceAttributes: []string{
+			"server_id",
+		},
 	}
 }
 
 func NewAzureMSSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	var costComponents []*schema.CostComponent
-	region := d.Get("location").String()
-	serviceName := "SQL Database"
+	server := d.References("server_id")
+	region := server[0].Get("location").String()
 
-	var sku, computeType, tier, family, cores string
-	var zoneRedundant bool
+	serviceName := "SQL Database"
+	var sku string
 	if d.Get("sku_name").Type != gjson.Null {
 		sku = d.Get("sku_name").String()
-		if s := strings.Split(sku, "_"); len(s) == 4 {
-			if s[1] == "S" {
-				computeType = "Serverless"
-				tier = s[0]
-				family = s[2]
-				cores = s[3]
-			}
-		} else if s := strings.Split(sku, "_"); len(s) == 3 {
-			computeType = "Provisioned"
-			tier = s[0]
-			family = s[1]
-			cores = s[2]
-		} else {
-			log.Warnf("Unrecognised MSSQL SKU format for resource %s: %s", d.Address, sku)
-			return nil
-		}
 	}
 
-	tierName := map[string]string{
-		"BC": "Business Critical",
-		"GP": "General Purpose",
-		"HS": "Hyperscale",
-	}[tier]
+	tier, family, cores, err := mssqlSkuSplit(d.Address, sku)
+	if err != nil {
+		log.Warnf(string(err.Error()))
+		return nil
+	}
 
+	var zoneRedundant bool
 	if d.Get("zone_redundant").Type != gjson.Null {
 		zoneRedundant = d.Get("zone_redundant").Bool()
 	}
 
-	skuName := cores + " vCore"
-	if zoneRedundant {
-		skuName += " Zone Redundancy"
+	productNameRegex := mssqlProductName(tier, family)
+	skuName := mssqlSkuName(cores, zoneRedundant)
+
+	if tier == "GPS" {
+		var vCoreHours *decimal.Decimal
+		if u != nil && u.Get("vcore_hours").Exists() {
+			vCoreHours = decimalPtr(decimal.NewFromInt(u.Get("vcore_hours").Int()))
+		}
+
+		serverlessSkuName := mssqlSkuName("1", zoneRedundant)
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            fmt.Sprintf("Compute (serverless, %s)", sku),
+			Unit:            "vCore-hours",
+			UnitMultiplier:  1,
+			MonthlyQuantity: vCoreHours,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("azure"),
+				Region:        strPtr(region),
+				Service:       strPtr(serviceName),
+				ProductFamily: strPtr("Databases"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", ValueRegex: strPtr(productNameRegex)},
+					{Key: "skuName", Value: strPtr(serverlessSkuName)},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		})
+	} else {
+		costComponents = append(costComponents, databaseComputeInstance(region, fmt.Sprintf("Compute (provisioned, %s)", sku), serviceName, productNameRegex, skuName))
 	}
 
-	productNameRegex := "/" + tierName + " -"
-	if computeType == "Serverless" {
-		productNameRegex += " Serverless -"
+	if tier == "HS" {
+		var replicaCount *decimal.Decimal
+		if d.Get("read_replica_count").Type != gjson.Null {
+			replicaCount = decimalPtr(decimal.NewFromInt(d.Get("read_replica_count").Int()))
+		}
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:           "Read replicas",
+			Unit:           "hours",
+			UnitMultiplier: 1,
+			HourlyQuantity: replicaCount,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("azure"),
+				Region:        strPtr(region),
+				Service:       strPtr(serviceName),
+				ProductFamily: strPtr("Databases"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", ValueRegex: strPtr(productNameRegex)},
+					{Key: "skuName", Value: strPtr(skuName)},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		})
 	}
-	productNameRegex += " Compute " + family + "/"
 
-	fmt.Println(productNameRegex)
-	fmt.Println(skuName)
-	fmt.Println("Location:", region)
+	if tier == "GP" || tier == "HS" || tier == "BC" {
+		var licenseType string
+		if d.Get("license_type").Type != gjson.Null {
+			licenseType = d.Get("license_type").String()
+			if licenseType == "LicenseIncluded" {
+				costComponents = append(costComponents, sqlLicenseCostComponent(region, cores, serviceName, tier))
+			}
+		}
+	}
 
-	costComponents = append(costComponents, databaseComputeInstance(region, serviceName, sku, productNameRegex, skuName))
+	storageGb := decimalPtr(decimal.NewFromInt(5))
+	if d.Get("max_size_gb").Type != gjson.Null {
+		storageGb = decimalPtr(decimal.NewFromInt(d.Get("max_size_gb").Int()))
+	}
+	costComponents = append(costComponents, mssqlStorageComponent(storageGb, region, serviceName, tier, zoneRedundant))
+
+	var retention *decimal.Decimal
+	if tier != "HS" {
+		if u != nil && u.Get("monthly_long_term_retention_storage_gb").Exists() {
+			retention = decimalPtr(decimal.NewFromInt(u.Get("monthly_long_term_retention_storage_gb").Int()))
+		}
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            "Long-term retention",
+			Unit:            "GB-months",
+			UnitMultiplier:  1,
+			MonthlyQuantity: retention,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("azure"),
+				Region:        strPtr(region),
+				Service:       strPtr(serviceName),
+				ProductFamily: strPtr("Databases"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", ValueRegex: strPtr("/LTR Backup Storage/")},
+					{Key: "skuName", Value: strPtr("Backup RA-GRS")},
+					{Key: "meterName", Value: strPtr("RA-GRS Data Stored")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		})
+	}
 
 	return &schema.Resource{
 		Name:           d.Address,
 		CostComponents: costComponents,
+	}
+}
+
+func mssqlSkuSplit(address, sku string) (string, string, string, error) {
+	if s := strings.Split(sku, "_"); len(s) == 4 && strings.HasPrefix(sku, "GP_S_Gen") {
+		return s[0] + s[1], s[2], s[3], nil
+	}
+	if s := strings.Split(sku, "_"); len(s) == 3 {
+		if strings.HasPrefix(sku, "HS_Gen") ||
+			strings.HasPrefix(sku, "HS_DC") ||
+			strings.HasPrefix(sku, "GP_Gen") ||
+			strings.HasPrefix(sku, "GP_Fsv2") ||
+			strings.HasPrefix(sku, "GP_DC") ||
+			strings.HasPrefix(sku, "BC_Gen") ||
+			strings.HasPrefix(sku, "BC_M") ||
+			strings.HasPrefix(sku, "BC_DC") ||
+			strings.HasPrefix(sku, "BC_DC") {
+			return s[0], s[1], s[2], nil
+		}
+	}
+	return "", "", "", errors.Errorf("Unrecognised MSSQL SKU format for resource %s: %s", address, sku)
+}
+
+func mssqlProductName(tier, family string) string {
+	tierName := map[string]string{
+		"GPS": "General Purpose - Serverless",
+		"HS":  "Hyperscale",
+		"GP":  "General Purpose",
+		"BC":  "Business Critical",
+	}[tier]
+
+	familyName := map[string]string{
+		"Gen5":    "Compute Gen5",
+		"Gen4":    "Compute Gen4",
+		"DC":      "Compute DC-Series",
+		"Fsv2":    "Compute FSv2 Series",
+		"M":       "Compute M Series",
+		"Storage": "Storage",
+		"License": "SQL License",
+	}[family]
+
+	return fmt.Sprintf("/%s - %s/", tierName, familyName)
+}
+
+func mssqlSkuName(cores string, zoneRedundant bool) string {
+	sku := cores + " vCore"
+	if zoneRedundant {
+		sku += " Zone Redundancy"
+	}
+	return sku
+}
+
+func sqlLicenseCostComponent(region, cores, serviceName, tier string) *schema.CostComponent {
+	licenseRegion := "Global"
+	if strings.Contains(region, "usgov") {
+		licenseRegion = "US Gov"
+	}
+	if strings.Contains(region, "china") {
+		licenseRegion = "China"
+	}
+	if strings.Contains(region, "germany") {
+		licenseRegion = "Germany"
+	}
+
+	coresNum, _ := strconv.ParseInt(cores, 10, 64)
+
+	return &schema.CostComponent{
+		Name:           "SQL License",
+		Unit:           "hours",
+		UnitMultiplier: 1,
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(coresNum)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(licenseRegion),
+			Service:       strPtr(serviceName),
+			ProductFamily: strPtr("Databases"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", ValueRegex: strPtr(mssqlProductName(tier, "License"))},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	}
+}
+
+func mssqlStorageComponent(storageGB *decimal.Decimal, region, serviceName, tier string, zoneRedundant bool) *schema.CostComponent {
+	tierName := map[string]string{
+		"GPS": "General Purpose",
+		"HS":  "Hyperscale",
+		"GP":  "General Purpose",
+		"BC":  "Business Critical",
+	}[tier]
+
+	skuName := tierName
+	if zoneRedundant {
+		skuName += " Zone Redundancy"
+	}
+
+	productNameRegex := fmt.Sprintf("/%s - Storage/", tierName)
+
+	return &schema.CostComponent{
+		Name:            "Storage",
+		Unit:            "GB-months",
+		UnitMultiplier:  1,
+		MonthlyQuantity: storageGB,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(region),
+			Service:       strPtr(serviceName),
+			ProductFamily: strPtr("Databases"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", ValueRegex: strPtr(productNameRegex)},
+				{Key: "skuName", Value: strPtr(skuName)},
+				{Key: "meterName", Value: strPtr("Data Stored")},
+			},
+		},
 	}
 }

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -1,0 +1,77 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/schema"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+)
+
+func GetAzureMSSQLDatabaseRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_mssql_database",
+		RFunc: NewAzureMSSQLDatabase,
+	}
+}
+
+func NewAzureMSSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	var costComponents []*schema.CostComponent
+	region := d.Get("location").String()
+	serviceName := "SQL Database"
+
+	var sku, computeType, tier, family, cores string
+	var zoneRedundant bool
+	if d.Get("sku_name").Type != gjson.Null {
+		sku = d.Get("sku_name").String()
+		if s := strings.Split(sku, "_"); len(s) == 4 {
+			if s[1] == "S" {
+				computeType = "Serverless"
+				tier = s[0]
+				family = s[2]
+				cores = s[3]
+			}
+		} else if s := strings.Split(sku, "_"); len(s) == 3 {
+			computeType = "Provisioned"
+			tier = s[0]
+			family = s[1]
+			cores = s[2]
+		} else {
+			log.Warnf("Unrecognised MSSQL SKU format for resource %s: %s", d.Address, sku)
+			return nil
+		}
+	}
+
+	tierName := map[string]string{
+		"BC": "Business Critical",
+		"GP": "General Purpose",
+		"HS": "Hyperscale",
+	}[tier]
+
+	if d.Get("zone_redundant").Type != gjson.Null {
+		zoneRedundant = d.Get("zone_redundant").Bool()
+	}
+
+	skuName := cores + " vCore"
+	if zoneRedundant {
+		skuName += " Zone Redundancy"
+	}
+
+	productNameRegex := "/" + tierName + " -"
+	if computeType == "Serverless" {
+		productNameRegex += " Serverless -"
+	}
+	productNameRegex += " Compute " + family + "/"
+
+	fmt.Println(productNameRegex)
+	fmt.Println(skuName)
+	fmt.Println("Location:", region)
+
+	costComponents = append(costComponents, databaseComputeInstance(region, serviceName, sku, productNameRegex, skuName))
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/providers/terraform/azure/mssql_database_test.go
+++ b/internal/providers/terraform/azure/mssql_database_test.go
@@ -1,0 +1,465 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/testutil"
+	"github.com/shopspring/decimal"
+)
+
+func TestMSSQLDatabase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "azurerm_resource_group" "example" {
+		name     = "example-resources"
+		location = "eastus"
+	}
+	
+	resource "azurerm_sql_server" "example" {
+		name                         = "example-sqlserver"
+		resource_group_name          = azurerm_resource_group.example.name
+		location                     = "eastus"
+		version                      = "12.0"
+		administrator_login          = "fake"
+		administrator_login_password = "fake"
+	}
+	
+	resource "azurerm_mssql_database" "general_purpose_gen" {
+		name           = "acctest-db-d"
+		server_id      = azurerm_sql_server.example.id
+		sku_name       = "GP_Gen5_4"
+	}
+	resource "azurerm_mssql_database" "business_critical_gen" {
+		name           = "acctest-db-d"
+		server_id      = azurerm_sql_server.example.id
+		sku_name       = "BC_Gen5_8"
+		max_size_gb    = 10
+	}
+	resource "azurerm_mssql_database" "business_critical_m" {
+		name           = "acctest-db-d"
+		server_id      = azurerm_sql_server.example.id
+		sku_name       = "BC_M_8"
+		max_size_gb    = 50
+	}
+	resource "azurerm_mssql_database" "hyperscale_gen" {
+		name           = "acctest-db-d"
+		server_id      = azurerm_sql_server.example.id
+		sku_name       = "HS_Gen5_2"
+		max_size_gb    = 100
+	}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name:      "azurerm_resource_group.example",
+			SkipCheck: true,
+		},
+		{
+			Name:      "azurerm_sql_server.example",
+			SkipCheck: true,
+		},
+		{
+			Name: "azurerm_mssql_database.general_purpose_gen",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Compute (provisioned, GP_Gen5_4)",
+					PriceHash:       "f42898ff48d81acaf7b657aacaf277db-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Storage",
+					PriceHash:        "7614d4c707b678cc053a4e75265fdfee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(5)),
+				},
+				{
+					Name:             "Long-term retention",
+					PriceHash:        "1fd081640191a4301b4354155c39bbee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "azurerm_mssql_database.business_critical_gen",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Compute (provisioned, BC_Gen5_8)",
+					PriceHash:       "8ad0fc701dd661618992c51d38418cd5-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Storage",
+					PriceHash:        "32f0514bc8bade7e28ef38328604cbdc-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(10)),
+				},
+				{
+					Name:             "Long-term retention",
+					PriceHash:        "1fd081640191a4301b4354155c39bbee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "azurerm_mssql_database.business_critical_m",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Compute (provisioned, BC_M_8)",
+					PriceHash:       "6d355ec153d614628a3847666d995f1a-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Storage",
+					PriceHash:        "32f0514bc8bade7e28ef38328604cbdc-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(50)),
+				},
+				{
+					Name:             "Long-term retention",
+					PriceHash:        "1fd081640191a4301b4354155c39bbee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+		{
+			Name: "azurerm_mssql_database.hyperscale_gen",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Compute (provisioned, HS_Gen5_2)",
+					PriceHash:       "49a7ab0d61cb0e246bb4a1db18e124bb-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Storage",
+					PriceHash:        "34bb4ebb9f806ef9b11c951a2dfa2d78-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(100)),
+				},
+				{
+					Name:             "Read replicas",
+					PriceHash:        "49a7ab0d61cb0e246bb4a1db18e124bb-60fc60896424f2f0b576ec5c4e380288",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestMSSQLDatabase_HS_with_replicas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "azurerm_resource_group" "example" {
+		name     = "example-resources"
+		location = "eastus"
+	}
+	
+	resource "azurerm_sql_server" "example" {
+		name                         = "example-sqlserver"
+		resource_group_name          = azurerm_resource_group.example.name
+		location                     = "eastus"
+		version                      = "12.0"
+		administrator_login          = "fake"
+		administrator_login_password = "fake"
+	}
+	resource "azurerm_mssql_database" "hyperscale_gen" {
+		name           = "acctest-db-d"
+		server_id      = azurerm_sql_server.example.id
+		sku_name       = "HS_Gen5_2"
+		read_replica_count = 2
+	}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name:      "azurerm_resource_group.example",
+			SkipCheck: true,
+		},
+		{
+			Name:      "azurerm_sql_server.example",
+			SkipCheck: true,
+		},
+		{
+			Name: "azurerm_mssql_database.hyperscale_gen",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Compute (provisioned, HS_Gen5_2)",
+					PriceHash:       "49a7ab0d61cb0e246bb4a1db18e124bb-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Storage",
+					PriceHash:        "34bb4ebb9f806ef9b11c951a2dfa2d78-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(5)),
+				},
+				{
+					Name:            "Read replicas",
+					PriceHash:       "49a7ab0d61cb0e246bb4a1db18e124bb-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(2)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestMSSQLDatabase_with_license(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "azurerm_resource_group" "example" {
+		name     = "example-resources"
+		location = "eastus"
+	}
+	
+	resource "azurerm_sql_server" "example" {
+		name                         = "example-sqlserver"
+		resource_group_name          = azurerm_resource_group.example.name
+		location                     = "eastus"
+		version                      = "12.0"
+		administrator_login          = "fake"
+		administrator_login_password = "fake"
+	}
+	resource "azurerm_mssql_database" "general_purpose_gen" {
+		name           = "acctest-db-d"
+		server_id      = azurerm_sql_server.example.id
+		sku_name       = "GP_Gen5_4"
+		license_type   = "LicenseIncluded"
+	}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name:      "azurerm_resource_group.example",
+			SkipCheck: true,
+		},
+		{
+			Name:      "azurerm_sql_server.example",
+			SkipCheck: true,
+		},
+		{
+			Name: "azurerm_mssql_database.general_purpose_gen",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Compute (provisioned, GP_Gen5_4)",
+					PriceHash:       "f42898ff48d81acaf7b657aacaf277db-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:            "SQL License",
+					PriceHash:       "884778bbd38c482d0fb8c655195422e7-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
+				},
+				{
+					Name:             "Storage",
+					PriceHash:        "7614d4c707b678cc053a4e75265fdfee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(5)),
+				},
+				{
+					Name:             "Long-term retention",
+					PriceHash:        "1fd081640191a4301b4354155c39bbee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestMSSQLDatabase_zone_redundant(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "azurerm_resource_group" "example" {
+		name     = "example-resources"
+		location = "eastus"
+	}
+	
+	resource "azurerm_sql_server" "example" {
+		name                         = "example-sqlserver"
+		resource_group_name          = azurerm_resource_group.example.name
+		location                     = "eastus"
+		version                      = "12.0"
+		administrator_login          = "fake"
+		administrator_login_password = "fake"
+	}
+	resource "azurerm_mssql_database" "general_purpose_gen" {
+		name           = "acctest-db-d"
+		server_id      = azurerm_sql_server.example.id
+		sku_name       = "GP_Gen5_4"
+		zone_redundant = true
+	}`
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name:      "azurerm_resource_group.example",
+			SkipCheck: true,
+		},
+		{
+			Name:      "azurerm_sql_server.example",
+			SkipCheck: true,
+		},
+		{
+			Name: "azurerm_mssql_database.general_purpose_gen",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Compute (provisioned, GP_Gen5_4)",
+					PriceHash:       "ebdf927dde026ddb10d829159f37543c-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Storage",
+					PriceHash:        "1336a17109124a6daeef5225cda70e88-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(5)),
+				},
+				{
+					Name:             "Long-term retention",
+					PriceHash:        "1fd081640191a4301b4354155c39bbee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+}
+
+func TestMSSQLDatabase_serverless(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "azurerm_resource_group" "example" {
+		name     = "example-resources"
+		location = "eastus"
+	}
+	
+	resource "azurerm_sql_server" "example" {
+		name                         = "example-sqlserver"
+		resource_group_name          = azurerm_resource_group.example.name
+		location                     = "eastus"
+		version                      = "12.0"
+		administrator_login          = "fake"
+		administrator_login_password = "fake"
+	}
+	
+	resource "azurerm_mssql_database" "serverless" {
+		name           = "acctest-db-d"
+		server_id      = azurerm_sql_server.example.id
+		sku_name       = "GP_S_Gen5_4"
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"azurerm_mssql_database.serverless": map[string]interface{}{
+			"vcore_hours": 500,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name:      "azurerm_resource_group.example",
+			SkipCheck: true,
+		},
+		{
+			Name:      "azurerm_sql_server.example",
+			SkipCheck: true,
+		},
+		{
+			Name: "azurerm_mssql_database.serverless",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:             "Compute (serverless, GP_S_Gen5_4)",
+					PriceHash:        "02cae7437956531c79530f317b7f58ce-60fc60896424f2f0b576ec5c4e380288",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(500)),
+				},
+				{
+					Name:             "Storage",
+					PriceHash:        "7614d4c707b678cc053a4e75265fdfee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(5)),
+				},
+				{
+					Name:             "Long-term retention",
+					PriceHash:        "1fd081640191a4301b4354155c39bbee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.NilMonthlyCostCheck(),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}
+
+func TestMSSQLDatabase_LTR(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tf := `
+	resource "azurerm_resource_group" "example" {
+		name     = "example-resources"
+		location = "eastus"
+	}
+	
+	resource "azurerm_sql_server" "example" {
+		name                         = "example-sqlserver"
+		resource_group_name          = azurerm_resource_group.example.name
+		location                     = "eastus"
+		version                      = "12.0"
+		administrator_login          = "fake"
+		administrator_login_password = "fake"
+	}
+	
+	resource "azurerm_mssql_database" "my_db" {
+		name           = "acctest-db-d"
+		server_id      = azurerm_sql_server.example.id
+		sku_name       = "GP_Gen5_4"
+	}`
+
+	usage := schema.NewUsageMap(map[string]interface{}{
+		"azurerm_mssql_database.my_db": map[string]interface{}{
+			"monthly_long_term_retention_storage_gb": 1000,
+		},
+	})
+
+	resourceChecks := []testutil.ResourceCheck{
+		{
+			Name:      "azurerm_resource_group.example",
+			SkipCheck: true,
+		},
+		{
+			Name:      "azurerm_sql_server.example",
+			SkipCheck: true,
+		},
+		{
+			Name: "azurerm_mssql_database.my_db",
+			CostComponentChecks: []testutil.CostComponentCheck{
+				{
+					Name:            "Compute (provisioned, GP_Gen5_4)",
+					PriceHash:       "f42898ff48d81acaf7b657aacaf277db-60fc60896424f2f0b576ec5c4e380288",
+					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
+				},
+				{
+					Name:             "Storage",
+					PriceHash:        "7614d4c707b678cc053a4e75265fdfee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(5)),
+				},
+				{
+					Name:             "Long-term retention",
+					PriceHash:        "1fd081640191a4301b4354155c39bbee-ea8c44e23e41502dcee5033e136055b6",
+					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1000)),
+				},
+			},
+		},
+	}
+
+	tftest.ResourceTests(t, tf, usage, resourceChecks)
+}

--- a/internal/providers/terraform/azure/mssql_database_test.go
+++ b/internal/providers/terraform/azure/mssql_database_test.go
@@ -251,7 +251,7 @@ func TestMSSQLDatabase_with_license(t *testing.T) {
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(1)),
 				},
 				{
-					Name:            "SQL License",
+					Name:            "SQL license",
 					PriceHash:       "884778bbd38c482d0fb8c655195422e7-60fc60896424f2f0b576ec5c4e380288",
 					HourlyCostCheck: testutil.HourlyPriceMultiplierCheck(decimal.NewFromInt(4)),
 				},
@@ -360,7 +360,7 @@ func TestMSSQLDatabase_serverless(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"azurerm_mssql_database.serverless": map[string]interface{}{
-			"vcore_hours": 500,
+			"monthly_vcore_hours": 500,
 		},
 	})
 
@@ -426,7 +426,7 @@ func TestMSSQLDatabase_LTR(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"azurerm_mssql_database.my_db": map[string]interface{}{
-			"monthly_long_term_retention_storage_gb": 1000,
+			"long_term_retention_storage_gb": 1000,
 		},
 	})
 

--- a/internal/providers/terraform/azure/mysql_server.go
+++ b/internal/providers/terraform/azure/mysql_server.go
@@ -47,7 +47,7 @@ func NewAzureMySQLServer(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 	productNameRegex := fmt.Sprintf("/%s - Compute %s/", tierName, family)
 	skuName := fmt.Sprintf("%s vCore", cores)
 
-	costComponents = append(costComponents, databaseComputeInstance(region, serviceName, sku, productNameRegex, skuName))
+	costComponents = append(costComponents, databaseComputeInstance(region, fmt.Sprintf("Compute (%s)", sku), serviceName, productNameRegex, skuName))
 
 	storageGB := d.Get("storage_mb").Int() / 1024
 

--- a/internal/providers/terraform/azure/postgresql_server.go
+++ b/internal/providers/terraform/azure/postgresql_server.go
@@ -47,7 +47,7 @@ func NewAzurePostrgreSQLServer(d *schema.ResourceData, u *schema.UsageData) *sch
 	productNameRegex := fmt.Sprintf("/%s - Compute %s/", tierName, family)
 	skuName := fmt.Sprintf("%s vCore", cores)
 
-	costComponents = append(costComponents, databaseComputeInstance(region, serviceName, sku, productNameRegex, skuName))
+	costComponents = append(costComponents, databaseComputeInstance(region, fmt.Sprintf("Compute (%s)", sku), serviceName, productNameRegex, skuName))
 
 	storageGB := d.Get("storage_mb").Int() / 1024
 

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -8,6 +8,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMLinuxVirtualMachineScaleSetRegistryItem(),
 	GetAzureRMManagedDiskRegistryItem(),
 	GetAzureMariaDBServerRegistryItem(),
+	GetAzureMSSQLDatabaseRegistryItem(),
 	GetAzureMySQLServerRegistryItem(),
 	GetAzurePostgreSQLServerRegistryItem(),
 	GetAzureRMWindowsVirtualMachineRegistryItem(),


### PR DESCRIPTION
Issue #569 

Output examples: 
```
With usage-file: 
 Name                                          Quantity  Unit         Monthly Cost
 azurerm_mssql_database.my_database                                                
 ├─ Compute (serverless, GP_S_Gen5_4)               600  vCore-hours       $313.05 
 ├─ Storage                                           5  GB-months           $0.57 
 └─ Long-term retention                           1,000  GB-months          $50.00 
 
 azurerm_mssql_database.my_database                                              
 ├─ Compute (provisioned, HS_Gen5_8)                730  hours           $1,066.73 
 ├─ Read replicas                                   730  hours           $1,066.73 
 ├─ SQL License                                   5,840  hours             $583.80 
 └─ Storage                                          50  GB-months           $5.00
 
 Without usage-file:
 azurerm_mssql_database.serverless                                                            
 ├─ Compute (serverless, GP_S_Gen5_4)          Cost depends on usage: $0.52 per vCore-hours   
 ├─ Storage                                           5  GB-months           $0.57 
 └─ Long-term retention                        Cost depends on usage: $0.05 per GB-months    
```
 
 **Details**: 
 Tests has `Multiple products` warnings as db has two identical components.