### PR TITLE
fix(azure): make Function pricing calcs more robust

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -497,8 +497,8 @@ resource_usage:
   azurerm_function_app.my_functions:
     monthly_executions: 100000 # Monthly executions to the function. Only applicable for Consumption plan.
     execution_duration_ms: 500 # Average duration of each execution in milliseconds. Only applicable for Consumption plan.
-    memory_mb: 128 # Average amount of memory consumed by function in MB. Only applicable for Consumption plan.
-    instances: 2 # Number of instances. Only applicable for Premium plan.
+    memory_mb: 128             # Average amount of memory consumed by function in MB. Only applicable for Consumption plan.
+    instances: 1               # Number of instances. Only applicable for Premium plan.
   
   azurerm_cdn_endpoint.my_endpoint:
     monthly_outbound_gb: 1000000 # Monthly number of outbound data transfers in GB.

--- a/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.tf
+++ b/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.tf
@@ -69,7 +69,7 @@ resource "aws_waf_web_acl" "my_waf" {
     rule_id  = aws_waf_rule.wafrule.id
     type     = "GROUP"
   }
-   rules {
+  rules {
     action {
       type = "BLOCK"
     }
@@ -119,7 +119,7 @@ resource "aws_waf_web_acl" "withoutUsage" {
     rule_id  = aws_waf_rule.wafrule.id
     type     = "GROUP"
   }
-   rules {
+  rules {
     action {
       type = "BLOCK"
     }

--- a/internal/providers/terraform/azure/function_app.go
+++ b/internal/providers/terraform/azure/function_app.go
@@ -1,6 +1,7 @@
 package azure
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/infracost/infracost/internal/schema"
@@ -20,20 +21,25 @@ func GetAzureRMAppFunctionRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMAppFunction(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	var memorySize, instances, executionTime, executions, skuMemory, skuCPU, instMulCPU, instMulMemory, execTimeMulMemorySize *decimal.Decimal
-	var multiplicationForExecTime, multiplicationForCPU, multiplicationForMemory decimal.Decimal
+	// No need to get the default region as location is required
+	region := d.Get("location").String()
 
+	var memorySize, executionTime, executions, gbSeconds *decimal.Decimal
+	var skuCPU *int64
+	var skuMemory *float64
+	var skuTier, skuSize string
 	kind := "Windows"
-	location := d.Get("location").String()
 
 	if u != nil && u.Get("monthly_executions").Type != gjson.Null {
-		executions = decimalPtr(decimal.NewFromFloat(u.Get("monthly_executions").Float()))
+		executions = decimalPtr(decimal.NewFromInt(u.Get("monthly_executions").Int()))
 	}
-	if u != nil && u.Get("execution_duration_ms").Type != gjson.Null && u.Get("memory_mb").Type != gjson.Null {
-		memorySize = decimalPtr(decimal.NewFromFloat(u.Get("memory_mb").Float() / 1000))
-		executionTime = decimalPtr(decimal.NewFromFloat(u.Get("execution_duration_ms").Float() / 1000))
-		multiplicationForExecTime = executionTime.Mul(*memorySize)
-		execTimeMulMemorySize = &multiplicationForExecTime
+	if u != nil && u.Get("execution_duration_ms").Type != gjson.Null &&
+		u.Get("memory_mb").Type != gjson.Null &&
+		executions != nil {
+
+		memorySize = decimalPtr(decimal.NewFromInt(u.Get("memory_mb").Int()))
+		executionTime = decimalPtr(decimal.NewFromInt(u.Get("execution_duration_ms").Int()))
+		gbSeconds = decimalPtr(calculateFunctionAppGBSeconds(*memorySize, *executionTime, *executions))
 	}
 
 	skuMapCPU := map[string]int64{
@@ -48,60 +54,58 @@ func NewAzureRMAppFunction(d *schema.ResourceData, u *schema.UsageData) *schema.
 	}
 
 	appServicePlanID := d.References("app_service_plan_id")
-	skuTier := strings.ToLower(appServicePlanID[0].Get("sku.0.tier").String())
-	skuSize := strings.ToLower(appServicePlanID[0].Get("sku.0.size").String())
 
 	if len(appServicePlanID) > 0 {
+		skuTier = strings.ToLower(appServicePlanID[0].Get("sku.0.tier").String())
+		skuSize = strings.ToLower(appServicePlanID[0].Get("sku.0.size").String())
 		kind = strings.ToLower(appServicePlanID[0].Get("kind").String())
 	}
 
 	if val, ok := skuMapCPU[skuSize]; ok {
-		skuCPU = decimalPtr(decimal.NewFromInt(val))
+		skuCPU = &val
 	}
 	if val, ok := skuMapMemory[skuSize]; ok {
-		skuMemory = decimalPtr(decimal.NewFromFloat(val))
-	}
-	if skuCPU == nil || skuMemory == nil {
-		log.Warnf("Skipping resource %s. Could not find its CPU or Memory from its SKU.", d.Address)
-		return nil
+		skuMemory = &val
 	}
 
+	instances := decimal.NewFromInt(1)
 	if u != nil && u.Get("instances").Type != gjson.Null {
-		instances = decimalPtr(decimal.NewFromFloat(u.Get("instances").Float()))
-		multiplicationForCPU = instances.Mul(*skuCPU)
-		multiplicationForMemory = instances.Mul(*skuMemory)
-		instMulCPU = &multiplicationForCPU
-		instMulMemory = &multiplicationForMemory
+		instances = decimal.NewFromInt(u.Get("instances").Int())
 	}
 
 	costComponents := make([]*schema.CostComponent, 0)
 
-	if kind == "elastic" || skuTier == "elasticpremium" {
-		costComponents = append(costComponents, AppFunctionPremiumCPUCostComponent(instMulCPU, location))
-		costComponents = append(costComponents, AppFunctionPremiumMemoryCostComponent(instMulMemory, location))
-	}
-	if kind == "functionapp" {
-		costComponents = append(costComponents, AppFunctionConsumptionExecutionTimeCostComponent(execTimeMulMemorySize, location))
-		costComponents = append(costComponents, AppFunctionConsumptionExecutionsCostComponent(executions, location))
+	if (kind == "elastic" || skuTier == "elasticpremium") && skuCPU != nil && skuMemory != nil {
+		costComponents = append(costComponents, AppFunctionPremiumCPUCostComponent(skuSize, instances, skuCPU, region))
+		costComponents = append(costComponents, AppFunctionPremiumMemoryCostComponent(skuSize, instances, skuMemory, region))
+	} else {
+		if kind == "functionapp" || gbSeconds != nil {
+			costComponents = append(costComponents, AppFunctionConsumptionExecutionTimeCostComponent(gbSeconds, region))
+		}
+		if kind == "functionapp" || executions != nil {
+			costComponents = append(costComponents, AppFunctionConsumptionExecutionsCostComponent(executions, region))
+		}
 	}
 
-	return &schema.Resource{
-		Name:           d.Address,
-		CostComponents: costComponents,
+	if len(costComponents) > 1 {
+		return &schema.Resource{
+			Name:           d.Address,
+			CostComponents: costComponents,
+		}
 	}
+	log.Warnf("Skipping resource %s. Could not find a way to get its cost components from the resource or usage file.", d.Address)
+	return nil
 }
 
-func AppFunctionPremiumCPUCostComponent(instMulCPU *decimal.Decimal, location string) *schema.CostComponent {
-
+func AppFunctionPremiumCPUCostComponent(skuSize string, instances decimal.Decimal, skuCPU *int64, region string) *schema.CostComponent {
 	return &schema.CostComponent{
-
-		Name:           "vCPU",
-		Unit:           "vCPU-hours",
-		UnitMultiplier: 1,
-		HourlyQuantity: instMulCPU,
+		Name:           fmt.Sprintf("vCPU (%s)", strings.ToUpper(skuSize)),
+		Unit:           "vCPU",
+		UnitMultiplier: schema.HourToMonthUnitMultiplier,
+		HourlyQuantity: decimalPtr(instances.Mul(decimal.NewFromInt(*skuCPU))),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("azure"),
-			Region:        strPtr(location),
+			Region:        strPtr(region),
 			Service:       strPtr("Functions"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
@@ -112,18 +116,17 @@ func AppFunctionPremiumCPUCostComponent(instMulCPU *decimal.Decimal, location st
 			PurchaseOption: strPtr("Consumption"),
 		},
 	}
-
 }
-func AppFunctionPremiumMemoryCostComponent(instMulMemory *decimal.Decimal, location string) *schema.CostComponent {
-	return &schema.CostComponent{
 
-		Name:           "Memory",
-		Unit:           "GB-hours",
-		UnitMultiplier: 1,
-		HourlyQuantity: instMulMemory,
+func AppFunctionPremiumMemoryCostComponent(skuSize string, instances decimal.Decimal, skuMemory *float64, region string) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("Memory (%s)", strings.ToUpper(skuSize)),
+		Unit:           "GB",
+		UnitMultiplier: schema.HourToMonthUnitMultiplier,
+		HourlyQuantity: decimalPtr(instances.Mul(decimal.NewFromFloat(*skuMemory))),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("azure"),
-			Region:        strPtr(location),
+			Region:        strPtr(region),
 			Service:       strPtr("Functions"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
@@ -135,16 +138,16 @@ func AppFunctionPremiumMemoryCostComponent(instMulMemory *decimal.Decimal, locat
 		},
 	}
 }
-func AppFunctionConsumptionExecutionTimeCostComponent(execTimeMulMemorySize *decimal.Decimal, location string) *schema.CostComponent {
-	return &schema.CostComponent{
 
-		Name:           "Execution time",
-		Unit:           "GB-Seconds",
-		UnitMultiplier: 1,
-		HourlyQuantity: execTimeMulMemorySize,
+func AppFunctionConsumptionExecutionTimeCostComponent(gbSeconds *decimal.Decimal, region string) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Execution time",
+		Unit:            "GB-seconds",
+		UnitMultiplier:  1,
+		MonthlyQuantity: gbSeconds,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("azure"),
-			Region:        strPtr(location),
+			Region:        strPtr(region),
 			Service:       strPtr("Functions"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
@@ -158,16 +161,21 @@ func AppFunctionConsumptionExecutionTimeCostComponent(execTimeMulMemorySize *dec
 		},
 	}
 }
-func AppFunctionConsumptionExecutionsCostComponent(executions *decimal.Decimal, location string) *schema.CostComponent {
-	return &schema.CostComponent{
 
+func AppFunctionConsumptionExecutionsCostComponent(executions *decimal.Decimal, region string) *schema.CostComponent {
+	// Azure's pricing API returns prices per 10 executions so if the user has provided the number of executions, we should divide it by 10
+	if executions != nil {
+		executions = decimalPtr(executions.Div(decimal.NewFromInt(10)))
+	}
+
+	return &schema.CostComponent{
 		Name:            "Executions",
 		Unit:            "1M requests",
 		UnitMultiplier:  100000,
 		MonthlyQuantity: executions,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("azure"),
-			Region:        strPtr(location),
+			Region:        strPtr(region),
 			Service:       strPtr("Functions"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
@@ -180,4 +188,19 @@ func AppFunctionConsumptionExecutionsCostComponent(executions *decimal.Decimal, 
 			StartUsageAmount: strPtr("100000"),
 		},
 	}
+}
+
+func calculateFunctionAppGBSeconds(memorySize decimal.Decimal, averageRequestDuration decimal.Decimal, monthlyRequests decimal.Decimal) decimal.Decimal {
+	// Use a min of 128MB, and round-up to nearest 128MB
+	if memorySize.LessThan(decimal.NewFromInt(128)) {
+		memorySize = decimal.NewFromInt(128)
+	}
+	roundedMemory := memorySize.Div(decimal.NewFromInt(128)).Ceil().Mul(decimal.NewFromInt(128))
+	// Apply the minimum request duration
+	if averageRequestDuration.LessThan(decimal.NewFromInt(100)) {
+		averageRequestDuration = decimal.NewFromInt(100)
+	}
+	durationSeconds := monthlyRequests.Mul(averageRequestDuration).Mul(decimal.NewFromFloat(0.001))
+	gbSeconds := durationSeconds.Mul(roundedMemory).Div(decimal.NewFromInt(1024))
+	return gbSeconds
 }

--- a/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
+++ b/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
@@ -1,27 +1,52 @@
 
- Name                                      Monthly Qty  Unit                    Monthly Cost 
-                                                                                             
- azurerm_function_app.my_functions                                                           
- ├─ vCPU                                         2,920  vCPU-hours                   $505.16 
- └─ Memory                                      10,220  GB-hours                     $125.71 
-                                                                                             
- azurerm_function_app.my_functions1                                                          
- ├─ Execution time                               46.72  GB-Seconds                     $0.00 
- └─ Executions                                       1  1M requests                    $0.20 
-                                                                                             
- azurerm_function_app.my_functions2                                                          
- ├─ vCPU                             Monthly cost depends on usage: $0.17 per vCPU-hours     
- └─ Memory                           Monthly cost depends on usage: $0.0123 per GB-hours     
-                                                                                             
- azurerm_function_app.my_functions3                                                          
- ├─ Execution time                   Monthly cost depends on usage: $0.000016 per GB-Seconds 
- └─ Executions                       Monthly cost depends on usage: $0.20 per 1M requests    
-                                                                                             
- PROJECT TOTAL                                                                       $631.07 
+ Name                                                                     Monthly Qty  Unit                    Monthly Cost 
+                                                                                                                            
+ azurerm_function_app.elasticFunction                                                                                       
+ ├─ vCPU (EP2)                                                                      2  vCPU                         $252.58 
+ └─ Memory (EP2)                                                                    7  GB                            $62.85 
+                                                                                                                            
+ azurerm_function_app.elasticFunctionWithUsage                                                                              
+ ├─ vCPU (EP2)                                                                      4  vCPU                         $505.16 
+ └─ Memory (EP2)                                                                   14  GB                           $125.71 
+                                                                                                                            
+ azurerm_function_app.elasticFunctionWithZeroInstances                                                                      
+ ├─ vCPU (EP2)                                                                      0  vCPU                           $0.00 
+ └─ Memory (EP2)                                                                    0  GB                             $0.00 
+                                                                                                                            
+ azurerm_function_app.elasticPremiumFunction                                                                                
+ ├─ vCPU (EP1)                                                                      1  vCPU                         $126.29 
+ └─ Memory (EP1)                                                                  3.5  GB                            $31.43 
+                                                                                                                            
+ azurerm_function_app.functionApp                                                                                           
+ ├─ Execution time                                                  Monthly cost depends on usage: $0.000016 per GB-seconds 
+ └─ Executions                                                      Monthly cost depends on usage: $0.20 per 1M requests    
+                                                                                                                            
+ azurerm_function_app.functionAppNoAvailableServicePlanButHasUsage                                                          
+ ├─ Execution time                                                       876,180.4425  GB-seconds                    $14.02 
+ └─ Executions                                                                 3.5401  1M requests                    $0.71 
+                                                                                                                            
+ azurerm_function_app.functionAppWithAllUsage                                                                               
+ ├─ Execution time                                                       876,180.4425  GB-seconds                    $14.02 
+ └─ Executions                                                                 3.5401  1M requests                    $0.71 
+                                                                                                                            
+ azurerm_function_app.functionAppWithLessThanMins                                                                           
+ ├─ Execution time                                                             37,500  GB-seconds                     $0.60 
+ └─ Executions                                                                      3  1M requests                    $0.60 
+                                                                                                                            
+ azurerm_function_app.functionAppWithMissingExecutions                                                                      
+ ├─ Execution time                                                  Monthly cost depends on usage: $0.000016 per GB-seconds 
+ └─ Executions                                                      Monthly cost depends on usage: $0.20 per 1M requests    
+                                                                                                                            
+ azurerm_function_app.functionAppWithOnlyExecutions                                                                         
+ ├─ Execution time                                                  Monthly cost depends on usage: $0.000016 per GB-seconds 
+ └─ Executions                                                                    0.1  1M requests                    $0.02 
+                                                                                                                            
+ PROJECT TOTAL                                                                                                    $1,134.69 
 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
 
-1 resource type wasn't estimated as it's not supported yet.
+2 resource types weren't estimated as they're not supported yet.
 Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+1 x azurerm_function_app
 1 x azurerm_storage_account

--- a/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.tf
+++ b/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.tf
@@ -20,6 +20,21 @@ resource "azurerm_app_service_plan" "elastic" {
     capacity = 1
   }
 }
+
+resource "azurerm_app_service_plan" "elasticPremium" {
+  name                = "api-appserviceplan-elasticPremium"
+  location            = azurerm_resource_group.example1.location
+  resource_group_name = azurerm_resource_group.example1.name
+  kind                = "elastic"
+  reserved            = false
+
+  sku {
+    tier     = "ElasticPremium"
+    size     = "EP1"
+    capacity = 1
+  }
+}
+
 resource "azurerm_app_service_plan" "funcApp" {
   name                = "api-appserviceplan-pro"
   location            = azurerm_resource_group.example1.location
@@ -41,35 +56,99 @@ resource "azurerm_storage_account" "example" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
-resource "azurerm_function_app" "my_functions" {
-  name                       = "test-azure-functions"
+
+resource "azurerm_function_app" "elasticFunction" {
+  name                       = "elasticFunction"
   location                   = azurerm_resource_group.example1.location
   resource_group_name        = azurerm_resource_group.example1.name
   app_service_plan_id        = azurerm_app_service_plan.elastic.id
   storage_account_name       = azurerm_storage_account.example.name
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
 }
-resource "azurerm_function_app" "my_functions1" {
-  name                       = "test-azure-functions"
-  location                   = azurerm_resource_group.example1.location
-  resource_group_name        = azurerm_resource_group.example1.name
-  app_service_plan_id        = azurerm_app_service_plan.funcApp.id
-  storage_account_name       = azurerm_storage_account.example.name
-  storage_account_access_key = azurerm_storage_account.example.primary_access_key
-}
-resource "azurerm_function_app" "my_functions2" {
-  name                       = "test-azure-functions"
+resource "azurerm_function_app" "elasticFunctionWithUsage" {
+  name                       = "elasticFunctionWithUsage"
   location                   = azurerm_resource_group.example1.location
   resource_group_name        = azurerm_resource_group.example1.name
   app_service_plan_id        = azurerm_app_service_plan.elastic.id
   storage_account_name       = azurerm_storage_account.example.name
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
 }
-resource "azurerm_function_app" "my_functions3" {
-  name                       = "test-azure-functions"
+resource "azurerm_function_app" "elasticFunctionWithZeroInstances" {
+  name                       = "elasticFunctionWithZeroInstances"
+  location                   = azurerm_resource_group.example1.location
+  resource_group_name        = azurerm_resource_group.example1.name
+  app_service_plan_id        = azurerm_app_service_plan.elastic.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+resource "azurerm_function_app" "elasticPremiumFunction" {
+  name                       = "elasticPremiumFunction"
+  location                   = azurerm_resource_group.example1.location
+  resource_group_name        = azurerm_resource_group.example1.name
+  app_service_plan_id        = azurerm_app_service_plan.elasticPremium.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+
+resource "azurerm_function_app" "functionApp" {
+  name                       = "functionApp"
   location                   = azurerm_resource_group.example1.location
   resource_group_name        = azurerm_resource_group.example1.name
   app_service_plan_id        = azurerm_app_service_plan.funcApp.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+
+resource "azurerm_function_app" "functionAppWithAllUsage" {
+  name                       = "functionAppWithAllUsage"
+  location                   = azurerm_resource_group.example1.location
+  resource_group_name        = azurerm_resource_group.example1.name
+  app_service_plan_id        = azurerm_app_service_plan.funcApp.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+
+resource "azurerm_function_app" "functionAppWithLessThanMins" {
+  name                       = "functionAppWithLessThanMins"
+  location                   = azurerm_resource_group.example1.location
+  resource_group_name        = azurerm_resource_group.example1.name
+  app_service_plan_id        = azurerm_app_service_plan.funcApp.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+
+resource "azurerm_function_app" "functionAppWithOnlyExecutions" {
+  name                       = "functionAppWithOnlyExecutions"
+  location                   = azurerm_resource_group.example1.location
+  resource_group_name        = azurerm_resource_group.example1.name
+  app_service_plan_id        = azurerm_app_service_plan.funcApp.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+
+resource "azurerm_function_app" "functionAppWithMissingExecutions" {
+  name                       = "functionAppWithMissingExecutions"
+  location                   = azurerm_resource_group.example1.location
+  resource_group_name        = azurerm_resource_group.example1.name
+  app_service_plan_id        = azurerm_app_service_plan.funcApp.id
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+
+resource "azurerm_function_app" "functionAppNoAvailableServicePlan" {
+  name                       = "functionAppNoAvailableServicePlan"
+  location                   = azurerm_resource_group.example1.location
+  resource_group_name        = azurerm_resource_group.example1.name
+  app_service_plan_id        = "in_another_module"
+  storage_account_name       = azurerm_storage_account.example.name
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+}
+
+resource "azurerm_function_app" "functionAppNoAvailableServicePlanButHasUsage" {
+  name                       = "functionAppNoAvailableServicePlanButHasUsage"
+  location                   = azurerm_resource_group.example1.location
+  resource_group_name        = azurerm_resource_group.example1.name
+  app_service_plan_id        = "in_another_module"
   storage_account_name       = azurerm_storage_account.example.name
   storage_account_access_key = azurerm_storage_account.example.primary_access_key
 }

--- a/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.usage.yml
@@ -1,13 +1,30 @@
 version: 0.1
 resource_usage:
-    azurerm_function_app.my_functions:
-        monthly_executions: 100000 
-        execution_duration_ms: 500 
-        memory_mb: 128 
-        instances: 2 
-
-    azurerm_function_app.my_functions1:
-        monthly_executions: 100000 
-        execution_duration_ms: 500 
-        memory_mb: 128 
+    azurerm_function_app.elasticFunctionWithUsage:
         instances: 2
+
+    azurerm_function_app.elasticFunctionWithZeroInstances:
+        instances: 0
+
+    azurerm_function_app.functionAppWithAllUsage:
+        monthly_executions: 3_540_123 
+        execution_duration_ms: 495 
+        memory_mb: 490
+        instances: 0
+
+    azurerm_function_app.functionAppNoAvailableServicePlanButHasUsage:
+        monthly_executions: 3_540_123
+        execution_duration_ms: 495
+        memory_mb: 490
+
+    azurerm_function_app.functionAppWithLessThanMins:
+        monthly_executions: 3_000_000
+        execution_duration_ms: 50 
+        memory_mb: 10
+       
+    azurerm_function_app.functionAppWithOnlyExecutions:
+        monthly_executions: 100000 
+
+    azurerm_function_app.functionAppWithMissingExecutions:
+        execution_duration_ms: 500
+        memory_mb: 128


### PR DESCRIPTION
- Handle azurerm_app_service_plan being unavailable by falling back to
any available usage file params
- fix bug in gbSecond calculation
- fix bug in Executions cost calc as the Azure pricing API returns
the price per 10 units

Fixes #757