### PR TITLE
fix(tests): Update Cosmos DB tests after merge

### DIFF
--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.golden
@@ -6,6 +6,7 @@
  ├─ Provisioned throughput (autoscale, Central US)                               45  RU/s x 100                     $262.80 
  ├─ Transactional storage (West US)                                           1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                        1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                               1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                            1,000  GB                             $246.00 
  └─ Restored data                                                             3,000  GB                             $450.00 
                                                                                                                             
@@ -30,6 +31,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                           6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                                           1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                        1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                               1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                            1,000  GB                             $246.00 
  └─ Restored data                                                             3,000  GB                             $450.00 
                                                                                                                             
@@ -42,7 +44,7 @@
  ├─ Periodic backup (West US)                                                 2,000  GB                             $300.00 
  └─ Restored data                                                             3,000  GB                             $450.00 
                                                                                                                             
- PROJECT TOTAL                                                                                                    $4,755.73 
+ PROJECT TOTAL                                                                                                    $5,155.73 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.golden
@@ -6,6 +6,7 @@
  ├─ Provisioned throughput (autoscale, Central US)               Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                              Monthly cost depends on usage: $0.25 per GB                
  ├─ Transactional storage (Central US)                           Monthly cost depends on usage: $0.25 per GB                
+ ├─ Continuous backup (West US)                                  Monthly cost depends on usage: $0.20 per GB                
  ├─ Continuous backup (Central US)                               Monthly cost depends on usage: $0.25 per GB                
  └─ Restored data                                                Monthly cost depends on usage: $0.15 per GB                
                                                                                                                             
@@ -22,7 +23,7 @@
  ├─ Provisioned throughput (autoscale, West US)                  Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                              Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                                 Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                        Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                        Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                         Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                                    Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                                Monthly cost depends on usage: $0.15 per GB                
@@ -32,6 +33,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                           6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                              Monthly cost depends on usage: $0.25 per GB                
  ├─ Transactional storage (Central US)                           Monthly cost depends on usage: $0.25 per GB                
+ ├─ Continuous backup (West US)                                  Monthly cost depends on usage: $0.20 per GB                
  ├─ Continuous backup (Central US)                               Monthly cost depends on usage: $0.25 per GB                
  └─ Restored data                                                Monthly cost depends on usage: $0.15 per GB                
                                                                                                                             
@@ -39,7 +41,7 @@
  ├─ Provisioned throughput (serverless)                          Monthly cost depends on usage: $0.28 per 1M RU             
  ├─ Transactional storage (West US)                              Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                                 Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                        Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                        Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                         Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                                    Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                                Monthly cost depends on usage: $0.15 per GB                
@@ -49,6 +51,7 @@
  ├─ Provisioned throughput (autoscale, Central US)                               45  RU/s x 100                     $262.80 
  ├─ Transactional storage (West US)                                           1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                        1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                               1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                            1,000  GB                             $246.00 
  └─ Restored data                                                             3,000  GB                             $450.00 
                                                                                                                             
@@ -63,7 +66,7 @@
  ├─ Provisioned throughput (autoscale, West US)                  Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                              Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                                 Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                        Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                        Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                         Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                                    Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                                Monthly cost depends on usage: $0.15 per GB                
@@ -73,6 +76,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                           6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                                           1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                        1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                               1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                            1,000  GB                             $246.00 
  └─ Restored data                                                             3,000  GB                             $450.00 
                                                                                                                             
@@ -85,7 +89,7 @@
  ├─ Periodic backup (West US)                                                 2,000  GB                             $300.00 
  └─ Restored data                                                             3,000  GB                             $450.00 
                                                                                                                             
- PROJECT TOTAL                                                                                                    $5,055.03 
+ PROJECT TOTAL                                                                                                    $5,455.03 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.golden
@@ -6,6 +6,7 @@
  ├─ Provisioned throughput (autoscale, Central US)                             45  RU/s x 100                     $262.80 
  ├─ Transactional storage (West US)                                         1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                      1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                             1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                          1,000  GB                             $246.00 
  └─ Restored data                                                           3,000  GB                             $450.00 
                                                                                                                           
@@ -20,7 +21,7 @@
  ├─ Provisioned throughput (autoscale, West US)                Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                            Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                               Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                      Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                      Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                       Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                                  Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                
@@ -30,6 +31,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                         6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                                         1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                      1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                             1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                          1,000  GB                             $246.00 
  └─ Restored data                                                           3,000  GB                             $450.00 
                                                                                                                           
@@ -42,7 +44,7 @@
  ├─ Periodic backup (West US)                                               2,000  GB                             $300.00 
  └─ Restored data                                                           3,000  GB                             $450.00 
                                                                                                                           
