### PR TITLE
Generate HTML output and keep JSON and HTML files so they c…

### DIFF
--- a/scripts/ci/diff.sh
+++ b/scripts/ci/diff.sh
@@ -17,6 +17,7 @@ process_args () {
   percentage_threshold=${6:-$percentage_threshold}
   post_condition=${7:-$post_condition}
   show_skipped=${8:-$show_skipped}
+  save_assets=${9:-$save_assets}
 
   # Validate post_condition
   if ! echo "$post_condition" | jq empty; then
@@ -351,6 +352,9 @@ load_azure_devops_env () {
 
 cleanup () {
   rm -f infracost_breakdown_cmd infracost_output_diff_cmd infracost_output_html_cmd
+  if [ -z "$save_assets" ]; then
+    rm -f infracost_breakdown.json infracost_output_html.json
+  fi
 }
 
 # MAIN
@@ -383,10 +387,12 @@ echo "Running infracost output using:"
 echo "  $ $(cat infracost_output_diff_cmd)"
 diff_output=$(cat infracost_output_diff_cmd | sh)
 
-infracost_output_html_cmd=$(build_output_cmd "infracost_breakdown.json" "html")
-echo "$infracost_output_html_cmd" > infracost_output_html_cmd
-html_output=$(cat infracost_output_html_cmd | sh)
-echo "$html_output" > infracost_breakdown.html
+if [ -n "$save_assets" ]; then
+  infracost_output_html_cmd=$(build_output_cmd "infracost_breakdown.json" "html")
+  echo "$infracost_output_html_cmd" > infracost_output_html_cmd
+  html_output=$(cat infracost_output_html_cmd | sh)
+  echo "$html_output" > infracost_breakdown.html
+fi
 
 echo "Running infracost output using:"
 echo "  $ $(cat infracost_output_html_cmd)"

--- a/scripts/ci/diff.sh
+++ b/scripts/ci/diff.sh
@@ -81,7 +81,7 @@ build_breakdown_cmd () {
 }
 
 build_output_cmd () {
-  output_cmd="${INFRACOST_BINARY} output --no-color --format diff --path $1"
+  output_cmd="${INFRACOST_BINARY} output --no-color --format $2 --path $1"
   if [ -n "$show_skipped" ]; then
     # The "=" is important as otherwise the value of the flag is ignored by the CLI
     output_cmd="$output_cmd --show-skipped=$show_skipped"
@@ -350,7 +350,7 @@ load_azure_devops_env () {
 }
 
 cleanup () {
-  rm -f infracost_breakdown.json infracost_breakdown_cmd infracost_output_cmd
+  rm -f infracost_breakdown_cmd infracost_output_diff_cmd infracost_output_html_cmd
 }
 
 # MAIN
@@ -376,12 +376,20 @@ echo "  $ $(cat infracost_breakdown_cmd)"
 breakdown_output=$(cat infracost_breakdown_cmd | sh)
 echo "$breakdown_output" > infracost_breakdown.json
 
-infracost_output_cmd=$(build_output_cmd "infracost_breakdown.json")
-echo "$infracost_output_cmd" > infracost_output_cmd
+infracost_output_diff_cmd=$(build_output_cmd "infracost_breakdown.json" "diff")
+echo "$infracost_output_diff_cmd" > infracost_output_diff_cmd
   
 echo "Running infracost output using:"
-echo "  $ $(cat infracost_output_cmd)"
-diff_output=$(cat infracost_output_cmd | sh)
+echo "  $ $(cat infracost_output_diff_cmd)"
+diff_output=$(cat infracost_output_diff_cmd | sh)
+
+infracost_output_html_cmd=$(build_output_cmd "infracost_breakdown.json" "html")
+echo "$infracost_output_html_cmd" > infracost_output_html_cmd
+html_output=$(cat infracost_output_html_cmd | sh)
+echo "$html_output" > infracost_breakdown.html
+
+echo "Running infracost output using:"
+echo "  $ $(cat infracost_output_html_cmd)"
 
 past_total_monthly_cost=$(jq '[.projects[].pastBreakdown.totalMonthlyCost | select (.!=null) | tonumber] | add' infracost_breakdown.json)
 total_monthly_cost=$(jq '[.projects[].breakdown.totalMonthlyCost | select (.!=null) | tonumber] | add' infracost_breakdown.json)


### PR DESCRIPTION
…an be used as assets.

This leaves the following files at the end of the diff.sh run, so they can be store as assets in the CI system.
- `infracost_breakdown.json`
- `infracost_breakdown.html`

I'm not sure if we want this by default or to have flag called something link `keep_assets`/`save_assets`/`create_assets`? @alikhajeh1 what do you think?

See https://github.com/infracost/infracost/issues/953 for a use case.