### PR TITLE
fix(azure): use more robust filters

### DIFF
--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -53,10 +53,8 @@ func linuxVirtualMachineCostComponent(region string, instanceType string) *schem
 		productNameRe = "/Virtual Machines .* Series Basic$/"
 	}
 
-	skuName := parseVMSKUName(instanceType)
-
 	return &schema.CostComponent{
-		Name:           fmt.Sprintf("Instance usage (%s, %s)", purchaseOptionLabel, skuName),
+		Name:           fmt.Sprintf("Instance usage (%s, %s)", purchaseOptionLabel, instanceType),
 		Unit:           "hours",
 		UnitMultiplier: 1,
 		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
@@ -66,9 +64,9 @@ func linuxVirtualMachineCostComponent(region string, instanceType string) *schem
 			Service:       strPtr("Virtual Machines"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "armSkuName", Value: strPtr(instanceType)},
+				{Key: "skuName", ValueRegex: strPtr("/.*(?<!Low Priority|Spot)$/i")},
+				{Key: "armSkuName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", instanceType))},
 				{Key: "productName", ValueRegex: strPtr(productNameRe)},
-				{Key: "skuName", Value: strPtr(skuName)},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
@@ -3,25 +3,25 @@
                                                                                          
  azurerm_kubernetes_cluster.example                                                      
  └─ default_node_pool                                                                    
-    ├─ Instance usage (pay as you go, D2 v2)                   730  hours        $106.58 
+    ├─ Instance usage (pay as you go, Standard_D2_v2)          730  hours        $106.58 
     └─ os_disk                                                                           
        └─ Storage (P1)                                           1  months         $0.60 
                                                                                          
  azurerm_kubernetes_cluster_node_pool.Standard_DS2_v2                                    
- └─ Instance usage (pay as you go, DS2 v2)                   1,460  hours        $213.16 
+ └─ Instance usage (pay as you go, Standard_DS2_v2)          1,460  hours        $213.16 
                                                                                          
  azurerm_kubernetes_cluster_node_pool.basic_A2                                           
- ├─ Instance usage (pay as you go, A2)                         730  hours         $57.67 
+ ├─ Instance usage (pay as you go, Basic_A2)                   730  hours         $57.67 
  └─ os_disk                                                                              
     └─ Storage (P1)                                              1  months         $0.60 
                                                                                          
  azurerm_kubernetes_cluster_node_pool.example                                            
- ├─ Instance usage (pay as you go, DS2 v2)                     730  hours        $106.58 
+ ├─ Instance usage (pay as you go, Standard_DS2_v2)            730  hours        $106.58 
  └─ os_disk                                                                              
     └─ Storage (P1)                                              1  months         $0.60 
                                                                                          
  azurerm_kubernetes_cluster_node_pool.usage_basic_A2                                     
- ├─ Instance usage (pay as you go, A2)                       1,460  hours        $115.34 
+ ├─ Instance usage (pay as you go, Basic_A2)                 1,460  hours        $115.34 
  └─ os_disk                                                                              
     └─ Storage (P1)                                              2  months         $1.20 
                                                                                          

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
@@ -1,29 +1,29 @@
 
