### PR TITLE
feat: remove 0 usage line items in breakdown

### DIFF
--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -1,0 +1,267 @@
+package output_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/infracost/infracost/internal/config"
+	. "github.com/infracost/infracost/internal/output"
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+	"github.com/infracost/infracost/internal/usage"
+)
+
+func TestToTable(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tests := []struct {
+		name        string
+		projectData []byte
+		usageData   []byte
+		want        string
+		wantErr     error
+	}{
+		{
+			name: "should build valid table output",
+			projectData: []byte(`
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_dx_connection" "my_dx_connection" {
+  bandwidth = "1Gbps"
+  location  = "EqDC2"
+  name      = "Test"
+}
+
+resource "aws_dx_connection" "my_dx_connection_usage" {
+  bandwidth = "1Gbps"
+  location  = "EqDC2"
+  name      = "Test_Usage"
+}
+
+resource "aws_dx_connection" "my_dx_connection_usage_backwards_compat" {
+  bandwidth = "1Gbps"
+  location  = "EqDC2"
+  name      = "Test_Usage_Backwards"
+}
+`),
+			usageData: []byte(`
+version: 0.1
+resource_usage:
+  aws_dx_connection.my_dx_connection_usage:
+    monthly_outbound_region_to_dx_location_gb: 100
+    monthly_outbound_from_region_to_dx_connection_location:
+      eu_west_1: 1000
+      ap_east_1: 3000
+      does_not_exist: 6000
+    dx_virtual_interface_type: private
+    dx_connection_type: dedicated
+  aws_dx_connection.my_dx_connection_usage_backwards_compat:
+    monthly_outbound_region_to_dx_location_gb: 200
+    dx_virtual_interface_type: private
+    dx_connection_type: dedicated
+`),
+			want: `
+ Name                                                       Monthly Qty  Unit   Monthly Cost 
+                                                                                             
+ aws_dx_connection.my_dx_connection                                                          
+ └─ DX connection                                                   730  hours       $219.00 
+                                                                                             
+ aws_dx_connection.my_dx_connection_usage                                                    
+ ├─ DX connection                                                   730  hours       $219.00 
+ ├─ Outbound data transfer (from ap-east-1, to EqDC2)             3,000  GB          $270.00 
+ └─ Outbound data transfer (from eu-west-1, to EqDC2)             1,000  GB           $28.20 
+                                                                                             
+ aws_dx_connection.my_dx_connection_usage_backwards_compat                                   
+ ├─ DX connection                                                   730  hours       $219.00 
+ └─ Outbound data transfer (from us-east-1, to EqDC2)               200  GB            $4.00 
+                                                                                             
+ OVERALL TOTAL                                                                       $959.20 `,
+		},
+		{
+			name: "should skip zero value cost component",
+			projectData: []byte(`
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_dx_connection" "my_dx_connection" {
+  bandwidth = "1Gbps"
+  location  = "EqDC2"
+  name      = "Test"
+}
+
+resource "aws_dx_connection" "should_not_show_ap_east_1" {
+  bandwidth = "1Gbps"
+  location  = "EqDC2"
+  name      = "Test_Usage"
+}
+`),
+			usageData: []byte(`
+version: 0.1
+resource_usage:
+  aws_dx_connection.should_not_show_ap_east_1:
+    monthly_outbound_from_region_to_dx_connection_location:
+      eu_west_1: 1000
+      ap_east_1: 0
+`),
+			want: `
+ Name                                                  Monthly Qty  Unit   Monthly Cost 
+                                                                                        
+ aws_dx_connection.my_dx_connection                                                     
+ └─ DX connection                                              730  hours       $219.00 
+                                                                                        
+ aws_dx_connection.should_not_show_ap_east_1                                            
+ ├─ DX connection                                              730  hours       $219.00 
+ └─ Outbound data transfer (from eu-west-1, to EqDC2)        1,000  GB           $28.20 
+                                                                                        
+ OVERALL TOTAL                                                                  $466.20 `,
+		},
+		{
+			name: "should skip resource entirely",
+			projectData: []byte(`provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_lambda_function" "should_show" {
+  function_name = "lambda_function_name"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+}
+
+resource "aws_lambda_function" "should_not_show" {
+  function_name = "lambda_function_name"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  memory_size   = 512
+}
+`),
+			usageData: []byte(`
+version: 0.1
+resource_usage:
+  aws_lambda_function.should_show:
+    monthly_requests: 100000
+    request_duration_ms: 350
+
+  aws_lambda_function.should_not_show:
+    monthly_requests: 0
+`),
+			want: `
+ Name                             Monthly Qty  Unit         Monthly Cost 
+                                                                         
+ aws_lambda_function.should_show                                         
+ ├─ Requests                              0.1  1M requests         $0.02 
+ └─ Duration                            4,375  GB-seconds          $0.07 
+                                                                         
+ OVERALL TOTAL                                                     $0.09 `,
+		},
+		{
+			name: "should remove sub resources",
+			projectData: []byte(`
+
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_s3_bucket" "usage" {
+  bucket = "bucket2_withUsage"
+}
+`),
+			usageData: []byte(`
+version: 0.1
+resource_usage:
+  aws_s3_bucket.usage:
+    standard:
+      storage_gb: 10000
+      monthly_select_data_scanned_gb: 0
+`),
+			want: `
+ Name                                             Monthly Qty  Unit                    Monthly Cost 
+                                                                                                    
+ aws_s3_bucket.usage                                                                                
+ └─ Standard                                                                                        
+    ├─ Storage                                         10,000  GB                           $230.00 
+    ├─ PUT, COPY, POST, LIST requests       Monthly cost depends on usage: $0.005 per 1k requests   
+    ├─ GET, SELECT, and all other requests  Monthly cost depends on usage: $0.0004 per 1k requests  
+    └─ Select data returned                 Monthly cost depends on usage: $0.0007 per GB           
+                                                                                                    
+ OVERALL TOTAL                                                                              $230.00 
+----------------------------------
+To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runCtx, err := config.NewRunContextFromEnv(context.Background())
+
+			assert.NoError(t, err)
+			tfProject := tftest.TerraformProject{
+				Files: []tftest.File{
+					{
+						Path:     "main.tf",
+						Contents: string(tt.projectData),
+					},
+				},
+			}
+
+			u, err := usage.ParseYaml(tt.usageData)
+			assert.NoError(t, err)
+
+			projects, err := tftest.RunCostCalculations(t, runCtx, tfProject, u)
+			assert.NoError(t, err)
+			assert.Len(t, projects, 1)
+
+			r := ToOutputFormat(projects)
+			r.Currency = runCtx.Config.Currency
+			actual, err := ToTable(r, Options{
+				ShowSkipped: true,
+				NoColor:     true,
+				Fields:      runCtx.Config.Fields,
+			})
+
+			assert.Equal(t, tt.wantErr, err)
+
+			endOfFirstLine := bytes.Index(actual, []byte("\n"))
+			if endOfFirstLine > 0 {
+				actual = actual[endOfFirstLine+1:]
+			}
+			assert.Equal(t, tt.want, string(actual))
+		})
+	}
+}

--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
@@ -22,7 +22,6 @@
  aws_autoscaling_group.asg_lc_cpu_credits_noUsage                                                  
  └─ aws_launch_configuration.lc_cpu_credits_noUsage                                                
     ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)           1,460  hours             $60.74 
-    ├─ CPU credits                                                     0  vCPU-hours         $0.00 
     └─ root_block_device                                                                           
        └─ Storage (general purpose SSD, gp2)                          16  GB                 $1.60 
                                                                                                    
@@ -37,7 +36,6 @@
  └─ aws_launch_configuration.lc_reserved                                                           
     ├─ Instance usage (Linux/UNIX, reserved, t3.medium)              730  hours             $19.05 
     ├─ EC2 detailed monitoring                                         7  metrics            $2.10 
-    ├─ CPU credits                                                     0  vCPU-hours         $0.00 
     └─ root_block_device                                                                           
        └─ Storage (general purpose SSD, gp2)                           8  GB                 $0.80 
                                                                                                    
@@ -60,7 +58,6 @@
  └─ aws_launch_configuration.lc_windows                                                            
     ├─ Instance usage (Windows, on-demand, t3.medium)                730  hours             $43.80 
     ├─ EC2 detailed monitoring                                         7  metrics            $2.10 
-    ├─ CPU credits                                                     0  vCPU-hours         $0.00 
     └─ root_block_device                                                                           
        └─ Storage (general purpose SSD, gp2)                           8  GB                 $0.80 
                                                                                                    
@@ -80,8 +77,7 @@
                                                                                                    
  aws_autoscaling_group.asg_lt_cpu_credits_noUsage                                                  
  └─ aws_launch_template.lt_cpu_credits_noUsage                                                     
-    ├─ Instance usage (Linux/UNIX, on-demand, t3.large)            1,460  hours            $121.47 
-    └─ CPU credits                                                     0  vCPU-hours         $0.00 
+    └─ Instance usage (Linux/UNIX, on-demand, t3.large)            1,460  hours            $121.47 
                                                                                                    
  aws_autoscaling_group.asg_lt_ebs_optimized                                                        
  └─ aws_launch_template.lt_ebs_optimized                                                           

--- a/internal/providers/terraform/aws/testdata/cloudformation_stack_set_test/cloudformation_stack_set_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudformation_stack_set_test/cloudformation_stack_set_test.golden
@@ -2,8 +2,7 @@
  Name                                                 Monthly Qty  Unit                    Monthly Cost 
                                                                                                         
  aws_cloudformation_stack_set.withoutTemplBody                                                          
- ├─ Handler operations                                     10,000  operations                     $9.00 
- └─ Durations above 30s                                         0  seconds                        $0.00 
+ └─ Handler operations                                     10,000  operations                     $9.00 
                                                                                                         
  aws_cloudformation_stack_set.withoutUsage                                                              
  ├─ Handler operations                          Monthly cost depends on usage: $0.0009 per operations   

--- a/internal/providers/terraform/aws/testdata/cloudformation_stack_test/cloudformation_stack_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudformation_stack_test/cloudformation_stack_test.golden
@@ -2,8 +2,7 @@
  Name                                             Monthly Qty  Unit                    Monthly Cost 
                                                                                                     
  aws_cloudformation_stack.withoutTemplBody                                                          
- ├─ Handler operations                                 10,000  operations                     $9.00 
- └─ Durations above 30s                                     0  seconds                        $0.00 
+ └─ Handler operations                                 10,000  operations                     $9.00 
                                                                                                     
  aws_cloudformation_stack.withoutUsage                                                              
  ├─ Handler operations                      Monthly cost depends on usage: $0.0009 per operations   

--- a/internal/providers/terraform/aws/testdata/dms_test/dms_test.golden
+++ b/internal/providers/terraform/aws/testdata/dms_test/dms_test.golden
@@ -6,7 +6,6 @@
  └─ Storage (general purpose SSD, gp2)                                                 20  GB            $4.60 
                                                                                                                
  aws_dms_replication_instance.my_dms_replication_instance_single_low_storage                                   
- ├─ Instance (t2.micro)                                                               730  hours        $13.14 
- └─ Storage (general purpose SSD, gp2)                                                  0  GB            $0.00 
+ └─ Instance (t2.micro)                                                               730  hours        $13.14 
                                                                                                                
  OVERALL TOTAL                                                                                          $44.02 

--- a/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.golden
+++ b/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.golden
@@ -6,8 +6,4 @@
  ├─ Per vCPU per hour                              2  CPU          $59.10 
  └─ Inference accelerator (eia2.medium)        1,460  hours       $175.20 
                                                                           
- aws_ecs_service.ecs_fargate2                                             
- ├─ Per GB per hour                                0  GB            $0.00 
- └─ Per vCPU per hour                              0  CPU           $0.00 
-                                                                          
  OVERALL TOTAL                                                    $247.28 

--- a/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
@@ -3,7 +3,6 @@
                                                                                                 
  aws_eks_node_group.example                                                                     
  ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)             730  hours             $30.37 
- ├─ CPU credits                                                     0  vCPU-hours         $0.00 
  └─ Storage (general purpose SSD, gp2)                             20  GB                 $2.00 
                                                                                                 
  aws_eks_node_group.example2                                                                    
@@ -12,7 +11,6 @@
                                                                                                 
  aws_eks_node_group.example_defaultCpuCredits                                                   
  ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)           2,190  hours             $91.10 
- ├─ CPU credits                                                     0  vCPU-hours         $0.00 
  └─ Storage (general purpose SSD, gp2)                             60  GB                 $6.00 
                                                                                                 
  aws_eks_node_group.example_with_launch_template                                                
@@ -26,7 +24,6 @@
  aws_eks_node_group.example_with_launch_template_2                                              
  └─ aws_launch_template.foo2                                                                    
     ├─ Instance usage (Linux/UNIX, on-demand, m5.xlarge)        2,190  hours            $420.48 
-    ├─ EBS-optimized usage                                      2,190  hours              $0.00 
     ├─ Inference accelerator (eia1.medium)                      2,190  hours            $284.70 
     └─ block_device_mapping[0]                                                                  
        └─ Storage (general purpose SSD, gp2)                       60  GB                 $6.00 
@@ -34,7 +31,6 @@
  aws_eks_node_group.example_with_launch_template_3                                              
  └─ aws_launch_template.foo3                                                                    
     ├─ Instance usage (Linux/UNIX, on-demand, m5.xlarge)        2,190  hours            $420.48 
-    ├─ EBS-optimized usage                                      2,190  hours              $0.00 
     ├─ Inference accelerator (eia1.medium)                      2,190  hours            $284.70 
     └─ block_device_mapping[0]                                                                  
        └─ Storage (general purpose SSD, gp2)                       60  GB                 $6.00 
@@ -52,7 +48,6 @@
                                                                                                 
  aws_eks_node_group.usage                                                                       
  ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)           4,380  hours            $182.21 
- ├─ CPU credits                                                     0  vCPU-hours         $0.00 
  └─ Storage (general purpose SSD, gp2)                            120  GB                $12.00 
                                                                                                 
  aws_eks_node_group.windows                                                                     

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
@@ -2,38 +2,30 @@
  Name                                                       Monthly Qty  Unit                  Monthly Cost 
                                                                                                             
  aws_instance.cnvr_1yr_all_upfront                                                                          
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.cnvr_1yr_no_upfront                                                                           
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $21.90 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.cnvr_1yr_partial_upfront                                                                      
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $10.44 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.cnvr_3yr_all_upfront                                                                          
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.cnvr_3yr_no_upfront                                                                           
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $15.04 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.cnvr_3yr_partial_upfront                                                                      
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $7.01 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
@@ -72,38 +64,30 @@
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.std_1yr_all_upfront                                                                           
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.std_1yr_no_upfront                                                                            
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $19.05 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.std_1yr_partial_upfront                                                                       
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $9.05 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.std_3yr_all_upfront                                                                           
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.std_3yr_no_upfront                                                                            
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $13.14 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  aws_instance.std_3yr_partial_upfront                                                                       
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $6.06 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
@@ -125,7 +109,6 @@
                                                                                                             
  aws_instance.t3_default_cpuCredits                                                                         
  ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               730  hours                       $30.37 
- ├─ CPU credits                                                       0  vCPU-hours                   $0.00 
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -13,17 +13,19 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/infracost/infracost/internal/output"
 	"github.com/infracost/infracost/internal/usage"
-	"github.com/stretchr/testify/require"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/prices"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/infracost/infracost/internal/testutil"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/infracost/infracost/internal/providers/terraform"
 )

--- a/internal/usage/usage_file.go
+++ b/internal/usage/usage_file.go
@@ -8,12 +8,13 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/infracost/infracost"
-	"github.com/infracost/infracost/internal/schema"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v2"
+
+	"github.com/infracost/infracost"
+	"github.com/infracost/infracost/internal/schema"
 )
 
 const minUsageFileVersion = "0.1"
@@ -217,7 +218,7 @@ func mapToSortedMapSlice(input map[string]interface{}) yaml.MapSlice {
 
 func loadReferenceFile() (map[string]*schema.UsageData, error) {
 	referenceUsageFileContents := infracost.GetReferenceUsageFileContents()
-	usageData, err := parseYAML(*referenceUsageFileContents)
+	usageData, err := ParseYaml(*referenceUsageFileContents)
 	if err != nil {
 		return usageData, errors.Wrapf(err, "Error parsing usage file")
 	}
@@ -256,7 +257,7 @@ func LoadFromFile(usageFilePath string, createIfNotExisting bool) (map[string]*s
 		return usageData, errors.Wrapf(err, "Error reading usage file")
 	}
 
-	usageData, err = parseYAML(out)
+	usageData, err = ParseYaml(out)
 	if err != nil {
 		return usageData, errors.Wrapf(err, "Error parsing usage file")
 	}
@@ -264,7 +265,7 @@ func LoadFromFile(usageFilePath string, createIfNotExisting bool) (map[string]*s
 	return usageData, nil
 }
 
-func parseYAML(y []byte) (map[string]*schema.UsageData, error) {
+func ParseYaml(y []byte) (map[string]*schema.UsageData, error) {
 	var usageFile UsageFile
 
 	err := yaml.Unmarshal(y, &usageFile)


### PR DESCRIPTION
Closes #929

Removes table output of 0 cost items. JSON output has been kept intact - see #929 for more info.

Cases covered by this pr:

1. **0 cost components removed**
```
 aws_dx_connection.my_dx_connection_usage                                                    
 ├─ DX connection                                                   730  hours       $219.00 
 ├─ Outbound data transfer (from ap-east-1, to EqDC2)                 0  GB           $0.00 
 └─ Outbound data transfer (from eu-west-1, to EqDC2)             1,000  GB           $28.20 
 
 now goes to:
 
  aws_dx_connection.my_dx_connection_usage                                                    
 ├─ DX connection                                                   730  hours       $219.00 
 └─ Outbound data transfer (from eu-west-1, to EqDC2)             1,000  GB           $28.20 
```
2. **0 cost sub resource cost components removed**
```
 aws_dx_connection.my_dx_connection_usage                                               
 └─ sub resource
    ├─ should not                                                0  GB           $0.00                                                                
    └─ should show                                           1,000  GB           $28.20 
 
 now goes to:
 
 aws_dx_connection.my_dx_connection_usage                                               
 └─ sub resource                                                          
    └─ should show                                           1,000  GB           $28.20 
```
3. **resource with 0 cost components removed**
```
 aws_dx_connection.my_dx_connection_usage                                                    
 └─ Outbound data transfer (from eu-west-1, to EqDC2)             0  GB           $0.00 
 
  now goes to:
 
```

Note: I haven't touched diffs - let me know if this in the scope of the issue. I'll also update the docs in a separate PR.