### PR TITLE
feat(aws): Add support for AWS Backup resource

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -54,6 +54,20 @@ resource_usage:
     monthly_cpu_credit_hrs: 350 # Number of hours in the month where the instance is expected to burst.
     vcpu_count: 2 # Number of the vCPUs for the instance type.
 
+  aws_backup_vault.usage:
+    monthly_efs_warm_restore_gb: 10000 # Monthly number of EFS warm restore in GB. 
+    monthly_efs_cold_restore_gb: 10000 # Monthly number of EFS cold restore in GB. 
+    monthly_efs_item_restore_requests: 10000 # Monthly number of EFS item-level restore requests. 
+    monthly_efs_warm_backup_gb: 10000 # Monthly number of EFS warm backup in GB. 
+    monthly_efs_cold_backup_gb: 10000 # Monthly number of EFS cold backup in GB. 
+    monthly_ebs_snapshot_gb: 10000 # Monthly number of EFS cold backup in GB.
+    monthly_rds_snapshot_gb: 10000
+    monthly_aurora_snapshot_gb: 10000
+    monthly_dynamodb_backup_gb: 10000
+    monthly_dynamodb_restore_gb: 10000
+    monthly_fsx_windows_backup_gb: 10000
+    monthly_fsx_lustre_backup_gb: 10000
+
   aws_cloudformation_stack.my_formation:
     monthly_handler_operations: 10000 # Monthly number of non-free handler operations (resources outside of the AWS::*, Alexa::*, and Custom::* namespaces).
     monthly_duration_secs: 0 # Monthly duration of non-free handler operations that go above 30 seconds, in seconds.  

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -58,15 +58,15 @@ resource_usage:
     monthly_efs_warm_restore_gb: 10000 # Monthly number of EFS warm restore in GB. 
     monthly_efs_cold_restore_gb: 10000 # Monthly number of EFS cold restore in GB. 
     monthly_efs_item_restore_requests: 10000 # Monthly number of EFS item-level restore requests. 
-    monthly_efs_warm_backup_gb: 10000 # Monthly number of EFS warm backup in GB. 
-    monthly_efs_cold_backup_gb: 10000 # Monthly number of EFS cold backup in GB. 
-    monthly_ebs_snapshot_gb: 10000 # Monthly number of EFS cold backup in GB.
-    monthly_rds_snapshot_gb: 10000
-    monthly_aurora_snapshot_gb: 10000
-    monthly_dynamodb_backup_gb: 10000
-    monthly_dynamodb_restore_gb: 10000
-    monthly_fsx_windows_backup_gb: 10000
-    monthly_fsx_lustre_backup_gb: 10000
+    monthly_efs_warm_backup_gb: 10000 # Monthly number of EFS warm backups in GB. 
+    monthly_efs_cold_backup_gb: 10000 # Monthly number of EFS cold backups in GB. 
+    monthly_ebs_snapshot_gb: 10000 # Monthly number of EBS snapshots in GB.
+    monthly_rds_snapshot_gb: 10000 # Monthly number of RDS snapshots in GB.
+    monthly_aurora_snapshot_gb: 10000 # Monthly number of Aurora snapshots in GB.
+    monthly_dynamodb_backup_gb: 10000 # Monthly number of DynamoDB backups in GB.
+    monthly_dynamodb_restore_gb: 10000 # Monthly number of DynamoDB restore in GB.
+    monthly_fsx_windows_backup_gb: 10000 # Monthly number of FSX Windows backups in GB.
+    monthly_fsx_lustre_backup_gb: 10000 # Monthly number of FSX Lustre backups in GB.
 
   aws_cloudformation_stack.my_formation:
     monthly_handler_operations: 10000 # Monthly number of non-free handler operations (resources outside of the AWS::*, Alexa::*, and Custom::* namespaces).

--- a/internal/providers/terraform/aws/backup_vault.go
+++ b/internal/providers/terraform/aws/backup_vault.go
@@ -12,6 +12,7 @@ func GetBackupVaultRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_backup_vault",
 		RFunc: NewBackupVault,
+		Notes: []string{"AWS Storage Gateway Volume Backup prices could not be found in the AWS pricing data."},
 	}
 }
 
