### PR TITLE
feat(cli): don’t use faint colors for “cost depends on usage” lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,10 +481,10 @@ The following notes are general guidelines, please leave a comment in your pull 
 	docker build --no-cache -t infracost/infracost-atlantis:latest .
 	docker push infracost/infracost-atlantis:latest
 	```
-
-6. Wait for the [infracost brew PR](https://github.com/Homebrew/homebrew-core/pulls?q=infracost) to be merged.
-7. Announce the release in the infracost-community Slack announcements channel.
-8. Update the docs repo with any required changes and supported resources.
-9. Close addressed issues and tag anyone who liked/commented in them to tell them it's live in version X.
+6. Update the [Infracost API](https://www.infracost.io/docs/integrations/infracost_api) to use the latest version.
+7. Wait for the [infracost brew PR](https://github.com/Homebrew/homebrew-core/pulls?q=infracost) to be merged.
+8. Announce the release in the infracost-community Slack announcements channel.
+9. Update the docs repo with any required changes and supported resources.
+10. Close addressed issues and tag anyone who liked/commented in them to tell them it's live in version X.
 
 If a new flag/feature is added that requires CI support, update the repos mentioned [here](https://github.com/infracost/infracost/tree/master/scripts/ci#infracost-ci-scripts). For the GitHub Action, a new tag is needed and the release should be published on the GitHub Marketplace. For the CircleCI orb, the readme mentions the commit prefix that triggers releases to the CircleCI orb marketplace.

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -202,7 +202,7 @@ func costComponentToDiff(diffComponent CostComponent, oldComponent *CostComponen
 
 	if oldCost == nil && newCost == nil {
 		s += "  Monthly cost depends on usage\n"
-		s += ui.FaintStringf("    %s per %s%s\n",
+		s += fmt.Sprintf("    %s per %s%s\n",
 			formatPriceChange(diffComponent.Price),
 			diffComponent.Unit,
 			formatPriceChangeDetails(oldPrice, newPrice),

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -218,9 +218,9 @@ func buildCostComponentRows(t table.Writer, costComponents []CostComponent, pref
 
 			t.AppendRow(table.Row{
 				label,
-				ui.FaintString(price),
-				ui.FaintString(price),
-				ui.FaintString(price),
+				price,
+				price,
+				price,
 			}, table.RowConfig{AutoMerge: true, AlignAutoMerge: text.AlignLeft})
 		} else {
 			var tableRow table.Row


### PR DESCRIPTION
This was making it hard to read on some terminals and given it was the
most useful data we show for these lines, it seemed better to unfaint it.

before:
![before](https://user-images.githubusercontent.com/638577/120559141-69d7fb00-c3f8-11eb-838d-9c17571a0d91.png)
after:
![after](https://user-images.githubusercontent.com/638577/120559145-6ba1be80-c3f8-11eb-9e21-ee92b20634d6.png)