- PROJECT TOTAL                                                                                                  $4,755.73 
+ PROJECT TOTAL                                                                                                  $5,155.73 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.golden
@@ -5,7 +5,7 @@
  ├─ Provisioned throughput (serverless)                     Monthly cost depends on usage: $0.28 per 1M RU             
  ├─ Transactional storage (West US)                         Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                            Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                    Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                               Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                           Monthly cost depends on usage: $0.15 per GB                
@@ -15,6 +15,7 @@
  ├─ Provisioned throughput (autoscale, Central US)                          45  RU/s x 100                     $262.80 
  ├─ Transactional storage (West US)                                      1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                   1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                          1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                       1,000  GB                             $246.00 
  └─ Restored data                                                        3,000  GB                             $450.00 
                                                                                                                        
@@ -29,7 +30,7 @@
  ├─ Provisioned throughput (autoscale, West US)             Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                         Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                            Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                    Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                               Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                           Monthly cost depends on usage: $0.15 per GB                
@@ -39,6 +40,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                      6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                                      1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                   1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                          1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                       1,000  GB                             $246.00 
  └─ Restored data                                                        3,000  GB                             $450.00 
                                                                                                                        
@@ -51,7 +53,7 @@
  ├─ Periodic backup (West US)                                            2,000  GB                             $300.00 
  └─ Restored data                                                        3,000  GB                             $450.00 
                                                                                                                        
- PROJECT TOTAL                                                                                               $4,755.73 
+ PROJECT TOTAL                                                                                               $5,155.73 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.golden
@@ -6,6 +6,7 @@
  ├─ Provisioned throughput (autoscale, Central US)                             45  RU/s x 100                     $262.80 
  ├─ Transactional storage (West US)                                         1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                      1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                             1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                          1,000  GB                             $246.00 
  └─ Restored data                                                           3,000  GB                             $450.00 
                                                                                                                           
@@ -20,7 +21,7 @@
  ├─ Provisioned throughput (autoscale, West US)                Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                            Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                               Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                      Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                      Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                       Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                                  Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                
@@ -30,6 +31,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                         6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                                         1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                      1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                             1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                          1,000  GB                             $246.00 
  └─ Restored data                                                           3,000  GB                             $450.00 
                                                                                                                           
@@ -47,6 +49,7 @@
  ├─ Provisioned throughput (autoscale, Central US)             Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                            Monthly cost depends on usage: $0.25 per GB                
  ├─ Transactional storage (Central US)                         Monthly cost depends on usage: $0.25 per GB                
+ ├─ Continuous backup (West US)                                Monthly cost depends on usage: $0.20 per GB                
  ├─ Continuous backup (Central US)                             Monthly cost depends on usage: $0.25 per GB                
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                
                                                                                                                           
@@ -63,7 +66,7 @@
  ├─ Provisioned throughput (autoscale, West US)                Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                            Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                               Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                      Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                      Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                       Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                                  Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                
@@ -73,6 +76,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                         6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                            Monthly cost depends on usage: $0.25 per GB                
  ├─ Transactional storage (Central US)                         Monthly cost depends on usage: $0.25 per GB                
+ ├─ Continuous backup (West US)                                Monthly cost depends on usage: $0.20 per GB                
  ├─ Continuous backup (Central US)                             Monthly cost depends on usage: $0.25 per GB                
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                
                                                                                                                           
@@ -80,12 +84,12 @@
  ├─ Provisioned throughput (serverless)                        Monthly cost depends on usage: $0.28 per 1M RU             
  ├─ Transactional storage (West US)                            Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                               Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                      Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                      Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                       Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                                  Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                
                                                                                                                           
- PROJECT TOTAL                                                                                                  $5,055.03 
+ PROJECT TOTAL                                                                                                  $5,455.03 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.golden
@@ -6,6 +6,7 @@
  ├─ Provisioned throughput (autoscale, Central US)                           45  RU/s x 100                     $262.80 
  ├─ Transactional storage (West US)                                       1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                    1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                           1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                        1,000  GB                             $246.00 
  └─ Restored data                                                         3,000  GB                             $450.00 
                                                                                                                         
@@ -20,7 +21,7 @@
  ├─ Provisioned throughput (autoscale, West US)              Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                          Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                             Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                    Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                    Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                     Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                                Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                            Monthly cost depends on usage: $0.15 per GB                
@@ -30,6 +31,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                       6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                                       1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                    1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                           1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                        1,000  GB                             $246.00 
  └─ Restored data                                                         3,000  GB                             $450.00 
                                                                                                                         
@@ -42,7 +44,7 @@
  ├─ Periodic backup (West US)                                             2,000  GB                             $300.00 
  └─ Restored data                                                         3,000  GB                             $450.00 
                                                                                                                         
- PROJECT TOTAL                                                                                                $4,755.73 
+ PROJECT TOTAL                                                                                                $5,155.73 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_container_test/cosmosdb_sql_container_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_container_test/cosmosdb_sql_container_test.golden
@@ -6,6 +6,7 @@
  ├─ Provisioned throughput (autoscale, Central US)                          45  RU/s x 100                     $262.80 
  ├─ Transactional storage (West US)                                      1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                   1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                          1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                       1,000  GB                             $246.00 
  └─ Restored data                                                        3,000  GB                             $450.00 
                                                                                                                        
