### PR TITLE
fix: don’t use hard-coded filters for us-east-1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,6 +258,8 @@ func TestMyResourceGoldenFile(t *testing.T) {
 }
 ```
 
+Terraform supports multiple provider blocks (e.g. `provider "aws"`) so you can test for multiple regions by adding resources that point to a different provider using the `alias = aws.my-other-provider` attribute. See [waf_web_acl_test.tf](internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.tf) for an example.
+
 Finally, generate the golden file by running the test with the `-update` flag. You should **verify** that these cost calculations are correct by manually checking them, or comparing them against cost calculators from the cloud vendors. You should also ensure that there are **no warnings** about "Multiple products found", "No products found for" or "No prices found for" in the logs. These warnings indicate that the price filters have an issue.
 
 ```sh

--- a/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
+++ b/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
@@ -3,16 +3,22 @@
                                                                                     
  aws_waf_web_acl.my_waf                                                             
  ├─ Web ACL usage                             1  months                       $5.00 
- ├─ Rules                                     7  months                       $7.00 
- ├─ Rule groups                               2  months                       $2.00 
+ ├─ Rules                                     7  rules                        $7.00 
+ ├─ Rule groups                               2  groups                       $2.00 
+ └─ Requests                                  1  1M requests                  $0.60 
+                                                                                    
+ aws_waf_web_acl.us_west_1                                                          
+ ├─ Web ACL usage                             1  months                       $5.00 
+ ├─ Rules                                     7  rules                        $7.00 
+ ├─ Rule groups                               2  groups                       $2.00 
  └─ Requests                                  1  1M requests                  $0.60 
                                                                                     
  aws_waf_web_acl.withoutUsage                                                       
  ├─ Web ACL usage                             1  months                       $5.00 
- ├─ Rules                                     2  months                       $2.00 
- ├─ Rule groups                               2  months                       $2.00 
+ ├─ Rules                                     2  rules                        $2.00 
+ ├─ Rule groups                               2  groups                       $2.00 
  └─ Requests                   Monthly cost depends on usage: $0.60 per 1M requests 
                                                                                     
- OVERALL TOTAL                                                               $23.60 
+ OVERALL TOTAL                                                               $38.20 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.tf
+++ b/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.tf
@@ -9,6 +9,18 @@ provider "aws" {
   secret_key                  = "mock_secret_key"
 }
 
