### PR TITLE
fix(aws): data transfer costs

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -84,7 +84,7 @@ resource_usage:
 
   aws_data_transfer.my_region:
     region: us-east-1                           # Region the data transfer is originating from.
-    monthly_intra_region_gb: 1000               # Monthly data transferred between availability zones in the region.
+    monthly_intra_region_gb: 1000               # Monthly data transferred between availability zones in the region. Infracost multiplies this by two to account for AWS charging in-bound and out-bound rates.
     monthly_outbound_us_east_to_us_east_gb: 500 # Monthly data transferred between US east regions. NOTE: this is only valid if the region is a us-east region.
     monthly_outbound_other_regions_gb: 750      # Monthly data transferred to other AWS regions.
     monthly_outbound_internet_gb: 5000          # Monthly data transferred to the Internet.

--- a/internal/providers/terraform/aws/data_transfer.go
+++ b/internal/providers/terraform/aws/data_transfer.go
@@ -107,7 +107,7 @@ func NewDataTransfer(d *schema.ResourceData, u *schema.UsageData) *schema.Resour
 			Name:            "Intra-region data transfer",
 			Unit:            "GB",
 			UnitMultiplier:  1,
-			MonthlyQuantity: intraRegionGb,
+			MonthlyQuantity: decimalPtr(intraRegionGb.Mul(decimal.NewFromInt(2))),
 			ProductFilter: &schema.ProductFilter{
 				VendorName:    strPtr("aws"),
 				Service:       strPtr("AWSDataTransfer"),

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -2,7 +2,7 @@
  Name                                                Monthly Qty  Unit  Monthly Cost 
                                                                                      
  aws_data_transfer.af-south-1                                                        
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,576.96 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $6,021.12 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB      $12,902.40 
@@ -10,7 +10,7 @@
  └─ Outbound data transfer to other regions                  750  GB         $110.25 
                                                                                      
  aws_data_transfer.ap-east-1                                                         
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,228.80 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,396.80 
@@ -18,7 +18,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $67.50 
                                                                                      
  aws_data_transfer.ap-northeast-1                                                    
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,167.36 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,645.44 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,806.40 
@@ -26,7 +26,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $67.50 
                                                                                      
  aws_data_transfer.ap-northeast-2                                                    
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,290.24 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,997.12 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB      $11,980.80 
@@ -34,7 +34,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $60.00 
                                                                                      
  aws_data_transfer.ap-northeast-3                                                    
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,167.36 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,645.44 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,806.40 
@@ -42,7 +42,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $67.50 
                                                                                      
  aws_data_transfer.ap-south-1                                                        
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,119.23 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,396.80 
@@ -50,7 +50,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $64.50 
                                                                                      
  aws_data_transfer.ap-southeast-1                                                    
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,228.80 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,396.80 
@@ -58,7 +58,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $67.50 
                                                                                      
  aws_data_transfer.ap-southeast-2                                                    
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,167.36 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,014.08 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $9,625.60 
@@ -66,7 +66,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $73.50 
                                                                                      
  aws_data_transfer.ca-central-1                                                      
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -74,17 +74,17 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.cn-north-1                                                        
- ├─ Intra-region data transfer                             1,000  GB          $10.32 
+ ├─ Intra-region data transfer                             2,000  GB          $20.64 
  ├─ Outbound data transfer to Internet                   157,000  GB      $22,558.07 
  └─ Outbound data transfer to other regions                  750  GB          $69.33 
                                                                                      
  aws_data_transfer.cn-northwest-1                                                    
- ├─ Intra-region data transfer                             1,000  GB          $10.32 
+ ├─ Intra-region data transfer                             2,000  GB          $20.64 
  ├─ Outbound data transfer to Internet                   157,000  GB      $22,558.07 
  └─ Outbound data transfer to other regions                  750  GB          $69.33 
                                                                                      
  aws_data_transfer.eu-central-1                                                      
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -92,7 +92,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.eu-north-1                                                        
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -100,7 +100,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.eu-south-1                                                        
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -108,7 +108,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.eu-west-1                                                         
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -116,7 +116,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.eu-west-2                                                         
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -124,7 +124,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.eu-west-3                                                         
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -132,7 +132,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.me-south-1                                                        
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,198.08 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,526.08 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $9,318.40 
@@ -140,7 +140,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $82.87 
                                                                                      
  aws_data_transfer.sa-east-1                                                         
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,536.00 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $5,652.48 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB      $12,902.40 
@@ -148,7 +148,7 @@
  └─ Outbound data transfer to other regions                  750  GB         $103.50 
                                                                                      
  aws_data_transfer.us-east-1                                                         
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)        5,800  GB         $406.00 
@@ -156,7 +156,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.us-east-2                                                         
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -165,7 +165,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.us-gov-east-1                                                     
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,587.20 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,710.40 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $9,216.00 
@@ -173,7 +173,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $22.50 
                                                                                      
  aws_data_transfer.us-gov-west-1                                                     
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,587.20 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,710.40 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $9,216.00 
@@ -181,7 +181,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $22.50 
                                                                                      
  aws_data_transfer.us-west-1                                                         
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -189,7 +189,7 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.us-west-2                                                         
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
@@ -197,11 +197,11 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  aws_data_transfer.us-west-2-lax-1                                                   
- ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
- PROJECT TOTAL                                                           $370,159.83 
+ PROJECT TOTAL                                                           $370,420.47 

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -1,146 +1,207 @@
 
