### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -57,7 +57,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 			currency := ""
 
 			for _, f := range inputFiles {
-				data, err := ioutil.ReadFile(f)
+				data, err := os.ReadFile(f)
 				if err != nil {
 					return errors.Wrap(err, "Error reading JSON file")
 				}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -152,7 +151,7 @@ func (c *Config) ConfigureLogger() error {
 	})
 
 	if c.LogLevel == "" {
-		logrus.SetOutput(ioutil.Discard)
+		logrus.SetOutput(io.Discard)
 		return nil
 	}
 

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ func LoadConfigFile(path string) (ConfigFileSpec, error) {
 		return cfgFile, fmt.Errorf("Config file does not exist at %s", path)
 	}
 
-	rawCfgFile, err := ioutil.ReadFile(path)
+	rawCfgFile, err := os.ReadFile(path)
 	if err != nil {
 		return cfgFile, err
 	}

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -54,7 +53,7 @@ func readConfigurationFileIfExists() (Configuration, error) {
 		return Configuration{}, nil
 	}
 
-	data, err := ioutil.ReadFile(ConfigurationFilePath())
+	data, err := os.ReadFile(ConfigurationFilePath())
 	if err != nil {
 		return Configuration{}, err
 	}
@@ -77,7 +76,7 @@ func writeConfigurationFile(c Configuration) error {
 		return err
 	}
 
