### PR TITLE
fix: broken test as a cloud-pricing-api change caused this hash to ch…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ The entire test suite can take >20 mins to run, so we recommend against running 
 
 You should run tests for a file you added/changed with `-v` and warn log level so you can see and fix any warnings:
 ```sh
-INFRACOST_LOG_LEVEL=warn go test -v internal/providers/terraform/aws/ebs_volume_test.go
+INFRACOST_LOG_LEVEL=warn go test -v -cover ./internal/providers/terraform/aws/ebs_volume_test.go
 
 time="2021-04-05T15:24:16Z" level=warning msg="Multiple prices found for aws_ebs_volume.gp3 Provisioned throughput, using the first price"
 ```

--- a/internal/providers/terraform/azure/app_service_certificate_order_test.go
+++ b/internal/providers/terraform/azure/app_service_certificate_order_test.go
@@ -38,7 +38,7 @@ func TestAzureRMAppServiceCertificateOrder(t *testing.T) {
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
 					Name:             "SSL certificate (Standard)",
-					PriceHash:        "4e8a819ae89e667ac4c8e5a86c983d49-e1f24f9fc7676b8cc310519e3f060f1d",
+					PriceHash:        "038927521c484b222968e9c66f83bb36-e1f24f9fc7676b8cc310519e3f060f1d",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1).Div(decimal.NewFromInt(12))),
 				},
 			},
@@ -48,7 +48,7 @@ func TestAzureRMAppServiceCertificateOrder(t *testing.T) {
 			CostComponentChecks: []testutil.CostComponentCheck{
 				{
 					Name:             "SSL certificate (wildcard)",
-					PriceHash:        "6ec315d71563d4fc7369d88c8869765f-e1f24f9fc7676b8cc310519e3f060f1d",
+					PriceHash:        "ef0fe7889d6b55197be8698bc60e0252-e1f24f9fc7676b8cc310519e3f060f1d",
 					MonthlyCostCheck: testutil.MonthlyPriceMultiplierCheck(decimal.NewFromInt(1).Div(decimal.NewFromInt(12))),
 				},
 			},


### PR DESCRIPTION
…ange

https://github.com/infracost/cloud-pricing-api/pull/42/files#diff-292e98a20dd8751e039cd6ea9feb66e6419f7b06ed590f2171cfb675fa336339R116