### PR TITLE
fix(build): add .exe to windows binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ build:
 	CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY) $(PKG)
 
 windows:
-	env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY)-windows-amd64 $(PKG)
+	env GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY)-windows-amd64.exe $(PKG)
 
 linux:
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o build/$(BINARY)-linux-amd64 $(PKG)
@@ -37,7 +37,7 @@ install:
 	CGO_ENABLED=0 go install $(BUILD_FLAGS) $(PKG)
 
 release: build_all
-	cd build; tar -czf $(BINARY)-windows-amd64.tar.gz $(BINARY)-windows-amd64
+	cd build; tar -czf $(BINARY)-windows-amd64.tar.gz $(BINARY)-windows-amd64.exe
 	cd build; tar -czf $(BINARY)-linux-amd64.tar.gz $(BINARY)-linux-amd64
 	cd build; tar -czf $(BINARY)-darwin-amd64.tar.gz $(BINARY)-darwin-amd64
 	cd build; tar -czf $(BINARY)-darwin-arm64.tar.gz $(BINARY)-darwin-arm64


### PR DESCRIPTION
Fix #652 