### PR TITLE
fix(cli): include quotes in help text

### DIFF
--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -28,11 +28,11 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 
   Create HTML report from multiple Infracost JSON files:
 
-      infracost output --format html --path out*.json > output.html
+      infracost output --format html --path "out*.json" > output.html
 
   Merge multiple Infracost JSON files:
 
-      infracost output --format json --path out*.json`,
+      infracost output --format json --path "out*.json"`,
 		ValidArgs: []string{"--", "-"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inputFiles := []string{}

--- a/cmd/infracost/testdata/output_help/output_help.golden
+++ b/cmd/infracost/testdata/output_help/output_help.golden
@@ -10,11 +10,11 @@ EXAMPLES
 
   Create HTML report from multiple Infracost JSON files:
 
-      infracost output --format html --path out*.json > output.html
+      infracost output --format html --path "out*.json" > output.html
 
   Merge multiple Infracost JSON files:
 
-      infracost output --format json --path out*.json
+      infracost output --format json --path "out*.json"
 
 FLAGS
       --fields strings     Comma separated list of output fields: all,price,monthlyQuantity,unit,hourlyCost,monthlyCost.


### PR DESCRIPTION
Without this the glob pattern is expanded by shells so the CLI sees the first path as the flag value, followed by arguments (that are ignored)

Partly addresses https://github.com/infracost/infracost/issues/927