-	return ioutil.WriteFile(ConfigurationFilePath(), data, 0600)
+	return os.WriteFile(ConfigurationFilePath(), data, 0600)
 }
 
 func ConfigurationFilePath() string {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -59,7 +58,7 @@ func readCredentialsFileIfExists() (Credentials, error) {
 		return Credentials{}, nil
 	}
 
-	data, err := ioutil.ReadFile(CredentialsFilePath())
+	data, err := os.ReadFile(CredentialsFilePath())
 	if err != nil {
 		return Credentials{}, err
 	}
@@ -82,7 +81,7 @@ func writeCredentialsFile(c Credentials) error {
 		return err
 	}
 
-	return ioutil.WriteFile(CredentialsFilePath(), data, 0600)
+	return os.WriteFile(CredentialsFilePath(), data, 0600)
 }
 
 func CredentialsFilePath() string {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -30,7 +29,7 @@ func (c *Config) migrateCredentials() error {
 			Version string `yaml:"version"`
 		}
 
-		data, err := ioutil.ReadFile(credPath)
+		data, err := os.ReadFile(credPath)
 		if err != nil {
 			return err
 		}
@@ -51,7 +50,7 @@ func (c *Config) migrateCredentials() error {
 func (c *Config) migrateV0_7_17(oldPath string, newPath string) error {
 	log.Debugf("Migrating old credentials from %s to %s", oldPath, newPath)
 
-	data, err := ioutil.ReadFile(oldPath)
+	data, err := os.ReadFile(oldPath)
 	if err != nil {
 		return err
 	}
@@ -91,7 +90,7 @@ func (c *Config) migrateV0_9_4(credPath string) error {
 	// Use MapSlice to keep the order of the items, so we can always use the first one
 	var oldCreds yaml.MapSlice
 
-	data, err := ioutil.ReadFile(credPath)
+	data, err := os.ReadFile(credPath)
 	if err != nil {
 		return err
 	}

--- a/internal/config/state.go
+++ b/internal/config/state.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -41,7 +40,7 @@ func readStateFileIfExists() (*State, error) {
 		return &State{}, nil
 	}
 
-	data, err := ioutil.ReadFile(stateFilePath())
+	data, err := os.ReadFile(stateFilePath())
 	if err != nil {
 		return &State{}, err
 	}
@@ -63,7 +62,7 @@ func writeStateFile(s *State) error {
 		return err
 	}
 
-	return ioutil.WriteFile(stateFilePath(), data, 0600)
+	return os.WriteFile(stateFilePath(), data, 0600)
 }
 
 func stateFilePath() string {

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -4,11 +4,11 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
-	"github.com/awslabs/goformation/v4"
-	"github.com/infracost/infracost/internal/providers/cloudformation"
-	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/awslabs/goformation/v4"
+	"github.com/infracost/infracost/internal/providers/cloudformation"
 
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/providers/terraform"
@@ -54,7 +54,7 @@ func Detect(ctx *config.ProjectContext) (schema.Provider, error) {
 }
 
 func isTerraformPlanJSON(path string) bool {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}
@@ -73,7 +73,7 @@ func isTerraformPlanJSON(path string) bool {
 }
 
 func isTerraformStateJSON(path string) bool {
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}

--- a/internal/providers/terraform/cloud.go
+++ b/internal/providers/terraform/cloud.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -49,7 +49,7 @@ func cloudAPI(host string, path string, token string) ([]byte, error) {
 		return []byte{}, errors.Errorf("invalid response from Terraform remote: %s", resp.Status)
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func findCloudToken(host string) string {
@@ -112,7 +112,7 @@ func credFromHCL(filename string, host string) (string, error) {
 }
 
 func credFromJSON(filename, host string) (string, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/internal/providers/terraform/cmd.go
+++ b/internal/providers/terraform/cmd.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -137,7 +136,7 @@ func CreateConfigFile(dir string, terraformCloudHost string, terraformCloudToken
 	}
 
 	log.Debug("Creating temporary config file for Terraform credentials")
-	tmpFile, err := ioutil.TempFile("", "")
+	tmpFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", err
 	}

--- a/internal/providers/terraform/plan_json_provider.go
+++ b/internal/providers/terraform/plan_json_provider.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/schema"
@@ -33,7 +33,7 @@ func (p *PlanJSONProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 }
 
 func (p *PlanJSONProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
-	j, err := ioutil.ReadFile(p.Path)
+	j, err := os.ReadFile(p.Path)
 	if err != nil {
 		return []*schema.Project{}, errors.Wrap(err, "Error reading Terraform plan JSON file")
 	}

--- a/internal/providers/terraform/state_json_provider.go
+++ b/internal/providers/terraform/state_json_provider.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/schema"
@@ -33,7 +33,7 @@ func (p *StateJSONProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 }
 
 func (p *StateJSONProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
-	j, err := ioutil.ReadFile(p.Path)
+	j, err := os.ReadFile(p.Path)
 	if err != nil {
 		return []*schema.Project{}, errors.Wrap(err, "Error reading Terraform state JSON file")
 	}

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -202,7 +201,7 @@ func GoldenFileResourceTestsWithOpts(t *testing.T, testName string, options *Gol
 	require.NoError(t, err)
 
 	// Load the terraform projects
-	tfProjectData, err := ioutil.ReadFile(filepath.Join("testdata", testName, testName+".tf"))
+	tfProjectData, err := os.ReadFile(filepath.Join("testdata", testName, testName+".tf"))
 	require.NoError(t, err)
 	tfProject := TerraformProject{
 		Files: []File{
@@ -279,7 +278,7 @@ func GoldenFileUsageSyncTest(t *testing.T, testName string) {
 	runCtx, err := config.NewRunContextFromEnv(context.Background())
 	require.NoError(t, err)
 
-	tfProjectData, err := ioutil.ReadFile(filepath.Join("testdata", testName, testName+".tf"))
+	tfProjectData, err := os.ReadFile(filepath.Join("testdata", testName, testName+".tf"))
 	require.NoError(t, err)
 	tfProject := TerraformProject{
 		Files: []File{
@@ -388,12 +387,12 @@ func copyInitCacheToPath(source, destination string) error {
 				}
 			} else {
 				if file.Name() != "init.tf" { // don't copy init.tf since the provider block will conflict with main.tf
-					srcData, err := ioutil.ReadFile(srcPath)
+					srcData, err := os.ReadFile(srcPath)
 					if err != nil {
 						return err
 					}
 
-					if err := ioutil.WriteFile(destPath, srcData, os.ModePerm); err != nil {
+					if err := os.WriteFile(destPath, srcData, os.ModePerm); err != nil {
 						return err
 					}
 				}
@@ -418,7 +417,7 @@ func writeToTmpDir(tmpDir string, tfProject TerraformProject) (string, error) {
 			}
 		}
 
-		err = ioutil.WriteFile(fullPath, []byte(terraformFile.Contents), 0600)
+		err = os.WriteFile(fullPath, []byte(terraformFile.Contents), 0600)
 		if err != nil {
 			return tmpDir, err
 		}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -162,7 +161,7 @@ func AssertGoldenFile(t *testing.T, goldenFilePath string, actual []byte) {
 	expected := []byte("")
 	if _, err := os.Stat(goldenFilePath); err == nil || !os.IsNotExist(err) {
 		// golden file exists, load the data
-		expected, err = ioutil.ReadFile(goldenFilePath)
+		expected, err = os.ReadFile(goldenFilePath)
 		assert.NoError(t, err)
 	}
 
@@ -176,7 +175,7 @@ func AssertGoldenFile(t *testing.T, goldenFilePath string, actual []byte) {
 				}
 			}
 
-			err := ioutil.WriteFile(goldenFilePath, actual, 0600)
+			err := os.WriteFile(goldenFilePath, actual, 0600)
 			assert.NoError(t, err)
 			t.Logf(fmt.Sprintf("Wrote golden file %s", goldenFilePath))
 		} else {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -142,7 +142,7 @@ func getLatestBrewVersion() (string, error) {
 		return "", err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +172,7 @@ func getLatestGitHubVersion() (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/internal/usage/usage_file.go
+++ b/internal/usage/usage_file.go
@@ -3,7 +3,6 @@ package usage
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -35,7 +34,7 @@ func LoadUsageFile(path string, createIfNotExist bool) (*UsageFile, error) {
 		}
 	}
 
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return &UsageFile{}, errors.Wrapf(err, "Error reading usage file")
 	}
@@ -132,12 +131,7 @@ See https://infracost.io/usage-file/ for docs`,
 	// If all the resources are commented then we also want to comment the resource_usage key
 	b = replaceCommentMarks(b)
 
-	err = ioutil.WriteFile(path, b, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(path, b, 0600)
 }
 
 func (u *UsageFile) ToUsageDataMap() map[string]*schema.UsageData {


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since infracost has been upgraded to Go 1.17 (#977), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.