### PR TITLE
chore: make the resource_group_name explicit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,7 +473,24 @@ The following notes are general guidelines, please leave a comment in your pull 
 
 > **Note:** Developing Azure resources requires Azure creds. See below for details.
 
-- Unless the resource has global or zone-based pricing, the first line of the resource function should be `region := lookupRegion(d, []string{})` where the second parameter is an optional list of parent resources where the region can be found. Search the code for `lookupRegion` to find examples of how this method is used in other Azure resources. The `resource_group_name` parameter does not need to be passed into `lookupRegion` as it is automatically checked.
+- Unless the resource has global or zone-based pricing, the first line of the resource function should be `region := lookupRegion(d, []string{})` where the second parameter is an optional list of parent resources where the region can be found. See the following examples of how this method is used in other Azure resources.
+	```go
+	func GetAzureRMAppServiceCertificateBindingRegistryItem() *schema.RegistryItem {
+		return &schema.RegistryItem{
+			Name:  "azurerm_app_service_certificate_binding",
+			RFunc: NewAzureRMAppServiceCertificateBinding,
+			ReferenceAttributes: []string{
+				"certificate_id",
+				"resource_group_name",
+			},
+		}
+	}
+
+	func NewAzureRMAppServiceCertificateBinding(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+		region := lookupRegion(d, []string{"certificate_id", "resource_group_name"})
+		...
+	}
+	```
 
 - The Azure Terraform provider requires real credentials to be able to run `terraform plan`. This means you must have Azure credentials for running the Infracost commands and integration tests for Azure. We recommend creating read-only Azure credentials for this purpose. If you have an Azure subscription, you can do this by running the `az` command line:
 	```sh

--- a/internal/providers/terraform/azure/util.go
+++ b/internal/providers/terraform/azure/util.go
@@ -30,14 +30,6 @@ func lookupRegion(d *schema.ResourceData, parentResourceKeys []string) string {
 		}
 	}
 
-	// Then check for a resource group
-	groups := d.References("resource_group_name")
-	for _, g := range groups {
-		if g.Get("location").String() != "" {
-			return g.Get("location").String()
-		}
-	}
-
 	// When all else fails use the default region
 	defaultRegion := d.Get("region").String()
 	log.Warnf("Using %s for resource %s as its 'location' property could not be found.", defaultRegion, d.Address)


### PR DESCRIPTION
This makes it clear where the region is being checked from and in what order.
Otherwise, it’s easy to forget to including resource_group_name in ReferenceAttributes.

@tim775 / @aliscott any thoughts on this? It came up when I was reviewing https://github.com/infracost/infracost/pull/787/files and https://github.com/infracost/infracost/pull/789/files