### PR TITLE
fix(aws): update filters to exclude non-Windows file systems

### DIFF
--- a/internal/providers/terraform/aws/fsx_windows_file_system.go
+++ b/internal/providers/terraform/aws/fsx_windows_file_system.go
@@ -82,6 +82,7 @@ func throughputCapacity(region string, isMultiAZ bool, throughput *decimal.Decim
 			ProductFamily: strPtr("Provisioned Throughput"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "deploymentOption", Value: strPtr(deploymentOption)},
+				{Key: "fileSystemType", Value: strPtr("Windows")},
 			},
 		},
 	}
@@ -105,6 +106,7 @@ func backupStorageCapacity(region string, isMultiAZ bool, backupStorage *decimal
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "deploymentOption", Value: strPtr(deploymentOption)},
 				{Key: "usagetype", ValueRegex: strPtr("/BackupUsage/")},
+				{Key: "fileSystemType", Value: strPtr("Windows")},
 			},
 		},
 	}


### PR DESCRIPTION
AWS have added support for NetAPP ONTAP to FSx which means multiple products were returned for our filters.
This filesystem isn't supported yet by Terraform (see https://github.com/hashicorp/terraform-provider-aws/issues/20778)