### PR TITLE
Proposal: use struct methods instead of functions for resources

### DIFF
--- a/internal/providers/cloudformation/aws/dynamodb_table.go
+++ b/internal/providers/cloudformation/aws/dynamodb_table.go
@@ -35,7 +35,7 @@ func NewDynamoDBTable(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		writeCapacity = cfr.ProvisionedThroughput.WriteCapacityUnits
 	}
 
-	args := &aws.DynamoDbTableArguments{
+	a := &aws.DynamoDBTable{
 		Address:        d.Address,
 		Region:         region,
 		BillingMode:    billingMode,
@@ -43,10 +43,10 @@ func NewDynamoDBTable(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		ReadCapacity:   &readCapacity,
 		ReplicaRegions: []string{}, // Global Tables are defined using AWS::DynamoDB::GlobalTable
 	}
-	args.PopulateUsage(u)
+	a.PopulateUsage(u)
 
-	r := aws.NewDynamoDBTable(args)
-	r.Tags = mapTags(cfr.Tags)
+	resource := a.BuildResource()
+	resource.Tags = mapTags(cfr.Tags)
 
-	return r
+	return resource
 }

--- a/internal/providers/terraform/aws/dynamodb_table.go
+++ b/internal/providers/terraform/aws/dynamodb_table.go
@@ -12,11 +12,11 @@ func GetDynamoDBTableRegistryItem() *schema.RegistryItem {
 		Notes: []string{
 			"DAX is not yet supported.",
 		},
-		RFunc: NewDynamoDBTable,
+		RFunc: NewDynamoDBTableResource,
 	}
 }
 
