### PR TITLE
feat(azure): Add support for Azure Firewall with Secured Virtual Hub

### DIFF
--- a/internal/providers/terraform/azure/firewall.go
+++ b/internal/providers/terraform/azure/firewall.go
@@ -24,6 +24,14 @@ func NewAzureFirewall(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		skuTier = d.Get("sku_tier").String()
 	}
 
+	if v := d.Get("virtual_hub").String(); v != "[]" {
+		if skuTier == "Standard" {
+			skuTier = "Secured Virtual Hub"
+		} else {
+			skuTier = fmt.Sprintf("%s Secured Virtual Hub", skuTier)
+		}
+	}
+
 	costComponents = append(costComponents, &schema.CostComponent{
 		Name:           fmt.Sprintf("Deployment (%s)", skuTier),
 		Unit:           "hours",

--- a/internal/providers/terraform/azure/firewall.go
+++ b/internal/providers/terraform/azure/firewall.go
@@ -24,6 +24,9 @@ func NewAzureFirewall(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		skuTier = d.Get("sku_tier").String()
 	}
 
+	// I compare d.Get() with empty array because defaulty exists empty array of virtual hub block: "virtual_hub":[]
+	// and it means that d.Get("virtual_hub").Type will never return gjson.Null
+
 	if v := d.Get("virtual_hub").String(); v != "[]" {
 		if skuTier == "Standard" {
 			skuTier = "Secured Virtual Hub"

--- a/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.golden
+++ b/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.golden
@@ -1,22 +1,35 @@
 
- Name                          Monthly Qty  Unit            Monthly Cost 
-                                                                         
- azurerm_firewall.non_usage                                              
- ├─ Deployment (Standard)              730  hours                $912.50 
- └─ Data processed           Monthly cost depends on usage: $0.02 per GB 
-                                                                         
- azurerm_firewall.premium                                                
- ├─ Deployment (Premium)               730  hours                $638.75 
- └─ Data processed                  10,000  GB                    $80.00 
-                                                                         
- azurerm_firewall.standard                                               
- ├─ Deployment (Standard)              730  hours                $912.50 
- └─ Data processed                  10,000  GB                   $160.00 
-                                                                         
- azurerm_public_ip.example                                               
- └─ IP address (static)                730  hours                  $3.65 
-                                                                         
- PROJECT TOTAL                                                 $2,707.40 
+ Name                                           Monthly Qty  Unit            Monthly Cost 
+                                                                                          
+ azurerm_firewall.non_usage                                                               
+ ├─ Deployment (Standard)                               730  hours                $912.50 
+ └─ Data processed                            Monthly cost depends on usage: $0.02 per GB 
+                                                                                          
+ azurerm_firewall.premium                                                                 
+ ├─ Deployment (Premium)                                730  hours                $638.75 
+ └─ Data processed                                   10,000  GB                    $80.00 
+                                                                                          
+ azurerm_firewall.premium_virtual_hub                                                     
+ ├─ Deployment (Premium Secured Virtual Hub)            730  hours                $638.75 
+ └─ Data processed                                   20,000  GB                   $160.00 
+                                                                                          
+ azurerm_firewall.standard                                                                
+ ├─ Deployment (Standard)                               730  hours                $912.50 
+ └─ Data processed                                   10,000  GB                   $160.00 
+                                                                                          
+ azurerm_firewall.standard_virtual_hub                                                    
+ ├─ Deployment (Secured Virtual Hub)                    730  hours                $912.50 
+ └─ Data processed                                   20,000  GB                   $320.00 
+                                                                                          
+ azurerm_public_ip.example                                                                
+ └─ IP address (static)                                 730  hours                  $3.65 
+                                                                                          
+ PROJECT TOTAL                                                                  $4,738.65 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+
+2 resource types weren't estimated as they're not supported yet.
+Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+1 x azurerm_virtual_hub
+1 x azurerm_virtual_wan

--- a/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.tf
+++ b/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.tf
@@ -1,6 +1,6 @@
 provider "azurerm" {
   features {}
-	skip_provider_registration = true
+  skip_provider_registration = true
 }
 
 resource "azurerm_resource_group" "example" {
@@ -30,6 +30,20 @@ resource "azurerm_public_ip" "example" {
   sku                 = "Standard"
 }
 
+resource "azurerm_virtual_wan" "example" {
+  name                = "example-virtualwan"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_virtual_hub" "example" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  virtual_wan_id      = azurerm_virtual_wan.example.id
+  address_prefix      = "10.0.1.0/24"
+}
+
 resource "azurerm_firewall" "standard" {
   name                = "testfirewall"
   location            = "eastus"
@@ -47,6 +61,40 @@ resource "azurerm_firewall" "premium" {
   location            = "eastus"
   resource_group_name = azurerm_resource_group.example.name
   sku_tier            = "Premium"
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.example.id
+    public_ip_address_id = azurerm_public_ip.example.id
+  }
+}
+
+resource "azurerm_firewall" "premium_virtual_hub" {
+  name                = "testfirewall"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.example.name
+  sku_tier            = "Premium"
+
+  virtual_hub {
+    virtual_hub_id = azurerm_virtual_hub.example.id
+  }
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.example.id
+    public_ip_address_id = azurerm_public_ip.example.id
+  }
+}
+
+resource "azurerm_firewall" "standard_virtual_hub" {
+  name                = "testfirewall"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.example.name
+  sku_tier            = "Standard"
+
+  virtual_hub {
+    virtual_hub_id = azurerm_virtual_hub.example.id
+  }
 
   ip_configuration {
     name                 = "configuration"

--- a/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.usage.yml
@@ -5,3 +5,10 @@ resource_usage:
 
   azurerm_firewall.premium:
     monthly_data_processed_gb: 10000
+
+  azurerm_firewall.premium_virtual_hub:
+    monthly_data_processed_gb: 20000
+
+  azurerm_firewall.standard_virtual_hub:
+    monthly_data_processed_gb: 20000
+    


### PR DESCRIPTION
Issue #672 

Details:
I compare `d.Get()` with empty array because defaulty exists empty array of virtual hub block: `"virtual_hub":[]` and it means that `d.Get("virtual_hub").Type` will never return `gjson.Null`