### PR TITLE
fix(output): Added count-alphabet sort for skipped resources to avoid random output

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -236,8 +236,23 @@ func (r *Root) unsupportedResourcesMessage(showSkipped bool) string {
 	)
 
 	if showSkipped {
+		type structMap struct {
+			key   string
+			value int
+		}
+		ind := []structMap{}
 		for t, c := range *r.Summary.UnsupportedResourceCounts {
-			msg += fmt.Sprintf("\n%d x %s", c, t)
+			ind = append(ind, structMap{key: t, value: c})
+		}
+		sort.Slice(ind, func(i, j int) bool {
+			if ind[i].value == ind[j].value {
+				return ind[i].key < ind[j].key
+			}
+			return ind[i].value > ind[j].value
+		})
+
+		for _, i := range ind {
+			msg += fmt.Sprintf("\n%d x %s", i.value, i.key)
 		}
 	}
 


### PR DESCRIPTION
Issue #712 

Output example: 

```
9 resource types weren't estimated as they're not supported yet.
Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
4 x azurerm_firewall
2 x azurerm_virtual_machine
1 x azurerm_cosmosdb_account
1 x azurerm_cosmosdb_cassandra_keyspace
1 x azurerm_cosmosdb_cassandra_table
1 x azurerm_network_interface
1 x azurerm_resource_group
1 x azurerm_subnet
1 x azurerm_virtual_network
```