- Name                                          Monthly Qty  Unit  Monthly Cost 
-                                                                               
- aws_data_transfer.af-south-1                                                  
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $735.00 
- └─ Outbound data transfer to other regions            750  GB         $110.25 
-                                                                               
- aws_data_transfer.ap-east-1                                                   
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $67.50 
-                                                                               
- aws_data_transfer.ap-northeast-1                                              
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $445.00 
- └─ Outbound data transfer to other regions            750  GB          $67.50 
-                                                                               
- aws_data_transfer.ap-northeast-2                                              
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $610.00 
- └─ Outbound data transfer to other regions            750  GB          $60.00 
-                                                                               
- aws_data_transfer.ap-northeast-3                                              
- ├─ Intra-region data transfer                       1,000  GB           $0.00 
- ├─ Outbound data transfer to Internet               5,000  GB           $0.00 
- └─ Outbound data transfer to other regions            750  GB           $0.00 
-                                                                               
- aws_data_transfer.ap-south-1                                                  
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $64.50 
-                                                                               
- aws_data_transfer.ap-southeast-1                                              
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $67.50 
-                                                                               
- aws_data_transfer.ap-southeast-2                                              
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $490.00 
- └─ Outbound data transfer to other regions            750  GB          $73.50 
-                                                                               
- aws_data_transfer.ca-central-1                                                
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.cn-north-1                                                  
- ├─ Intra-region data transfer                       1,000  GB          $10.32 
- ├─ Outbound data transfer to Internet               5,000  GB           $0.00 
- └─ Outbound data transfer to other regions            750  GB           $0.00 
-                                                                               
- aws_data_transfer.cn-northwest-1                                              
- ├─ Intra-region data transfer                       1,000  GB          $10.32 
- ├─ Outbound data transfer to Internet               5,000  GB           $0.00 
- └─ Outbound data transfer to other regions            750  GB           $0.00 
-                                                                               
- aws_data_transfer.eu-central-1                                                
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.eu-north-1                                                  
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.eu-south-1                                                  
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.eu-west-1                                                   
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.eu-west-2                                                   
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.eu-west-3                                                   
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.me-south-1                                                  
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $552.50 
- └─ Outbound data transfer to other regions            750  GB          $82.87 
-                                                                               
- aws_data_transfer.sa-east-1                                                   
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $690.00 
- └─ Outbound data transfer to other regions            750  GB         $103.50 
-                                                                               
- aws_data_transfer.us-east-1                                                   
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- ├─ Outbound data transfer to US East regions          500  GB           $5.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.us-east-2                                                   
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- ├─ Outbound data transfer to US East regions          200  GB           $2.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.us-gov-east-1                                               
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $575.00 
- └─ Outbound data transfer to other regions            750  GB          $22.50 
-                                                                               
- aws_data_transfer.us-gov-west-1                                               
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $575.00 
- └─ Outbound data transfer to other regions            750  GB          $22.50 
-                                                                               
- aws_data_transfer.us-iso-east-1                                               
- ├─ Intra-region data transfer                       1,000  GB           $0.00 
- ├─ Outbound data transfer to Internet               5,000  GB           $0.00 
- └─ Outbound data transfer to other regions            750  GB           $0.00 
-                                                                               
- aws_data_transfer.us-isob-east-1                                              
- ├─ Intra-region data transfer                       1,000  GB           $0.00 
- ├─ Outbound data transfer to Internet               5,000  GB           $0.00 
- └─ Outbound data transfer to other regions            750  GB           $0.00 
-                                                                               
- aws_data_transfer.us-west-1                                                   
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB           $0.00 
-                                                                               
- aws_data_transfer.us-west-2                                                   
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- aws_data_transfer.us-west-2-lax-1                                             
- ├─ Intra-region data transfer                       1,000  GB          $10.00 
- ├─ Outbound data transfer to Internet               5,000  GB         $425.00 
- └─ Outbound data transfer to other regions            750  GB          $15.00 
-                                                                               
- PROJECT TOTAL                                                      $12,212.26 
+ Name                                                Monthly Qty  Unit  Monthly Cost 
+                                                                                     
+ aws_data_transfer.af-south-1                                                        
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,576.96 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $6,021.12 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $14,192.64 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $380.80 
+ └─ Outbound data transfer to other regions                  750  GB         $110.25 
+                                                                                     
+ aws_data_transfer.ap-east-1                                                         
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,228.80 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,236.48 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $272.00 
+ └─ Outbound data transfer to other regions                  750  GB          $67.50 
+                                                                                     
+ aws_data_transfer.ap-northeast-1                                                    
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,167.36 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,645.44 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,687.04 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $285.60 
+ └─ Outbound data transfer to other regions                  750  GB          $67.50 
+                                                                                     
+ aws_data_transfer.ap-northeast-2                                                    
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,290.24 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,997.12 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $13,178.88 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $367.20 
+ └─ Outbound data transfer to other regions                  750  GB          $60.00 
+                                                                                     
+ aws_data_transfer.ap-northeast-3                                                    
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,167.36 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,645.44 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,687.04 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $285.60 
+ └─ Outbound data transfer to other regions                  750  GB          $67.50 
+                                                                                     
+ aws_data_transfer.ap-south-1                                                        
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,119.23 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,236.48 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $272.00 
+ └─ Outbound data transfer to other regions                  750  GB          $64.50 
+                                                                                     
+ aws_data_transfer.ap-southeast-1                                                    
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,228.80 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,236.48 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $272.00 
+ └─ Outbound data transfer to other regions                  750  GB          $67.50 
+                                                                                     
+ aws_data_transfer.ap-southeast-2                                                    
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,167.36 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,014.08 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $10,588.16 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $312.80 
+ └─ Outbound data transfer to other regions                  750  GB          $73.50 
+                                                                                     
+ aws_data_transfer.ca-central-1                                                      
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.cn-north-1                                                        
+ ├─ Intra-region data transfer                             1,000  GB          $10.32 
+ ├─ Outbound data transfer to Internet                   157,000  GB      $22,558.07 
+ └─ Outbound data transfer to other regions                  750  GB          $69.33 
+                                                                                     
+ aws_data_transfer.cn-northwest-1                                                    
+ ├─ Intra-region data transfer                             1,000  GB          $10.32 
+ ├─ Outbound data transfer to Internet                   157,000  GB      $22,558.07 
+ └─ Outbound data transfer to other regions                  750  GB          $69.33 
+                                                                                     
+ aws_data_transfer.eu-central-1                                                      
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.eu-north-1                                                        
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.eu-south-1                                                        
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.eu-west-1                                                         
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.eu-west-2                                                         
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.eu-west-3                                                         
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.me-south-1                                                        
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,198.08 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,526.08 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $10,250.24 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $221.00 
+ └─ Outbound data transfer to other regions                  750  GB          $82.87 
+                                                                                     
+ aws_data_transfer.sa-east-1                                                         
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,536.00 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $5,652.48 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $14,192.64 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $387.60 
+ └─ Outbound data transfer to other regions                  750  GB         $103.50 
+                                                                                     
+ aws_data_transfer.us-east-1                                                         
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)        5,800  GB         $406.00 
+ ├─ Outbound data transfer to US East regions                500  GB           $5.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.us-east-2                                                         
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ ├─ Outbound data transfer to US East regions                200  GB           $2.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.us-gov-east-1                                                     
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,587.20 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,710.40 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $10,137.60 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $221.00 
+ └─ Outbound data transfer to other regions                  750  GB          $22.50 
+                                                                                     
+ aws_data_transfer.us-gov-west-1                                                     
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,587.20 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,710.40 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $10,137.60 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $221.00 
+ └─ Outbound data transfer to other regions                  750  GB          $22.50 
+                                                                                     
+ aws_data_transfer.us-west-1                                                         
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.us-west-2                                                         
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ aws_data_transfer.us-west-2-lax-1                                                   
+ ├─ Intra-region data transfer                             1,000  GB          $10.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
+ └─ Outbound data transfer to other regions                  750  GB          $15.00 
+                                                                                     
+ PROJECT TOTAL                                                           $389,841.11 

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -5,7 +5,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,576.96 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $6,021.12 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $14,192.64 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB      $12,902.40 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $380.80 
  └─ Outbound data transfer to other regions                  750  GB         $110.25 
                                                                                      
