### PR TITLE
feat(aws): update aws_vpc_endpoint to use new pricing

### DIFF
--- a/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
+++ b/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
@@ -1,22 +1,28 @@
 
- Name                                      Monthly Qty  Unit              Monthly Cost 
-                                                                                       
- aws_vpc_endpoint.gateway_loadbalancer                                                 
- ├─ Endpoint (GatewayLoadBalancer)                 730  hours                    $7.30 
- └─ Data processed                      Monthly cost depends on usage: $0.0035 per GB  
-                                                                                       
- aws_vpc_endpoint.interface                                                            
- ├─ Endpoint (Interface)                           730  hours                    $7.30 
- └─ Data processed                      Monthly cost depends on usage: $0.01 per GB    
-                                                                                       
- aws_vpc_endpoint.interface_withUsage                                                  
- ├─ Endpoint (Interface)                           730  hours                    $7.30 
- └─ Data processed                               1,000  GB                      $10.00 
-                                                                                       
- aws_vpc_endpoint.multiple_interfaces                                                  
- ├─ Endpoint (Interface)                         1,460  hours                   $14.60 
- └─ Data processed                      Monthly cost depends on usage: $0.01 per GB    
-                                                                                       
- OVERALL TOTAL                                                                  $46.50 
+ Name                                        Monthly Qty  Unit              Monthly Cost 
+                                                                                         
+ aws_vpc_endpoint.gateway_loadbalancer                                                   
+ ├─ Data processed                        Monthly cost depends on usage: $0.0035 per GB  
+ └─ Endpoint (GatewayLoadBalancer)                   730  hours                    $7.30 
+                                                                                         
+ aws_vpc_endpoint.interface                                                              
+ ├─ Data processed (first 1PB)            Monthly cost depends on usage: $0.01 per GB    
+ └─ Endpoint (Interface)                             730  hours                    $7.30 
+                                                                                         
+ aws_vpc_endpoint.interface_withBigUsage                                                 
+ ├─ Data processed (first 1PB)                     1,000  GB                      $10.00 
+ ├─ Data processed (next 4PB)                      4,000  GB                      $24.00 
+ ├─ Data processed (over 5PB)                      2,000  GB                       $8.00 
+ └─ Endpoint (Interface)                             730  hours                    $7.30 
+                                                                                         
+ aws_vpc_endpoint.interface_withUsage                                                    
+ ├─ Data processed (first 1PB)                     1,000  GB                      $10.00 
+ └─ Endpoint (Interface)                             730  hours                    $7.30 
+                                                                                         
+ aws_vpc_endpoint.multiple_interfaces                                                    
+ ├─ Data processed (first 1PB)            Monthly cost depends on usage: $0.01 per GB    
+ └─ Endpoint (Interface)                           1,460  hours                   $14.60 
+                                                                                         
+ OVERALL TOTAL                                                                    $95.80 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.tf
+++ b/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.tf
@@ -21,6 +21,12 @@ resource "aws_vpc_endpoint" "interface_withUsage" {
   vpc_endpoint_type = "Interface"
 }
 
