### PR TITLE
Warn on invalid TF_CLI_CONFIG_FILE instead of error

### DIFF
--- a/internal/providers/terraform/cmd.go
+++ b/internal/providers/terraform/cmd.go
@@ -147,15 +147,17 @@ func CreateConfigFile(dir string, terraformCloudHost string, terraformCloudToken
 		path := os.Getenv("TF_CLI_CONFIG_FILE")
 
 		if !filepath.IsAbs(path) {
-			path, err = filepath.Abs(filepath.Join(dir, os.Getenv("TF_CLI_CONFIG_FILE")))
+			path, err = filepath.Abs(filepath.Join(dir, path))
 			if err != nil {
-				return tmpFile.Name(), err
+				log.Warningf("Unable to copy existing config from %s: %v", path, err)
 			}
 		}
 
-		err = copyFile(path, tmpFile.Name())
-		if err != nil {
-			return tmpFile.Name(), err
+		if err == nil {
+			err = copyFile(path, tmpFile.Name())
+			if err != nil {
+				log.Warningf("Unable to copy existing config from %s: %v", path, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
As discussed in #943.

Instead of hard failing if the user has a non-existent `TF_CLI_CONFIG_FILE` when trying to copy it to a temporary file, this logs a warning and will just create a new blank temporary file. @alikhajeh1 do you think there's any issues with this? I'm hesitant in case it hides an error the user would want to know about.