@@ -41,7 +42,6 @@ func NewBackupVault(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		{ref: "monthly_rds_snapshot_gb", name: "RDS snapshot", unit: "GB", usageType: "RDS:ChargedBackupUsage", service: "AmazonRDS", family: "Storage Snapshot"},
 		{ref: "monthly_dynamodb_backup_gb", name: "DynamoDB backup", unit: "GB", usageType: "TimedBackupStorage-ByteHrs", service: "AmazonDynamoDB", family: "Amazon DynamoDB On-Demand Backup Storage"},
 		{ref: "monthly_dynamodb_restore_gb", name: "DynamoDB restore", unit: "GB", usageType: "RestoreDataSize-Bytes", service: "AmazonDynamoDB", family: "Amazon DynamoDB Restore Data Size"},
-		//	{ref: "monthly_storage_gateway_backup_gb", name: "Storage gateway backup", unit: "GB", usageType: "", service: "", family: ""},
 	}
 
 	for _, d := range data {

--- a/internal/providers/terraform/aws/backup_vault.go
+++ b/internal/providers/terraform/aws/backup_vault.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+	"github.com/tidwall/gjson"
+)
+
+func GetBackupVaultRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_backup_vault",
+		RFunc: NewBackupVault,
+	}
+}
+
+type backupData struct {
+	ref       string
+	name      string
+	unit      string
+	usageType string
+	service   string
+	family    string
+	key       string
+	value     string
+	qty       *decimal.Decimal
+}
+
+func NewBackupVault(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+	costComponents := []*schema.CostComponent{}
+
+	data := []backupData{
+		{ref: "monthly_efs_warm_backup_gb", name: "EFS backup (warm)", unit: "GB", usageType: "WarmStorage-ByteHrs-EFS", service: "AWSBackup", family: "AWS Backup Storage"},
+		{ref: "monthly_efs_cold_backup_gb", name: "EFS backup (cold)", unit: "GB", usageType: "EarlyDelete-ColdByteHrs-EFS", service: "AWSBackup", family: "AWS Backup Early Delete Size"},
+		{ref: "monthly_efs_warm_restore_gb", name: "EFS restore (warm)", unit: "GB", usageType: "PartialRestore-Warm-EFS", service: "AWSBackup", family: "AWS Backup Storage"},
+		{ref: "monthly_efs_cold_restore_gb", name: "EFS restore (cold)", unit: "GB", usageType: "PartialRestore-Cold-EFS", service: "AWSBackup", family: "AWS Backup Storage"},
+		{ref: "monthly_efs_item_restore_requests", name: "EFS restore (item-level)", unit: "requests", usageType: "PartialRestore-Jobs-EFS", service: "AWSBackup", family: "AWS Backup Storage"},
+		{ref: "monthly_ebs_snapshot_gb", name: "EBS snapshot", unit: "GB", usageType: "EBS:SnapshotUsage$", service: "AmazonEC2", family: "Storage Snapshot"},
+		{ref: "monthly_rds_snapshot_gb", name: "RDS snapshot", unit: "GB", usageType: "RDS:ChargedBackupUsage", service: "AmazonRDS", family: "Storage Snapshot"},
+		{ref: "monthly_dynamodb_backup_gb", name: "DynamoDB backup", unit: "GB", usageType: "TimedBackupStorage-ByteHrs", service: "AmazonDynamoDB", family: "Amazon DynamoDB On-Demand Backup Storage"},
+		{ref: "monthly_dynamodb_restore_gb", name: "DynamoDB restore", unit: "GB", usageType: "RestoreDataSize-Bytes", service: "AmazonDynamoDB", family: "Amazon DynamoDB Restore Data Size"},
+		//	{ref: "monthly_storage_gateway_backup_gb", name: "Storage gateway backup", unit: "GB", usageType: "", service: "", family: ""},
+	}
+
+	for _, d := range data {
+		if u != nil && u.Get(d.ref).Type != gjson.Null {
+			d.qty = decimalPtr(decimal.NewFromInt(u.Get(d.ref).Int()))
+		}
+
+		costComponents = append(costComponents, backupVaultCostComponent(region, d))
+	}
+
+	additData := []backupData{
+		{ref: "monthly_aurora_snapshot_gb", name: "Aurora snapshot", unit: "GB",
+			usageType: "Aurora:BackupUsage", service: "AmazonRDS", family: "Storage Snapshot", key: "databaseEngine", value: "Aurora PostgreSQL"}, // Prices of PostgreSQL and MySQL are equals for all regions.
+
+		{ref: "monthly_fsx_windows_backup_gb", name: "FSx for windows backup", unit: "GB", usageType: "BackupUsage", service: "AmazonFSx", family: "Storage",
+			key: "fileSystemType", value: "Lustre"},
+
+		{ref: "monthly_fsx_lustre_backup_gb", name: "FSx for lustre backup", unit: "GB", usageType: "BackupUsage", service: "AmazonFSx", family: "Storage",
+			key: "fileSystemType", value: "Lustre"}, // Prices for Windows/Lustre backup are equals for all regions.
+	}
+
+	for _, d := range additData {
+		if u != nil && u.Get(d.ref).Type != gjson.Null {
+			d.qty = decimalPtr(decimal.NewFromInt(u.Get(d.ref).Int()))
+		}
+
+		costComponents = append(costComponents, additionalBackupVaultCostComponent(region, d))
+	}
+
+	return &schema.Resource{
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}
+
+func backupVaultCostComponent(region string, d backupData) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            d.name,
+		Unit:            d.unit,
+		UnitMultiplier:  1,
+		MonthlyQuantity: d.qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr(d.service),
+			ProductFamily: strPtr(d.family),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", d.usageType))},
+			},
+		},
+	}
+}
+
+func additionalBackupVaultCostComponent(region string, d backupData) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            d.name,
+		Unit:            d.unit,
+		UnitMultiplier:  1,
+		MonthlyQuantity: d.qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr(d.service),
+			ProductFamily: strPtr(d.family),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", d.usageType))},
+				{Key: d.key, Value: strPtr(d.value)},
+			},
+		},
+	}
+}