+provider "aws" {
+  alias                       = "us-west-1"
+  region                      = "us-west-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
 resource "aws_waf_ipset" "ipset" {
   name = "tfIPSet"
 
@@ -78,8 +90,8 @@ resource "aws_waf_web_acl" "my_waf" {
     rule_id  = aws_waf_rule.wafrule.id
     type     = "GROUP"
   }
-
 }
+
 resource "aws_waf_web_acl" "withoutUsage" {
   depends_on = [
     aws_waf_ipset.ipset,
@@ -128,5 +140,55 @@ resource "aws_waf_web_acl" "withoutUsage" {
     rule_id  = aws_waf_rule.wafrule.id
     type     = "GROUP"
   }
+}
 
+resource "aws_waf_web_acl" "us_west_1" {
+  provider = aws.us-west-1
+  depends_on = [
+    aws_waf_ipset.ipset,
+    aws_waf_rule.wafrule,
+  ]
+  name        = "tfWebACL"
+  metric_name = "tfWebACL"
+
+  default_action {
+    type = "ALLOW"
+  }
+
+  rules {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 1
+    rule_id  = aws_waf_rule.wafrule.id
+    type     = "REGULAR"
+  }
+  rules {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 1
+    rule_id  = aws_waf_rule.wafrule.id
+    type     = "RATE_BASED"
+  }
+  rules {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 1
+    rule_id  = aws_waf_rule.wafrule.id
+    type     = "GROUP"
+  }
+  rules {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 1
+    rule_id  = aws_waf_rule.wafrule.id
+    type     = "GROUP"
+  }
 }

--- a/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.usage.yml
@@ -3,3 +3,6 @@ resource_usage:
   aws_waf_web_acl.my_waf:
     rule_group_rules: 5 
     monthly_requests: 1000000  
+  aws_waf_web_acl.us_west_1:
+    rule_group_rules: 5
+    monthly_requests: 1000000

--- a/internal/providers/terraform/aws/testdata/wafv2_web_acl_test/wafv2_web_acl_test.golden
+++ b/internal/providers/terraform/aws/testdata/wafv2_web_acl_test/wafv2_web_acl_test.golden
@@ -3,15 +3,15 @@
                                                                                       
  aws_wafv2_web_acl.my_waf2                                                            
  ├─ Web ACL usage                               1  months                       $5.00 
- ├─ Rules                                      16  months                      $16.00 
- ├─ Rule groups                                 1  months                       $1.00 
- ├─ Managed rule groups                         1  months                       $1.00 
+ ├─ Rules                                      16  rules                       $16.00 
+ ├─ Rule groups                                 1  groups                       $1.00 
+ ├─ Managed rule groups                         1  groups                       $1.00 
  └─ Requests                                    1  1M requests                  $0.60 
                                                                                       
  aws_wafv2_web_acl.withoutUsage                                                       
  ├─ Web ACL usage                               1  months                       $5.00 
- ├─ Rule groups                                 1  months                       $1.00 
- ├─ Managed rule groups                         1  months                       $1.00 
+ ├─ Rule groups                                 1  groups                       $1.00 
+ ├─ Managed rule groups                         1  groups                       $1.00 
  └─ Requests                     Monthly cost depends on usage: $0.60 per 1M requests 
                                                                                       
  OVERALL TOTAL                                                                 $30.60 

--- a/internal/providers/terraform/aws/waf_web_acl.go
+++ b/internal/providers/terraform/aws/waf_web_acl.go
@@ -29,7 +29,7 @@ func NewWafWebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resource 
 		region,
 		"Web ACL usage",
 		"months",
-		".*[^ShieldProtected]-WebACL",
+		"[A-Z0-9]*-(?!ShieldProtected-)WebACL",
 		1,
 		decimalPtr(decimal.NewFromInt(1)),
 	))
@@ -56,8 +56,8 @@ func NewWafWebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resource 
 	costComponents = append(costComponents, wafWebACLUsageCostComponent(
 		region,
 		"Rules",
-		"months",
-		".*[^ShieldProtected]-Rule",
+		"rules",
+		"[A-Z0-9]*-(?!ShieldProtected-)Rule",
 		1,
 		rule,
 	))
@@ -75,8 +75,8 @@ func NewWafWebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resource 
 		costComponents = append(costComponents, wafWebACLUsageCostComponent(
 			region,
 			"Rule groups",
-			"months",
-			".*[^ShieldProtected]-Rule",
+			"groups",
+			"[A-Z0-9]*-(?!ShieldProtected-)Rule",
 			1,
 			decimalPtr(decimal.NewFromInt(int64(count))),
 		))
@@ -90,7 +90,7 @@ func NewWafWebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resource 
 		region,
 		"Requests",
 		"1M requests",
-		".*[^ShieldProtected]-Request",
+		"[A-Z0-9]*-(?!ShieldProtected-)Request",
 		1000000,
 		monthlyRequests,
 	))

--- a/internal/providers/terraform/aws/waf_web_acl.go
+++ b/internal/providers/terraform/aws/waf_web_acl.go
@@ -29,7 +29,7 @@ func NewWafWebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resource 
 		region,
 		"Web ACL usage",
 		"months",
-		"USE1-WebACL",
+		".*[^ShieldProtected]-WebACL",
 		1,
 		decimalPtr(decimal.NewFromInt(1)),
 	))
@@ -57,7 +57,7 @@ func NewWafWebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resource 
 		region,
 		"Rules",
 		"months",
-		"USE1-Rule",
+		".*[^ShieldProtected]-Rule",
 		1,
 		rule,
 	))
@@ -76,7 +76,7 @@ func NewWafWebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resource 
 			region,
 			"Rule groups",
 			"months",
