### PR TITLE
feat(ci): add MVP of posting a comment to Slack webhook URLs

### DIFF
--- a/scripts/ci/diff.sh
+++ b/scripts/ci/diff.sh
@@ -227,6 +227,14 @@ post_to_azure_devops () {
   fi
 }
 
+post_to_slack () {
+  echo "Posting comment to Slack"
+  msg="$(build_msg false)"
+  jq -Mnc --arg msg "$msg" '{"text": "\($msg)"}' | curl -L -X POST -d @- \
+    -H "Content-Type: application/json" \
+    "$SLACK_WEBHOOK_URL"
+}
+
 load_github_env () {
   export VCS_REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY
 }
@@ -325,6 +333,10 @@ elif [ ! -z "$BITBUCKET_PIPELINES" ]; then
   post_to_bitbucket
 elif [ ! -z "$SYSTEM_COLLECTIONURI" ]; then
   post_to_azure_devops
+fi
+
+if [ ! -z "$SLACK_WEBHOOK_URL" ]; then
+  post_to_slack
 fi
 
 cleanup


### PR DESCRIPTION
This is just an MVP. There’s a lot more we can do, e.g. add the repo URL and improve the formatting. Here's what the output looks like:

![Screen Shot 2021-06-07 at 10 51 20 AM](https://user-images.githubusercontent.com/638577/120996534-502f0e80-c77e-11eb-913c-f81e555b3119.png)
