### PR TITLE
Update docker tagging

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,14 +36,30 @@ jobs:
             ./build/infracost-darwin-arm64.tar.gz
             ./docs/generated/docs.tar.gz
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}
-          tags: latest
-          tag_with_ref: true
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
 
       - name: Update Homebrew formula
         uses: dawidd6/action-homebrew-bump-formula@v3


### PR DESCRIPTION
**TODO: test this in next release if approved**

Currently we tag new version with: `:v0.9.11` and `:latest`. This updates it so we tag with `:0.9.11`, `:0.9`, and `:latest`. We remove the `v` prefix to be consistent with how other docker images are tagged.