-			"USE1-Rule",
+			".*[^ShieldProtected]-Rule",
 			1,
 			decimalPtr(decimal.NewFromInt(int64(count))),
 		))
@@ -90,7 +90,7 @@ func NewWafWebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resource 
 		region,
 		"Requests",
 		"1M requests",
-		"USE1-Request",
+		".*[^ShieldProtected]-Request",
 		1000000,
 		monthlyRequests,
 	))

--- a/internal/providers/terraform/aws/wafv2_web_acl.go
+++ b/internal/providers/terraform/aws/wafv2_web_acl.go
@@ -27,7 +27,7 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		region,
 		"Web ACL usage",
 		"months",
-		".*[^ShieldProtected]-WebACLV2",
+		"[A-Z0-9]*-(?!ShieldProtected-)WebACLV2",
 		1,
 		decimalPtr(decimal.NewFromInt(1)),
 	))
@@ -48,8 +48,8 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		costComponents = append(costComponents, wafWebACLUsageCostComponent(
 			region,
 			"Rules",
-			"months",
-			".*[^ShieldProtected]-RuleV2",
+			"rules",
+			"[A-Z0-9]*-(?!ShieldProtected-)RuleV2",
 			1,
 			&sumForRules,
 		))
@@ -75,8 +75,8 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 			costComponents = append(costComponents, wafWebACLUsageCostComponent(
 				region,
 				"Rule groups",
-				"months",
-				".*[^ShieldProtected]-RuleV2",
+				"groups",
+				"[A-Z0-9]*-(?!ShieldProtected-)RuleV2",
 				1,
 				decimalPtr(decimal.NewFromInt(int64(counter))),
 			))
@@ -88,8 +88,8 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		costComponents = append(costComponents, wafWebACLUsageCostComponent(
 			region,
 			"Managed rule groups",
-			"months",
-			".*[^ShieldProtected]-RuleV2",
+			"groups",
+			"[A-Z0-9]*-(?!ShieldProtected-)RuleV2",
 			1,
 			decimalPtr(decimal.NewFromInt(int64(len(manageQuantity)))),
 		))
@@ -103,7 +103,7 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		region,
 		"Requests",
 		"1M requests",
-		".*[^ShieldProtected]-RequestV2-Tier1",
+		"[A-Z0-9]*-(?!ShieldProtected-)RequestV2-Tier1",
 		1000000,
 		monthlyRequests,
 	))

--- a/internal/providers/terraform/aws/wafv2_web_acl.go
+++ b/internal/providers/terraform/aws/wafv2_web_acl.go
@@ -27,7 +27,7 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		region,
 		"Web ACL usage",
 		"months",
-		"USE1-WebACLV2",
+		".*[^ShieldProtected]-WebACLV2",
 		1,
 		decimalPtr(decimal.NewFromInt(1)),
 	))
@@ -49,7 +49,7 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 			region,
 			"Rules",
 			"months",
-			"USE1-RuleV2",
+			".*[^ShieldProtected]-RuleV2",
 			1,
 			&sumForRules,
 		))
@@ -76,7 +76,7 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 				region,
 				"Rule groups",
 				"months",
-				"USE1-RuleV2",
+				".*[^ShieldProtected]-RuleV2",
 				1,
 				decimalPtr(decimal.NewFromInt(int64(counter))),
 			))
@@ -89,7 +89,7 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 			region,
 			"Managed rule groups",
 			"months",
-			"USE1-RuleV2",
+			".*[^ShieldProtected]-RuleV2",
 			1,
 			decimalPtr(decimal.NewFromInt(int64(len(manageQuantity)))),
 		))
@@ -103,7 +103,7 @@ func NewWafv2WebACL(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		region,
 		"Requests",
 		"1M requests",
-		"USE1-RequestV2-Tier1",
+		".*[^ShieldProtected]-RequestV2-Tier1",
 		1000000,
 		monthlyRequests,
 	))


### PR DESCRIPTION
Previously this was returning no matches for non-us-east-1 regions

Fixes #958