### PR TITLE
 fix(aws): cloudfront monthly http requests usage

### DIFF
--- a/internal/providers/terraform/aws/cloudfront_distribution.go
+++ b/internal/providers/terraform/aws/cloudfront_distribution.go
@@ -2,11 +2,13 @@ package aws
 
 import (
 	"fmt"
-	"github.com/infracost/infracost/internal/schema"
-	"github.com/infracost/infracost/internal/usage"
+	"strconv"
+
 	"github.com/shopspring/decimal"
 	"github.com/tidwall/gjson"
-	"strconv"
+
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
 )
 
 type regionData struct {
@@ -236,8 +238,8 @@ func httpRequests(u *schema.UsageData) *schema.Resource {
 	}
 
 	var uMap map[string]gjson.Result
-	if u != nil && u.Get("monthly_https_requests").Exists() {
-		uMap = u.Get("monthly_https_requests").Map()
+	if u != nil && u.Get("monthly_http_requests").Exists() {
+		uMap = u.Get("monthly_http_requests").Map()
 	}
 
 	regionsData := []*regionData{

--- a/internal/providers/terraform/aws/testdata/cloudfront_distribution_test/cloudfront_distribution_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudfront_distribution_test/cloudfront_distribution_test.golden
@@ -125,14 +125,14 @@
  │  ├─ Hong Kong, Philippines, Asia Pacific                           1,234  GB                            $74.04 
  │  └─ India                                                          1,234  GB                           $197.44 
  ├─ HTTP requests                                                                                                 
- │  ├─ US, Mexico, Canada                                             12.34  10k requests                   $0.09 
- │  ├─ Europe, Israel                                                 12.34  10k requests                   $0.11 
- │  ├─ South Africa, Kenya, Middle East                               12.34  10k requests                   $0.11 
- │  ├─ South America                                                  12.34  10k requests                   $0.20 
- │  ├─ Japan                                                          12.34  10k requests                   $0.11 
- │  ├─ Australia, New Zealand                                         12.34  10k requests                   $0.11 
- │  ├─ Hong Kong, Philippines, Asia Pacific                           12.34  10k requests                   $0.11 
- │  └─ India                                                          12.34  10k requests                   $0.11 
+ │  ├─ US, Mexico, Canada                                             22.34  10k requests                   $0.17 
+ │  ├─ Europe, Israel                                                 22.34  10k requests                   $0.20 
+ │  ├─ South Africa, Kenya, Middle East                               22.34  10k requests                   $0.20 
+ │  ├─ South America                                                  22.34  10k requests                   $0.36 
+ │  ├─ Japan                                                          22.34  10k requests                   $0.20 
+ │  ├─ Australia, New Zealand                                         22.34  10k requests                   $0.20 
+ │  ├─ Hong Kong, Philippines, Asia Pacific                           22.34  10k requests                   $0.20 
+ │  └─ India                                                          22.34  10k requests                   $0.20 
  ├─ HTTPS requests                                                                                                
  │  ├─ US, Mexico, Canada                                             12.34  10k requests                   $0.12 
  │  ├─ Europe, Israel                                                 12.34  10k requests                   $0.15 
@@ -160,6 +160,6 @@
     ├─ Select data scanned                                Monthly cost depends on usage: $0.002 per GB            
     └─ Select data returned                               Monthly cost depends on usage: $0.0007 per GB           
                                                                                                                   
- OVERALL TOTAL                                                                                      $5,266,435.41 
+ OVERALL TOTAL                                                                                      $5,266,436.19 
 ----------------------------------
 To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudfront_distribution_test/cloudfront_distribution_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/cloudfront_distribution_test/cloudfront_distribution_test.usage.yml
@@ -20,14 +20,14 @@ resource_usage:
       asia_pacific: 1234 # Hong Kong, Philippines, Singapore, South Korea, Taiwan, Thailand
       india: 1234 # India
     monthly_http_requests:
-      us: 123400 # United States, Mexico, Canada
-      europe: 123400 # Europe, Israel
-      south_africa: 123400 # South Africa, Kenya, Middle East
-      south_america: 123400 # South America
-      japan: 123400 # Japan
-      australia: 123400 # Australia, New Zealand
-      asia_pacific: 123400 # Hong Kong, Philippines, Singapore, South Korea, Taiwan, Thailand
-      india: 123400 # India
+      us: 223400 # United States, Mexico, Canada
+      europe: 223400 # Europe, Israel
+      south_africa: 223400 # South Africa, Kenya, Middle East
+      south_america: 223400 # South America
+      japan: 223400 # Japan
+      australia: 223400 # Australia, New Zealand
+      asia_pacific: 223400 # Hong Kong, Philippines, Singapore, South Korea, Taiwan, Thailand
+      india: 223400 # India
     monthly_https_requests:
       us: 123400 # United States, Mexico, Canada
       europe: 123400 # Europe, Israel


### PR DESCRIPTION
 @tim775 spotted a minor typo in `monthly_http_requests` when tackling #1043. 
 
 Updated with the correct usage key and changed tests to pick up if altered in future.