### PR TITLE
feat: add support for nested usage properties using struct tags

### DIFF
--- a/internal/resources/core_resource.go
+++ b/internal/resources/core_resource.go
@@ -57,13 +57,33 @@ func PopulateArgsWithUsage(args interface{}, u *schema.UsageData) {
 			// Set the value of the arg to the value specified in the usage data.
 			if f.Type() == reflect.TypeOf(floatPtr) {
 				f.Set(reflect.ValueOf(u.GetFloat(usageKey)))
-			} else if f.Type() == reflect.TypeOf(intPtr) {
-				f.Set(reflect.ValueOf(u.GetInt(usageKey)))
-			} else if f.Type() == reflect.TypeOf(strPtr) {
-				f.Set(reflect.ValueOf(u.GetString(usageKey)))
-			} else {
-				log.Errorf("Unsupported field { UsageKey: %s, Type: %v }", usageKey, f.Type())
+				continue
 			}
+
+			if f.Type() == reflect.TypeOf(intPtr) {
+				f.Set(reflect.ValueOf(u.GetInt(usageKey)))
+				continue
+			}
+
+			if f.Type() == reflect.TypeOf(strPtr) {
+				f.Set(reflect.ValueOf(u.GetString(usageKey)))
+				continue
+			}
+
+			if f.Type().Elem().Kind() == reflect.Struct {
+				if f.IsNil() {
+					f.Set(reflect.New(f.Type().Elem()))
+				}
+
+				PopulateArgsWithUsage(f.Interface(), &schema.UsageData{
+					Address:    usageKey,
+					Attributes: u.Get(usageKey).Map(),
+				})
+
+				continue
+			}
+
+			log.Errorf("Unsupported field { UsageKey: %s, Type: %v }", usageKey, f.Type())
 		}
 	}
 }

--- a/internal/resources/core_resource_test.go
+++ b/internal/resources/core_resource_test.go
@@ -1,0 +1,140 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+
+	"github.com/infracost/infracost/internal/schema"
+)
+
+type resourceWithFloat struct {
+	MyFloat *float64 `infracost_usage:"my_float"`
+}
+
+type resourceWithString struct {
+	MyString *string `infracost_usage:"my_string"`
+}
+
+type resourceWithInt struct {
+	MyInt *int64 `infracost_usage:"my_int"`
+}
+
+type resourceWithSubUsage struct {
+	MySubUsage *subUsageResource `infracost_usage:"my_sub_usage"`
+}
+
+type subUsageResource struct {
+	MyInt    *int64  `infracost_usage:"my_int"`
+	MyString *string `infracost_usage:"my_string"`
+}
+
+type args struct {
+	args interface{}
+	u    *schema.UsageData
+}
+
+func TestPopulateArgsWithUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		args args
+		want interface{}
+	}{
+		{
+			name: "parses float usage",
+			args: args{
+				args: &resourceWithFloat{},
+				u: &schema.UsageData{
+					Attributes: map[string]gjson.Result{
+						"my_float": {
+							Type: gjson.Number,
+							Raw:  "1.4",
+							Num:  1.4,
+						},
+					},
+				},
+			},
+			want: &resourceWithFloat{
+				MyFloat: newFloat(1.4),
+			},
+		},
+		{
+			name: "parses int usage",
+			args: args{
+				args: &resourceWithInt{},
+				u: &schema.UsageData{
+					Attributes: map[string]gjson.Result{
+						"my_int": {
+							Type: gjson.Number,
+							Raw:  "2",
+							Num:  2,
+						},
+					},
+				},
+			},
+			want: &resourceWithInt{
+				MyInt: newInt(2),
+			},
+		},
+		{
+			name: "parses string usage",
+			args: args{
+				args: &resourceWithString{},
+				u: &schema.UsageData{
+					Attributes: map[string]gjson.Result{
+						"my_string": {
+							Type: gjson.String,
+							Raw:  "mystring",
+							Str:  "mystring",
+						},
+					},
+				},
+			},
+			want: &resourceWithString{
+				MyString: newString("mystring"),
+			},
+		},
+		{
+			name: "parses sub resources usage",
+			args: args{
+				args: &resourceWithSubUsage{},
+				u: &schema.UsageData{
+					Attributes: map[string]gjson.Result{
+						"my_sub_usage": {
+							Type: gjson.JSON,
+							Raw:  `{"my_int": 3, "my_string": "test"}`,
+						},
+					},
+				},
+			},
+			want: &resourceWithSubUsage{
+				MySubUsage: &subUsageResource{
+					MyInt:    newInt(3),
+					MyString: newString("test"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := tt.args.args
+
+			PopulateArgsWithUsage(v, tt.args.u)
+
+			assert.Equal(t, tt.want, v)
+		})
+	}
+}
+
+func newString(s string) *string {
+	return &s
+}
+
+func newInt(i int64) *int64 {
+	return &i
+}
+
+func newFloat(f float64) *float64 {
+	return &f
+}


### PR DESCRIPTION
With #441,  **AWS Directory Service** requires a nested usage parameter `monthly_data_processed_gb` which can be configured on a per-region basis. The usage file would work as such:

```
   monthly_data_processed_gb:
      us_east_1: 99
      eu_west_2: 77
```

(much like dx connection and cloudfront usage).

Now we support complex usage parsing `u.Get('usage_key').Map()` I've changed the `PopulateArgsWithUsage` function to populate resources that have complex usage properties. e.g. The above usage example could be written as such:

```
type MyResource struct {
    ....
    MonthlyDataProcessedGB *MonthlyData `infracost_usage:"monthly_data_processed_gb"`
}

type MonthlyData struct {
    EuWest2 *int64 `infracost_usage:"eu_west_2"`
    UsEast1 *int64 `infracost_usage:"us_east_1"`
}
```

Thought I'd open this as a separate PR rather than merging in with the changes in #441 so that PR doesn't get too large
