### PR TITLE
fix: don't detect Terraform dir by looking for .hcl files.

### DIFF
--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -406,7 +406,7 @@ func (p *DirProvider) runShow(opts *CmdOptions, spinner *ui.Spinner, planFile st
 }
 
 func IsTerraformDir(path string) bool {
-	for _, ext := range []string{"tf", "hcl", "hcl.json", "tf.json"} {
+	for _, ext := range []string{"tf", "tf.json"} {
 		matches, err := filepath.Glob(filepath.Join(path, fmt.Sprintf("*.%s", ext)))
 		if matches != nil && err == nil {
 			return true


### PR DESCRIPTION
This messes with Terragrunt detection and Terraform needs .tf files anyway.