-func NewDynamoDBTable(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+func NewDynamoDBTableResource(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	replicaRegions := []string{}
 	if d.Get("replica").Exists() {
 		for _, data := range d.Get("replica").Array() {
@@ -24,7 +24,7 @@ func NewDynamoDBTable(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		}
 	}
 
-	args := &aws.DynamoDbTableArguments{
+	a := &aws.DynamoDBTable{
 		Address:        d.Address,
 		Region:         d.Get("region").String(),
 		Name:           d.Get("name").String(),
@@ -33,7 +33,7 @@ func NewDynamoDBTable(d *schema.ResourceData, u *schema.UsageData) *schema.Resou
 		ReadCapacity:   intPtr(d.Get("read_capacity").Int()),
 		ReplicaRegions: replicaRegions,
 	}
-	args.PopulateUsage(u)
+	a.PopulateUsage(u)
 
-	return aws.NewDynamoDBTable(args)
+	return a.BuildResource()
 }

--- a/internal/providers/terraform/aws/lambda_function.go
+++ b/internal/providers/terraform/aws/lambda_function.go
@@ -22,13 +22,13 @@ func NewLambdaFunction(d *schema.ResourceData, u *schema.UsageData) *schema.Reso
 		memorySize = d.Get("memory_size").Int()
 	}
 
-	args := &aws.LambdaFunctionArguments{
+	a := &aws.LambdaFunction{
 		Address:    d.Address,
 		Region:     region,
 		Name:       name,
 		MemorySize: memorySize,
 	}
-	args.PopulateUsage(u)
+	a.PopulateUsage(u)
 
-	return aws.NewLambdaFunction(args)
+	return a.BuildResource()
 }

--- a/internal/providers/terraform/aws/nat_gateway.go
+++ b/internal/providers/terraform/aws/nat_gateway.go
@@ -15,11 +15,11 @@ func GetNATGatewayRegistryItem() *schema.RegistryItem {
 func NewNATGateway(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := d.Get("region").String()
 
-	args := &aws.NATGatewayArguments{
+	a := &aws.NATGateway{
 		Address: d.Address,
 		Region:  region,
 	}
-	args.PopulateUsage(u)
+	a.PopulateUsage(u)
 
-	return aws.NewNATGateway(args)
+	return a.BuildResource()
 }

--- a/internal/resources/aws/dynamodb_table_estimate_test.go
+++ b/internal/resources/aws/dynamodb_table_estimate_test.go
@@ -32,7 +32,8 @@ func TestDynamoDBStorage(t *testing.T) {
 	defer stub.Close()
 	stubDescribeTable(stub)
 
-	resource := resources.NewDynamoDBTable(&resources.DynamoDbTableArguments{})
+	args := resources.DynamoDBTable{}
+	resource := args.BuildResource()
 	estimates := newEstimates(stub.ctx, t, resource)
 	estimates.mustHave("storage_gb", int64(10))
 }
@@ -68,9 +69,10 @@ func TestDynamoDBPayPerRequest(t *testing.T) {
 	  </GetMetricStatisticsResult>
 	</GetMetricStatisticsResponse>`)
 
-	resource := resources.NewDynamoDBTable(&resources.DynamoDbTableArguments{
+	args := resources.DynamoDBTable{
 		BillingMode: "PAY_PER_REQUEST",
-	})
+	}
+	resource := args.BuildResource()
 	estimates := newEstimates(stub.ctx, t, resource)
 
 	estimates.mustHave("monthly_read_request_units", int64(123))
@@ -82,9 +84,10 @@ func TestDynamoDBProvisioned(t *testing.T) {
 	defer stub.Close()
 	stubDescribeTable(stub)
 
-	resource := resources.NewDynamoDBTable(&resources.DynamoDbTableArguments{
+	args := resources.DynamoDBTable{
 		BillingMode: "PROVISIONED",
-	})
+	}
+	resource := args.BuildResource()
 	estimates := newEstimates(stub.ctx, t, resource)
 
 	estimates.mustHave("monthly_read_request_units", nil)

--- a/internal/resources/aws/lambda_function_estimate_test.go
+++ b/internal/resources/aws/lambda_function_estimate_test.go
@@ -45,7 +45,8 @@ func TestLambda(t *testing.T) {
 		</GetMetricStatisticsResponse>
 	`)
 
-	resource := resources.NewLambdaFunction(&resources.LambdaFunctionArguments{})
+	args := &resources.LambdaFunction{}
+	resource := args.BuildResource()
 	estimates := newEstimates(stub.ctx, t, resource)
 	estimates.mustHave("monthly_requests", float64(1234))
 	estimates.mustHave("request_duration_ms", float64(5678.9))

--- a/internal/resources/aws/nat_gateway.go
+++ b/internal/resources/aws/nat_gateway.go
@@ -6,29 +6,29 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-type NATGatewayArguments struct {
+type NATGateway struct {
 	Address string
 	Region  string
 
 	MonthlyDataProcessedGB *float64 `infracost_usage:"monthly_data_processed_gb"`
 }
 
-func (args *NATGatewayArguments) PopulateUsage(u *schema.UsageData) {
-	resources.PopulateArgsWithUsage(args, u)
-}
-
 var NATGatewayUsageSchema = []*schema.UsageSchemaItem{
 	{Key: "monthly_data_processed_gb", DefaultValue: 0, ValueType: schema.Float64},
 }
 
-func NewNATGateway(args *NATGatewayArguments) *schema.Resource {
+func (a *NATGateway) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(a, u)
+}
+
+func (a *NATGateway) BuildResource() *schema.Resource {
 	var gbDataProcessed *decimal.Decimal
-	if args.MonthlyDataProcessedGB != nil {
-		gbDataProcessed = decimalPtr(decimal.NewFromFloat(*args.MonthlyDataProcessedGB))
+	if a.MonthlyDataProcessedGB != nil {
+		gbDataProcessed = decimalPtr(decimal.NewFromFloat(*a.MonthlyDataProcessedGB))
 	}
 
 	return &schema.Resource{
-		Name:        args.Address,
+		Name:        a.Address,
 		UsageSchema: NATGatewayUsageSchema,
 		CostComponents: []*schema.CostComponent{
 			{
@@ -38,7 +38,7 @@ func NewNATGateway(args *NATGatewayArguments) *schema.Resource {
 				HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("aws"),
-					Region:        strPtr(args.Region),
+					Region:        strPtr(a.Region),
 					Service:       strPtr("AmazonEC2"),
 					ProductFamily: strPtr("NAT Gateway"),
 					AttributeFilters: []*schema.AttributeFilter{
@@ -53,7 +53,7 @@ func NewNATGateway(args *NATGatewayArguments) *schema.Resource {
 				MonthlyQuantity: gbDataProcessed,
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("aws"),
-					Region:        strPtr(args.Region),
+					Region:        strPtr(a.Region),
 					Service:       strPtr("AmazonEC2"),
 					ProductFamily: strPtr("NAT Gateway"),
 					AttributeFilters: []*schema.AttributeFilter{


### PR DESCRIPTION
I'm wondering if we should use struct methods for the generic resources by default, to avoid potential name clashes as we move over more resources to this format. Here's an example for the DynamoDB resource.

What do you think @tim775?