@@ -13,7 +13,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,228.80 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,236.48 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,396.80 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $272.00 
  └─ Outbound data transfer to other regions                  750  GB          $67.50 
                                                                                      
@@ -21,7 +21,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,167.36 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,645.44 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,687.04 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,806.40 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $285.60 
  └─ Outbound data transfer to other regions                  750  GB          $67.50 
                                                                                      
@@ -29,7 +29,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,290.24 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,997.12 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $13,178.88 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB      $11,980.80 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $367.20 
  └─ Outbound data transfer to other regions                  750  GB          $60.00 
                                                                                      
@@ -37,7 +37,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,167.36 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,645.44 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,687.04 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,806.40 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $285.60 
  └─ Outbound data transfer to other regions                  750  GB          $67.50 
                                                                                      
@@ -45,7 +45,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,119.23 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,236.48 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,396.80 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $272.00 
  └─ Outbound data transfer to other regions                  750  GB          $64.50 
                                                                                      
@@ -53,7 +53,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,228.80 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $9,236.48 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $8,396.80 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $272.00 
  └─ Outbound data transfer to other regions                  750  GB          $67.50 
                                                                                      
@@ -61,7 +61,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,167.36 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,014.08 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $10,588.16 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $9,625.60 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $312.80 
  └─ Outbound data transfer to other regions                  750  GB          $73.50 
                                                                                      
