### PR TITLE
chore: bump Terraform and Terragrunt versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:1.16 as builder
 
 ARG ARCH=linux
-ARG DEFAULT_TERRAFORM_VERSION=0.14.9
-ARG TERRAGRUNT_VERSION=0.28.22
+ARG DEFAULT_TERRAFORM_VERSION=0.15.4
+ARG TERRAGRUNT_VERSION=0.29.6
 
 # Set Environment Variables
 SHELL ["/bin/bash", "-c"]
@@ -13,7 +13,7 @@ ENV CGO_ENABLED 0
 RUN apt-get update -q && apt-get -y install unzip
 
 # Install latest of each Terraform version after 0.12 as we don't support versions before that
-RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.30 0.13.6 ${DEFAULT_TERRAFORM_VERSION}" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.31 0.13.7 0.14.11 ${DEFAULT_TERRAFORM_VERSION}" && \
     for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do \
     wget -q https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \
     wget -q https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_SHA256SUMS && \
@@ -24,9 +24,10 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.30 0.13.6 ${DEFAULT_TERRAFORM_VERSION}" &
     rm terraform_${VERSION}_linux_amd64.zip && \
     rm terraform_${VERSION}_SHA256SUMS; \
     done && \
-    ln -s /usr/bin/terraform_0.12.30 /usr/bin/terraform_0.12 && \
-    ln -s /usr/bin/terraform_0.13.6 /usr/bin/terraform_0.13 && \
-    ln -s /usr/bin/terraform_${DEFAULT_TERRAFORM_VERSION} /usr/bin/terraform_0.14 && \
+    ln -s /usr/bin/terraform_0.12.31 /usr/bin/terraform_0.12 && \
+    ln -s /usr/bin/terraform_0.13.7 /usr/bin/terraform_0.13 && \
+    ln -s /usr/bin/terraform_0.14.11 /usr/bin/terraform_0.14 && \
+    ln -s /usr/bin/terraform_${DEFAULT_TERRAFORM_VERSION} /usr/bin/terraform_0.15 && \
     ln -s /usr/bin/terraform_${DEFAULT_TERRAFORM_VERSION} /usr/bin/terraform
 
 # Install Terragrunt


### PR DESCRIPTION
This increases the compressed size of our docker image from ~260MB to ~320MB. Not the end of the world but we should probably stop adding other dependencies soon?