--- a/internal/providers/terraform/aws/backup_vault_test.go
+++ b/internal/providers/terraform/aws/backup_vault_test.go
@@ -1,0 +1,16 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestBackupVault(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "backup_vault_test")
+}

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -124,6 +124,14 @@ var FreeResources []string = []string{
 	"aws_apigatewayv2_stage",
 	"aws_apigatewayv2_vpc_link",
 
+	// AWS Backup
+	"aws_backup_global_settings",
+	"aws_backup_plan",
+	"aws_backup_region_settings",
+	"aws_backup_selection",
+	"aws_backup_vault_notifications",
+	"aws_backup_vault_policy",
+
 	// AWS DX Transit.
 	"aws_dx_bgp_peer",
 	"aws_dx_gateway",

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -9,6 +9,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAutoscalingGroupRegistryItem(),
 	GetACMCertificate(),
 	GetACMPCACertificateAuthorityRegistryItem(),
+	GetBackupVaultRegistryItem(),
 	GetCloudFormationStackRegistryItem(),
 	GetCloudFormationStackSetRegistryItem(),
 	GetCloudfrontDistributionRegistryItem(),

--- a/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.golden
+++ b/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.golden
@@ -1,0 +1,34 @@
+
+ Name                             Monthly Qty  Unit                Monthly Cost 
+                                                                                
+ aws_backup_vault.non_usage                                                     
+ ├─ EFS backup (warm)         Monthly cost depends on usage: $0.06 per GB       
+ ├─ EFS backup (cold)         Monthly cost depends on usage: $0.012 per GB      
+ ├─ EFS restore (warm)        Monthly cost depends on usage: $0.024 per GB      
+ ├─ EFS restore (cold)        Monthly cost depends on usage: $0.036 per GB      
+ ├─ EFS restore (item-level)  Monthly cost depends on usage: $0.60 per requests 
+ ├─ EBS snapshot              Monthly cost depends on usage: $0.055 per GB      
+ ├─ RDS snapshot              Monthly cost depends on usage: $0.095 per GB      
+ ├─ DynamoDB backup           Monthly cost depends on usage: $0.11 per GB       
+ ├─ DynamoDB restore          Monthly cost depends on usage: $0.17 per GB       
+ ├─ Aurora snapshot           Monthly cost depends on usage: $0.024 per GB      
+ ├─ FSx for windows backup    Monthly cost depends on usage: $0.055 per GB      
+ └─ FSx for lustre backup     Monthly cost depends on usage: $0.055 per GB      
+                                                                                
+ aws_backup_vault.usage                                                         
+ ├─ EFS backup (warm)                  10,000  GB                       $600.00 
+ ├─ EFS backup (cold)                  10,000  GB                       $120.00 
+ ├─ EFS restore (warm)                 10,000  GB                       $240.00 
+ ├─ EFS restore (cold)                 10,000  GB                       $360.00 
+ ├─ EFS restore (item-level)           10,000  requests               $6,000.00 
+ ├─ EBS snapshot                       10,000  GB                       $550.00 
+ ├─ RDS snapshot                       10,000  GB                       $950.00 
+ ├─ DynamoDB backup                    10,000  GB                     $1,120.00 
+ ├─ DynamoDB restore                   10,000  GB                     $1,680.00 
+ ├─ Aurora snapshot                    10,000  GB                       $240.00 
+ ├─ FSx for windows backup             10,000  GB                       $550.00 
+ └─ FSx for lustre backup              10,000  GB                       $550.00 
+                                                                                
+ OVERALL TOTAL                                                       $12,960.00 
+----------------------------------
+To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.tf
+++ b/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  region                      = "us-west-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_backup_vault" "usage" {
+  name = "aws_backup_vault"
+}
+
+resource "aws_backup_vault" "non_usage" {
+  name = "aws_backup_vault"
+}

--- a/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.usage.yml
@@ -1,0 +1,15 @@
+version: 0.1
+resource_usage: 
+  aws_backup_vault.usage:
+    monthly_efs_warm_restore_gb: 10000
+    monthly_efs_cold_restore_gb: 10000
+    monthly_efs_warm_backup_gb: 10000
+    monthly_efs_cold_backup_gb: 10000
+    monthly_efs_item_restore_requests: 10000
+    monthly_ebs_snapshot_gb: 10000
+    monthly_rds_snapshot_gb: 10000
+    monthly_aurora_snapshot_gb: 10000
+    monthly_dynamodb_backup_gb: 10000
+    monthly_dynamodb_restore_gb: 10000
+    monthly_fsx_windows_backup_gb: 10000
+    monthly_fsx_lustre_backup_gb: 10000


### PR DESCRIPTION
Issue #344 

Details: 

- I didn't find cost component for `AWS Storage Gateway Volume Backup`, searched by services, prices - nothing. 
- Didn't add part with cross-region data transfer as we already have resource `aws_data_transfer` which cover all of that functionality
- I compared prices all of non-usage cost components (`Monthly cost depends on...`) from Golden file with [AWS Pricing page](https://aws.amazon.com/backup/pricing/), they are equals