### PR TITLE
fix: register command

### DIFF
--- a/cmd/infracost/register.go
+++ b/cmd/infracost/register.go
@@ -20,6 +20,25 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 		Short: "Register for a free Infracost API key",
 		Long:  "Register for a free Infracost API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			var msg string
+			var isRegenerate bool
+
+			if _, ok := ctx.Config.Credentials[ctx.Config.PricingAPIEndpoint]; ok {
+
+				isRegenerate = true
+				fmt.Printf("\nYou already have an Infracost API key saved in %s.\n", config.CredentialsFilePath())
+
+				status, err := promptGenerateNewKey()
+				if err != nil {
+					return err
+				}
+
+				if !status {
+					return nil
+				}
+			}
+
 			fmt.Println("Please enter your name and email address to get an API key.")
 			fmt.Println("See our FAQ (https://www.infracost.io/docs/faq) for more details.")
 
@@ -36,6 +55,7 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 			}
 
 			d := apiclient.NewDashboardAPIClient(ctx)
+
 			r, err := d.CreateAPIKey(name, email)
 			if err != nil {
 				return err
@@ -49,42 +69,39 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 
 			fmt.Printf("\nThank you %s!\nYour API key is: %s\n", name, r.APIKey)
 
-			msg := fmt.Sprintf("%s\nYou can now run %s and point to your Terraform directory or JSON/plan file.",
-				fmt.Sprintf("Your API key has been saved to %s", config.CredentialsFilePath()),
-				ui.PrimaryString("infracost breakdown --path=..."),
-			)
-
-			saveAPIKey := true
-
-			if _, ok := ctx.Config.Credentials[ctx.Config.PricingAPIEndpoint]; ok {
-				fmt.Printf("\nYou already have an Infracost API key saved in %s\n", config.CredentialsFilePath())
+			if isRegenerate {
 				confirm, err := promptOverwriteAPIKey()
 				if err != nil {
 					return err
 				}
 
 				if !confirm {
-					saveAPIKey = false
-
 					msg = fmt.Sprintf("%s\n%s %s %s",
 						"Setting the INFRACOST_API_KEY environment variable overrides the key from credentials.yml.",
 						"You can now run",
 						ui.PrimaryString("infracost breakdown --path=..."),
 						"and point to your Terraform directory or JSON/plan file.",
 					)
+
+					fmt.Println("")
+					ui.PrintSuccess(msg)
+					return nil
 				}
 			}
 
-			if saveAPIKey {
-				ctx.Config.Credentials[ctx.Config.PricingAPIEndpoint] = config.CredentialsProfileSpec{
-					APIKey: r.APIKey,
-				}
-
-				err = ctx.Config.Credentials.Save()
-				if err != nil {
-					return err
-				}
+			ctx.Config.Credentials[ctx.Config.PricingAPIEndpoint] = config.CredentialsProfileSpec{
+				APIKey: r.APIKey,
 			}
+
+			err = ctx.Config.Credentials.Save()
+			if err != nil {
+				return err
+			}
+
+			msg = fmt.Sprintf("%s\nYou can now run %s and point to your Terraform directory or JSON/plan file.",
+				fmt.Sprintf("Your API key has been saved to %s", config.CredentialsFilePath()),
+				ui.PrimaryString("infracost breakdown --path=..."),
+			)
 
 			fmt.Println("")
 			ui.PrintSuccess(msg)
@@ -137,7 +154,7 @@ func promptForEmail() (string, error) {
 
 func promptOverwriteAPIKey() (bool, error) {
 	p := promptui.Prompt{
-		Label:     "Would you like to overwrite your existing saved API key",
+		Label:     "Would you like to overwrite your existing saved API key?",
 		IsConfirm: true,
 	}
 
@@ -147,6 +164,23 @@ func promptOverwriteAPIKey() (bool, error) {
 			return false, nil
 		}
 
+		return false, err
+	}
+
+	return true, nil
+}
+
+func promptGenerateNewKey() (bool, error) {
+	p := promptui.Prompt{
+		Label:     "Would you like to generate a new one?",
+		IsConfirm: true,
+	}
+
+	_, err := p.Run()
+	if err != nil {
+		if errors.Is(err, promptui.ErrAbort) {
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/cmd/infracost/register.go
+++ b/cmd/infracost/register.go
@@ -27,7 +27,7 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 			if _, ok := ctx.Config.Credentials[ctx.Config.PricingAPIEndpoint]; ok {
 
 				isRegenerate = true
-				fmt.Printf("\nYou already have an Infracost API key saved in %s.\n", config.CredentialsFilePath())
+				fmt.Printf("You already have an Infracost API key saved in %s.\n", config.CredentialsFilePath())
 
 				status, err := promptGenerateNewKey()
 				if err != nil {
@@ -70,6 +70,7 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 			fmt.Printf("\nThank you %s!\nYour API key is: %s\n", name, r.APIKey)
 
 			if isRegenerate {
+				fmt.Println()
 				confirm, err := promptOverwriteAPIKey()
 				if err != nil {
 					return err
@@ -154,7 +155,7 @@ func promptForEmail() (string, error) {
 
 func promptOverwriteAPIKey() (bool, error) {
 	p := promptui.Prompt{
-		Label:     "Would you like to overwrite your existing saved API key?",
+		Label:     "Would you like to overwrite your existing saved API key",
 		IsConfirm: true,
 	}
 
@@ -172,7 +173,7 @@ func promptOverwriteAPIKey() (bool, error) {
 
 func promptGenerateNewKey() (bool, error) {
 	p := promptui.Prompt{
-		Label:     "Would you like to generate a new one?",
+		Label:     "Would you like to generate a new API key",
 		IsConfirm: true,
 	}
 


### PR DESCRIPTION
Issue: https://github.com/infracost/infracost/issues/858

First Flow:

If the Key is not present:

1. We will prompt for name and email, generate the key and save it. 

Second Flow:

If the Key is present:

1. Ask the user `Would you like to generate a new one?` 
2. If no to 1, we exit. 
3. If yes to 1, we prompt for name, email, and generate the key and show them.
4. Then we prompt for `Would you like to overwrite your existing saved API key?`
5. If no to 4, we exit. 
6. If yes to 4, we save the new API key.