- Name                                             Monthly Qty  Unit    Monthly Cost 
-                                                                                    
- azurerm_kubernetes_cluster.free_D2V2                                               
- └─ default_node_pool                                                               
-    ├─ Instance usage (pay as you go, D2 v2)              730  hours        $106.58 
-    └─ os_disk                                                                      
-       └─ Storage (P1)                                      1  months         $0.60 
-                                                                                    
- azurerm_kubernetes_cluster.paid_5nc_32gb                                           
- ├─ Uptime SLA                                            730  hours         $73.00 
- └─ default_node_pool                                                               
-    ├─ Instance usage (pay as you go, D2 v2)            3,650  hours        $532.90 
-    └─ os_disk                                                                      
-       └─ Storage (P4)                                      5  months        $26.40 
-                                                                                    
- azurerm_kubernetes_cluster.paid_D2SV2_3nc_128gb                                    
- ├─ Uptime SLA                                            730  hours         $73.00 
- └─ default_node_pool                                                               
-    ├─ Instance usage (pay as you go, DS2 v2)           2,190  hours        $319.74 
-    └─ os_disk                                                                      
-       └─ Storage (P10)                                     3  months        $59.13 
-                                                                                    
- azurerm_kubernetes_cluster.usage_ephemeral                                         
- ├─ Uptime SLA                                            730  hours         $73.00 
- └─ default_node_pool                                                               
-    └─ Instance usage (pay as you go, D2 v2)            1,460  hours        $213.16 
-                                                                                    
- PROJECT TOTAL                                                            $1,477.51 
+ Name                                                   Monthly Qty  Unit    Monthly Cost 
+                                                                                          
+ azurerm_kubernetes_cluster.free_D2V2                                                     
+ └─ default_node_pool                                                                     
+    ├─ Instance usage (pay as you go, Standard_D2_v2)           730  hours        $106.58 
+    └─ os_disk                                                                            
+       └─ Storage (P1)                                            1  months         $0.60 
+                                                                                          
+ azurerm_kubernetes_cluster.paid_5nc_32gb                                                 
+ ├─ Uptime SLA                                                  730  hours         $73.00 
+ └─ default_node_pool                                                                     
+    ├─ Instance usage (pay as you go, Standard_D2_v2)         3,650  hours        $532.90 
+    └─ os_disk                                                                            
+       └─ Storage (P4)                                            5  months        $26.40 
+                                                                                          
+ azurerm_kubernetes_cluster.paid_D2SV2_3nc_128gb                                          
+ ├─ Uptime SLA                                                  730  hours         $73.00 
+ └─ default_node_pool                                                                     
+    ├─ Instance usage (pay as you go, Standard_DS2_v2)        2,190  hours        $319.74 
+    └─ os_disk                                                                            
+       └─ Storage (P10)                                           3  months        $59.13 
+                                                                                          
+ azurerm_kubernetes_cluster.usage_ephemeral                                               
+ ├─ Uptime SLA                                                  730  hours         $73.00 
+ └─ default_node_pool                                                                     
+    └─ Instance usage (pay as you go, Standard_D2_v2)         1,460  hours        $213.16 
+                                                                                          
+ PROJECT TOTAL                                                                  $1,477.51 

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_scale_set_test/linux_virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_scale_set_test/linux_virtual_machine_scale_set_test.golden
@@ -2,13 +2,13 @@
  Name                                                           Monthly Qty  Unit                      Monthly Cost 
                                                                                                                     
  azurerm_linux_virtual_machine_scale_set.basic_a2                                                                   
- ├─ Instance usage (pay as you go, A2)                                2,190  hours                          $173.01 
+ ├─ Instance usage (pay as you go, Basic_A2)                          2,190  hours                          $173.01 
  └─ os_disk                                                                                                         
     ├─ Storage (S4)                                                       3  months                           $4.61 
     └─ Disk operations                                   Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                     
  azurerm_linux_virtual_machine_scale_set.basic_a2_usage                                                             
- ├─ Instance usage (pay as you go, A2)                                2,920  hours                          $230.68 
+ ├─ Instance usage (pay as you go, Basic_A2)                          2,920  hours                          $230.68 
  └─ os_disk                                                                                                         
     ├─ Storage (S4)                                                       4  months                           $6.14 
     └─ Disk operations                                   Monthly cost depends on usage: $0.0005 per 10k operations  

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
@@ -2,26 +2,26 @@
  Name                                                             Monthly Qty  Unit                      Monthly Cost 
                                                                                                                       
  azurerm_linux_virtual_machine.basic_a2                                                                               
- ├─ Instance usage (pay as you go, A2)                                    730  hours                           $57.67 
+ ├─ Instance usage (pay as you go, Basic_A2)                              730  hours                           $57.67 
  └─ os_disk                                                                                                           
     ├─ Storage (S4)                                                         1  months                           $1.54 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
  azurerm_linux_virtual_machine.standard_a2_ultra_enabled                                                              
- ├─ Instance usage (pay as you go, A2 v2)                                 730  hours                           $66.43 
+ ├─ Instance usage (pay as you go, Standard_A2_v2)                        730  hours                           $66.43 
  ├─ Ultra disk reservation (if unattached)                 Monthly cost depends on usage: $4.38 per vCPU              
  └─ os_disk                                                                                                           
     ├─ Storage (E4)                                                         1  months                           $2.40 
     └─ Disk operations                                     Monthly cost depends on usage: $0.002 per 10k operations   
                                                                                                                       
  azurerm_linux_virtual_machine.standard_a2_v2_custom_disk                                                             
- ├─ Instance usage (pay as you go, A2 v2)                                 730  hours                           $66.43 
+ ├─ Instance usage (pay as you go, Standard_A2_v2)                        730  hours                           $66.43 
  └─ os_disk                                                                                                           
     ├─ Storage (E30)                                                        1  months                          $76.80 
     └─ Disk operations                                                      2  10k operations                   $0.00 
                                                                                                                       
  azurerm_linux_virtual_machine.standard_f2_premium_disk                                                               
