### PR TITLE
fix: sort error keys before output to avoid test collisions

### DIFF
--- a/cmd/infracost/testdata/infracost-config-invalid-key.yml
+++ b/cmd/infracost/testdata/infracost-config-invalid-key.yml
@@ -2,7 +2,7 @@ version: 0.1
 
 projects:
   - path: "../../examples/terraform"
-    a_bad_key: "here"
     second_bad_key: "again"
+    a_bad_key: "here"
   - path: "../../examples/test"
     a_further_bad_key: "here"

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -160,7 +161,13 @@ func (f *fileSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			base: fmt.Sprintf("project config defined for path: [%s] is invalid", fields["path"]),
 		}
 
+		sorted := make([]string, 0, len(fields))
 		for k := range fields {
+			sorted = append(sorted, k)
+		}
+		sort.Strings(sorted)
+
+		for _, k := range sorted {
 			if _, ok := allowedKeys[k]; ok {
 				continue
 			}


### PR DESCRIPTION
Solves issues with golden file tests reporting failures because the output is out of order.