### PR TITLE
feat(azure): Add support for Azure Key Vault

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -472,14 +472,14 @@ resource_usage:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 
   azurerm_key_vault_certificate.my_certificate:
-    monthly_certificate_renewal_requests: 100 # Monthly number of certificate reneval requests.
+    monthly_certificate_renewal_requests: 100    # Monthly number of certificate renewal requests.
     monthly_certificate_other_operations: 100000 # Monthly number of non-renewal certificate operations.
 
   azurerm_key_vault_key.my_keys:
-    monthly_secrets_operations: 10000 # Monthly number of secrets transactions.
-    monthly_key_rotation_renewals: 50 # Monthly number of Managed Azure Storage account key rotation renewals.
+    monthly_secrets_operations: 10000          # Monthly number of secrets transactions.
+    monthly_key_rotation_renewals: 50          # Monthly number of Managed Azure Storage account key rotation renewals.
     monthly_protected_keys_operations: 1000000 # Monthly number of Software or HSM transactions.
-    hsm_protected_keys: 3000 # Number of protected keys.
+    hsm_protected_keys: 3000                   # Number of protected keys.
 
   azurerm_linux_virtual_machine_scale_set.standard_f2:
     instances: 10 # Override the number of instances in the scale set.
@@ -493,7 +493,7 @@ resource_usage:
     additional_backup_storage_gb: 2000 # Additional consumption of backup storage in GB.
 
   azurerm_mssql_database.my_database:
-    monthly_vcore_hours: 600 # Monthly number of used vCore-hours for serverless compute.
+    monthly_vcore_hours: 600             # Monthly number of used vCore-hours for serverless compute.
     long_term_retention_storage_gb: 1000 # Number of GBs used by long-term retention backup storage.
 
   azurerm_mysql_server.my_server:

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -472,12 +472,12 @@ resource_usage:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 
   azurerm_key_vault_key.my_keys:
-    monthly_secrets_operations: 10000 # Monthly number of secrets transactions
-    monthly_certificate_renewal_requests: 100 # Monthly number of certificate reneval requests
-    monthly_certificate_all_other_operations: 100000 # Monthly number of all other certificate transactions
-    monthly_key_rotation_renewals: 50 # Monthly number of Managed Azure Storage account key rotation renewals
-    monthly_protected_keys_operations: 1000000 # Monthly number of Software or HSM transactions
-    hsm_protected_keys: 3000
+    monthly_secrets_operations: 10000 # Monthly number of secrets transactions.
+    monthly_certificate_renewal_requests: 100 # Monthly number of certificate reneval requests.
+    monthly_certificate_all_other_operations: 100000 # Monthly number of all other certificate transactions.
+    monthly_key_rotation_renewals: 50 # Monthly number of Managed Azure Storage account key rotation renewals.
+    monthly_protected_keys_operations: 1000000 # Monthly number of Software or HSM transactions.
+    hsm_protected_keys: 3000 # Number of protected keys.
 
   azurerm_linux_virtual_machine_scale_set.standard_f2:
     instances: 10 # Override the number of instances in the scale set.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -471,6 +471,14 @@ resource_usage:
     os_disk:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 
+  azurerm_key_vault_key.my_keys:
+    monthly_secrets_operations: 10000 # Monthly number of secrets transactions
+    monthly_certificate_renewal_requests: 100 # Monthly number of certificate reneval requests
+    monthly_certificate_all_other_operations: 100000 # Monthly number of all other certificate transactions
+    monthly_key_rotation_renewals: 50 # Monthly number of Managed Azure Storage account key rotation renewals
+    monthly_protected_keys_operations: 1000000 # Monthly number of Software or HSM transactions
+    hsm_protected_keys: 3000
+
   azurerm_linux_virtual_machine_scale_set.standard_f2:
     instances: 10 # Override the number of instances in the scale set.
     os_disk:

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -471,10 +471,12 @@ resource_usage:
     os_disk:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 
-  azurerm_key_vault_key.my_keys:
-    monthly_secrets_operations: 10000 # Monthly number of secrets transactions.
+  azurerm_key_vault_certificate.my_certificate:
     monthly_certificate_renewal_requests: 100 # Monthly number of certificate reneval requests.
     monthly_certificate_other_operations: 100000 # Monthly number of non-renewal certificate operations.
+
+  azurerm_key_vault_key.my_keys:
+    monthly_secrets_operations: 10000 # Monthly number of secrets transactions.
     monthly_key_rotation_renewals: 50 # Monthly number of Managed Azure Storage account key rotation renewals.
     monthly_protected_keys_operations: 1000000 # Monthly number of Software or HSM transactions.
     hsm_protected_keys: 3000 # Number of protected keys.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -474,7 +474,7 @@ resource_usage:
   azurerm_key_vault_key.my_keys:
     monthly_secrets_operations: 10000 # Monthly number of secrets transactions.
     monthly_certificate_renewal_requests: 100 # Monthly number of certificate reneval requests.
-    monthly_certificate_all_other_operations: 100000 # Monthly number of all other certificate transactions.
+    monthly_certificate_other_operations: 100000 # Monthly number of non-renewal certificate operations.
     monthly_key_rotation_renewals: 50 # Monthly number of Managed Azure Storage account key rotation renewals.
     monthly_protected_keys_operations: 1000000 # Monthly number of Software or HSM transactions.
     hsm_protected_keys: 3000 # Number of protected keys.

--- a/internal/providers/terraform/azure/key_vault_certificate.go
+++ b/internal/providers/terraform/azure/key_vault_certificate.go
@@ -36,9 +36,9 @@ func NewAzureKeyVaultCertificate(d *schema.ResourceData, u *schema.UsageData) *s
 		certificateRenewals = decimalPtr(decimal.NewFromInt(u.Get("monthly_certificate_renewal_requests").Int()))
 	}
 	costComponents = append(costComponents, vaultKeysCostComponent(
-		"Certificate operations",
+		"Certificate renewal",
 		location,
-		"renewals",
+		"requests",
 		skuName,
 		"Certificate Renewal Request",
 		"0",

--- a/internal/providers/terraform/azure/key_vault_certificate.go
+++ b/internal/providers/terraform/azure/key_vault_certificate.go
@@ -1,0 +1,65 @@
+package azure
+
+import (
+	"strings"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+	log "github.com/sirupsen/logrus"
+)
+
+func GetAzureRMKeyVaultCertificateRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_key_vault_certificate",
+		RFunc: NewAzureKeyVaultCertificate,
+		ReferenceAttributes: []string{
+			"key_vault_id",
+		},
+	}
+}
+
+func NewAzureKeyVaultCertificate(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	var location, skuName string
+	keyVault := d.References("key_vault_id")
+	location = keyVault[0].Get("location").String()
+
+	if location == "" {
+		log.Warnf("Skipping resource %s. Infracost currently cannot find the location for this resource.", d.Address)
+		return nil
+	}
+
+	var costComponents []*schema.CostComponent
+	skuName = strings.Title(keyVault[0].Get("sku_name").String())
+
+	var certificateRenewals, certificateOperations *decimal.Decimal
+	if u != nil && u.Get("monthly_certificate_renewal_requests").Exists() {
+		certificateRenewals = decimalPtr(decimal.NewFromInt(u.Get("monthly_certificate_renewal_requests").Int()))
+	}
+	costComponents = append(costComponents, vaultKeysCostComponent(
+		"Certificate operations",
+		location,
+		"renewals",
+		skuName,
+		"Certificate Renewal Request",
+		"0",
+		certificateRenewals,
+		1))
+
+	if u != nil && u.Get("monthly_certificate_other_operations").Exists() {
+		certificateOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_certificate_other_operations").Int()))
+	}
+	costComponents = append(costComponents, vaultKeysCostComponent(
+		"Certificate operations",
+		location,
+		"10K transactions",
+		skuName,
+		"Operations",
+		"0",
+		certificateOperations,
+		10000))
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/providers/terraform/azure/key_vault_certificate_test.go
+++ b/internal/providers/terraform/azure/key_vault_certificate_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureKeyVaultCertificate(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "key_vault_certificate_test")
+}