- ├─ Instance usage (pay as you go, F2)                                    730  hours                           $72.27 
+ ├─ Instance usage (pay as you go, Standard_F2)                           730  hours                           $72.27 
  └─ os_disk                                                                                                           
     └─ Storage (P4)                                                         1  months                           $5.28 
                                                                                                                       

--- a/internal/providers/terraform/azure/testdata/virtual_machine_scale_set_test/virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_scale_set_test/virtual_machine_scale_set_test.golden
@@ -1,31 +1,31 @@
 
- Name                                              Monthly Qty  Unit                      Monthly Cost 
-                                                                                                       
- azurerm_virtual_machine_scale_set.linux                                                               
- ├─ Instance usage (hybrid benefit, F2)                  1,460  hours                          $166.44 
- ├─ storage_os_disk                                                                                    
- │  ├─ Storage (S4)                                          1  months                           $1.54 
- │  └─ Disk operations                      Monthly cost depends on usage: $0.0005 per 10k operations  
- ├─ storage_data_disk                                                                                  
- │  ├─ Storage (E4)                                          1  months                           $2.40 
- │  └─ Disk operations                      Monthly cost depends on usage: $0.002 per 10k operations   
- └─ storage_data_disk                                                                                  
-    ├─ Storage (S4)                                          1  months                           $1.54 
-    └─ Disk operations                      Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                       
- azurerm_virtual_machine_scale_set.windows                                                             
- ├─ Instance usage (hybrid benefit, F2)                  2,190  hours                          $249.66 
- ├─ storage_os_disk                                                                                    
- │  ├─ Storage (S4)                                          1  months                           $1.54 
- │  └─ Disk operations                                     100  10k operations                   $0.05 
- ├─ storage_data_disk                                                                                  
- │  ├─ Storage (E4)                                          1  months                           $2.40 
- │  └─ Disk operations                                     200  10k operations                   $0.40 
- └─ storage_data_disk                                                                                  
-    ├─ Storage (S4)                                          1  months                           $1.54 
-    └─ Disk operations                                     200  10k operations                   $0.10 
-                                                                                                       
- PROJECT TOTAL                                                                                 $427.59 
+ Name                                                    Monthly Qty  Unit                      Monthly Cost 
+                                                                                                             
+ azurerm_virtual_machine_scale_set.linux                                                                     
+ ├─ Instance usage (hybrid benefit, Standard_F2)               1,460  hours                          $166.44 
+ ├─ storage_os_disk                                                                                          
+ │  ├─ Storage (S4)                                                1  months                           $1.54 
+ │  └─ Disk operations                            Monthly cost depends on usage: $0.0005 per 10k operations  
+ ├─ storage_data_disk                                                                                        
+ │  ├─ Storage (E4)                                                1  months                           $2.40 
+ │  └─ Disk operations                            Monthly cost depends on usage: $0.002 per 10k operations   
+ └─ storage_data_disk                                                                                        
+    ├─ Storage (S4)                                                1  months                           $1.54 
+    └─ Disk operations                            Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                             
+ azurerm_virtual_machine_scale_set.windows                                                                   
+ ├─ Instance usage (hybrid benefit, Standard_F2)               2,190  hours                          $249.66 
+ ├─ storage_os_disk                                                                                          
+ │  ├─ Storage (S4)                                                1  months                           $1.54 
+ │  └─ Disk operations                                           100  10k operations                   $0.05 
+ ├─ storage_data_disk                                                                                        
+ │  ├─ Storage (E4)                                                1  months                           $2.40 
+ │  └─ Disk operations                                           200  10k operations                   $0.40 
+ └─ storage_data_disk                                                                                        
+    ├─ Storage (S4)                                                1  months                           $1.54 
+    └─ Disk operations                                           200  10k operations                   $0.10 
+                                                                                                             
+ PROJECT TOTAL                                                                                       $427.59 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
@@ -1,33 +1,33 @@
 
