### PR TITLE
feat: Add configure command

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-INFRACOST_PRICING_API_ENDPOINT=https://pricing.api.infracost.io

--- a/cmd/infracost/configure.go
+++ b/cmd/infracost/configure.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/ui"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var validConfigureKeys = []string{"api_key", "pricing_api_endpoint"}
+
+func configureCmd(ctx *config.RunContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Configure Infracost",
+		Long:  "Configure Infracost CLI",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Show the help
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(configureSetCmd(ctx), configureGetCmd(ctx))
+
+	return cmd
+}
+
+func configureSetCmd(ctx *config.RunContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set Infracost CLI global configuration",
+		Long:  "Set Infracost CLI global configuration",
+		Example: `  Set your Infracost API key:
+
+      infracost configure set api_key API_KEY_VALUE
+
+  Set your Infracost Pricing API Endpoint:
+
+      infracost	configure set pricing_api_endpoint https://cloud-pricing-api.internal
+
+  Set your Infracost API key for a specific Pricing API Endpoint:
+
+      infracost configure set api_key API_KEY_VALUE --pricing-api-endpoint https://cloud-pricing-api.internal`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 2 {
+				return errors.New("Too many arguments")
+			}
+
+			if len(args) < 2 {
+				return errors.New("You must specify a key and a value")
+			}
+
+			if !isValidConfigureKey(args[0]) {
+				return fmt.Errorf("Invalid key, valid keys are: %s", strings.Join(validConfigureKeys, ", "))
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+			value := args[1]
+
+			if cmd.Flags().Changed("pricing-api-endpoint") && key != "api_key" {
+				ui.PrintWarning("--pricing-api-endpoint flag is only used when key is api_key")
+			}
+
+			if key == "pricing_api_endpoint" {
+				if existing, ok := ctx.Config.Credentials[value]; ok {
+					existing.Default = true
+				} else {
+					ctx.Config.Credentials[value] = &config.CredentialsProfileSpec{
+						Default: true,
+					}
+				}
+
+				for k, v := range ctx.Config.Credentials {
+					if k != value {
+						v.Default = false
+					}
+				}
+
+				err := ctx.Config.Credentials.Save()
+				if err != nil {
+					return err
+				}
+			}
+
+			if key == "api_key" {
+				pricingAPIEndpoint, _ := cmd.Flags().GetString("pricing-api-endpoint")
+				if pricingAPIEndpoint == "" {
+					pricingAPIEndpoint = ctx.Config.PricingAPIEndpoint
+				}
+
+				ctx.Config.Credentials[pricingAPIEndpoint] = &config.CredentialsProfileSpec{
+					APIKey:  value,
+					Default: true,
+				}
+
+				for k, v := range ctx.Config.Credentials {
+					if k != pricingAPIEndpoint {
+						v.Default = false
+					}
+				}
+
+				err := ctx.Config.Credentials.Save()
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String("pricing-api-endpoint", "", "The Pricing API Endpoint. Only applicable when key is api_key")
+
+	return cmd
+}
+
+func configureGetCmd(ctx *config.RunContext) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <key>",
+		Short: "Get Infracost CLI global configuration",
+		Long:  "Get Infracost CLI global configuration",
+		Example: `  Get your saved Infracost API key:
+
+      infracost configure get api_key
+
+  Get your saved Infracost Pricing API Endpoint:
+
+      infracost	configure get pricing_api_endpoint
+
+  Get your saved Infracost API key for a specific Pricing API Endpoint:
+
+      infracost configure get api_key --pricing-api-endpoint https://cloud-pricing-api.internal`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 1 {
+				return errors.New("Too many arguments")
+			}
+
+			if len(args) < 1 {
+				return errors.New("You must specify a key")
+			}
+
+			if !isValidConfigureKey(args[0]) {
+				return fmt.Errorf("Invalid key, valid keys are: %s", strings.Join(validConfigureKeys, ", "))
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+			var value string
+
+			if cmd.Flags().Changed("pricing-api-endpoint") && key != "api_key" {
+				ui.PrintWarning("--pricing-api-endpoint flag is only used when key is api_key")
+			}
+
+			if key == "pricing_api_endpoint" {
+				value = ctx.Config.Credentials.GetDefaultPricingAPIEndpoint()
+
+				if value == "" {
+					ui.PrintWarning("Could not find any Pricing API Endpoint in your saved config")
+				}
+			}
+
+			if key == "api_key" {
+				pricingAPIEndpoint, _ := cmd.Flags().GetString("pricing-api-endpoint")
+				if pricingAPIEndpoint == "" {
+					pricingAPIEndpoint = ctx.Config.Credentials.GetDefaultPricingAPIEndpoint()
+				}
+
+				profile := ctx.Config.Credentials[pricingAPIEndpoint]
+
+				if profile != nil {
+					value = profile.APIKey
+				} else {
+					if pricingAPIEndpoint != ctx.Config.DefaultPricingAPIEndpoint {
+						ui.PrintWarningf("Could not find an API key for Pricing API Endpoint %s in your saved config", pricingAPIEndpoint)
+					} else {
+						ui.PrintWarning("Could not find an API key in your saved config")
+					}
+				}
+			}
+
+			if value != "" {
+				fmt.Println(value)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String("pricing-api-endpoint", "", "The Pricing API Endpoint. Only applicable when key is api_key")
+
+	return cmd
+}
+
+func isValidConfigureKey(key string) bool {
+	for _, validKey := range validConfigureKeys {
+		if key == validKey {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -84,6 +84,7 @@ func main() {
 	rootCmd.PersistentFlags().String("log-level", "", "Log level (trace, debug, info, warn, error, fatal)")
 
 	rootCmd.AddCommand(registerCmd(ctx))
+	rootCmd.AddCommand(configureCmd(ctx))
 	rootCmd.AddCommand(diffCmd(ctx))
 	rootCmd.AddCommand(breakdownCmd(ctx))
 	rootCmd.AddCommand(outputCmd(ctx))
@@ -207,10 +208,6 @@ func loadGlobalFlags(ctx *config.RunContext, cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if cmd.Flags().Changed("pricing-api-endpoint") {
-		ctx.Config.PricingAPIEndpoint, _ = cmd.Flags().GetString("pricing-api-endpoint")
 	}
 
 	ctx.SetContextValue("isDefaultPricingAPIEndpoint", ctx.Config.PricingAPIEndpoint == ctx.Config.DefaultPricingAPIEndpoint)

--- a/cmd/infracost/register.go
+++ b/cmd/infracost/register.go
@@ -92,8 +92,9 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 				}
 			}
 
-			ctx.Config.Credentials[ctx.Config.PricingAPIEndpoint] = config.CredentialsProfileSpec{
-				APIKey: r.APIKey,
+			ctx.Config.Credentials[ctx.Config.PricingAPIEndpoint] = &config.CredentialsProfileSpec{
+				APIKey:  r.APIKey,
+				Default: true,
 			}
 
 			err = ctx.Config.Credentials.Save()

--- a/cmd/infracost/register.go
+++ b/cmd/infracost/register.go
@@ -24,7 +24,7 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 			var msg string
 			var isRegenerate bool
 
-			if _, ok := ctx.Config.Credentials[ctx.Config.PricingAPIEndpoint]; ok {
+			if ctx.Config.Credentials.APIKey != "" {
 
 				isRegenerate = true
 				fmt.Printf("You already have an Infracost API key saved in %s\n", config.CredentialsFilePath())
@@ -92,10 +92,8 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 				}
 			}
 
-			ctx.Config.Credentials[ctx.Config.PricingAPIEndpoint] = &config.CredentialsProfileSpec{
-				APIKey:  r.APIKey,
-				Default: true,
-			}
+			ctx.Config.Credentials.APIKey = r.APIKey
+			ctx.Config.Credentials.PricingAPIEndpoint = ctx.Config.PricingAPIEndpoint
 
 			err = ctx.Config.Credentials.Save()
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,7 +97,7 @@ func (c *Config) LoadFromEnv() error {
 
 	err = loadCredentials(c)
 	if err != nil {
-		logrus.Fatal(err)
+		return err
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,7 +57,7 @@ func DefaultConfig() *Config {
 		NoColor:  false,
 
 		DefaultPricingAPIEndpoint: "https://pricing.api.infracost.io",
-		PricingAPIEndpoint:        "https://pricing.api.infracost.io",
+		PricingAPIEndpoint:        "",
 		DashboardAPIEndpoint:      "https://dashboard.api.infracost.io",
 
 		Projects: []*Project{{}},

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -7,18 +7,43 @@ import (
 	"path"
 	"time"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
 func (c *Config) migrateCredentials() error {
 	oldPath := path.Join(userConfigDir(), "config.yml")
-	newPath := CredentialsFilePath()
+	credPath := CredentialsFilePath()
 
-	if !fileExists(oldPath) || fileExists(newPath) {
-		return nil
+	if fileExists(oldPath) && !fileExists(credPath) {
+		return c.migrateV0_7_17(oldPath, credPath)
 	}
 
+	if fileExists(credPath) {
+		var content struct {
+			Version string `yaml:"version"`
+		}
+
+		data, err := ioutil.ReadFile(credPath)
+		if err != nil {
+			return err
+		}
+
+		err = yaml.Unmarshal(data, &content)
+		if err != nil {
+			return err
+		}
+
+		if content.Version == "" {
+			return c.migrateV0_9_4(credPath)
+		}
+	}
+
+	return nil
+}
+
+func (c *Config) migrateV0_7_17(oldPath string, newPath string) error {
 	log.Debugf("Migrating old credentials from %s to %s", oldPath, newPath)
 
 	data, err := ioutil.ReadFile(oldPath)
@@ -36,9 +61,8 @@ func (c *Config) migrateCredentials() error {
 	}
 
 	if oldCreds.APIKey != "" {
-		c.Credentials[c.PricingAPIEndpoint] = &CredentialsProfileSpec{
-			APIKey: oldCreds.APIKey,
-		}
+		c.Credentials.APIKey = oldCreds.APIKey
+		c.Credentials.Version = "0.1"
 
 		err = c.Credentials.Save()
 		if err != nil {
@@ -52,6 +76,61 @@ func (c *Config) migrateCredentials() error {
 
 		log.Debug("Credentials successfully migrated")
 	}
+
+	return nil
+}
+
+func (c *Config) migrateV0_9_4(credPath string) error {
+	log.Debugf("Migrating old credentials format to v0.1")
+
+	// Use MapSlice to keep the order of the items, so we can always use the first one
+	var oldCreds yaml.MapSlice
+
+	data, err := ioutil.ReadFile(credPath)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(data, &oldCreds)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(credPath, fmt.Sprintf("%s.backup-%d", credPath, time.Now().Unix()))
+	if err != nil {
+		return err
+	}
+
+	// Get the first values
+	var pricingAPIEndpoint string
+	var apiKey string
+
+	if len(oldCreds) > 0 {
+		pricingAPIEndpoint = oldCreds[0].Key.(string)
+
+		values, ok := oldCreds[0].Value.(yaml.MapSlice)
+		if !ok {
+			return errors.New("Invalid credentials format")
+		}
+
+		for _, item := range values {
+			if item.Key.(string) == "api_key" {
+				apiKey = item.Value.(string)
+				break
+			}
+		}
+	}
+
+	c.Credentials.PricingAPIEndpoint = pricingAPIEndpoint
+	c.Credentials.APIKey = apiKey
+	c.Credentials.Version = "0.1"
+
+	err = c.Credentials.Save()
+	if err != nil {
+		return err
+	}
+
+	log.Debug("Credentials successfully migrated")
 
 	return nil
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -36,7 +36,7 @@ func (c *Config) migrateCredentials() error {
 	}
 
 	if oldCreds.APIKey != "" {
-		c.Credentials[c.PricingAPIEndpoint] = CredentialsProfileSpec{
+		c.Credentials[c.PricingAPIEndpoint] = &CredentialsProfileSpec{
 			APIKey: oldCreds.APIKey,
 		}
 


### PR DESCRIPTION
This command allow you to configure Infracost CLI globally with an API key and pricing API endpoint (if self-hosting this).

Currently I've added it as the following commands:

```
infracost configure get <key>
infracost configure set <key> <value>
```

So you'd use it like:

```
infracost configure set pricing_api_endpoint http://self-hosted-pricing-api.internal
infracost configure set api_key MY_API_KEY
```

I was wondering if anyone has any thoughts/suggestions for what this command should be called? I considered calling it `infracost config` but was worried that would cause confusion with the `--config-file` flag which allows you to pass run configuration in.