@@ -69,7 +69,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
@@ -87,7 +87,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
@@ -95,7 +95,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
@@ -103,7 +103,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
@@ -111,7 +111,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
@@ -119,7 +119,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
@@ -127,7 +127,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
@@ -135,7 +135,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,198.08 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,526.08 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $10,250.24 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $9,318.40 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $221.00 
  └─ Outbound data transfer to other regions                  750  GB          $82.87 
                                                                                      
@@ -143,7 +143,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,536.00 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $5,652.48 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $14,192.64 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB      $12,902.40 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $387.60 
  └─ Outbound data transfer to other regions                  750  GB         $103.50 
                                                                                      
@@ -159,7 +159,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  ├─ Outbound data transfer to US East regions                200  GB           $2.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
@@ -168,7 +168,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,587.20 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,710.40 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $10,137.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $9,216.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $221.00 
  └─ Outbound data transfer to other regions                  750  GB          $22.50 
                                                                                      
@@ -176,7 +176,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,587.20 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $4,710.40 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB      $10,137.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $9,216.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $221.00 
  └─ Outbound data transfer to other regions                  750  GB          $22.50 
                                                                                      
@@ -184,7 +184,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
@@ -192,7 +192,7 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
@@ -200,8 +200,8 @@
  ├─ Intra-region data transfer                             1,000  GB          $10.00 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60 
  ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      112,640  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,168.00 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $170.00 
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
- PROJECT TOTAL                                                           $389,841.11 
+ PROJECT TOTAL                                                           $370,159.83 

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.usage.yml
@@ -4,168 +4,156 @@ resource_usage:
         region: ap-northeast-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.ap-south-1:
         region: ap-south-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.us-gov-east-1:
         region: us-gov-east-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.us-west-1:
         region: us-west-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.cn-northwest-1:
         region: cn-northwest-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.eu-south-1:
         region: eu-south-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.ap-east-1:
         region: ap-east-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.us-east-2:
         region: us-east-2
         monthly_intra_region_gb: 1000
         monthly_outbound_us_east_to_us_east_gb: 200
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.us-west-2-lax-1:
         region: us-west-2-lax-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.ca-central-1:
         region: ca-central-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.eu-west-2:
         region: eu-west-2
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.eu-west-3:
         region: eu-west-3
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.eu-north-1:
         region: eu-north-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.sa-east-1:
         region: sa-east-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.us-east-1:
         region: us-east-1
         monthly_intra_region_gb: 1000
         monthly_outbound_us_east_to_us_east_gb: 500
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
-
-    aws_data_transfer.us-iso-east-1:
-        region: us-iso-east-1
-        monthly_intra_region_gb: 1000
-        monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
-
-    aws_data_transfer.us-isob-east-1:
-        region: us-isob-east-1
-        monthly_intra_region_gb: 1000
-        monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 57000
 
     aws_data_transfer.cn-north-1:
         region: cn-north-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.us-gov-west-1:
         region: us-gov-west-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.us-west-2:
         region: us-west-2
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.eu-central-1:
         region: eu-central-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.eu-west-1:
         region: eu-west-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.me-south-1:
         region: me-south-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.ap-northeast-2:
         region: ap-northeast-2
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.ap-northeast-3:
         region: ap-northeast-3
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.ap-southeast-1:
         region: ap-southeast-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.ap-southeast-2:
         region: ap-southeast-2
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000
 
     aws_data_transfer.af-south-1:
         region: af-south-1
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
-        monthly_outbound_internet_gb: 5000
+        monthly_outbound_internet_gb: 157000


### PR DESCRIPTION
Fix #713 

The changes can be divided into few sections:

## A) Unknown regions
Two regions `us-iso-east-1` and `us-isob-east-1` are totally missing in pricing API and amazon pages and I couldn't find much information for them. So I removed them.

## B) Wrong region names
One region's name was wrong which I assume might have changed recently. The `ap-northeast-3`'s name was changed from `Asia Pacific (Osaka-Local)` to `Asia Pacific (Osaka)`

## C) Data transfer to other regions mismatch
As I understood, since data transfer to all regions seems to have the same price the default `us-west-1` is selected. It caused two problems:

1. When the region is `us-west-1` itself, we should query data output to some other region. I used `us-west-2`.
2. Chinese regions `cn-north-1` and `cn-northwest-1` have data transfer prices just between themselves.

## C) Data transfer to the Internet
The pricing is actually a stepped price (like first 10TB, then next 40Tb, and ...). Most regions have the same steps but the 2 Chinese regions are different.
You can see all possible outputs by checking:
1. `us-east-2` for a full stepped costs
2. `us-east-1` for a partial stepping
3. `cn-north-1` and `cn-northwest-1` for no stepping at all