### PR TITLE
fix(aws): fix a few issues in the Amazon MQ resource

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -179,7 +179,7 @@ resource_usage:
     monthly_data_processed_gb: 10 # Monthly data processed by the NAT Gateway in GB.
 
   aws_mq_broker.my_aws_mq_broker:
-    storage_size_gb: 12   # Data storage per instance in GB.
+    storage_size_gb: 12 # Data storage per instance in GB.
 
   aws_rds_cluster.my_cluster:
     capacity_units_per_hr: 50          # Number of aurora capacity units per hour. Only used when engine_mode is "serverless"

--- a/internal/providers/terraform/aws/mq_broker.go
+++ b/internal/providers/terraform/aws/mq_broker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
+	"github.com/tidwall/gjson"
 )
 
 func GetMQBrokerRegistryItem() *schema.RegistryItem {
@@ -19,18 +20,27 @@ func NewMQBroker(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := d.Get("region").String()
 	engine := d.Get("engine_type").String()
 	instanceType := d.Get("host_instance_type").String()
+
 	storageType := "efs"
-	if d.Get("storage_type").Exists() {
-		storageType = d.Get("storage_type").String()
+	if strings.ToLower(engine) == "rabbitmq" {
+		storageType = "ebs"
 	}
-	deploymentMode := d.Get("deployment_mode").String()
+	if d.Get("storage_type").Type != gjson.Null {
+		storageType = strings.ToLower(d.Get("storage_type").String())
+	}
+
+	deploymentMode := "single_instance"
+	if d.Get("deployment_mode").Type != gjson.Null {
+		deploymentMode = strings.ToLower(d.Get("deployment_mode").String())
+	}
+
 	isMultiAZ := false
-	if deploymentMode == "ACTIVE_STANDBY_MULTI_AZ" || deploymentMode == "CLUSTER_MULTI_AZ" {
+	if deploymentMode == "active_standby_multi_az" || deploymentMode == "cluster_multi_az" {
 		isMultiAZ = true
 	}
 
 	var storageSizeGB *decimal.Decimal
-	if u != nil && u.Get("storage_size_gb").Exists() {
+	if u != nil && u.Get("storage_size_gb").Type != gjson.Null {
 		storageSizeGB = decimalPtr(decimal.NewFromInt(u.Get("storage_size_gb").Int()))
 	}
 
@@ -59,27 +69,31 @@ func instance(region, engine, instanceType, deploymentMode string, isMultiAZ boo
 			Service:       strPtr("AmazonMQ"),
 			ProductFamily: strPtr("Broker Instances"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/", instanceType))},
-				{Key: "brokerEngine", Value: strPtr(engine)},
-				{Key: "deploymentOption", Value: strPtr(deploymentOption)},
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", instanceType))},
+				{Key: "brokerEngine", ValueRegex: strPtr(fmt.Sprintf("/%s/i", engine))},
+				{Key: "deploymentOption", ValueRegex: strPtr(fmt.Sprintf("/%s/i", deploymentOption))},
 			},
 		},
 	}
 }
 
 func storage(region, engine, storageType string, isMultiAZ bool, storageSizeGB *decimal.Decimal) *schema.CostComponent {
-
 	instancesCount := decimalPtr(decimal.NewFromInt(1))
-	if engine == "RabbitMQ" {
-		storageType = "ebs"
-		instancesCount = decimalPtr(decimal.NewFromInt(3))
-	} else if isMultiAZ {
+	usageType := ""
+
+	if strings.ToLower(engine) == "rabbitmq" {
+		usageType = "TimedStorage-RabbitMQ-ByteHrs"
+		if isMultiAZ {
+			instancesCount = decimalPtr(decimal.NewFromInt(3))
+		}
+	} else {
 		// ActiveMQ
-		instancesCount = decimalPtr(decimal.NewFromInt(2))
-	}
-	deploymentOption := "Single-AZ"
-	if engine != "RabbitMQ" && storageType == "efs" {
-		deploymentOption = "Multi-AZ"
+		if storageType == "ebs" {
+			usageType = "TimedStorage-EBS-ByteHrs"
+		} else {
+			// EFS
+			usageType = "TimedStorage-ByteHrs"
+		}
 	}
 
 	var summedStorageSizeGB *decimal.Decimal
@@ -98,15 +112,9 @@ func storage(region, engine, storageType string, isMultiAZ bool, storageSizeGB *
 			Service:       strPtr("AmazonMQ"),
 			ProductFamily: strPtr("Broker Storage"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "deploymentOption", Value: strPtr(deploymentOption)},
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", usageType))},
 			},
 		},
-	}
-	if engine == "RabbitMQ" {
-		costComponent.ProductFilter.AttributeFilters = append(costComponent.ProductFilter.AttributeFilters, &schema.AttributeFilter{
-			Key:        "usagetype",
-			ValueRegex: strPtr("/RabbitMQ/"),
-		})
 	}
 	return costComponent
 }

--- a/internal/providers/terraform/aws/testdata/mq_broker_test/mq_broker_test.golden
+++ b/internal/providers/terraform/aws/testdata/mq_broker_test/mq_broker_test.golden
@@ -5,9 +5,13 @@
  ├─ Instance usage (ActiveMQ, mq.t2.micro, single_instance)                    730  hours                 $21.90 
  └─ Storage (ActiveMQ, EFS)                                          Monthly cost depends on usage: $0.30 per GB 
                                                                                                                  
- aws_mq_broker.my_aws_mq_broker_activemq_single_standby_ebs                                                      
+ aws_mq_broker.my_aws_mq_broker_activemq_single_ebs                                                              
+ ├─ Instance usage (ActiveMQ, mq.t2.micro, single_instance)                    730  hours                 $21.90 
+ └─ Storage (ActiveMQ, EBS)                                          Monthly cost depends on usage: $0.10 per GB 
+                                                                                                                 
+ aws_mq_broker.my_aws_mq_broker_activemq_standby_efs                                                             
  ├─ Instance usage (ActiveMQ, mq.m5.large, active_standby_multi_az)            730  hours                $420.48 
- └─ Storage (ActiveMQ, EBS)                                                     10  GB                     $1.00 
+ └─ Storage (ActiveMQ, EFS)                                          Monthly cost depends on usage: $0.30 per GB 
                                                                                                                  
  aws_mq_broker.my_aws_mq_broker_rabbitmq_cluster                                                                 
  ├─ Instance usage (RabbitMQ, mq.m5.xlarge, cluster_multi_az)                  730  hours              $1,261.44 
@@ -17,7 +21,7 @@
  ├─ Instance usage (RabbitMQ, mq.m5.xlarge, single_instance)                   730  hours                $420.48 
  └─ Storage (RabbitMQ, EBS)                                          Monthly cost depends on usage: $0.10 per GB 
                                                                                                                  
- PROJECT TOTAL                                                                                         $2,128.30 
+ PROJECT TOTAL                                                                                         $2,149.20 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/mq_broker_test/mq_broker_test.tf
+++ b/internal/providers/terraform/aws/testdata/mq_broker_test/mq_broker_test.tf
@@ -68,7 +68,28 @@ resource "aws_mq_broker" "my_aws_mq_broker_activemq_single_default" {
   }
 }
 
-resource "aws_mq_broker" "my_aws_mq_broker_activemq_single_standby_ebs" {
+resource "aws_mq_broker" "my_aws_mq_broker_activemq_single_ebs" {
+  broker_name = "example"
+
+  configuration {
+    id       = aws_mq_configuration.my_aws_mq_configuration.id
+    revision = aws_mq_configuration.my_aws_mq_configuration.latest_revision
+  }
+
+  engine_type        = "ActiveMQ"
+  engine_version     = "5.15.9"
+  host_instance_type = "mq.t2.micro"
+  security_groups    = [aws_security_group.my_aws_security_group.id]
+  deployment_mode    = "SINGLE_INSTANCE"
+  storage_type       = "ebs"
+
+  user {
+    username = "ExampleUser"
+    password = "MindTheGappp"
+  }
+}
+
+resource "aws_mq_broker" "my_aws_mq_broker_activemq_standby_efs" {
   broker_name = "example"
 
   configuration {
@@ -79,7 +100,7 @@ resource "aws_mq_broker" "my_aws_mq_broker_activemq_single_standby_ebs" {
   engine_type        = "ActiveMQ"
   engine_version     = "5.15.9"
   host_instance_type = "mq.m5.large"
-  storage_type       = "ebs"
+  storage_type       = "efs"
   security_groups    = [aws_security_group.my_aws_security_group.id]
   deployment_mode    = "ACTIVE_STANDBY_MULTI_AZ"
 
@@ -121,7 +142,7 @@ resource "aws_mq_broker" "my_aws_mq_broker_rabbitmq_cluster" {
   engine_version     = "3.8.11"
   host_instance_type = "mq.m5.xlarge"
   security_groups    = [aws_security_group.my_aws_security_group.id]
-  deployment_mode    = "CLUSTER_MULTI_AZ"
+  deployment_mode    = "cluster_multi_az"
 
   user {
     username = "ExampleUser"


### PR DESCRIPTION
- Terraform string values are case-insensitive for most part, changed the
Regex lookups to be case-insensitive
- Simplified the logic and fix a bug that was causing a warning before “Multiple products found for aws_mq_broker.my_aws_mq_broker_activemq_single_standby_ebs Storage (ActiveMQ, EBS), using the first product”