### PR TITLE
feat(aws) edited aws_ebs_snapshot fast_snapshot_restore_hour optional

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -143,6 +143,7 @@ resource_usage:
     monthly_list_block_requests: 1000000  # Monthly number of ListChangedBlocks and ListSnapshotBlocks requests.
     monthly_get_block_requests: 100000    # Monthly number of GetSnapshotBlock requests (block size is 512KiB).
     monthly_put_block_requests: 100000    # Monthly number of PutSnapshotBlock requests (block size is 512KiB).
+    fast_snapshot_restore_hours: 100      # Monthly number of DSU-hours for Fast snapshot restore  
 
   aws_ebs_volume.my_standard_volume:
     monthly_standard_io_requests: 10000000 # Monthly I/O requests for standard volume (Magnetic storage).

--- a/internal/providers/terraform/aws/ebs_snapshot.go
+++ b/internal/providers/terraform/aws/ebs_snapshot.go
@@ -41,13 +41,18 @@ func NewEBSSnapshot(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 		putSnapshotBlockRequests = decimalPtr(decimal.NewFromInt(u.Get("monthly_put_block_requests").Int()))
 	}
 
+	var fastSnapshotRestoreHours *decimal.Decimal
+	if u != nil && u.Get("monthly_put_block_requests").Exists() {
+		fastSnapshotRestoreHours = decimalPtr(decimal.NewFromInt(u.Get("fast_snapshot_restore_hours").Int()))
+	}
+
 	costComponents := []*schema.CostComponent{
 		ebsSnapshotCostComponent(region, gbVal),
 		{
-			Name:           "Fast snapshot restore",
-			Unit:           "DSU",
-			UnitMultiplier: schema.HourToMonthUnitMultiplier,
-			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			Name:            "Fast snapshot restore",
+			Unit:            "DSU-hours",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: fastSnapshotRestoreHours,
 			ProductFilter: &schema.ProductFilter{
 				VendorName:    strPtr("aws"),
 				Region:        strPtr(region),

--- a/internal/providers/terraform/aws/testdata/ebs_snapshot_copy_test/ebs_snapshot_copy_test.golden
+++ b/internal/providers/terraform/aws/testdata/ebs_snapshot_copy_test/ebs_snapshot_copy_test.golden
@@ -3,7 +3,7 @@
                                                                                                                        
  aws_ebs_snapshot.gp2                                                                                                  
  ├─ EBS snapshot storage                                                  10  GB                                 $0.50 
- ├─ Fast snapshot restore                                                  1  DSU                              $547.50 
+ ├─ Fast snapshot restore                                Monthly cost depends on usage: $0.75 per DSU-hours            
  ├─ ListChangedBlocks & ListSnapshotBlocks API requests  Monthly cost depends on usage: $0.0006 per 1k requests        
  ├─ GetSnapshotBlock API requests                        Monthly cost depends on usage: $0.003 per 1k SnapshotAPIUnits 
  └─ PutSnapshotBlock API requests                        Monthly cost depends on usage: $0.006 per 1k SnapshotAPIUnits 
@@ -14,6 +14,6 @@
  aws_ebs_volume.gp2                                                                                                    
  └─ Storage (general purpose SSD, gp2)                                    10  GB                                 $1.00 
                                                                                                                        
- OVERALL TOTAL                                                                                                 $549.50 
+ OVERALL TOTAL                                                                                                   $2.00 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ebs_snapshot_test/ebs_snapshot_test.golden
+++ b/internal/providers/terraform/aws/testdata/ebs_snapshot_test/ebs_snapshot_test.golden
@@ -3,14 +3,14 @@
                                                                                                                        
  aws_ebs_snapshot.gp2                                                                                                  
  ├─ EBS snapshot storage                                                  10  GB                                 $0.50 
- ├─ Fast snapshot restore                                                  1  DSU                              $547.50 
+ ├─ Fast snapshot restore                                Monthly cost depends on usage: $0.75 per DSU-hours            
  ├─ ListChangedBlocks & ListSnapshotBlocks API requests  Monthly cost depends on usage: $0.0006 per 1k requests        
  ├─ GetSnapshotBlock API requests                        Monthly cost depends on usage: $0.003 per 1k SnapshotAPIUnits 
  └─ PutSnapshotBlock API requests                        Monthly cost depends on usage: $0.006 per 1k SnapshotAPIUnits 
                                                                                                                        
  aws_ebs_snapshot.gp2_usage                                                                                            
  ├─ EBS snapshot storage                                                   8  GB                                 $0.40 
- ├─ Fast snapshot restore                                                  1  DSU                              $547.50 
+ ├─ Fast snapshot restore                                                100  DSU-hours                         $75.00 
  ├─ ListChangedBlocks & ListSnapshotBlocks API requests                1,000  1k requests                        $0.60 
  ├─ GetSnapshotBlock API requests                                        100  1k SnapshotAPIUnits                $0.30 
  └─ PutSnapshotBlock API requests                                        100  1k SnapshotAPIUnits                $0.60 
@@ -18,6 +18,6 @@
  aws_ebs_volume.gp2                                                                                                    
  └─ Storage (general purpose SSD, gp2)                                    10  GB                                 $1.00 
                                                                                                                        
- OVERALL TOTAL                                                                                               $1,098.40 
+ OVERALL TOTAL                                                                                                  $78.40 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ebs_snapshot_test/ebs_snapshot_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/ebs_snapshot_test/ebs_snapshot_test.usage.yml
@@ -4,3 +4,4 @@ resource_usage:
     monthly_list_block_requests: 1000000
     monthly_get_block_requests: 100000
     monthly_put_block_requests: 100000
+    fast_snapshot_restore_hours: 100


### PR DESCRIPTION
Objective: Fixes https://github.com/infracost/infracost/issues/940

Edit support for aws_ebs_snapshot,  added fast_snapshot_restore_hours as usage-based cost component.

Example output without usage-file:
```
Running "infracost breakdown --path ." against a main.tf with:
resource "aws_ebs_volume" "example" {
  availability_zone = "us-west-2a"
  size              = 40
  tags = {
    Name = "HelloWorld"
  }
}
resource "aws_ebs_snapshot" "example_snapshot" {
  volume_id = aws_ebs_volume.example.id
  tags = {
    Name = "HelloWorld_snap"
  }
}

 Name                                                            Monthly Qty  Unit                        Monthly Cost 
                                                                                                                       
 aws_ebs_snapshot.example_snapshot                                                                                     
 ├─ EBS snapshot storage                                                  40  GB                                 $2.00 
 ├─ Fast snapshot restore                                Monthly cost depends on usage: $0.75 per DSU-hours            
 ├─ ListChangedBlocks & ListSnapshotBlocks API requests  Monthly cost depends on usage: $0.0006 per 1k requests        
 ├─ GetSnapshotBlock API requests                        Monthly cost depends on usage: $0.003 per 1k SnapshotAPIUnits 
 └─ PutSnapshotBlock API requests                        Monthly cost depends on usage: $0.006 per 1k SnapshotAPIUnits 
                                                                                                                       
 aws_ebs_volume.example                                                                                                
 └─ Storage (general purpose SSD, gp2)                                    40  GB                                 $4.00 
                                                                                                                       
 OVERALL TOTAL                                                                                                   $6.00 
```
Example output with usage-file:
```
Running "infracost breakdown --path . --usage-file infracost-usage-example.yml" against a main.tf with:
resource "aws_ebs_volume" "example" {
  availability_zone = "us-west-2a"
  size              = 40
  tags = {
    Name = "HelloWorld"
  }
}
resource "aws_ebs_snapshot" "example_snapshot" {
  volume_id = aws_ebs_volume.example.id
  tags = {
    Name = "HelloWorld_snap"
  }
}
 Name                                                    Monthly Qty  Unit                 Monthly Cost 
                                                                                                        
 aws_ebs_snapshot.example_snapshot                                                                      
 ├─ EBS snapshot storage                                          40  GB                          $2.00 
 ├─ Fast snapshot restore                                        100  DSU-hours                  $75.00 
 ├─ ListChangedBlocks & ListSnapshotBlocks API requests        1,000  1k requests                 $0.60 
 ├─ GetSnapshotBlock API requests                                100  1k SnapshotAPIUnits         $0.30 
 └─ PutSnapshotBlock API requests                                100  1k SnapshotAPIUnits         $0.60 
                                                                                                        
 aws_ebs_volume.example                                                                                 
 └─ Storage (general purpose SSD, gp2)                            40  GB                          $4.00 
                                                                                                        
 OVERALL TOTAL                                                                                   $82.50 
```

Pricing details:

ebs_snapshot has a component called Fast Snapshot Restore (FSR) allows you to promptly restore fully provisioned EBS volumes, 

Fast Snapshot Restore | $0.75 per 1 DSU hour on each snapshot and in each AZ it is enabled

Status:

Edited ebs_snapshot.go
Added resource file
Added integration tests for ebs_snapshot and ebs_snapshot_copy

   Edited unit tests if applicable

Issues:

Useful links:

    Pricing: https://aws.amazon.com/ebs/pricing/
    Terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_snapshot