- Name                                              Monthly Qty  Unit                      Monthly Cost 
-                                                                                                       
- azurerm_virtual_machine.linux                                                                         
- ├─ Instance usage (pay as you go, DS1 v2)                 730  hours                           $53.29 
- ├─ Ultra disk reservation (if unattached)  Monthly cost depends on usage: $4.38 per vCPU              
- └─ storage_os_disk                                                                                    
-    ├─ Storage (S4)                                          1  months                           $1.54 
-    └─ Disk operations                      Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                       
- azurerm_virtual_machine.windows                                                                       
- ├─ Instance usage (pay as you go, DS1 v2)                 730  hours                           $91.98 
- ├─ Ultra disk reservation (if unattached)  Monthly cost depends on usage: $4.38 per vCPU              
- ├─ storage_os_disk                                                                                    
- │  ├─ Storage (S4)                                          1  months                           $1.54 
- │  └─ Disk operations                                     100  10k operations                   $0.05 
- ├─ storage_data_disk                                                                                  
- │  ├─ Storage (S4)                                          1  months                           $1.54 
- │  └─ Disk operations                                     200  10k operations                   $0.10 
- ├─ storage_data_disk                                                                                  
- │  ├─ Storage (E4)                                          1  months                           $2.40 
- │  └─ Disk operations                                     200  10k operations                   $0.40 
- ├─ storage_data_disk                                                                                  
- │  └─ Storage (P4)                                          1  months                           $5.28 
- └─ storage_data_disk                                                                                  
-    ├─ Storage (ultra, 1024 GiB)                         1,024  GiB                            $122.59 
-    ├─ Provisioned IOPS                                  2,048  IOPS                           $101.66 
-    └─ Throughput                                            8  MB/s                             $2.80 
-                                                                                                       
- PROJECT TOTAL                                                                                 $385.16 
+ Name                                                       Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                
+ azurerm_virtual_machine.linux                                                                                  
+ ├─ Instance usage (pay as you go, Standard_DS1_v2)                 730  hours                           $53.29 
+ ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $4.38 per vCPU              
+ └─ storage_os_disk                                                                                             
+    ├─ Storage (S4)                                                   1  months                           $1.54 
+    └─ Disk operations                               Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                
+ azurerm_virtual_machine.windows                                                                                
+ ├─ Instance usage (pay as you go, Standard_DS1_v2)                 730  hours                           $91.98 
+ ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $4.38 per vCPU              
+ ├─ storage_os_disk                                                                                             
+ │  ├─ Storage (S4)                                                   1  months                           $1.54 
+ │  └─ Disk operations                                              100  10k operations                   $0.05 
+ ├─ storage_data_disk                                                                                           
+ │  ├─ Storage (S4)                                                   1  months                           $1.54 
+ │  └─ Disk operations                                              200  10k operations                   $0.10 
+ ├─ storage_data_disk                                                                                           
+ │  ├─ Storage (E4)                                                   1  months                           $2.40 
+ │  └─ Disk operations                                              200  10k operations                   $0.40 
+ ├─ storage_data_disk                                                                                           
+ │  └─ Storage (P4)                                                   1  months                           $5.28 
+ └─ storage_data_disk                                                                                           
+    ├─ Storage (ultra, 1024 GiB)                                  1,024  GiB                            $122.59 
+    ├─ Provisioned IOPS                                           2,048  IOPS                           $101.66 
+    └─ Throughput                                                     8  MB/s                             $2.80 
+                                                                                                                
+ PROJECT TOTAL                                                                                          $385.16 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_scale_set_test/windows_virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_scale_set_test/windows_virtual_machine_scale_set_test.golden
@@ -2,13 +2,13 @@
  Name                                                             Monthly Qty  Unit                      Monthly Cost 
                                                                                                                       
  azurerm_windows_virtual_machine_scale_set.basic_a2                                                                   
- ├─ Instance usage (pay as you go, A2)                                  2,190  hours                          $291.27 
+ ├─ Instance usage (pay as you go, Basic_A2)                            2,190  hours                          $291.27 
  └─ os_disk                                                                                                           
     ├─ Storage (S4)                                                         3  months                           $4.61 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
  azurerm_windows_virtual_machine_scale_set.basic_a2_usage                                                             
- ├─ Instance usage (pay as you go, A2)                                  2,920  hours                          $388.36 
+ ├─ Instance usage (pay as you go, Basic_A2)                            2,920  hours                          $388.36 
  └─ os_disk                                                                                                           
     ├─ Storage (S4)                                                         4  months                           $6.14 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
@@ -1,37 +1,43 @@
 
  Name                                                                  Monthly Qty  Unit                      Monthly Cost 
                                                                                                                            
+ azurerm_windows_virtual_machine.Standard_E16-8as_v4                                                                       
+ ├─ Instance usage (pay as you go, Standard_E16-8as_v4)                        730  hours                        $1,273.12 
+ └─ os_disk                                                                                                                
+    ├─ Storage (S4)                                                              1  months                           $1.54 
+    └─ Disk operations                                          Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                           
  azurerm_windows_virtual_machine.basic_a2                                                                                  
- ├─ Instance usage (pay as you go, A2)                                         730  hours                           $97.09 
+ ├─ Instance usage (pay as you go, Basic_A2)                                   730  hours                           $97.09 
  └─ os_disk                                                                                                                
     ├─ Storage (S4)                                                              1  months                           $1.54 
     └─ Disk operations                                          Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                            
  azurerm_windows_virtual_machine.standard_a2_ultra_enabled                                                                 
