### PR TITLE
fix(aws): remove hours from units as we already take that into account

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -187,7 +187,7 @@ resource_usage:
     write_requests_per_sec: 100        # Total number of reads per second for the cluster.
     read_requests_per_sec: 100         # Total number of writes per second for the cluster.
     backup_snapshot_size_gb: 200       # Individual storage size for backup snapshots, used in conjunction with resource parameter "backup_retention_period".
-    average_statements_per_hr: 10000   # Number of statements generated per hour when backtrack is enabled. Only availble for MySQl-compatible Aurora
+    average_statements_per_hr: 10000   # Number of statements generated per hour when backtrack is enabled. Only available for MySQl-compatible Aurora
     change_records_per_statement: 0.38 # Records changed per statement executed.
     backtrack_window_hrs: 24           # The duration window for which Aurora will support rewinding the DB cluster to a specific point in time.
     snapshot_export_size_gb: 200       # Size of snapshot that's exported to s3 in parquet format.

--- a/internal/providers/terraform/aws/rds_cluster.go
+++ b/internal/providers/terraform/aws/rds_cluster.go
@@ -42,7 +42,7 @@ func NewRDSCluster(d *schema.ResourceData, u *schema.UsageData) *schema.Resource
 	if databaseEngineMode == "Serverless" {
 		costComponents = append(costComponents, &schema.CostComponent{
 			Name:           "Aurora serverless",
-			Unit:           "ACU hours",
+			Unit:           "ACU-hours",
 			UnitMultiplier: 1,
 			HourlyQuantity: auroraCapacityUnits,
 			ProductFilter: &schema.ProductFilter{
@@ -145,7 +145,7 @@ func auroraStorageCostComponent(region string, u *schema.UsageData, databaseEngi
 
 	return []*schema.CostComponent{
 		{
-			Name:            "Storage rate",
+			Name:            "Storage",
 			Unit:            "GB",
 			UnitMultiplier:  1,
 			MonthlyQuantity: &storageGB,
@@ -200,7 +200,7 @@ func auroraBackupStorageCostComponent(region string, totalBackupStorageGB decima
 func auroraBacktrackCostComponent(region string, backtrackChangeRecords decimal.Decimal) *schema.CostComponent {
 	return &schema.CostComponent{
 		Name:            "Backtrack",
-		Unit:            "1M CR-hours",
+		Unit:            "1M change-records",
 		UnitMultiplier:  1000000,
 		MonthlyQuantity: decimalPtr(backtrackChangeRecords),
 		ProductFilter: &schema.ProductFilter{

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
@@ -2,11 +2,11 @@
  Name                                            Monthly Qty  Unit         Monthly Cost 
                                                                                         
  aws_rds_cluster.default                                                                
- ├─ Storage rate                                           0  GB                  $0.00 
+ ├─ Storage                                                0  GB                  $0.00 
  └─ I/O rate                                               0  1M requests         $0.00 
                                                                                         
  aws_rds_cluster.default_t3                                                             
- ├─ Storage rate                                           0  GB                  $0.00 
+ ├─ Storage                                                0  GB                  $0.00 
  └─ I/O rate                                               0  1M requests         $0.00 
                                                                                         
  aws_rds_cluster_instance.cluster_instance                                              

--- a/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
@@ -1,34 +1,34 @@
 
- Name                                           Monthly Qty  Unit         Monthly Cost 
-                                                                                       
- aws_rds_cluster.my_sql_serverless                                                     
- ├─ Aurora serverless                               730,000  ACU hours      $43,800.00 
- ├─ Storage rate                                        100  GB                 $10.00 
- └─ I/O rate                                          52.56  1M requests        $10.51 
-                                                                                       
- aws_rds_cluster.mysql_backtrack                                                       
- ├─ Storage rate                                        100  GB                 $10.00 
- ├─ I/O rate                                          52.56  1M requests        $10.51 
- ├─ Backup storage                                      400  GB                  $8.40 
- ├─ Backtrack                                        66,576  1M CR-hours       $798.91 
- └─ Snapshot export                                     200  GB                  $2.00 
-                                                                                       
- aws_rds_cluster.postgres_serverless                                                   
- ├─ Aurora serverless                               730,000  ACU hours      $43,800.00 
- ├─ Storage rate                                        100  GB                 $10.00 
- └─ I/O rate                                          52.56  1M requests        $10.51 
-                                                                                       
- aws_rds_cluster.postgres_serverlessWithBackup                                         
- ├─ Aurora serverless                               730,000  ACU hours      $43,800.00 
- ├─ Storage rate                                        100  GB                 $10.00 
- ├─ I/O rate                                          52.56  1M requests        $10.51 
- └─ Backup storage                                      400  GB                  $8.40 
-                                                                                       
- aws_rds_cluster.postgres_serverlessWithExport                                         
- ├─ Aurora serverless                               730,000  ACU hours      $43,800.00 
- ├─ Storage rate                                        100  GB                 $10.00 
- ├─ I/O rate                                          52.56  1M requests        $10.51 
- ├─ Backup storage                                      400  GB                  $8.40 
- └─ Snapshot export                                     200  GB                  $2.00 
-                                                                                       
- PROJECT TOTAL                                                             $176,130.67 
+ Name                                           Monthly Qty  Unit               Monthly Cost 
+                                                                                             
+ aws_rds_cluster.my_sql_serverless                                                           
+ ├─ Aurora serverless                               730,000  ACU-hours            $43,800.00 
+ ├─ Storage                                             100  GB                       $10.00 
+ └─ I/O rate                                          52.56  1M requests              $10.51 
+                                                                                             
+ aws_rds_cluster.mysql_backtrack                                                             
+ ├─ Storage                                             100  GB                       $10.00 
+ ├─ I/O rate                                          52.56  1M requests              $10.51 
+ ├─ Backup storage                                      400  GB                        $8.40 
+ ├─ Backtrack                                        66,576  1M change-records       $798.91 
+ └─ Snapshot export                                     200  GB                        $2.00 
+                                                                                             
+ aws_rds_cluster.postgres_serverless                                                         
+ ├─ Aurora serverless                               730,000  ACU-hours            $43,800.00 
+ ├─ Storage                                             100  GB                       $10.00 
+ └─ I/O rate                                          52.56  1M requests              $10.51 
+                                                                                             
+ aws_rds_cluster.postgres_serverlessWithBackup                                               
+ ├─ Aurora serverless                               730,000  ACU-hours            $43,800.00 
+ ├─ Storage                                             100  GB                       $10.00 
+ ├─ I/O rate                                          52.56  1M requests              $10.51 
+ └─ Backup storage                                      400  GB                        $8.40 
+                                                                                             
+ aws_rds_cluster.postgres_serverlessWithExport                                               
+ ├─ Aurora serverless                               730,000  ACU-hours            $43,800.00 
+ ├─ Storage                                             100  GB                       $10.00 
+ ├─ I/O rate                                          52.56  1M requests              $10.51 
+ ├─ Backup storage                                      400  GB                        $8.40 
+ └─ Snapshot export                                     200  GB                        $2.00 
+                                                                                             
+ PROJECT TOTAL                                                                   $176,130.67 


### PR DESCRIPTION
CR = change-record, where we calculate it as follows:
averageStatements.Mul(decimal.NewFromInt(730)).Mul(changeRecords).Mul(windowHours)
So I think it’s clearer if we remove the hours and call it “change-records” as we’re already taking into account the hours