### PR TITLE
884 error on terraform env var with config file

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -284,21 +284,13 @@ func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {
 		cmd.Flags().Changed("terraform-workspace") ||
 		cmd.Flags().Changed("terraform-use-state"))
 
-	envProjectCfg := cfg.Projects[0]
+	projectCfg := cfg.Projects[0]
 
-	hasProjectEnvs := envProjectCfg.Path != "" ||
-		envProjectCfg.TerraformBinary != "" ||
-		envProjectCfg.TerraformCloudHost != "" ||
-		envProjectCfg.TerraformWorkspace != "" ||
-		envProjectCfg.TerraformCloudToken != ""
-
-	projectCfg := &config.Project{}
-
-	if hasProjectFlags {
-		cfg.Projects = []*config.Project{
-			projectCfg,
-		}
-	}
+	hasProjectEnvs := projectCfg.Path != "" ||
+		projectCfg.TerraformBinary != "" ||
+		projectCfg.TerraformCloudHost != "" ||
+		projectCfg.TerraformWorkspace != "" ||
+		projectCfg.TerraformCloudToken != ""
 
 	if hasConfigFile && (hasProjectFlags || hasProjectEnvs) {
 		m := "--config-file flag cannot be used with the following flags or environement variables: "
@@ -320,14 +312,6 @@ func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {
 	if hasConfigFile {
 		cfgFilePath, _ := cmd.Flags().GetString("config-file")
 		err := cfg.LoadFromConfigFile(cfgFilePath)
-
-		if err != nil {
-			return err
-		}
-	}
-
-	if !hasConfigFile {
-		err := cfg.LoadFromEnv()
 
 		if err != nil {
 			return err


### PR DESCRIPTION
This is an intent to fix https://github.com/infracost/infracost/issues/884. 

The CLI errors if any of the project options (terraform-*, path, and usage-file) are used in conjunction with the --config-file flag independent of the use of environment variables or flags. 

This PR fixes another small bug:  Don't override terraform-workspace flag by ENV variable
 - Old behavior: INFRACOST_TERRAFORM_WORKSPACE environment variable overrides --terraform-workspace flag
 - New behavior: INFRACOST_TERRAFORM_WORKSPACE environment variable does not overrides --terraform-workspace flag
 as mentioned in https://www.infracost.io/docs/multi_project/config_file#precedence.

Any feedback welcome. 