### PR TITLE
fix: don't warn about usage file if not syncing

### DIFF
--- a/internal/usage/usage_file.go
+++ b/internal/usage/usage_file.go
@@ -187,18 +187,14 @@ func loadReferenceFile() (map[string]*schema.UsageData, error) {
 	return usageData, nil
 }
 
-func LoadFromFile(usageFilePath string, syncUsageFile bool) (map[string]*schema.UsageData, error) {
+func LoadFromFile(usageFilePath string, createIfNotExisting bool) (map[string]*schema.UsageData, error) {
 	usageData := make(map[string]*schema.UsageData)
 
 	if usageFilePath == "" {
-		if syncUsageFile {
-			log.Warn("Can't sync usage file as it's not specified")
-		}
-
 		return usageData, nil
 	}
 
-	if syncUsageFile {
+	if createIfNotExisting {
 		if _, err := os.Stat(usageFilePath); os.IsNotExist(err) {
 			log.Debug("Specified usage file does not exist. It will be created")
 			fileContent := yaml.MapSlice{

--- a/internal/usage/usage_file.go
+++ b/internal/usage/usage_file.go
@@ -187,15 +187,18 @@ func loadReferenceFile() (map[string]*schema.UsageData, error) {
 	return usageData, nil
 }
 
-func LoadFromFile(usageFilePath string, createIfNotExisting bool) (map[string]*schema.UsageData, error) {
+func LoadFromFile(usageFilePath string, syncUsageFile bool) (map[string]*schema.UsageData, error) {
 	usageData := make(map[string]*schema.UsageData)
 
 	if usageFilePath == "" {
-		log.Warn("Can't sync usage file as it's not specified")
+		if syncUsageFile {
+			log.Warn("Can't sync usage file as it's not specified")
+		}
+
 		return usageData, nil
 	}
 
-	if createIfNotExisting {
+	if syncUsageFile {
 		if _, err := os.Stat(usageFilePath); os.IsNotExist(err) {
 			log.Debug("Specified usage file does not exist. It will be created")
 			fileContent := yaml.MapSlice{


### PR DESCRIPTION
Don't warn about the usage file not being specified unless the `--sync-usage-file` flag has also been specified.

Fixes #832

One thing I'd like to check is that the output when the `--sync-usage-file` flag is specified is a little verbose:

```shell
$ infracost breakdown --path plan.json --format=json --log-level=warn --sync-usage-file
Warning: Ignoring sync-usage-file as no usage-file is specified.

time="2021-06-25T16:33:25+01:00" level=warning msg="Can't sync usage file as it's not specified"
```

It's because there's an earlier check here: https://github.com/infracost/infracost/blob/87a41b5a32e85b065eb64d3d0564c39105cc2b6b/cmd/infracost/run.go#L279

Maybe the warning could just be removed completely? I just didn't want to do that without checking.