- ├─ Instance usage (pay as you go, A2 v2)                                      730  hours                           $99.28 
+ ├─ Instance usage (pay as you go, Standard_A2_v2)                             730  hours                           $99.28 
  ├─ Ultra disk reservation (if unattached)                      Monthly cost depends on usage: $4.38 per vCPU              
  └─ os_disk                                                                                                                
     ├─ Storage (E4)                                                              1  months                           $2.40 
     └─ Disk operations                                          Monthly cost depends on usage: $0.002 per 10k operations   
                                                                                                                            
  azurerm_windows_virtual_machine.standard_a2_v2_custom_disk                                                                
- ├─ Instance usage (pay as you go, A2 v2)                                      730  hours                           $99.28 
+ ├─ Instance usage (pay as you go, Standard_A2_v2)                             730  hours                           $99.28 
  └─ os_disk                                                                                                                
     ├─ Storage (E30)                                                             1  months                          $76.80 
     └─ Disk operations                                                           2  10k operations                   $0.00 
                                                                                                                            
  azurerm_windows_virtual_machine.standard_d2_v4_hybrid_benefit                                                             
- ├─ Instance usage (hybrid benefit, D2 v4)                                     730  hours                           $70.08 
+ ├─ Instance usage (hybrid benefit, Standard_D2_v4)                            730  hours                           $70.08 
  └─ os_disk                                                                                                                
     ├─ Storage (E30)                                                             1  months                          $76.80 
     └─ Disk operations                                          Monthly cost depends on usage: $0.002 per 10k operations   
                                                                                                                            
  azurerm_windows_virtual_machine.standard_f2_premium_disk                                                                  
- ├─ Instance usage (pay as you go, F2)                                         730  hours                          $140.16 
+ ├─ Instance usage (pay as you go, Standard_F2)                                730  hours                          $140.16 
  └─ os_disk                                                                                                                
     └─ Storage (P4)                                                              1  months                           $5.28 
                                                                                                                            
- PROJECT TOTAL                                                                                                     $668.71 
+ PROJECT TOTAL                                                                                                   $1,943.37 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.tf
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.tf
@@ -140,3 +140,30 @@ resource "azurerm_windows_virtual_machine" "standard_a2_ultra_enabled" {
     version   = "latest"
   }
 }
+
+
+resource "azurerm_windows_virtual_machine" "Standard_E16-8as_v4" {
+  name                = "Standard_E16"
+  resource_group_name = "fake_resource_group"
+  location            = "eastus"
+
+  size           = "Standard_E16-8as_v4"
+  admin_username = "fakeuser"
+  admin_password = "fakepass"
+
+  network_interface_ids = [
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic",
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "fake"
+    offer     = "fake"
+    sku       = "fake"
+    version   = "fake"
+  }
+}

--- a/internal/providers/terraform/azure/windows_virtual_machine.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/infracost/infracost/internal/schema"
-
 	"github.com/shopspring/decimal"
 )
 
@@ -59,10 +58,8 @@ func windowsVirtualMachineCostComponent(region string, instanceType string, lice
 		purchaseOptionLabel = "hybrid benefit"
 	}
 
-	skuName := parseVMSKUName(instanceType)
-
 	return &schema.CostComponent{
-		Name:           fmt.Sprintf("Instance usage (%s, %s)", purchaseOptionLabel, skuName),
+		Name:           fmt.Sprintf("Instance usage (%s, %s)", purchaseOptionLabel, instanceType),
 		Unit:           "hours",
 		UnitMultiplier: 1,
 		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
@@ -72,9 +69,9 @@ func windowsVirtualMachineCostComponent(region string, instanceType string, lice
 			Service:       strPtr("Virtual Machines"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "armSkuName", Value: strPtr(instanceType)},
+				{Key: "skuName", ValueRegex: strPtr("/.*(?<!Low Priority|Spot)$/i")},
+				{Key: "armSkuName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", instanceType))},
 				{Key: "productName", ValueRegex: strPtr(productNameRe)},
-				{Key: "skuName", Value: strPtr(skuName)},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{


### PR DESCRIPTION
Terraform supports 396 different VM instance types but Azure's pricing data is missing prices for 4, I can understand promo ones missing prices but not sure why ND40s_v3 doesn’t have prices. We can create a GH issue if a user hits these and ask MS for help.
Standard_ND40s_v3
Standard_NV12_Promo
Standard_NV24_Promo
Standard_NV6_Promo

Fixes #756