@@ -13,7 +14,7 @@
  ├─ Provisioned throughput (provisioned, West US)                           10  RU/s x 100                      $58.40 
  ├─ Transactional storage (West US)                                      1,000  GB                             $250.00 
  ├─ Analytical storage (West US)                                         1,000  GB                              $30.00 
- ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                    Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                                            2,000  GB                             $300.00 
  └─ Restored data                                           Monthly cost depends on usage: $0.15 per GB                
@@ -22,7 +23,7 @@
  ├─ Provisioned throughput (autoscale, West US)             Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                         Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                            Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                    Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                               Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                           Monthly cost depends on usage: $0.15 per GB                
@@ -32,6 +33,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                      6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                                      1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                   1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                          1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                       1,000  GB                             $246.00 
  └─ Restored data                                                        3,000  GB                             $450.00 
                                                                                                                        
@@ -48,12 +50,12 @@
  ├─ Provisioned throughput (autoscale, West US)             Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                         Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                            Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                   Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                    Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                               Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                           Monthly cost depends on usage: $0.15 per GB                
                                                                                                                        
- PROJECT TOTAL                                                                                               $4,660.53 
+ PROJECT TOTAL                                                                                               $5,060.53 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.golden
@@ -6,6 +6,7 @@
  ├─ Provisioned throughput (autoscale, Central US)                         45  RU/s x 100                     $262.80 
  ├─ Transactional storage (West US)                                     1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                  1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                         1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                      1,000  GB                             $246.00 
  └─ Restored data                                                       3,000  GB                             $450.00 
                                                                                                                       
@@ -20,7 +21,7 @@
  ├─ Provisioned throughput (autoscale, West US)            Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                        Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                           Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)                  Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)                  Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)                   Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                              Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                          Monthly cost depends on usage: $0.15 per GB                
@@ -30,6 +31,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                     6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                                     1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                                  1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                         1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                      1,000  GB                             $246.00 
  └─ Restored data                                                       3,000  GB                             $450.00 
                                                                                                                       
@@ -42,7 +44,7 @@
  ├─ Periodic backup (West US)                                           2,000  GB                             $300.00 
  └─ Restored data                                                       3,000  GB                             $450.00 
                                                                                                                       
- PROJECT TOTAL                                                                                              $4,755.73 
+ PROJECT TOTAL                                                                                              $5,155.73 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.golden
@@ -6,6 +6,7 @@
  ├─ Provisioned throughput (autoscale, Central US)                    45  RU/s x 100                     $262.80 
  ├─ Transactional storage (West US)                                1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                             1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                    1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                 1,000  GB                             $246.00 
  └─ Restored data                                                  3,000  GB                             $450.00 
                                                                                                                  
@@ -20,7 +21,7 @@
  ├─ Provisioned throughput (autoscale, West US)       Monthly cost depends on usage: $5.84 per RU/s x 100        
  ├─ Transactional storage (West US)                   Monthly cost depends on usage: $0.25 per GB                
  ├─ Analytical storage (West US)                      Monthly cost depends on usage: $0.03 per GB                
- ├─ Analytical write operations (West US)             Monthly cost depends on usage: $0.06 per 10K operations    
+ ├─ Analytical write operations (West US)             Monthly cost depends on usage: $0.055 per 10K operations   
  ├─ Analytical read operations (West US)              Monthly cost depends on usage: $0.0054 per 10K operations  
  ├─ Periodic backup (West US)                         Monthly cost depends on usage: $0.15 per GB                
  └─ Restored data                                     Monthly cost depends on usage: $0.15 per GB                
@@ -30,6 +31,7 @@
  ├─ Provisioned throughput (provisioned, Central US)                6.25  RU/s x 100                      $36.50 
  ├─ Transactional storage (West US)                                1,000  GB                             $250.00 
  ├─ Transactional storage (Central US)                             1,000  GB                             $250.00 
+ ├─ Continuous backup (West US)                                    1,000  GB                             $200.00 
  ├─ Continuous backup (Central US)                                 1,000  GB                             $246.00 
  └─ Restored data                                                  3,000  GB                             $450.00 
                                                                                                                  
@@ -42,7 +44,7 @@
  ├─ Periodic backup (West US)                                      2,000  GB                             $300.00 
  └─ Restored data                                                  3,000  GB                             $450.00 
                                                                                                                  
- PROJECT TOTAL                                                                                         $4,755.73 
+ PROJECT TOTAL                                                                                         $5,155.73 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file


### PR DESCRIPTION
Updated after price rounding merge. And it looks like Azure added support for continuous backups in `westus` region last night