+resource "aws_vpc_endpoint" "interface_withBigUsage" {
+  service_name      = "com.amazonaws.region.ec2"
+  vpc_id            = "vpc-123456"
+  vpc_endpoint_type = "Interface"
+}
+
 resource "aws_vpc_endpoint" "gateway_loadbalancer" {
   service_name      = "com.amazonaws.region.ec2"
   vpc_id            = "vpc-123456"

--- a/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.usage.yml
@@ -1,4 +1,7 @@
 version: 0.1
 resource_usage:
   aws_vpc_endpoint.interface_withUsage:
-    monthly_data_processed_gb: 1000 # Monthly data processed by the VPC endpoint(s) in GB.
+    monthly_data_processed_gb: 1000
+
+  aws_vpc_endpoint.interface_withBigUsage:
+    monthly_data_processed_gb: 7000

--- a/internal/providers/terraform/aws/vpc_endpoint.go
+++ b/internal/providers/terraform/aws/vpc_endpoint.go
@@ -2,11 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/infracost/infracost/internal/schema"
-
+	"github.com/infracost/infracost/internal/usage"
 	"github.com/shopspring/decimal"
+	"strings"
 )
 
 func GetVpcEndpointRegistryItem() *schema.RegistryItem {
@@ -18,13 +17,11 @@ func GetVpcEndpointRegistryItem() *schema.RegistryItem {
 
 func NewVpcEndpoint(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := d.Get("region").String()
-
+	costComponents := []*schema.CostComponent{}
 	vpcEndpointType := "Gateway"
-
 	vpcEndpointInterfaces := 1
-
-	var endpointHours string
-	var endpointBytes string
+	var endpointHours, endpointBytes string
+	var gbDataProcessed *decimal.Decimal
 
 	if d.Get("vpc_endpoint_type").Exists() {
 		vpcEndpointType = d.Get("vpc_endpoint_type").String()
@@ -42,53 +39,88 @@ func NewVpcEndpoint(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		}
 	}
 
-	switch vpcEndpointType {
-	case "Interface":
-		endpointHours = "VpcEndpoint-Hours"
-		endpointBytes = "VpcEndpoint-Bytes"
-	case "GatewayLoadBalancer":
-		endpointHours = "VpcEndpoint-GWLBE-Hours"
-		endpointBytes = "VpcEndpoint-GWLBE-Bytes"
-	}
-
-	var gbDataProcessed *decimal.Decimal
 	if u != nil && u.Get("monthly_data_processed_gb").Exists() {
 		gbDataProcessed = decimalPtr(decimal.NewFromFloat(u.Get("monthly_data_processed_gb").Float()))
 	}
 
+	if strings.ToLower(vpcEndpointType) == "interface" {
+		endpointHours = "VpcEndpoint-Hours"
+		endpointBytes = "VpcEndpoint-Bytes"
+		if gbDataProcessed != nil {
+			gbLimits := []int{1000, 4000}
+			tiers := usage.CalculateTierBuckets(*gbDataProcessed, gbLimits)
+
+			if tiers[0].GreaterThan(decimal.NewFromInt(0)) {
+				costComponents = append(costComponents, vpcEndpointDataProcessedCostComponent(region, endpointBytes, "Data processed (first 1PB)", "0", &tiers[0]))
+			}
+			if tiers[1].GreaterThan(decimal.NewFromInt(0)) {
+				costComponents = append(costComponents, vpcEndpointDataProcessedCostComponent(region, endpointBytes, "Data processed (next 4PB)", "1048576", &tiers[1]))
+			}
+			if tiers[2].GreaterThan(decimal.NewFromInt(0)) {
+				costComponents = append(costComponents, vpcEndpointDataProcessedCostComponent(region, endpointBytes, "Data processed (over 5PB)", "5242880", &tiers[2]))
+			}
+		} else {
+			costComponents = append(costComponents, vpcEndpointDataProcessedCostComponent(region, endpointBytes, "Data processed (first 1PB)", "0", gbDataProcessed))
+		}
+	} else if strings.ToLower(vpcEndpointType) == "gatewayloadbalancer" {
+		endpointHours = "VpcEndpoint-GWLBE-Hours"
+		endpointBytes = "VpcEndpoint-GWLBE-Bytes"
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            "Data processed",
+			Unit:            "GB",
+			UnitMultiplier:  1,
+			MonthlyQuantity: gbDataProcessed,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(region),
+				Service:       strPtr("AmazonVPC"),
+				ProductFamily: strPtr("VpcEndpoint"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", endpointBytes))},
+				},
+			},
+		})
+	}
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:           fmt.Sprintf("Endpoint (%s)", vpcEndpointType),
+		Unit:           "hours",
+		UnitMultiplier: 1,
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(int64(vpcEndpointInterfaces))),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonVPC"),
+			ProductFamily: strPtr("VpcEndpoint"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", endpointHours))},
+			},
+		},
+	})
+
 	return &schema.Resource{
-		Name: d.Address,
-		CostComponents: []*schema.CostComponent{
-			{
-				Name:           fmt.Sprintf("Endpoint (%s)", vpcEndpointType),
-				Unit:           "hours",
-				UnitMultiplier: 1,
-				HourlyQuantity: decimalPtr(decimal.NewFromInt(int64(vpcEndpointInterfaces))),
-				ProductFilter: &schema.ProductFilter{
-					VendorName:    strPtr("aws"),
-					Region:        strPtr(region),
-					Service:       strPtr("AmazonVPC"),
-					ProductFamily: strPtr("VpcEndpoint"),
-					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", endpointHours))},
-					},
-				},
+		Name:           d.Address,
+		CostComponents: costComponents,
+	}
+}
+
+func vpcEndpointDataProcessedCostComponent(region string, endpointBytes string, displayName string, usageTier string, gbDataProcessed *decimal.Decimal) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            displayName,
+		Unit:            "GB",
+		UnitMultiplier:  1,
+		MonthlyQuantity: gbDataProcessed,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr("AmazonVPC"),
+			ProductFamily: strPtr("VpcEndpoint"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", endpointBytes))},
 			},
-			{
-				Name:            "Data processed",
-				Unit:            "GB",
-				UnitMultiplier:  1,
-				MonthlyQuantity: gbDataProcessed,
-				ProductFilter: &schema.ProductFilter{
-					VendorName:    strPtr("aws"),
-					Region:        strPtr(region),
-					Service:       strPtr("AmazonVPC"),
-					ProductFamily: strPtr("VpcEndpoint"),
-					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", endpointBytes))},
-					},
-				},
-			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			StartUsageAmount: strPtr(usageTier),
 		},
 	}
 }


### PR DESCRIPTION
This was detected by the integration test warnings on the master branch:
```
 === CONT  TestAwsStepFunctionGoldenFile
time="2021-07-13T10:26:25Z" level=warning msg="Multiple prices found for aws_vpc_endpoint.interface_withUsage Data processed, using the first price"
time="2021-07-13T10:26:25Z" level=warning msg="Multiple prices found for aws_vpc_endpoint.interface Data processed, using the first price"
time="2021-07-13T10:26:25Z" level=warning msg="Multiple prices found for aws_vpc_endpoint.multiple_interfaces Data processed, using the first price"
```

It was caused by this: https://aws.amazon.com/about-aws/whats-new/2021/07/aws-lowers-data-processing-charges-aws-privatelink/

I verified the prices by calculating the costs manually.