### PR TITLE
feat(Atlantis): check if $PLANFILE.json exist and use that first

### DIFF
--- a/scripts/ci/atlantis_diff.sh
+++ b/scripts/ci/atlantis_diff.sh
@@ -50,7 +50,13 @@ build_breakdown_cmd () {
   if [ ! -z "$config_file" ]; then
     breakdown_cmd="$breakdown_cmd --config-file $config_file"
   else
-    breakdown_cmd="$breakdown_cmd --path $PLANFILE"
+    if [ -f "$PLANFILE.json" ]; then
+      breakdown_cmd="$breakdown_cmd --path $PLANFILE.json"
+    elif [ -f "$PLANFILE" ]; then
+      breakdown_cmd="$breakdown_cmd --path $PLANFILE"
+    else
+      echo "Error: $PLANFILE does not exist"
+    fi
   fi
   if [ "$atlantis_debug" != "true" ]; then
     breakdown_cmd="$breakdown_cmd 2>/dev/null"


### PR DESCRIPTION
This enables users to generate the plan JSON from the plan binary file
as part of their Atlantis config so Infracost doesn’t need to invoke
“terraform show”

Here's how this could be used in Atlantis configs, notice the manual `terraform show` step, which can be customized as needed based on which Terraform version or binary is being used:

```
workflows:
  infracost:
    plan:
      steps:
      - init
      - plan
      - env:
          name: INFRACOST_API_KEY
          command: echo "MY_API_KEY" 
      - run: terraform show -no-color -json $PLANFILE > $PLANFILE.json 
      - run: /home/atlantis/infracost_atlantis_diff.sh
      - run: rm -rf $PLANFILE.json
```

This issue was reported in the [Atlantis community Slack](https://atlantis-community.slack.com/archives/C5MGGAV0C/p1624923969118900)