--- a/internal/providers/terraform/azure/key_vault_key.go
+++ b/internal/providers/terraform/azure/key_vault_key.go
@@ -1,0 +1,170 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
+	"github.com/shopspring/decimal"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+)
+
+func GetAzureKeyVaultKeyRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_key_vault_key",
+		RFunc: NewAzureKeyVaultKey,
+		ReferenceAttributes: []string{
+			"key_vault_id",
+		},
+	}
+}
+
+func NewAzureKeyVaultKey(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	var location, skuName, keyType, keySize, meterName string
+	keyVault := d.References("key_vault_id")
+	location = keyVault[0].Get("location").String()
+
+	if location == "" {
+		log.Warnf("Skipping resource %s. Infracost currently cannot find the location for this resource.", d.Address)
+		return nil
+	}
+
+	skuName = strings.Title(keyVault[0].Get("sku_name").String())
+	keyType = d.Get("key_type").String()
+
+	if d.Get("key_size").Type != gjson.Null {
+		keySize = d.Get("key_size").String()
+	}
+
+	var costComponents []*schema.CostComponent
+
+	unit := "10K transactions"
+
+	var secretsTransactions *decimal.Decimal
+	if u != nil && u.Get("monthly_secrets_operations").Exists() {
+		secretsTransactions = decimalPtr(decimal.NewFromInt(u.Get("monthly_secrets_operations").Int()))
+	}
+	meterName = "Operations"
+	costComponents = append(costComponents, vaultKeysCostComponent("Secrets operations", location, unit, skuName, meterName, "0", secretsTransactions, 10000))
+
+	var certificateRenewals, certificateOperations *decimal.Decimal
+	if u != nil && u.Get("monthly_certificate_renewal_requests").Exists() {
+		certificateRenewals = decimalPtr(decimal.NewFromInt(u.Get("monthly_certificate_renewal_requests").Int()))
+	}
+	meterName = "Certificate Renewal Request"
+	costComponents = append(costComponents, vaultKeysCostComponent("Certificate operations", location, "renewals", skuName, meterName, "0", certificateRenewals, 1))
+
+	if u != nil && u.Get("monthly_certificate_all_other_operations").Exists() {
+		certificateOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_certificate_all_other_operations").Int()))
+	}
+	meterName = "Operations"
+	costComponents = append(costComponents, vaultKeysCostComponent("Certificate operations", location, unit, skuName, meterName, "0", certificateOperations, 10000))
+
+	var keyRotationRenewals *decimal.Decimal
+	if u != nil && u.Get("monthly_key_rotation_renewals").Exists() {
+		keyRotationRenewals = decimalPtr(decimal.NewFromInt(u.Get("monthly_key_rotation_renewals").Int()))
+	}
+	meterName = "Secret Renewal"
+	costComponents = append(costComponents, vaultKeysCostComponent("Storage key rotation", location, "renewals", skuName, meterName, "0", keyRotationRenewals, 1))
+
+	if !strings.HasSuffix(keyType, "HSM") {
+		var softwareProtectedTransactions *decimal.Decimal
+		if u != nil && u.Get("monthly_protected_keys_operations").Exists() {
+			softwareProtectedTransactions = decimalPtr(decimal.NewFromInt(u.Get("monthly_protected_keys_operations").Int()))
+		}
+
+		name := "Software-protected keys"
+		meterName = "Operations"
+
+		if keyType == "RSA" && keySize == "2048" {
+			costComponents = append(costComponents, vaultKeysCostComponent(name, location, unit, skuName, meterName, "0", softwareProtectedTransactions, 10000))
+		} else {
+			meterName = "Advanced Key Operations"
+			costComponents = append(costComponents, vaultKeysCostComponent(name, location, unit, skuName, meterName, "0", softwareProtectedTransactions, 10000))
+		}
+	}
+
+	if strings.HasSuffix(keyType, "HSM") && skuName == "Premium" {
+		var protectedKeys, hsmProtectedTransactions *decimal.Decimal
+
+		name := "HSM-protected keys"
+		keyUnit := "Per key per month"
+
+		if u != nil && u.Get("hsm_protected_keys").Exists() {
+			protectedKeys = decimalPtr(decimal.NewFromInt(u.Get("hsm_protected_keys").Int()))
+
+			fmt.Println(keyType, keySize)
+
+			if keyType == "RSA-HSM" && keySize == "2048" {
+				meterName = "Premium HSM-protected RSA 2048-bit key"
+				costComponents = append(costComponents, vaultKeysCostComponent(name, location, keyUnit, skuName, meterName, "0", protectedKeys, 1))
+			} else {
+				meterName = "Premium HSM-protected Advanced Key"
+
+				tierLimits := []int{250, 1250, 2500}
+				keysQuantities := usage.CalculateTierBuckets(*protectedKeys, tierLimits)
+
+				costComponents = append(costComponents, vaultKeysCostComponent(name+" (first 250)", location, keyUnit, skuName, meterName, "0", &keysQuantities[0], 1))
+				if keysQuantities[1].GreaterThan(decimal.Zero) {
+					costComponents = append(costComponents, vaultKeysCostComponent(name+" (next 1250)", location, keyUnit, skuName, meterName, "250", &keysQuantities[1], 1))
+				}
+				if keysQuantities[2].GreaterThan(decimal.Zero) {
+					costComponents = append(costComponents, vaultKeysCostComponent(name+" (next 2500)", location, keyUnit, skuName, meterName, "1500", &keysQuantities[2], 1))
+				}
+				if keysQuantities[3].GreaterThan(decimal.Zero) {
+					costComponents = append(costComponents, vaultKeysCostComponent(name+" (over 4000)", location, keyUnit, skuName, meterName, "4000", &keysQuantities[3], 1))
+				}
+			}
+		} else {
+			var unknown *decimal.Decimal
+			costComponents = append(costComponents, vaultKeysCostComponent(name, location, keyUnit, skuName, meterName, "0", unknown, 1))
+		}
+
+		if u != nil && u.Get("monthly_protected_keys_operations").Exists() {
+			hsmProtectedTransactions = decimalPtr(decimal.NewFromInt(u.Get("monthly_protected_keys_operations").Int()))
+
+			if keyType == "RSA" && keySize == "2048" {
+				meterName = "Operations"
+				costComponents = append(costComponents, vaultKeysCostComponent(name, location, unit, skuName, meterName, "0", hsmProtectedTransactions, 10000))
+			} else {
+				meterName = "Advanced Key Operations"
+				costComponents = append(costComponents, vaultKeysCostComponent(name, location, unit, skuName, meterName, "0", hsmProtectedTransactions, 10000))
+			}
+		}
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}
+
+func vaultKeysCostComponent(name, location, unit, skuName, meterName, startUsage string, quantity *decimal.Decimal, multi int) *schema.CostComponent {
+	if quantity != nil {
+		quantity = decimalPtr(quantity.Div(decimal.NewFromInt(int64(multi))))
+	}
+
+	return &schema.CostComponent{
+		Name:            name,
+		Unit:            unit,
+		UnitMultiplier:  1,
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(location),
+			Service:       strPtr("Key Vault"),
+			ProductFamily: strPtr("Security"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Key Vault")},
+				{Key: "skuName", Value: strPtr(skuName)},
+				{Key: "meterName", Value: strPtr(meterName)},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr(startUsage),
+		},
+	}
+}

--- a/internal/providers/terraform/azure/key_vault_key.go
+++ b/internal/providers/terraform/azure/key_vault_key.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func GetAzureKeyVaultKeyRegistryItem() *schema.RegistryItem {
+func GetAzureRMKeyVaultKeyRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "azurerm_key_vault_key",
 		RFunc: NewAzureKeyVaultKey,
@@ -47,19 +47,6 @@ func NewAzureKeyVaultKey(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 	}
 	meterName = "Operations"
 	costComponents = append(costComponents, vaultKeysCostComponent("Secrets operations", location, unit, skuName, meterName, "0", secretsTransactions, 10000))
-
-	var certificateRenewals, certificateOperations *decimal.Decimal
-	if u != nil && u.Get("monthly_certificate_renewal_requests").Exists() {
-		certificateRenewals = decimalPtr(decimal.NewFromInt(u.Get("monthly_certificate_renewal_requests").Int()))
-	}
-	meterName = "Certificate Renewal Request"
-	costComponents = append(costComponents, vaultKeysCostComponent("Certificate operations", location, "renewals", skuName, meterName, "0", certificateRenewals, 1))
-
-	if u != nil && u.Get("monthly_certificate_other_operations").Exists() {
-		certificateOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_certificate_other_operations").Int()))
-	}
-	meterName = "Operations"
-	costComponents = append(costComponents, vaultKeysCostComponent("Certificate operations", location, unit, skuName, meterName, "0", certificateOperations, 10000))
 
 	var keyRotationRenewals *decimal.Decimal
 	if u != nil && u.Get("monthly_key_rotation_renewals").Exists() {

--- a/internal/providers/terraform/azure/key_vault_key.go
+++ b/internal/providers/terraform/azure/key_vault_key.go
@@ -1,7 +1,6 @@
 package azure
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/infracost/infracost/internal/schema"
@@ -56,8 +55,8 @@ func NewAzureKeyVaultKey(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 	meterName = "Certificate Renewal Request"
 	costComponents = append(costComponents, vaultKeysCostComponent("Certificate operations", location, "renewals", skuName, meterName, "0", certificateRenewals, 1))
 
-	if u != nil && u.Get("monthly_certificate_all_other_operations").Exists() {
-		certificateOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_certificate_all_other_operations").Int()))
+	if u != nil && u.Get("monthly_certificate_other_operations").Exists() {
+		certificateOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_certificate_other_operations").Int()))
 	}
 	meterName = "Operations"
 	costComponents = append(costComponents, vaultKeysCostComponent("Certificate operations", location, unit, skuName, meterName, "0", certificateOperations, 10000))
@@ -90,12 +89,10 @@ func NewAzureKeyVaultKey(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 		var protectedKeys, hsmProtectedTransactions *decimal.Decimal
 
 		name := "HSM-protected keys"
-		keyUnit := "Per key per month"
+		keyUnit := "months"
 
 		if u != nil && u.Get("hsm_protected_keys").Exists() {
 			protectedKeys = decimalPtr(decimal.NewFromInt(u.Get("hsm_protected_keys").Int()))
-
-			fmt.Println(keyType, keySize)
 
 			if keyType == "RSA-HSM" && keySize == "2048" {
 				meterName = "Premium HSM-protected RSA 2048-bit key"

--- a/internal/providers/terraform/azure/key_vault_key_test.go
+++ b/internal/providers/terraform/azure/key_vault_key_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureKeyVaultKey(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "key_vault_key_test")
+}

--- a/internal/providers/terraform/azure/key_vault_managed_hardware_security_module.go
+++ b/internal/providers/terraform/azure/key_vault_managed_hardware_security_module.go
@@ -1,0 +1,46 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+func GetAzureRMKeyVaultManagedHSMRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_key_vault_managed_hardware_security_module",
+		RFunc: NewAzureKeyVaultManagedHSM,
+	}
+}
+
+func NewAzureKeyVaultManagedHSM(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	location := d.Get("location").String()
+
+	var costComponents []*schema.CostComponent
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:           "HSM pools",
+		Unit:           "hours",
+		UnitMultiplier: 1,
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(location),
+			Service:       strPtr("Key Vault"),
+			ProductFamily: strPtr("Security"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Azure Dedicated HSM")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard Instance")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("0"),
+		},
+	})
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/providers/terraform/azure/key_vault_managed_hardware_security_module_test.go
+++ b/internal/providers/terraform/azure/key_vault_managed_hardware_security_module_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureKeyVaultManagedHSMPools(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "key_vault_managed_hardware_security_module_test")
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -8,6 +8,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMLinuxVirtualMachineRegistryItem(),
 	GetAzureRMLinuxVirtualMachineScaleSetRegistryItem(),
 	GetAzureRMManagedDiskRegistryItem(),
+	GetAzureKeyVaultKeyRegistryItem(),
 	GetAzureMariaDBServerRegistryItem(),
 	GetAzureMSSQLDatabaseRegistryItem(),
 	GetAzureMySQLServerRegistryItem(),

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -8,7 +8,9 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMLinuxVirtualMachineRegistryItem(),
 	GetAzureRMLinuxVirtualMachineScaleSetRegistryItem(),
 	GetAzureRMManagedDiskRegistryItem(),
-	GetAzureKeyVaultKeyRegistryItem(),
+	GetAzureRMKeyVaultCertificateRegistryItem(),
+	GetAzureRMKeyVaultKeyRegistryItem(),
+	GetAzureRMKeyVaultManagedHSMRegistryItem(),
 	GetAzureMariaDBServerRegistryItem(),
 	GetAzureMSSQLDatabaseRegistryItem(),
 	GetAzureMySQLServerRegistryItem(),
@@ -31,6 +33,7 @@ var FreeResources []string = []string{
 
 	// Azure Key Vault
 	"azurerm_key_vault_access_policy",
+	"azurerm_key_vault_certificate_data",
 	"azurerm_key_vault_certificate_issuer",
 	"azurerm_key_vault_secret",
 

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -32,6 +32,7 @@ var FreeResources []string = []string{
 	"azurerm_blueprint_assignment",
 
 	// Azure Key Vault
+	"azurerm_key_vault",
 	"azurerm_key_vault_access_policy",
 	"azurerm_key_vault_certificate_data",
 	"azurerm_key_vault_certificate_issuer",

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -29,6 +29,11 @@ var FreeResources []string = []string{
 	// Azure Blueprints
 	"azurerm_blueprint_assignment",
 
+	// Azure Key Vault
+	"azurerm_key_vault_access_policy",
+	"azurerm_key_vault_certificate_issuer",
+	"azurerm_key_vault_secret",
+
 	// Azure Networking
 	"azurerm_application_security_group",
 	"azurerm_network_security_group",

--- a/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.golden
@@ -1,0 +1,23 @@
+
+ Name                                         Monthly Qty  Unit                 Monthly Cost 
+                                                                                             
+ azurerm_key_vault_certificate.non-usage                                                     
+ ├─ Certificate operations                Cost depends on usage: $3.00 per renewals          
+ └─ Certificate operations                Cost depends on usage: $0.03 per 10K transactions  
+                                                                                             
+ azurerm_key_vault_certificate.premium                                                       
+ ├─ Certificate operations                            100  renewals                  $300.00 
+ └─ Certificate operations                             10  10K transactions            $0.30 
+                                                                                             
+ azurerm_key_vault_certificate.standard                                                      
+ ├─ Certificate operations                            100  renewals                  $300.00 
+ └─ Certificate operations                             10  10K transactions            $0.30 
+                                                                                             
+ PROJECT TOTAL                                                                       $600.60 
+
+----------------------------------
+To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+
+1 resource type wasn't estimated as it's not supported yet.
+Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+2 x azurerm_key_vault

--- a/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.golden
@@ -2,22 +2,20 @@
  Name                                         Monthly Qty  Unit                 Monthly Cost 
                                                                                              
  azurerm_key_vault_certificate.non-usage                                                     
- ├─ Certificate operations                Cost depends on usage: $3.00 per renewals          
+ ├─ Certificate renewals                  Cost depends on usage: $3.00 per requests          
  └─ Certificate operations                Cost depends on usage: $0.03 per 10K transactions  
                                                                                              
  azurerm_key_vault_certificate.premium                                                       
- ├─ Certificate operations                            100  renewals                  $300.00 
- └─ Certificate operations                             10  10K transactions            $0.30 
+ ├─ Certificate renewals                               100  requests                  $300.00 
+ └─ Certificate operations                             10   10K transactions            $0.30 
                                                                                              
  azurerm_key_vault_certificate.standard                                                      
- ├─ Certificate operations                            100  renewals                  $300.00 
- └─ Certificate operations                             10  10K transactions            $0.30 
+ ├─ Certificate renewals                               100  requests                  $300.00 
+ └─ Certificate operations                             10   10K transactions            $0.30 
                                                                                              
  PROJECT TOTAL                                                                       $600.60 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
 
-1 resource type wasn't estimated as it's not supported yet.
 Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-2 x azurerm_key_vault

--- a/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.tf
+++ b/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.tf
@@ -1,0 +1,102 @@
+provider "azurerm" {
+  features {}
+	skip_provider_registration = true
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_key_vault" "premium" {
+  name                       = "examplekeyvault"
+  location                   = "eastus"
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = "00000000-0000-0000-0000-000000000000"
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault" "standard" {
+  name                       = "examplekeyvault"
+  location                   = "eastus"
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = "00000000-0000-0000-0000-000000000000"
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault_certificate" "non-usage" {
+  name         = "imported-cert"
+  key_vault_id = azurerm_key_vault.standard.id
+
+  certificate {
+    contents = ""
+  }
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_type   = "RSA"
+      reuse_key  = false
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+  }
+}
+
+resource "azurerm_key_vault_certificate" "standard" {
+  name         = "imported-cert"
+  key_vault_id = azurerm_key_vault.standard.id
+
+  certificate {
+    contents = ""
+  }
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_type   = "RSA"
+      reuse_key  = false
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+  }
+}
+
+resource "azurerm_key_vault_certificate" "premium" {
+  name         = "imported-cert"
+  key_vault_id = azurerm_key_vault.premium.id
+
+  certificate {
+    contents = ""
+  }
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_type   = "RSA"
+      reuse_key  = false
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+  }
+}

--- a/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.usage.yml
@@ -1,0 +1,9 @@
+version: 0.1
+resource_usage:
+  azurerm_key_vault_certificate.standard:
+    monthly_certificate_renewal_requests: 100 
+    monthly_certificate_other_operations: 100000 
+
+  azurerm_key_vault_certificate.premium:
+    monthly_certificate_renewal_requests: 100 
+    monthly_certificate_other_operations: 100000 

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
@@ -3,30 +3,22 @@
                                                                                            
  azurerm_key_vault_key.no_usage                                                            
  ├─ Secrets operations                  Cost depends on usage: $0.03 per 10K transactions  
- ├─ Certificate operations              Cost depends on usage: $3.00 per renewals          
- ├─ Certificate operations              Cost depends on usage: $0.03 per 10K transactions  
  ├─ Storage key rotation                Cost depends on usage: $1.00 per renewals          
  └─ Software-protected keys             Cost depends on usage: $0.15 per 10K transactions  
                                                                                            
  azurerm_key_vault_key.pr_ec                                                               
  ├─ Secrets operations                                3  10K transactions            $0.09 
- ├─ Certificate operations                          300  renewals                  $900.00 
- ├─ Certificate operations                           30  10K transactions            $0.90 
  ├─ Storage key rotation                             30  renewals                   $30.00 
  └─ Software-protected keys                         300  10K transactions           $45.00 
                                                                                            
  azurerm_key_vault_key.pr_hsm_rsa2048                                                      
  ├─ Secrets operations                                4  10K transactions            $0.12 
- ├─ Certificate operations                          400  renewals                $1,200.00 
- ├─ Certificate operations                           40  10K transactions            $1.20 
  ├─ Storage key rotation                             40  renewals                   $40.00 
  ├─ HSM-protected keys                            5,000  months                  $5,000.00 
  └─ HSM-protected keys                              400  10K transactions           $60.00 
                                                                                            
  azurerm_key_vault_key.pr_hsm_rsa3072                                                      
  ├─ Secrets operations                                4  10K transactions            $0.12 
- ├─ Certificate operations                          400  renewals                $1,200.00 
- ├─ Certificate operations                           40  10K transactions            $1.20 
  ├─ Storage key rotation                             40  renewals                   $40.00 
  ├─ HSM-protected keys (first 250)                  250  months                  $1,250.00 
  ├─ HSM-protected keys (next 1250)                1,250  months                  $3,125.00 
@@ -36,40 +28,30 @@
                                                                                            
  azurerm_key_vault_key.pr_rsa2048                                                          
  ├─ Secrets operations                                1  10K transactions            $0.03 
- ├─ Certificate operations                          100  renewals                  $300.00 
- ├─ Certificate operations                           10  10K transactions            $0.30 
  ├─ Storage key rotation                             10  renewals                   $10.00 
  └─ Software-protected keys                         100  10K transactions            $3.00 
                                                                                            
  azurerm_key_vault_key.pr_rsa3072                                                          
  ├─ Secrets operations                                2  10K transactions            $0.06 
- ├─ Certificate operations                          200  renewals                  $600.00 
- ├─ Certificate operations                           20  10K transactions            $0.60 
  ├─ Storage key rotation                             20  renewals                   $20.00 
  └─ Software-protected keys                         200  10K transactions           $30.00 
                                                                                            
  azurerm_key_vault_key.std_hsm_rsa3072                                                     
  ├─ Secrets operations                                5  10K transactions            $0.15 
- ├─ Certificate operations                          500  renewals                $1,500.00 
- ├─ Certificate operations                           50  10K transactions            $1.50 
  ├─ Storage key rotation                             50  renewals                   $50.00 
  └─ Software-protected keys                         500  10K transactions           $75.00 
                                                                                            
  azurerm_key_vault_key.std_rsa2048                                                         
  ├─ Secrets operations                                7  10K transactions            $0.21 
- ├─ Certificate operations                          700  renewals                $2,100.00 
- ├─ Certificate operations                           70  10K transactions            $2.10 
  ├─ Storage key rotation                             70  renewals                   $70.00 
  └─ Software-protected keys                         700  10K transactions          $105.00 
                                                                                            
  azurerm_key_vault_key.std_rsa3072                                                         
  ├─ Secrets operations                                6  10K transactions            $0.18 
- ├─ Certificate operations                          600  renewals                $1,800.00 
- ├─ Certificate operations                           60  10K transactions            $1.80 
  ├─ Storage key rotation                             60  renewals                   $60.00 
  └─ Software-protected keys                         600  10K transactions           $90.00 
                                                                                            
- PROJECT TOTAL                                                                  $22,423.56 
+ PROJECT TOTAL                                                                  $12,813.96 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
@@ -1,75 +1,75 @@
 
- Name                                       Monthly Qty  Unit                  Monthly Cost 
-                                                                                            
- azurerm_key_vault_key.no_usage                                                             
- ├─ Secrets operations                  Cost depends on usage: $0.03 per 10K transactions   
- ├─ Certificate operations              Cost depends on usage: $3.00 per renewals           
- ├─ Certificate operations              Cost depends on usage: $0.03 per 10K transactions   
- ├─ Storage key rotation                Cost depends on usage: $1.00 per renewals           
- └─ Software-protected keys             Cost depends on usage: $0.15 per 10K transactions   
-                                                                                            
- azurerm_key_vault_key.pr_ec                                                                
- ├─ Secrets operations                                3  10K transactions             $0.09 
- ├─ Certificate operations                          300  renewals                   $900.00 
- ├─ Certificate operations                           30  10K transactions             $0.90 
- ├─ Storage key rotation                             30  renewals                    $30.00 
- └─ Software-protected keys                         300  10K transactions            $45.00 
-                                                                                            
- azurerm_key_vault_key.pr_hsm_rsa2048                                                       
- ├─ Secrets operations                                4  10K transactions             $0.12 
- ├─ Certificate operations                          400  renewals                 $1,200.00 
- ├─ Certificate operations                           40  10K transactions             $1.20 
- ├─ Storage key rotation                             40  renewals                    $40.00 
- ├─ HSM-protected keys                            5,000  Per key per month        $5,000.00 
- └─ HSM-protected keys                              400  10K transactions            $60.00 
-                                                                                            
- azurerm_key_vault_key.pr_hsm_rsa3072                                                       
- ├─ Secrets operations                                4  10K transactions             $0.12 
- ├─ Certificate operations                          400  renewals                 $1,200.00 
- ├─ Certificate operations                           40  10K transactions             $1.20 
- ├─ Storage key rotation                             40  renewals                    $40.00 
- ├─ HSM-protected keys (first 250)                  250  Per key per month        $1,250.00 
- ├─ HSM-protected keys (next 1250)                1,250  Per key per month        $3,125.00 
- ├─ HSM-protected keys (next 2500)                2,500  Per key per month        $2,250.00 
- ├─ HSM-protected keys (over 4000)                1,000  Per key per month          $400.00 
- └─ HSM-protected keys                              400  10K transactions            $60.00 
-                                                                                            
- azurerm_key_vault_key.pr_rsa2048                                                           
- ├─ Secrets operations                                1  10K transactions             $0.03 
- ├─ Certificate operations                          100  renewals                   $300.00 
- ├─ Certificate operations                           10  10K transactions             $0.30 
- ├─ Storage key rotation                             10  renewals                    $10.00 
- └─ Software-protected keys                         100  10K transactions             $3.00 
-                                                                                            
- azurerm_key_vault_key.pr_rsa3072                                                           
- ├─ Secrets operations                                2  10K transactions             $0.06 
- ├─ Certificate operations                          200  renewals                   $600.00 
- ├─ Certificate operations                           20  10K transactions             $0.60 
- ├─ Storage key rotation                             20  renewals                    $20.00 
- └─ Software-protected keys                         200  10K transactions            $30.00 
-                                                                                            
- azurerm_key_vault_key.std_hsm_rsa3072                                                      
- ├─ Secrets operations                                5  10K transactions             $0.15 
- ├─ Certificate operations                          500  renewals                 $1,500.00 
- ├─ Certificate operations                           50  10K transactions             $1.50 
- ├─ Storage key rotation                             50  renewals                    $50.00 
- └─ Software-protected keys                         500  10K transactions            $75.00 
-                                                                                            
- azurerm_key_vault_key.std_rsa2048                                                          
- ├─ Secrets operations                                7  10K transactions             $0.21 
- ├─ Certificate operations                          700  renewals                 $2,100.00 
- ├─ Certificate operations                           70  10K transactions             $2.10 
- ├─ Storage key rotation                             70  renewals                    $70.00 
- └─ Software-protected keys                         700  10K transactions           $105.00 
-                                                                                            
- azurerm_key_vault_key.std_rsa3072                                                          
- ├─ Secrets operations                                6  10K transactions             $0.18 
- ├─ Certificate operations                          600  renewals                 $1,800.00 
- ├─ Certificate operations                           60  10K transactions             $1.80 
- ├─ Storage key rotation                             60  renewals                    $60.00 
- └─ Software-protected keys                         600  10K transactions            $90.00 
-                                                                                            
- PROJECT TOTAL                                                                   $22,423.56 
+ Name                                       Monthly Qty  Unit                 Monthly Cost 
+                                                                                           
+ azurerm_key_vault_key.no_usage                                                            
+ ├─ Secrets operations                  Cost depends on usage: $0.03 per 10K transactions  
+ ├─ Certificate operations              Cost depends on usage: $3.00 per renewals          
+ ├─ Certificate operations              Cost depends on usage: $0.03 per 10K transactions  
+ ├─ Storage key rotation                Cost depends on usage: $1.00 per renewals          
+ └─ Software-protected keys             Cost depends on usage: $0.15 per 10K transactions  
+                                                                                           
+ azurerm_key_vault_key.pr_ec                                                               
+ ├─ Secrets operations                                3  10K transactions            $0.09 
+ ├─ Certificate operations                          300  renewals                  $900.00 
+ ├─ Certificate operations                           30  10K transactions            $0.90 
+ ├─ Storage key rotation                             30  renewals                   $30.00 
+ └─ Software-protected keys                         300  10K transactions           $45.00 
+                                                                                           
+ azurerm_key_vault_key.pr_hsm_rsa2048                                                      
+ ├─ Secrets operations                                4  10K transactions            $0.12 
+ ├─ Certificate operations                          400  renewals                $1,200.00 
+ ├─ Certificate operations                           40  10K transactions            $1.20 
+ ├─ Storage key rotation                             40  renewals                   $40.00 
+ ├─ HSM-protected keys                            5,000  months                  $5,000.00 
+ └─ HSM-protected keys                              400  10K transactions           $60.00 
+                                                                                           
+ azurerm_key_vault_key.pr_hsm_rsa3072                                                      
+ ├─ Secrets operations                                4  10K transactions            $0.12 
+ ├─ Certificate operations                          400  renewals                $1,200.00 
+ ├─ Certificate operations                           40  10K transactions            $1.20 
+ ├─ Storage key rotation                             40  renewals                   $40.00 
+ ├─ HSM-protected keys (first 250)                  250  months                  $1,250.00 
+ ├─ HSM-protected keys (next 1250)                1,250  months                  $3,125.00 
+ ├─ HSM-protected keys (next 2500)                2,500  months                  $2,250.00 
+ ├─ HSM-protected keys (over 4000)                1,000  months                    $400.00 
+ └─ HSM-protected keys                              400  10K transactions           $60.00 
+                                                                                           
+ azurerm_key_vault_key.pr_rsa2048                                                          
+ ├─ Secrets operations                                1  10K transactions            $0.03 
+ ├─ Certificate operations                          100  renewals                  $300.00 
+ ├─ Certificate operations                           10  10K transactions            $0.30 
+ ├─ Storage key rotation                             10  renewals                   $10.00 
+ └─ Software-protected keys                         100  10K transactions            $3.00 
+                                                                                           
+ azurerm_key_vault_key.pr_rsa3072                                                          
+ ├─ Secrets operations                                2  10K transactions            $0.06 
+ ├─ Certificate operations                          200  renewals                  $600.00 
+ ├─ Certificate operations                           20  10K transactions            $0.60 
+ ├─ Storage key rotation                             20  renewals                   $20.00 
+ └─ Software-protected keys                         200  10K transactions           $30.00 
+                                                                                           
+ azurerm_key_vault_key.std_hsm_rsa3072                                                     
+ ├─ Secrets operations                                5  10K transactions            $0.15 
+ ├─ Certificate operations                          500  renewals                $1,500.00 
+ ├─ Certificate operations                           50  10K transactions            $1.50 
+ ├─ Storage key rotation                             50  renewals                   $50.00 
+ └─ Software-protected keys                         500  10K transactions           $75.00 
+                                                                                           
+ azurerm_key_vault_key.std_rsa2048                                                         
+ ├─ Secrets operations                                7  10K transactions            $0.21 
+ ├─ Certificate operations                          700  renewals                $2,100.00 
+ ├─ Certificate operations                           70  10K transactions            $2.10 
+ ├─ Storage key rotation                             70  renewals                   $70.00 
+ └─ Software-protected keys                         700  10K transactions          $105.00 
+                                                                                           
+ azurerm_key_vault_key.std_rsa3072                                                         
+ ├─ Secrets operations                                6  10K transactions            $0.18 
+ ├─ Certificate operations                          600  renewals                $1,800.00 
+ ├─ Certificate operations                           60  10K transactions            $1.80 
+ ├─ Storage key rotation                             60  renewals                   $60.00 
+ └─ Software-protected keys                         600  10K transactions           $90.00 
+                                                                                           
+ PROJECT TOTAL                                                                  $22,423.56 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
@@ -56,6 +56,4 @@
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
 
-1 resource type wasn't estimated as it's not supported yet.
 Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-2 x azurerm_key_vault

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
@@ -1,0 +1,79 @@
+
+ Name                                       Monthly Qty  Unit                  Monthly Cost 
+                                                                                            
+ azurerm_key_vault_key.no_usage                                                             
+ ├─ Secrets operations                  Cost depends on usage: $0.03 per 10K transactions   
+ ├─ Certificate operations              Cost depends on usage: $3.00 per renewals           
+ ├─ Certificate operations              Cost depends on usage: $0.03 per 10K transactions   
+ ├─ Storage key rotation                Cost depends on usage: $1.00 per renewals           
+ └─ Software-protected keys             Cost depends on usage: $0.15 per 10K transactions   
+                                                                                            
+ azurerm_key_vault_key.pr_ec                                                                
+ ├─ Secrets operations                                3  10K transactions             $0.09 
+ ├─ Certificate operations                          300  renewals                   $900.00 
+ ├─ Certificate operations                           30  10K transactions             $0.90 
+ ├─ Storage key rotation                             30  renewals                    $30.00 
+ └─ Software-protected keys                         300  10K transactions            $45.00 
+                                                                                            
+ azurerm_key_vault_key.pr_hsm_rsa2048                                                       
+ ├─ Secrets operations                                4  10K transactions             $0.12 
+ ├─ Certificate operations                          400  renewals                 $1,200.00 
+ ├─ Certificate operations                           40  10K transactions             $1.20 
+ ├─ Storage key rotation                             40  renewals                    $40.00 
+ ├─ HSM-protected keys                            5,000  Per key per month        $5,000.00 
+ └─ HSM-protected keys                              400  10K transactions            $60.00 
+                                                                                            
+ azurerm_key_vault_key.pr_hsm_rsa3072                                                       
+ ├─ Secrets operations                                4  10K transactions             $0.12 
+ ├─ Certificate operations                          400  renewals                 $1,200.00 
+ ├─ Certificate operations                           40  10K transactions             $1.20 
+ ├─ Storage key rotation                             40  renewals                    $40.00 
+ ├─ HSM-protected keys (first 250)                  250  Per key per month        $1,250.00 
+ ├─ HSM-protected keys (next 1250)                1,250  Per key per month        $3,125.00 
+ ├─ HSM-protected keys (next 2500)                2,500  Per key per month        $2,250.00 
+ ├─ HSM-protected keys (over 4000)                1,000  Per key per month          $400.00 
+ └─ HSM-protected keys                              400  10K transactions            $60.00 
+                                                                                            
+ azurerm_key_vault_key.pr_rsa2048                                                           
+ ├─ Secrets operations                                1  10K transactions             $0.03 
+ ├─ Certificate operations                          100  renewals                   $300.00 
+ ├─ Certificate operations                           10  10K transactions             $0.30 
+ ├─ Storage key rotation                             10  renewals                    $10.00 
+ └─ Software-protected keys                         100  10K transactions             $3.00 
+                                                                                            
+ azurerm_key_vault_key.pr_rsa3072                                                           
+ ├─ Secrets operations                                2  10K transactions             $0.06 
+ ├─ Certificate operations                          200  renewals                   $600.00 
+ ├─ Certificate operations                           20  10K transactions             $0.60 
+ ├─ Storage key rotation                             20  renewals                    $20.00 
+ └─ Software-protected keys                         200  10K transactions            $30.00 
+                                                                                            
+ azurerm_key_vault_key.std_hsm_rsa3072                                                      
+ ├─ Secrets operations                                5  10K transactions             $0.15 
+ ├─ Certificate operations                          500  renewals                 $1,500.00 
+ ├─ Certificate operations                           50  10K transactions             $1.50 
+ ├─ Storage key rotation                             50  renewals                    $50.00 
+ └─ Software-protected keys                         500  10K transactions            $75.00 
+                                                                                            
+ azurerm_key_vault_key.std_rsa2048                                                          
+ ├─ Secrets operations                                7  10K transactions             $0.21 
+ ├─ Certificate operations                          700  renewals                 $2,100.00 
+ ├─ Certificate operations                           70  10K transactions             $2.10 
+ ├─ Storage key rotation                             70  renewals                    $70.00 
+ └─ Software-protected keys                         700  10K transactions           $105.00 
+                                                                                            
+ azurerm_key_vault_key.std_rsa3072                                                          
+ ├─ Secrets operations                                6  10K transactions             $0.18 
+ ├─ Certificate operations                          600  renewals                 $1,800.00 
+ ├─ Certificate operations                           60  10K transactions             $1.80 
+ ├─ Storage key rotation                             60  renewals                    $60.00 
+ └─ Software-protected keys                         600  10K transactions            $90.00 
+                                                                                            
+ PROJECT TOTAL                                                                   $22,423.56 
+
+----------------------------------
+To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+
+1 resource type wasn't estimated as it's not supported yet.
+Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+2 x azurerm_key_vault

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.tf
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.tf
@@ -1,0 +1,115 @@
+provider "azurerm" {
+  features {}
+	skip_provider_registration = true
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_key_vault" "premium" {
+  name                       = "examplekeyvault"
+  location                   = "eastus"
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = "00000000-0000-0000-0000-000000000000"
+  sku_name                   = "premium"
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault" "standatd" {
+  name                       = "examplekeyvault"
+  location                   = "eastus"
+  resource_group_name        = azurerm_resource_group.example.name
+  tenant_id                  = "00000000-0000-0000-0000-000000000000"
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault_key" "pr_rsa2048" {
+  name         = "generated-certificate"
+  key_vault_id = azurerm_key_vault.premium.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+  ]
+}
+
+resource "azurerm_key_vault_key" "pr_rsa3072" {
+  name         = "generated-certificate"
+  key_vault_id = azurerm_key_vault.premium.id
+  key_type     = "RSA"
+  key_size     = 3072
+
+  key_opts = [
+  ]
+}
+
+resource "azurerm_key_vault_key" "pr_ec" {
+  name         = "generated-certificate"
+  key_vault_id = azurerm_key_vault.premium.id
+  key_type     = "EC"
+
+  key_opts = [
+  ]
+}
+
+resource "azurerm_key_vault_key" "pr_hsm_rsa3072" {
+  name         = "generated-certificate"
+  key_vault_id = azurerm_key_vault.premium.id
+  key_type     = "RSA-HSM"
+  key_size     = 3072
+
+  key_opts = [
+  ]
+}
+
+resource "azurerm_key_vault_key" "pr_hsm_rsa2048" {
+  name         = "generated-certificate"
+  key_vault_id = azurerm_key_vault.premium.id
+  key_type     = "RSA-HSM"
+  key_size     = 2048
+
+  key_opts = [
+  ]
+}
+
+resource "azurerm_key_vault_key" "std_hsm_rsa3072" {
+  name         = "generated-certificate"
+  key_vault_id = azurerm_key_vault.standatd.id
+  key_type     = "RSA"
+  key_size     = 3072
+
+  key_opts = [
+  ]
+}
+
+resource "azurerm_key_vault_key" "std_rsa3072" {
+  name         = "generated-certificate"
+  key_vault_id = azurerm_key_vault.standatd.id
+  key_type     = "RSA"
+  key_size     = 3072
+
+  key_opts = [
+  ]
+}
+
+resource "azurerm_key_vault_key" "std_rsa2048" {
+  name         = "generated-certificate"
+  key_vault_id = azurerm_key_vault.standatd.id
+  key_type     = "RSA"
+  key_size     = 3072
+
+  key_opts = [
+  ]
+}
+
+resource "azurerm_key_vault_key" "no_usage" {
+  name         = "generated-certificate"
+  key_vault_id = azurerm_key_vault.premium.id
+  key_type     = "EC"
+
+  key_opts = [
+  ]
+}

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.usage.yml
@@ -1,0 +1,66 @@
+version: 0.1
+resource_usage:  
+  azurerm_key_vault_key.pr_rsa2048:
+    monthly_secrets_operations: 10000
+    monthly_certificate_renewal_requests: 100
+    monthly_certificate_all_other_operations: 100000
+    monthly_key_rotation_renewals: 10
+    monthly_protected_keys_operations: 1000000
+    hsm_protected_keys: 1000
+
+  azurerm_key_vault_key.pr_rsa3072:
+    monthly_secrets_operations: 20000
+    monthly_certificate_renewal_requests: 200
+    monthly_certificate_all_other_operations: 200000
+    monthly_key_rotation_renewals: 20
+    monthly_protected_keys_operations: 2000000
+    hsm_protected_keys: 2000
+
+  azurerm_key_vault_key.pr_ec:
+    monthly_secrets_operations: 30000
+    monthly_certificate_renewal_requests: 300
+    monthly_certificate_all_other_operations: 300000
+    monthly_key_rotation_renewals: 30
+    monthly_protected_keys_operations: 3000000
+    hsm_protected_keys: 3000
+
+  azurerm_key_vault_key.pr_hsm_rsa3072:
+    monthly_secrets_operations: 40000
+    monthly_certificate_renewal_requests: 400
+    monthly_certificate_all_other_operations: 400000
+    monthly_key_rotation_renewals: 40
+    monthly_protected_keys_operations: 4000000
+    hsm_protected_keys: 5000
+
+  azurerm_key_vault_key.pr_hsm_rsa2048:
+    monthly_secrets_operations: 40000
+    monthly_certificate_renewal_requests: 400
+    monthly_certificate_all_other_operations: 400000
+    monthly_key_rotation_renewals: 40
+    monthly_protected_keys_operations: 4000000
+    hsm_protected_keys: 5000
+
+  azurerm_key_vault_key.std_hsm_rsa3072:
+    monthly_secrets_operations: 50000
+    monthly_certificate_renewal_requests: 500
+    monthly_certificate_all_other_operations: 500000
+    monthly_key_rotation_renewals: 50
+    monthly_protected_keys_operations: 5000000
+    hsm_protected_keys: 5000
+
+  azurerm_key_vault_key.std_rsa3072:
+    monthly_secrets_operations: 60000
+    monthly_certificate_renewal_requests: 600
+    monthly_certificate_all_other_operations: 600000
+    monthly_key_rotation_renewals: 60
+    monthly_protected_keys_operations: 6000000
+    hsm_protected_keys: 6000
+
+  azurerm_key_vault_key.std_rsa2048:
+    monthly_secrets_operations: 70000
+    monthly_certificate_renewal_requests: 700
+    monthly_certificate_all_other_operations: 700000
+    monthly_key_rotation_renewals: 70
+    monthly_protected_keys_operations: 7000000
+    hsm_protected_keys: 7000
+    

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.usage.yml
@@ -3,7 +3,7 @@ resource_usage:
   azurerm_key_vault_key.pr_rsa2048:
     monthly_secrets_operations: 10000
     monthly_certificate_renewal_requests: 100
-    monthly_certificate_all_other_operations: 100000
+    monthly_certificate_other_operations: 100000
     monthly_key_rotation_renewals: 10
     monthly_protected_keys_operations: 1000000
     hsm_protected_keys: 1000
@@ -11,7 +11,7 @@ resource_usage:
   azurerm_key_vault_key.pr_rsa3072:
     monthly_secrets_operations: 20000
     monthly_certificate_renewal_requests: 200
-    monthly_certificate_all_other_operations: 200000
+    monthly_certificate_other_operations: 200000
     monthly_key_rotation_renewals: 20
     monthly_protected_keys_operations: 2000000
     hsm_protected_keys: 2000
@@ -19,7 +19,7 @@ resource_usage:
   azurerm_key_vault_key.pr_ec:
     monthly_secrets_operations: 30000
     monthly_certificate_renewal_requests: 300
-    monthly_certificate_all_other_operations: 300000
+    monthly_certificate_other_operations: 300000
     monthly_key_rotation_renewals: 30
     monthly_protected_keys_operations: 3000000
     hsm_protected_keys: 3000
@@ -27,7 +27,7 @@ resource_usage:
   azurerm_key_vault_key.pr_hsm_rsa3072:
     monthly_secrets_operations: 40000
     monthly_certificate_renewal_requests: 400
-    monthly_certificate_all_other_operations: 400000
+    monthly_certificate_other_operations: 400000
     monthly_key_rotation_renewals: 40
     monthly_protected_keys_operations: 4000000
     hsm_protected_keys: 5000
@@ -35,7 +35,7 @@ resource_usage:
   azurerm_key_vault_key.pr_hsm_rsa2048:
     monthly_secrets_operations: 40000
     monthly_certificate_renewal_requests: 400
-    monthly_certificate_all_other_operations: 400000
+    monthly_certificate_other_operations: 400000
     monthly_key_rotation_renewals: 40
     monthly_protected_keys_operations: 4000000
     hsm_protected_keys: 5000
@@ -43,7 +43,7 @@ resource_usage:
   azurerm_key_vault_key.std_hsm_rsa3072:
     monthly_secrets_operations: 50000
     monthly_certificate_renewal_requests: 500
-    monthly_certificate_all_other_operations: 500000
+    monthly_certificate_other_operations: 500000
     monthly_key_rotation_renewals: 50
     monthly_protected_keys_operations: 5000000
     hsm_protected_keys: 5000
@@ -51,7 +51,7 @@ resource_usage:
   azurerm_key_vault_key.std_rsa3072:
     monthly_secrets_operations: 60000
     monthly_certificate_renewal_requests: 600
-    monthly_certificate_all_other_operations: 600000
+    monthly_certificate_other_operations: 600000
     monthly_key_rotation_renewals: 60
     monthly_protected_keys_operations: 6000000
     hsm_protected_keys: 6000
@@ -59,7 +59,7 @@ resource_usage:
   azurerm_key_vault_key.std_rsa2048:
     monthly_secrets_operations: 70000
     monthly_certificate_renewal_requests: 700
-    monthly_certificate_all_other_operations: 700000
+    monthly_certificate_other_operations: 700000
     monthly_key_rotation_renewals: 70
     monthly_protected_keys_operations: 7000000
     hsm_protected_keys: 7000

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.usage.yml
@@ -2,64 +2,48 @@ version: 0.1
 resource_usage:  
   azurerm_key_vault_key.pr_rsa2048:
     monthly_secrets_operations: 10000
-    monthly_certificate_renewal_requests: 100
-    monthly_certificate_other_operations: 100000
     monthly_key_rotation_renewals: 10
     monthly_protected_keys_operations: 1000000
     hsm_protected_keys: 1000
 
   azurerm_key_vault_key.pr_rsa3072:
     monthly_secrets_operations: 20000
-    monthly_certificate_renewal_requests: 200
-    monthly_certificate_other_operations: 200000
     monthly_key_rotation_renewals: 20
     monthly_protected_keys_operations: 2000000
     hsm_protected_keys: 2000
 
   azurerm_key_vault_key.pr_ec:
     monthly_secrets_operations: 30000
-    monthly_certificate_renewal_requests: 300
-    monthly_certificate_other_operations: 300000
     monthly_key_rotation_renewals: 30
     monthly_protected_keys_operations: 3000000
     hsm_protected_keys: 3000
 
   azurerm_key_vault_key.pr_hsm_rsa3072:
     monthly_secrets_operations: 40000
-    monthly_certificate_renewal_requests: 400
-    monthly_certificate_other_operations: 400000
     monthly_key_rotation_renewals: 40
     monthly_protected_keys_operations: 4000000
     hsm_protected_keys: 5000
 
   azurerm_key_vault_key.pr_hsm_rsa2048:
     monthly_secrets_operations: 40000
-    monthly_certificate_renewal_requests: 400
-    monthly_certificate_other_operations: 400000
     monthly_key_rotation_renewals: 40
     monthly_protected_keys_operations: 4000000
     hsm_protected_keys: 5000
 
   azurerm_key_vault_key.std_hsm_rsa3072:
     monthly_secrets_operations: 50000
-    monthly_certificate_renewal_requests: 500
-    monthly_certificate_other_operations: 500000
     monthly_key_rotation_renewals: 50
     monthly_protected_keys_operations: 5000000
     hsm_protected_keys: 5000
 
   azurerm_key_vault_key.std_rsa3072:
     monthly_secrets_operations: 60000
-    monthly_certificate_renewal_requests: 600
-    monthly_certificate_other_operations: 600000
     monthly_key_rotation_renewals: 60
     monthly_protected_keys_operations: 6000000
     hsm_protected_keys: 6000
 
   azurerm_key_vault_key.std_rsa2048:
     monthly_secrets_operations: 70000
-    monthly_certificate_renewal_requests: 700
-    monthly_certificate_other_operations: 700000
     monthly_key_rotation_renewals: 70
     monthly_protected_keys_operations: 7000000
     hsm_protected_keys: 7000

--- a/internal/providers/terraform/azure/testdata/key_vault_managed_hardware_security_module_test/key_vault_managed_hardware_security_module_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_managed_hardware_security_module_test/key_vault_managed_hardware_security_module_test.golden
@@ -1,0 +1,7 @@
+
+ Name                                                          Monthly Qty  Unit   Monthly Cost 
+                                                                                                
+ azurerm_key_vault_managed_hardware_security_module.my_module                                   
+ └─ HSM pools                                                          730  hours     $3,540.50 
+                                                                                                
+ PROJECT TOTAL                                                                        $3,540.50 

--- a/internal/providers/terraform/azure/testdata/key_vault_managed_hardware_security_module_test/key_vault_managed_hardware_security_module_test.tf
+++ b/internal/providers/terraform/azure/testdata/key_vault_managed_hardware_security_module_test/key_vault_managed_hardware_security_module_test.tf
@@ -1,0 +1,23 @@
+provider "azurerm" {
+  features {}
+	skip_provider_registration = true
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module" "my_module" {
+  name                       = "exampleKVHsm"
+  resource_group_name        = azurerm_resource_group.example.name
+  location                   = "eastus"
+  sku_name                   = "Standard_B1"
+  purge_protection_enabled   = false
+  soft_delete_retention_days = 90
+  tenant_id                  = "00000000-0000-0000-0000-000000000000"
+  admin_object_ids           = [data.azurerm_client_config.current.object_id]
+}


### PR DESCRIPTION
Issue #647 

Links:
[Terraform](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key)
[Pricing page](https://azure.microsoft.com/en-us/pricing/details/key-vault/)

Details:
About Managed HSM Pools - I think we should add resource [azurerm_key_vault_managed_hardware_security_module](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_managed_hardware_security_module) to cover it, but Terraform added it in v2.57.0 azurerm provider, but only v2.56 is available for now.