### PR TITLE
fix: Fix cloudfront dist to check keys with .Empty instead of .Exists

### DIFF
--- a/internal/providers/terraform/aws/cloudfront_distribution.go
+++ b/internal/providers/terraform/aws/cloudfront_distribution.go
@@ -344,7 +344,7 @@ func shieldRequests(d *schema.ResourceData, u *schema.UsageData) *schema.CostCom
 	}
 
 	region := d.Get("region").String()
-	if !d.Empty("origin.0.origin_shield.0.origin_shield_region") {
+	if !d.IsEmpty("origin.0.origin_shield.0.origin_shield_region") {
 		region = d.Get("origin.0.origin_shield.0.origin_shield_region").String()
 	}
 
@@ -399,7 +399,7 @@ func shieldRequests(d *schema.ResourceData, u *schema.UsageData) *schema.CostCom
 func invalidationRequests(u *schema.UsageData) []*schema.CostComponent {
 	var freeQuantity *decimal.Decimal
 	var paidQuantity *decimal.Decimal
-	if u != nil && !u.Empty("monthly_invalidation_requests") {
+	if u != nil && !u.IsEmpty("monthly_invalidation_requests") {
 		usageAmount := u.Get("monthly_invalidation_requests").Int()
 		if usageAmount < 1000 {
 			freeQuantity = decimalPtr(decimal.NewFromInt(usageAmount))
@@ -451,12 +451,12 @@ func invalidationRequests(u *schema.UsageData) []*schema.CostComponent {
 }
 
 func encryptionRequests(d *schema.ResourceData, u *schema.UsageData) *schema.CostComponent {
-	if d.Empty("default_cache_behavior.0.field_level_encryption_id") {
+	if d.IsEmpty("default_cache_behavior.0.field_level_encryption_id") {
 		return nil
 	}
 
 	var quantity *decimal.Decimal
-	if u != nil && !u.Empty("monthly_encryption_requests") {
+	if u != nil && !u.IsEmpty("monthly_encryption_requests") {
 		quantity = decimalPtr(decimal.NewFromInt(u.Get("monthly_encryption_requests").Int()))
 	}
 
@@ -477,12 +477,12 @@ func encryptionRequests(d *schema.ResourceData, u *schema.UsageData) *schema.Cos
 }
 
 func realtimeLogs(d *schema.ResourceData, u *schema.UsageData) *schema.CostComponent {
-	if d.Empty("logging_config.0.bucket") {
+	if d.IsEmpty("logging_config.0.bucket") {
 		return nil
 	}
 
 	var quantity *decimal.Decimal
-	if u != nil && !u.Empty("monthly_log_lines") {
+	if u != nil && !u.IsEmpty("monthly_log_lines") {
 		quantity = decimalPtr(decimal.NewFromInt(u.Get("monthly_log_lines").Int()))
 	}
 
@@ -507,7 +507,7 @@ func customSSLCertificate(d *schema.ResourceData, u *schema.UsageData) *schema.C
 	}
 
 	quantity := decimalPtr(decimal.NewFromInt(1))
-	if u != nil && !u.Empty("custom_ssl_certificates") {
+	if u != nil && !u.IsEmpty("custom_ssl_certificates") {
 		quantity = decimalPtr(decimal.NewFromInt(u.Get("custom_ssl_certificates").Int()))
 	}
 	return &schema.CostComponent{

--- a/internal/schema/resource_data.go
+++ b/internal/schema/resource_data.go
@@ -47,7 +47,7 @@ func (d *ResourceData) Get(key string) gjson.Result {
 
 // Return true if the key doesn't exist, is null, or is an empty string.
 // Needed because gjson.Exists returns true as long as a key exists, even if it's empty or null.
-func (d *ResourceData) Empty(key string) bool {
+func (d *ResourceData) IsEmpty(key string) bool {
 	g := d.RawValues.Get(key)
 	return g.Type == gjson.Null || len(g.Raw) == 0 || g.Raw == "\"\"" || emptyObjectOrArray(g)
 }

--- a/internal/schema/resource_data_test.go
+++ b/internal/schema/resource_data_test.go
@@ -67,7 +67,7 @@ func TestResourceDataEmpty(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.key, func(t *testing.T) {
-			assert.Equal(t, tt.want, r.Empty(tt.key))
+			assert.Equal(t, tt.want, r.IsEmpty(tt.key))
 		})
 	}
 

--- a/internal/schema/usage_data.go
+++ b/internal/schema/usage_data.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
@@ -72,23 +71,9 @@ func (u *UsageData) GetStringArray(key string) *[]string {
 	return nil
 }
 
-func (u *UsageData) IsEmpty(key string) bool {
-	if u.Attributes[key].Type == gjson.Null {
-		return true
-	}
-
-	if u.Attributes[key].Value() == nil {
-		return true
-	}
-
-	val := reflect.ValueOf(u.Attributes[key].Value())
-
-	return val.IsZero() || val.Len() == 0
-}
-
 // Return true if the key doesn't exist, is null, or is an empty string.
 // Needed because gjson.Exists returns true as long as a key exists, even if it's empty or null.
-func (u *UsageData) Empty(key string) bool {
+func (u *UsageData) IsEmpty(key string) bool {
 	g := u.Get(key)
 	return g.Type == gjson.Null || len(g.Raw) == 0 || g.Raw == "\"\"" || emptyObjectOrArray(g)
 }

--- a/internal/usage/usage_file_test.go
+++ b/internal/usage/usage_file_test.go
@@ -100,7 +100,7 @@ resource_usage:
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.key, func(t *testing.T) {
-			assert.Equal(t, tt.want, u.Empty(tt.key))
+			assert.Equal(t, tt.want, u.IsEmpty(tt.key))
 		})
 	}
 


### PR DESCRIPTION
@alikhajeh1 Noticed that the `Field level encryption requests                Monthly cost depends on usage: $0.02 per 10k requests` line was still showing up in some cases even after #1049.  It turns out sometimes `field_level_encryption_id` can be null, sometimes empty string.

@aliscott if the new `.Empty` looks good, what do you think about replacing all use of `.Exists` with it (since that's a known anti-pattern)?