### PR TITLE
Inprogress: Package manager chocolately

### DIFF
--- a/scripts/chocolately/build.ps1
+++ b/scripts/chocolately/build.ps1
@@ -1,0 +1,13 @@
+$outfile="infracost.zip"
+$version=(Invoke-Webrequest https://api.github.com/repos/infracost/infracost/releases/latest|convertfrom-json).name
+
+Write-Host "$(get-date) - downloading release $version"
+Invoke-WebRequest -uri "https://github.com/bridgecrewio/yor/releases/download/$($version)/yor-$($version)-windows-amd64.zip" -OutFile $outfile
+tar -xvf $outfile -C .\tools\
+
+Write-Host "$(get-date) - packing"
+choco pack --version $version
+
+Get-ChildItem *.nupkg
+Write-Host "$(get-date) - Pushing to Chocolatey Feed"
+choco push $package.Name -s https://push.chocolatey.org/ --api-key=$env:CHOCOPUSHKEY

--- a/scripts/chocolately/build.ps1
+++ b/scripts/chocolately/build.ps1
@@ -2,9 +2,11 @@ $outfile="infracost.zip"
 $version=(Invoke-Webrequest https://api.github.com/repos/infracost/infracost/releases/latest|convertfrom-json).name
 
 Write-Host "$(get-date) - downloading release $version"
-Invoke-WebRequest -uri "https://github.com/bridgecrewio/yor/releases/download/$($version)/yor-$($version)-windows-amd64.zip" -OutFile $outfile
+Invoke-WebRequest -uri "https://github.com/infracost/infracost/releases/download/$($version)/infracost-windows-amd64.tar.gz" -OutFile $outfile
 tar -xvf $outfile -C .\tools\
 
+# removing the first v as chocolately doesnt like this version
+$version=${version:1}
 Write-Host "$(get-date) - packing"
 choco pack --version $version
 

--- a/scripts/chocolately/infracost.nuspec
+++ b/scripts/chocolately/infracost.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>infracost</id>
+    <version>0.9.8</version>
+    <packageSourceUrl>https://github.com/infracost/infracost/scripts/chocolately</packageSourceUrl>
+    <owners>OWNER HERE</owners>
+    <title>infracost</title>
+    <authors>AUTHOR HERE</authors>
+    <projectUrl>https://github.com/infracost/infracost</projectUrl>
+    <copyright>2021 Infracost</copyright>
+   <projectSourceUrl>https://github.com/infracostinfracost</projectSourceUrl>
+    <docsUrl>https://www.infracost.io/</docsUrl>
+    <tags>Infracost shows cloud cost estimates for infrastructure-as-code projects such as Terraform.</tags>
+    <summary>Cloud cost estimates for Terraform in pull requests</summary>
+    <description>Cloud cost estimates for Terraform in pull requests. The ultimate way to estimate cost in pull requests.</description>
+  </metadata>
+  <files>
+    <!-- this section controls what actually gets packaged into the Chocolatey package -->
+    <file src="tools\**" target="tools" />
+    <!--Building from Linux? You may need this instead: <file src="tools/**" target="tools" />-->
+  </files>
+</package>

--- a/scripts/chocolately/tools/LICENSE
+++ b/scripts/chocolately/tools/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021 Infracost Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/scripts/chocolately/tools/README.md
+++ b/scripts/chocolately/tools/README.md
@@ -1,0 +1,88 @@
+[![Infracost logo](.github/assets/logo.svg)](https://www.infracost.io)
+
+<a href="https://www.infracost.io/community-chat"><img alt="Community Slack channel" src="https://img.shields.io/badge/chat-Slack-%234a154b"/></a>
+<a href="https://github.com/infracost/infracost/actions?query=workflow%3AGo+branch%3Amaster"><img alt="Build Status" src="https://img.shields.io/github/workflow/status/infracost/infracost/Go/master"/></a>
+<a href="https://hub.docker.com/r/infracost/infracost/tags"><img alt="Docker Image" src="https://img.shields.io/docker/cloud/build/infracost/infracost"/></a>
+<a href="https://twitter.com/intent/tweet?text=Get%20cost%20estimates%20for%20cloud%20infrastructure%20in%20pull%20requests!&url=https://www.infracost.io&hashtags=cloud,cost,aws,IaC,terraform"><img alt="Tweet" src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"/></a>
+
+<a href="https://www.infracost.io/docs/"><img alt="Getting started" src="https://img.shields.io/badge/get%20started-blue?style=for-the-badge&logo=read-the-docs&label=docs"/></a> 
+
+Infracost shows cloud cost estimates for infrastructure-as-code projects such as Terraform. It helps DevOps, SRE and developers to quickly see a cost breakdown and compare different options upfront.
+
+#### Show full breakdown of costs
+
+<img src=".github/assets/breakdown_screenshot.png" alt="Infracost breakdown command" width=600 />
+
+#### Show diff of monthly costs between current and planned state
+
+<img src=".github/assets/diff_screenshot.png" alt="Infracost diff command" width=600 />
+
+## Quick start
+
+1. Assuming [Terraform](https://www.terraform.io/downloads.html) is already installed, get the latest Infracost release:
+
+    macOS Homebrew:
+    ```sh
+    brew install infracost
+    ```
+
+    Linux/macOS manual download:
+    ```sh
+    # Downloads the CLI based on your OS/arch and puts it in /usr/local/bin
+    curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
+    ```
+
+    Docker and Windows users see [here](https://www.infracost.io/docs/#quick-start).
+
+2.	Register for a free API key:
+    ```sh
+    infracost register
+    ```
+
+    The key is saved in `~/.config/infracost/credentials.yml`.
+
+3.  Run Infracost using our example Terraform project to see how it works:
+    ```sh
+    git clone https://github.com/infracost/example-terraform.git
+    cd example-terraform/sample1
+
+    # Play with main.tf and re-run to compare costs
+    infracost breakdown --path .
+
+    # Show diff of monthly costs, edit the yml file and re-run to compare costs
+    infracost diff --path . --sync-usage-file --usage-file infracost-usage.yml
+    ```
+
+Please **watch/star** this repo as we add new cloud resources every week or so.
+
+## Usage
+
+The `infracost` CLI has the following main commands, their usage is described in our short [**getting started**](https://www.infracost.io/docs/#usage) page:
+- `breakdown`: show full breakdown of costs
+- `diff`: show diff of monthly costs between current and planned state
+
+As mentioned in our [FAQ](https://www.infracost.io/docs/faq), no cloud credentials or secrets are sent to the Cloud Pricing API. Infracost does not make any changes to your Terraform state or cloud resources.
+
+## CI/CD integrations
+
+Infracost's [CI/CD integrations](https://www.infracost.io/docs/integrations/cicd) can be used to automatically add a pull request comment showing the diff of monthly costs between the current and planned state. We have integrations for GitHub Actions, GitLab CI, Atlantis, Azure DevOps, CircleCI, Bitbucket Pipelines and Jenkins.
+
+If you run into any issues with CI/CD integrations, please join our [community Slack channel](https://www.infracost.io/community-chat), we'd be happy to guide you through it.
+
+<img src="https://raw.githubusercontent.com/infracost/infracost-gh-action/master/screenshot.png" width=480 alt="Example infracost diff usage" />
+
+## Supported clouds and resources
+
+Infracost supports over [200 Terraform resources](https://www.infracost.io/docs/supported_resources/) across AWS, Google and Azure. Other IaC tools ([Pulumi](https://github.com/infracost/infracost/issues/187), [CloudFormation](https://github.com/infracost/infracost/issues/190)) are on our roadmap.
+
+We regularly add support for new resources so we recommend watching this repo for releases: click on the Watch button > selecting Custom > Releases and click on Apply.
+
+See [this page](https://www.infracost.io/docs/usage_based_resources) for details on cost estimation of usage-based resources such as AWS Lambda or Google Cloud Storage.
+
+## Contributing
+
+Issues and pull requests are welcome! For development details, see the [contributing](CONTRIBUTING.md) guide. For major changes, including CLI interface changes, please open an issue first to discuss what you would like to change. [Join our community Slack channel](https://www.infracost.io/community-chat), we are a friendly bunch and happy to help you get started :)
+
+## License
+
+[Apache License 2.0](https://choosealicense.com/licenses/apache-2.0/)

--- a/scripts/chocolately/tools/VERIFICATION.txt
+++ b/scripts/chocolately/tools/VERIFICATION.txt
@@ -1,0 +1,9 @@
+﻿VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+The original zip and extracted exe are downloaded from the Github Release e.g.:
+https://github.com/infracost/infracost/releases/tag/0.9.8
+
+<Include details of how to verify checksum contents>
+This open source tools is made by Us/Bridgecrew.


### PR DESCRIPTION
Objective:

Add package manager support for chocolately

for windows
```
run .\scripts\chocolately\build.ps1
Output
No .nupkg files (or more than 1) were found to build in 'C:\Users\Rupan\ops\infracost\scripts\chocolately'. Please specify the .nupkg file or try in a different directory
```
Pricing details:
NA

Status:

Added chocolately folder under scripts with related files
- build.ps1 
- nuspec
- tools folder where the binary will be packaged

Issues:

    Not able to create nupkg file by choco pack command.  I think the problem is with nuspec where I define the src and target.
    I ended up looking at below mentioned link but couldn't understand what should be done next:

Useful links:

    From a convention-based working directory: https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package#from-a-convention-based-working-directory
