### PR TITLE
Add resource summary

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -268,10 +268,12 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 
 	spinner.Success()
 
-	r := output.ToOutputFormat(projects)
-	r.Currency = runCtx.Config.Currency
+	r, err := output.ToOutputFormat(projects)
+	if err != nil {
+		return err
+	}
 
-	var err error
+	r.Currency = runCtx.Config.Currency
 
 	dashboardClient := apiclient.NewDashboardAPIClient(runCtx)
 	r.RunID, err = dashboardClient.AddRun(runCtx, projectContexts, r)
@@ -457,6 +459,7 @@ func buildRunEnv(runCtx *config.RunContext, projectContexts []*config.ProjectCon
 	summary := r.FullSummary
 	env["supportedResourceCounts"] = summary.SupportedResourceCounts
 	env["unsupportedResourceCounts"] = summary.UnsupportedResourceCounts
+	env["noPriceResourceCounts"] = summary.NoPriceResourceCounts
 	env["totalSupportedResources"] = summary.TotalSupportedResources
 	env["totalUnsupportedResources"] = summary.TotalUnsupportedResources
 	env["totalNoPriceResources"] = summary.TotalNoPriceResources

--- a/cmd/infracost/testdata/breakdown_format_html/breakdown_format_html.golden
+++ b/cmd/infracost/testdata/breakdown_format_html/breakdown_format_html.golden
@@ -631,7 +631,7 @@ iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAMAAABlApw1AAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
     </table>
 
     <div class="warnings">
-      <p></p>
+      <p>5 cloud resources were detected, rerun with --show-skipped to see details:<br />∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file</p>
     </div>
   </body>
 </html>

--- a/cmd/infracost/testdata/breakdown_format_json/breakdown_format_json.golden
+++ b/cmd/infracost/testdata/breakdown_format_json/breakdown_format_json.golden
@@ -502,7 +502,13 @@
         "totalMonthlyCost": "1361.3075"
       },
       "summary": {
-        "unsupportedResourceCounts": {}
+        "totalDetectedResources": 5,
+        "totalSupportedResources": 5,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 5,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
       }
     }
   ],
@@ -514,6 +520,12 @@
   "diffTotalMonthlyCost": "1361.3075",
   "timeGenerated": "REPLACED_TIME",
   "summary": {
-    "unsupportedResourceCounts": {}
+    "totalDetectedResources": 5,
+    "totalSupportedResources": 5,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 5,
+    "totalNoPriceResources": 0,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {}
   }
 }

--- a/cmd/infracost/testdata/breakdown_format_jsonshow_skipped/breakdown_format_jsonshow_skipped.golden
+++ b/cmd/infracost/testdata/breakdown_format_jsonshow_skipped/breakdown_format_jsonshow_skipped.golden
@@ -502,7 +502,13 @@
         "totalMonthlyCost": "1361.3075"
       },
       "summary": {
-        "unsupportedResourceCounts": {}
+        "totalDetectedResources": 5,
+        "totalSupportedResources": 5,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 5,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
       }
     }
   ],
@@ -514,7 +520,13 @@
   "diffTotalMonthlyCost": "1361.3075",
   "timeGenerated": "REPLACED_TIME",
   "summary": {
-    "unsupportedResourceCounts": {}
+    "totalDetectedResources": 5,
+    "totalSupportedResources": 5,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 5,
+    "totalNoPriceResources": 0,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {}
   }
 }
 

--- a/cmd/infracost/testdata/breakdown_format_table/breakdown_format_table.golden
+++ b/cmd/infracost/testdata/breakdown_format_table/breakdown_format_table.golden
@@ -24,3 +24,6 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                             25,000,000  GB-seconds        $416.67 
                                                                                                
  OVERALL TOTAL                                                                       $1,361.31 
+----------------------------------
+5 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_directory/breakdown_terraform_directory.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_directory/breakdown_terraform_directory.golden
@@ -17,4 +17,5 @@ Project: infracost/infracost/examples/terraform
                                                                                                                       
  OVERALL TOTAL                                                                                                $742.64 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_fields_all/breakdown_terraform_fields_all.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_fields_all/breakdown_terraform_fields_all.golden
@@ -24,3 +24,6 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                            $0.0000166667   25,000,000  GB-seconds         $0.57       $416.67 
                                                                                                                            
  OVERALL TOTAL                                                                                                   $1,361.31 
+----------------------------------
+5 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_fields_invalid/breakdown_terraform_fields_invalid.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_fields_invalid/breakdown_terraform_fields_invalid.golden
@@ -24,6 +24,9 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                            $0.0000166667        $0.57 
                                                                                    
  OVERALL TOTAL                                                           $1,361.31 
+----------------------------------
+5 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 
 Err:
 Warning: Invalid field 'invalid' specified, valid fields are: [price monthlyQuantity unit hourlyCost monthlyCost] or 'all' to include all fields

--- a/cmd/infracost/testdata/breakdown_terraform_plan_json/breakdown_terraform_plan_json.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_plan_json/breakdown_terraform_plan_json.golden
@@ -24,3 +24,6 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                             25,000,000  GB-seconds        $416.67 
                                                                                                
  OVERALL TOTAL                                                                       $1,361.31 
+----------------------------------
+5 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_show_skipped/breakdown_terraform_show_skipped.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_show_skipped/breakdown_terraform_show_skipped.golden
@@ -28,9 +28,12 @@ Project: infracost/infracost/cmd/infracost/testdata/azure_firewall_plan.json
                                                                                              
  OVERALL TOTAL                                                                     $5,296.15 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_virtual_hub
-1 x azurerm_virtual_wan
+11 cloud resources were detected:
+∙ 6 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_virtual_hub
+  ∙ 1 x azurerm_virtual_wan
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/cmd/infracost/testdata/breakdown_terraform_sync_usage_file/breakdown_terraform_sync_usage_file.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_sync_usage_file/breakdown_terraform_sync_usage_file.golden
@@ -31,7 +31,8 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_terraform_sync_usa
                                                                                                     
  OVERALL TOTAL                                                                              $251.12 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
 
 Err:
     └─ Synced 0 of 6 resources

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file/breakdown_terraform_usage_file.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file/breakdown_terraform_usage_file.golden
@@ -24,3 +24,6 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                             25,000,000  GB-seconds        $416.67 
                                                                                                
  OVERALL TOTAL                                                                       $1,361.31 
+----------------------------------
+5 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file_invalid_key/breakdown_terraform_usage_file_invalid_key.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file_invalid_key/breakdown_terraform_usage_file_invalid_key.golden
@@ -37,7 +37,8 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
                                                                                                                       
  OVERALL TOTAL                                                                                              $1,921.95 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 
 Err:
 Warning: The following usage file parameters are invalid and will be ignored: dup_invalid_key, invalid_key_1, invalid_key_2, invalid_key_3

--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
@@ -39,5 +39,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_state.json
                                                                                                     
  OVERALL TOTAL                                                                               $40.56 
 ----------------------------------
-1 resource type wasn't estimated as it's not supported yet, rerun with --show-skipped to see.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+14 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 7 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
+∙ 6 were free

--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
@@ -39,5 +39,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_state.json
                                                                                                     
  OVERALL TOTAL                                                                               $40.56 
 ----------------------------------
-1 resource type wasn't estimated as it's not supported yet, rerun with --show-skipped to see.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+14 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 7 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
+∙ 6 were free

--- a/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
@@ -73,5 +73,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
                                                                                                     
  OVERALL TOTAL                                                                               $81.12 
 ----------------------------------
-1 resource type wasn't estimated as it's not supported yet, rerun with --show-skipped to see.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+26 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+∙ 10 were free

--- a/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
@@ -73,5 +73,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
                                                                                                     
  OVERALL TOTAL                                                                               $81.12 
 ----------------------------------
-1 resource type wasn't estimated as it's not supported yet, rerun with --show-skipped to see.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+26 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+∙ 10 were free

--- a/cmd/infracost/testdata/breakdown_terragrunt/breakdown_terragrunt.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt/breakdown_terragrunt.golden
@@ -38,4 +38,5 @@ Project: infracost/infracost/examples/terragrunt/prod
 
  OVERALL TOTAL                                                                                                $799.61 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terragrunt_nested/breakdown_terragrunt_nested.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_nested/breakdown_terragrunt_nested.golden
@@ -38,4 +38,5 @@ Project: infracost/infracost/examples/terragrunt/prod
 
  OVERALL TOTAL                                                                                                $799.61 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/diff_terraform_directory/diff_terraform_directory.golden
+++ b/cmd/infracost/testdata/diff_terraform_directory/diff_terraform_directory.golden
@@ -37,4 +37,5 @@ Amount:  +$743 ($0.00 -> $743)
 ----------------------------------
 Key: ~ changed, + added, - removed
 
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/diff_terraform_plan_json/diff_terraform_plan_json.golden
+++ b/cmd/infracost/testdata/diff_terraform_plan_json/diff_terraform_plan_json.golden
@@ -82,3 +82,6 @@ Amount:  +$1,361 ($0.00 -> $1,361)
 
 ----------------------------------
 Key: ~ changed, + added, - removed
+
+5 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/diff_terraform_show_skipped/diff_terraform_show_skipped.golden
+++ b/cmd/infracost/testdata/diff_terraform_show_skipped/diff_terraform_show_skipped.golden
@@ -63,9 +63,12 @@ Amount:  +$5,296 ($0.00 -> $5,296)
 ----------------------------------
 Key: ~ changed, + added, - removed
 
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_virtual_hub
-1 x azurerm_virtual_wan
+11 cloud resources were detected:
+∙ 6 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_virtual_hub
+  ∙ 1 x azurerm_virtual_wan
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/cmd/infracost/testdata/diff_terraform_usage_file/diff_terraform_usage_file.golden
+++ b/cmd/infracost/testdata/diff_terraform_usage_file/diff_terraform_usage_file.golden
@@ -82,3 +82,6 @@ Amount:  +$1,361 ($0.00 -> $1,361)
 
 ----------------------------------
 Key: ~ changed, + added, - removed
+
+5 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
@@ -101,5 +101,7 @@ Percent: +100%
 ----------------------------------
 Key: ~ changed, + added, - removed
 
-1 resource type wasn't estimated as it's not supported yet, rerun with --show-skipped to see.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+26 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+∙ 10 were free

--- a/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
@@ -101,5 +101,7 @@ Percent: +100%
 ----------------------------------
 Key: ~ changed, + added, - removed
 
-1 resource type wasn't estimated as it's not supported yet, rerun with --show-skipped to see.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
+26 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+∙ 10 were free

--- a/cmd/infracost/testdata/diff_terragrunt/diff_terragrunt.golden
+++ b/cmd/infracost/testdata/diff_terragrunt/diff_terragrunt.golden
@@ -73,4 +73,5 @@ Amount:  +$748 ($0.00 -> $748)
 ----------------------------------
 Key: ~ changed, + added, - removed
 
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/diff_terragrunt_nested/diff_terragrunt_nested.golden
+++ b/cmd/infracost/testdata/diff_terragrunt_nested/diff_terragrunt_nested.golden
@@ -73,4 +73,5 @@ Amount:  +$748 ($0.00 -> $748)
 ----------------------------------
 Key: ~ changed, + added, - removed
 
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/flag_errors_config_file_and_terraform_workspace_env/flag_errors_config_file_and_terraform_workspace_env.golden
+++ b/cmd/infracost/testdata/flag_errors_config_file_and_terraform_workspace_env/flag_errors_config_file_and_terraform_workspace_env.golden
@@ -17,4 +17,5 @@ Project: infracost/infracost/examples/terraform (dev)
                                                                                                                       
  OVERALL TOTAL                                                                                                $742.64 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/flag_errors_terraform_workspace_flag_and_env/flag_errors_terraform_workspace_flag_and_env.golden
+++ b/cmd/infracost/testdata/flag_errors_terraform_workspace_flag_and_env/flag_errors_terraform_workspace_flag_and_env.golden
@@ -17,4 +17,5 @@ Project: infracost/infracost/examples/terraform (prod)
                                                                                                                       
  OVERALL TOTAL                                                                                                $742.64 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/output_format_html/output_format_html.golden
+++ b/cmd/infracost/testdata/output_format_html/output_format_html.golden
@@ -1033,7 +1033,7 @@ iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAMAAABlApw1AAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
     </table>
 
     <div class="warnings">
-      <p>2 resource types weren&#39;t estimated as they&#39;re not supported yet, rerun with --show-skipped to see.<br />Please watch/star https://github.com/infracost/infracost as new resources are added regularly.</p>
+      <p></p>
     </div>
   </body>
 </html>

--- a/cmd/infracost/testdata/output_format_table/output_format_table.golden
+++ b/cmd/infracost/testdata/output_format_table/output_format_table.golden
@@ -55,8 +55,3 @@ Project: infracost/infracost/cmd/infracost/testdata/azure_firewall_plan.json
  Project total                                                                     $4,018.65 
 
  OVERALL TOTAL                                                                     $5,379.96 
-----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-2 resource types weren't estimated as they're not supported yet, rerun with --show-skipped to see.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.

--- a/cmd/infracost/testdata/output_terraform_fields_all/output_terraform_fields_all.golden
+++ b/cmd/infracost/testdata/output_terraform_fields_all/output_terraform_fields_all.golden
@@ -55,8 +55,3 @@ Project: infracost/infracost/cmd/infracost/testdata/azure_firewall_plan.json
  Project total                                                                                                $4,018.65 
 
  OVERALL TOTAL                                                                                                $5,379.96 
-----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-2 resource types weren't estimated as they're not supported yet, rerun with --show-skipped to see.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -19,7 +19,6 @@ const (
 func ToDiff(out Root, opts Options) ([]byte, error) {
 	s := ""
 
-	hasNilCosts := false
 	noDiffProjects := make([]string, 0)
 
 	for i, project := range out.Projects {
@@ -45,11 +44,6 @@ func ToDiff(out Root, opts Options) ([]byte, error) {
 		for _, diffResource := range project.Diff.Resources {
 			oldResource := findResourceByName(project.PastBreakdown.Resources, diffResource.Name)
 			newResource := findResourceByName(project.Breakdown.Resources, diffResource.Name)
-
-			if (newResource == nil || resourceHasNilCosts(*newResource)) &&
-				(oldResource == nil || resourceHasNilCosts(*oldResource)) {
-				hasNilCosts = true
-			}
 
 			s += resourceToDiff(out.Currency, diffResource, oldResource, newResource, true)
 			s += "\n"
@@ -99,13 +93,7 @@ func ToDiff(out Root, opts Options) ([]byte, error) {
 		)
 	}
 
-	if hasNilCosts {
-		s += fmt.Sprintf("\n\nTo estimate usage-based resources use --usage-file, see %s",
-			ui.LinkString("https://infracost.io/usage-file"),
-		)
-	}
-
-	unsupportedMsg := out.unsupportedResourcesMessage(opts.ShowSkipped)
+	unsupportedMsg := out.summaryMessage(opts.ShowSkipped)
 	if unsupportedMsg != "" {
 		s += "\n\n" + unsupportedMsg
 	}

--- a/internal/output/html.go
+++ b/internal/output/html.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/shopspring/decimal"
 	"html/template"
 	"strings"
+
+	"github.com/infracost/infracost/internal/ui"
+	"github.com/shopspring/decimal"
 
 	"github.com/Masterminds/sprig"
 
@@ -28,7 +30,8 @@ func ToHTML(out Root, opts Options) ([]byte, error) {
 			safe = strings.ReplaceAll(safe, "\n", "<br />")
 			return template.HTML(safe) // nolint:gosec
 		},
-		"contains": contains,
+		"stripColor": ui.StripColor,
+		"contains":   contains,
 		"hasCost": func(cc []CostComponent, sr []Resource, resourceName string) bool {
 			if len(cc) > 0 || len(sr) > 0 {
 				return true
@@ -52,13 +55,13 @@ func ToHTML(out Root, opts Options) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	unsupportedResourcesMessage := out.unsupportedResourcesMessage(opts.ShowSkipped)
+	summaryMessage := out.summaryMessage(opts.ShowSkipped)
 
 	err = tmpl.Execute(bufw, struct {
-		Root                        Root
-		UnsupportedResourcesMessage string
-		Options                     Options
-	}{out, unsupportedResourcesMessage, opts})
+		Root           Root
+		SummaryMessage string
+		Options        Options
+	}{out, summaryMessage, opts})
 	if err != nil {
 		return []byte{}, err
 	}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -17,8 +17,6 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 
 	s := ""
 
-	hasNilCosts := false
-
 	// Don't show the project total if there's only one project result
 	// since we will show the overall total anyway
 	includeProjectTotals := len(out.Projects) != 1
@@ -36,10 +34,6 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 			ui.BoldString("Project:"),
 			project.Label(opts.DashboardEnabled),
 		)
-
-		if breakdownHasNilCosts(*project.Breakdown) {
-			hasNilCosts = true
-		}
 
 		tableOut := tableForBreakdown(out.Currency, *project.Breakdown, opts.Fields, includeProjectTotals)
 
@@ -69,24 +63,10 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 		fmt.Sprintf("%*s ", tableLen-(len(overallTitle)+1), totalOut), // pad based on the last line length
 	)
 
-	unsupportedMsg := out.unsupportedResourcesMessage(opts.ShowSkipped)
+	summaryMsg := out.summaryMessage(opts.ShowSkipped)
 
-	if hasNilCosts || unsupportedMsg != "" {
-		s += "\n----------------------------------"
-	}
-
-	if hasNilCosts {
-		s += fmt.Sprintf("\nTo estimate usage-based resources use --usage-file, see %s",
-			ui.LinkString("https://infracost.io/usage-file"),
-		)
-
-		if unsupportedMsg != "" {
-			s += "\n"
-		}
-	}
-
-	if unsupportedMsg != "" {
-		s += "\n" + unsupportedMsg
+	if summaryMsg != "" {
+		s += "\n----------------------------------\n" + summaryMsg
 	}
 
 	return []byte(s), nil

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -283,7 +283,7 @@ iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAMAAABlApw1AAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7O
     </table>
 
     <div class="warnings">
-      <p>{{.UnsupportedResourcesMessage | replaceNewLines}}</p>
+      <p>{{.SummaryMessage | stripColor | replaceNewLines}}</p>
     </div>
   </body>
 </html>`

--- a/internal/providers/terraform/aws/testdata/acm_certificate_test/acm_certificate_test.golden
+++ b/internal/providers/terraform/aws/testdata/acm_certificate_test/acm_certificate_test.golden
@@ -5,3 +5,6 @@
  └─ Certificate                              1  requests         $0.75 
                                                                        
  OVERALL TOTAL                                                   $0.75 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/acmpca_certificate_authority_test/acmpca_certificate_authority_test.golden
+++ b/internal/providers/terraform/aws/testdata/acmpca_certificate_authority_test/acmpca_certificate_authority_test.golden
@@ -22,4 +22,5 @@
                                                                                                             
  OVERALL TOTAL                                                                                   $10,160.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/api_gateway_rest_api_test/api_gateway_rest_api_test.golden
+++ b/internal/providers/terraform/aws/testdata/api_gateway_rest_api_test/api_gateway_rest_api_test.golden
@@ -12,4 +12,5 @@
                                                                                             
  OVERALL TOTAL                                                                   $49,763.10 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/api_gateway_stage_test/api_gateway_stage_test.golden
+++ b/internal/providers/terraform/aws/testdata/api_gateway_stage_test/api_gateway_stage_test.golden
@@ -8,3 +8,6 @@
  └─ Cache memory (237 GB)               730  hours     $2,774.00 
                                                                  
  OVERALL TOTAL                                         $2,788.60 
+----------------------------------
+2 cloud resources were detected:
+∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/apigatewayv2_api_test/apigatewayv2_api_test.golden
+++ b/internal/providers/terraform/aws/testdata/apigatewayv2_api_test/apigatewayv2_api_test.golden
@@ -19,4 +19,5 @@
                                                                                             
  OVERALL TOTAL                                                                    $2,332.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
@@ -114,9 +114,13 @@
                                                                                                    
  OVERALL TOTAL                                                                           $3,133.01 
 ----------------------------------
-1 resource type wasn't estimated as it's not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-2 x aws_autoscaling_group
+40 cloud resources were detected:
+∙ 18 were estimated, 18 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 2 x aws_autoscaling_group
+∙ 20 were free
+  ∙ 11 x aws_launch_template
+  ∙ 9 x aws_launch_configuration
 Logs:
 
 level=warning msg="Skipping resource aws_launch_configuration.lc_tenancy_host. Infracost currently does not support host tenancy for AWS Launch Configurations"

--- a/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.golden
+++ b/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.golden
@@ -31,4 +31,5 @@
                                                                                 
  OVERALL TOTAL                                                       $12,960.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudformation_stack_set_test/cloudformation_stack_set_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudformation_stack_set_test/cloudformation_stack_set_test.golden
@@ -10,4 +10,7 @@
                                                                                                         
  OVERALL TOTAL                                                                                    $9.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x aws_cloudformation_stack_set

--- a/internal/providers/terraform/aws/testdata/cloudformation_stack_test/cloudformation_stack_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudformation_stack_test/cloudformation_stack_test.golden
@@ -10,4 +10,7 @@
                                                                                                     
  OVERALL TOTAL                                                                                $9.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x aws_cloudformation_stack

--- a/internal/providers/terraform/aws/testdata/cloudfront_distribution_test/cloudfront_distribution_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudfront_distribution_test/cloudfront_distribution_test.golden
@@ -176,4 +176,5 @@
                                                                                                                                     
  OVERALL TOTAL                                                                                                       $21,684,502.45 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+9 cloud resources were detected:
+∙ 9 were estimated, 9 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudwatch_dashboard_test/cloudwatch_dashboard_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudwatch_dashboard_test/cloudwatch_dashboard_test.golden
@@ -5,3 +5,6 @@
  └─ Dashboard                                  1  months         $3.00 
                                                                        
  OVERALL TOTAL                                                   $3.00 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/cloudwatch_event_bus_test/cloudwatch_event_bus_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudwatch_event_bus_test/cloudwatch_event_bus_test.golden
@@ -17,4 +17,5 @@
                                                                                                     
  OVERALL TOTAL                                                                               $17.70 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudwatch_log_group_test/cloudwatch_log_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudwatch_log_group_test/cloudwatch_log_group_test.golden
@@ -28,4 +28,5 @@
                                                                                                   
  OVERALL TOTAL                                                                          $2,065.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudwatch_metric_alarm_test/cloudwatch_metric_alarm_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudwatch_metric_alarm_test/cloudwatch_metric_alarm_test.golden
@@ -14,3 +14,6 @@
  └─ Standard resolution                                   1  alarm metrics         $0.10 
                                                                                          
  OVERALL TOTAL                                                                     $1.50 
+----------------------------------
+4 cloud resources were detected:
+∙ 4 were estimated

--- a/internal/providers/terraform/aws/testdata/codebuild_project_test/codebuild_project_test.golden
+++ b/internal/providers/terraform/aws/testdata/codebuild_project_test/codebuild_project_test.golden
@@ -18,4 +18,5 @@
                                                                                                    
  OVERALL TOTAL                                                                           $5,705.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/config_config_rule_test/config_config_rule_test.golden
+++ b/internal/providers/terraform/aws/testdata/config_config_rule_test/config_config_rule_test.golden
@@ -11,4 +11,5 @@
                                                                                                      
  OVERALL TOTAL                                                                               $670.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/config_configuration_recorder_test/config_configuration_recorder_test.golden
+++ b/internal/providers/terraform/aws/testdata/config_configuration_recorder_test/config_configuration_recorder_test.golden
@@ -11,4 +11,7 @@
                                                                                                                              
  OVERALL TOTAL                                                                                                         $9.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free
+  ∙ 2 x aws_iam_role

--- a/internal/providers/terraform/aws/testdata/config_organization_custom_rule_test/config_organization_custom_rule_test.golden
+++ b/internal/providers/terraform/aws/testdata/config_organization_custom_rule_test/config_organization_custom_rule_test.golden
@@ -11,4 +11,5 @@
                                                                                                                                        
  OVERALL TOTAL                                                                                                                 $470.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/config_organization_managed_rule_test/config_organization_managed_rule_test.golden
+++ b/internal/providers/terraform/aws/testdata/config_organization_managed_rule_test/config_organization_managed_rule_test.golden
@@ -11,4 +11,5 @@
                                                                                                                                          
  OVERALL TOTAL                                                                                                                   $470.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -195,3 +195,6 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  OVERALL TOTAL                                                           $325,124.38 
+----------------------------------
+24 cloud resources were detected:
+∙ 24 were estimated, 24 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
@@ -95,4 +95,5 @@
                                                                                                                  
  OVERALL TOTAL                                                                                         $5,293.39 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+22 cloud resources were detected:
+∙ 22 were estimated

--- a/internal/providers/terraform/aws/testdata/directory_service_directory_test/directory_service_directory_test.golden
+++ b/internal/providers/terraform/aws/testdata/directory_service_directory_test/directory_service_directory_test.golden
@@ -26,3 +26,6 @@
  └─ Additional domain controllers                                   3  controllers       $109.50 
                                                                                                  
  OVERALL TOTAL                                                                         $1,295.02 
+----------------------------------
+7 cloud resources were detected:
+∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/dms_test/dms_test.golden
+++ b/internal/providers/terraform/aws/testdata/dms_test/dms_test.golden
@@ -9,3 +9,6 @@
  └─ Instance (t2.micro)                                                               730  hours        $13.14 
                                                                                                                
  OVERALL TOTAL                                                                                          $44.02 
+----------------------------------
+2 cloud resources were detected:
+∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/docdb_cluster_instance_test/docdb_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/docdb_cluster_instance_test/docdb_cluster_instance_test.golden
@@ -20,4 +20,5 @@
                                                                                                        
  OVERALL TOTAL                                                                               $1,936.46 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/docdb_cluster_snapshot_test/docdb_cluster_snapshot_test.golden
+++ b/internal/providers/terraform/aws/testdata/docdb_cluster_snapshot_test/docdb_cluster_snapshot_test.golden
@@ -9,4 +9,5 @@
                                                                                                                 
  OVERALL TOTAL                                                                                           $21.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/docdb_cluster_test/docdb_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/docdb_cluster_test/docdb_cluster_test.golden
@@ -9,4 +9,5 @@
                                                                                   
  OVERALL TOTAL                                                            $210.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/dx_connection_test/dx_connection_test.golden
+++ b/internal/providers/terraform/aws/testdata/dx_connection_test/dx_connection_test.golden
@@ -14,6 +14,9 @@
  └─ Outbound data transfer (from us-east-1, to EqDC2)               200  GB            $4.00 
                                                                                              
  OVERALL TOTAL                                                                       $959.20 
+----------------------------------
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 Logs:
 
 level=warning msg="Skipping resource aws_dx_connection.my_dx_connection_usage usage cost: Outbound data transfer. Could not find mapping for region does_not_exist"

--- a/internal/providers/terraform/aws/testdata/dx_gateway_association_test/dx_gateway_association_test.golden
+++ b/internal/providers/terraform/aws/testdata/dx_gateway_association_test/dx_gateway_association_test.golden
@@ -11,4 +11,5 @@
                                                                                                              
  OVERALL TOTAL                                                                                        $75.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/dynamodb_table_test/dynamodb_table_test.golden
+++ b/internal/providers/terraform/aws/testdata/dynamodb_table_test/dynamodb_table_test.golden
@@ -29,4 +29,5 @@
                                                                                                        
  OVERALL TOTAL                                                                                 $658.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ebs_snapshot_copy_test/ebs_snapshot_copy_test.golden
+++ b/internal/providers/terraform/aws/testdata/ebs_snapshot_copy_test/ebs_snapshot_copy_test.golden
@@ -16,4 +16,5 @@
                                                                                                                        
  OVERALL TOTAL                                                                                                   $2.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ebs_snapshot_test/ebs_snapshot_test.golden
+++ b/internal/providers/terraform/aws/testdata/ebs_snapshot_test/ebs_snapshot_test.golden
@@ -20,4 +20,5 @@
                                                                                                                        
  OVERALL TOTAL                                                                                                  $78.40 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ebs_volume_test/ebs_volume_test.golden
+++ b/internal/providers/terraform/aws/testdata/ebs_volume_test/ebs_volume_test.golden
@@ -33,4 +33,5 @@
                                                                                                   
  OVERALL TOTAL                                                                             $60.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+8 cloud resources were detected:
+∙ 8 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ec2_client_vpn_endpoint_test/ec2_client_vpn_endpoint_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_client_vpn_endpoint_test/ec2_client_vpn_endpoint_test.golden
@@ -5,3 +5,6 @@
  └─ Connection                                 730  hours        $36.50 
                                                                         
  OVERALL TOTAL                                                   $36.50 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/ec2_client_vpn_network_association_test/ec2_client_vpn_network_association_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_client_vpn_network_association_test/ec2_client_vpn_network_association_test.golden
@@ -5,3 +5,6 @@
  └─ Endpoint association                                     730  hours        $73.00 
                                                                                       
  OVERALL TOTAL                                                                 $73.00 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/ec2_traffic_mirror_session_test/ec2_traffic_mirror_session_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_traffic_mirror_session_test/ec2_traffic_mirror_session_test.golden
@@ -5,3 +5,6 @@
  └─ Traffic mirror                               730  hours        $10.95 
                                                                           
  OVERALL TOTAL                                                     $10.95 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/ec2_transit_gateway_peering_attachment_test/ec2_transit_gateway_peering_attachment_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_transit_gateway_peering_attachment_test/ec2_transit_gateway_peering_attachment_test.golden
@@ -5,3 +5,6 @@
  └─ Transit gateway attachment                               730  hours        $36.50 
                                                                                       
  OVERALL TOTAL                                                                 $36.50 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/ec2_transit_gateway_vpc_attachment_test/ec2_transit_gateway_vpc_attachment_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_transit_gateway_vpc_attachment_test/ec2_transit_gateway_vpc_attachment_test.golden
@@ -7,4 +7,5 @@
                                                                                                     
  OVERALL TOTAL                                                                               $36.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+1 cloud resource was detected:
+∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ecr_repository_test/ecr_repository_test.golden
+++ b/internal/providers/terraform/aws/testdata/ecr_repository_test/ecr_repository_test.golden
@@ -9,4 +9,5 @@
                                                                        
  OVERALL TOTAL                                                   $0.10 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.golden
+++ b/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.golden
@@ -7,3 +7,10 @@
  └─ Inference accelerator (eia2.medium)        1,460  hours       $175.20 
                                                                           
  OVERALL TOTAL                                                    $247.28 
+----------------------------------
+7 cloud resources were detected:
+∙ 2 were estimated
+∙ 5 were free
+  ∙ 3 x aws_ecs_cluster
+  ∙ 1 x aws_ecs_service
+  ∙ 1 x aws_ecs_task_definition

--- a/internal/providers/terraform/aws/testdata/efs_file_system_test/efs_file_system_test.golden
+++ b/internal/providers/terraform/aws/testdata/efs_file_system_test/efs_file_system_test.golden
@@ -22,4 +22,5 @@
                                                                                        
  OVERALL TOTAL                                                                 $712.63 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/eip_test/eip_test.golden
+++ b/internal/providers/terraform/aws/testdata/eip_test/eip_test.golden
@@ -5,3 +5,6 @@
  └─ IP address (if unused)          730  hours         $3.65 
                                                              
  OVERALL TOTAL                                         $3.65 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
@@ -5,3 +5,10 @@
  └─ EKS cluster                              730  hours        $73.00 
                                                                       
  OVERALL TOTAL                                                 $73.00 
+----------------------------------
+4 cloud resources were detected:
+∙ 1 was estimated
+∙ 3 were free
+  ∙ 1 x aws_iam_role
+  ∙ 1 x aws_subnet
+  ∙ 1 x aws_vpc

--- a/internal/providers/terraform/aws/testdata/eks_fargate_profile_test/eks_fargate_profile_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_fargate_profile_test/eks_fargate_profile_test.golden
@@ -9,3 +9,6 @@
  └─ Per vCPU per hour                       1  CPU          $29.55 
                                                                    
  OVERALL TOTAL                                             $105.80 
+----------------------------------
+2 cloud resources were detected:
+∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
@@ -58,3 +58,8 @@
  └─ Storage (general purpose SSD, gp2)                             20  GB                 $2.00 
                                                                                                 
  OVERALL TOTAL                                                                        $2,590.80 
+----------------------------------
+14 cloud resources were detected:
+∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 4 x aws_launch_template

--- a/internal/providers/terraform/aws/testdata/elasticache_cluster_test/elasticache_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/elasticache_cluster_test/elasticache_cluster_test.golden
@@ -17,4 +17,5 @@
                                                                                                 
  OVERALL TOTAL                                                                        $8,867.59 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.golden
@@ -13,4 +13,5 @@
                                                                                                         
  OVERALL TOTAL                                                                               $13,387.47 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated

--- a/internal/providers/terraform/aws/testdata/elasticsearch_domain_test/elasticsearch_domain_test.golden
+++ b/internal/providers/terraform/aws/testdata/elasticsearch_domain_test/elasticsearch_domain_test.golden
@@ -17,3 +17,6 @@
  └─ Storage (standard)                                                       123  GB            $8.24 
                                                                                                       
  OVERALL TOTAL                                                                              $6,149.50 
+----------------------------------
+3 cloud resources were detected:
+∙ 3 were estimated

--- a/internal/providers/terraform/aws/testdata/elb_test/elb_test.golden
+++ b/internal/providers/terraform/aws/testdata/elb_test/elb_test.golden
@@ -11,4 +11,5 @@
                                                                           
  OVERALL TOTAL                                                    $116.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/fsx_windows_file_system_test/fsx_windows_file_system_test.golden
+++ b/internal/providers/terraform/aws/testdata/fsx_windows_file_system_test/fsx_windows_file_system_test.golden
@@ -13,4 +13,5 @@
                                                                                          
  OVERALL TOTAL                                                                 $9,731.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
@@ -129,11 +129,10 @@
                                                                                                             
  OVERALL TOTAL                                                                                      $992.14 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-1 resource type wasn't estimated as it's not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x aws_instance
+23 cloud resources were detected:
+∙ 22 were estimated, 22 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
+  ∙ 1 x aws_instance
 Logs:
 
 level=warning msg="Skipping resource aws_instance.instance1_hostTenancy. Infracost currently does not support host tenancy for AWS EC2 instances"

--- a/internal/providers/terraform/aws/testdata/kinesis_firehose_delivery_stream_test/kinesis_firehose_delivery_stream_test.golden
+++ b/internal/providers/terraform/aws/testdata/kinesis_firehose_delivery_stream_test/kinesis_firehose_delivery_stream_test.golden
@@ -45,4 +45,7 @@
                                                                                                                 
  OVERALL TOTAL                                                                                      $687,286.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+8 cloud resources were detected:
+∙ 7 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x aws_iam_role

--- a/internal/providers/terraform/aws/testdata/kinesisanalytics_application_test/kinesisanalytics_application_test.golden
+++ b/internal/providers/terraform/aws/testdata/kinesisanalytics_application_test/kinesisanalytics_application_test.golden
@@ -9,4 +9,5 @@
                                                                                                 
  OVERALL TOTAL                                                                          $927.10 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/kinesisanalyticsv2_application_snapshot_test/kinesisanalyticsv2_application_snapshot_test.golden
+++ b/internal/providers/terraform/aws/testdata/kinesisanalyticsv2_application_snapshot_test/kinesisanalyticsv2_application_snapshot_test.golden
@@ -21,4 +21,7 @@
                                                                                                           
  OVERALL TOTAL                                                                                    $187.82 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x aws_iam_role

--- a/internal/providers/terraform/aws/testdata/kinesisanalyticsv2_application_test/kinesisanalyticsv2_application_test.golden
+++ b/internal/providers/terraform/aws/testdata/kinesisanalyticsv2_application_test/kinesisanalyticsv2_application_test.golden
@@ -18,4 +18,7 @@
                                                                                                  
  OVERALL TOTAL                                                                         $2,100.02 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x aws_iam_role

--- a/internal/providers/terraform/aws/testdata/kms_external_key_test/kms_external_key_test.golden
+++ b/internal/providers/terraform/aws/testdata/kms_external_key_test/kms_external_key_test.golden
@@ -5,3 +5,6 @@
  └─ Customer master key              1  months         $1.00 
                                                              
  OVERALL TOTAL                                         $1.00 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/kms_key_test/kms_key_test.golden
+++ b/internal/providers/terraform/aws/testdata/kms_key_test/kms_key_test.golden
@@ -17,4 +17,5 @@
                                                                                               
  OVERALL TOTAL                                                                          $3.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated

--- a/internal/providers/terraform/aws/testdata/lambda_function_test/lambda_function_test.golden
+++ b/internal/providers/terraform/aws/testdata/lambda_function_test/lambda_function_test.golden
@@ -15,4 +15,5 @@
                                                                                                            
  OVERALL TOTAL                                                                                       $0.40 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/lb_test/lb_test.golden
+++ b/internal/providers/terraform/aws/testdata/lb_test/lb_test.golden
@@ -23,4 +23,5 @@
                                                                                  
  OVERALL TOTAL                                                            $96.13 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
@@ -8,3 +8,6 @@
  └─ Virtual server (Windows)             730  hours        $19.62 
                                                                   
  OVERALL TOTAL                                             $98.12 
+----------------------------------
+2 cloud resources were detected:
+∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/mq_broker_test/mq_broker_test.golden
+++ b/internal/providers/terraform/aws/testdata/mq_broker_test/mq_broker_test.golden
@@ -23,4 +23,8 @@
                                                                                                                  
  OVERALL TOTAL                                                                                         $2,149.20 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+8 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 3 were free
+  ∙ 2 x aws_mq_configuration
+  ∙ 1 x aws_security_group

--- a/internal/providers/terraform/aws/testdata/msk_cluster_test/msk_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/msk_cluster_test/msk_cluster_test.golden
@@ -10,3 +10,6 @@
  └─ Storage                             4,000  GB          $400.00 
                                                                    
  OVERALL TOTAL                                          $30,000.18 
+----------------------------------
+2 cloud resources were detected:
+∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/mwaa_environment_test/mwaa_environment_test.golden
+++ b/internal/providers/terraform/aws/testdata/mwaa_environment_test/mwaa_environment_test.golden
@@ -29,4 +29,10 @@
                                                                                                          
  OVERALL TOTAL                                                                                 $2,603.90 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+8 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 1 x aws_iam_role
+  ∙ 1 x aws_security_group
+  ∙ 1 x aws_subnet
+  ∙ 1 x aws_vpc

--- a/internal/providers/terraform/aws/testdata/nat_gateway_test/nat_gateway_test.golden
+++ b/internal/providers/terraform/aws/testdata/nat_gateway_test/nat_gateway_test.golden
@@ -11,4 +11,5 @@
                                                                                
  OVERALL TOTAL                                                          $70.20 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/neptune_cluster_instance_test/neptune_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/neptune_cluster_instance_test/neptune_cluster_instance_test.golden
@@ -21,4 +21,5 @@
                                                                                                        
  OVERALL TOTAL                                                                               $1,854.20 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/neptune_cluster_snapshot_test/neptune_cluster_snapshot_test.golden
+++ b/internal/providers/terraform/aws/testdata/neptune_cluster_snapshot_test/neptune_cluster_snapshot_test.golden
@@ -26,4 +26,7 @@
                                                                                                         
  OVERALL TOTAL                                                                                   $22.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+7 cloud resources were detected:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x aws_neptune_cluster_snapshot

--- a/internal/providers/terraform/aws/testdata/neptune_cluster_test/neptune_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/neptune_cluster_test/neptune_cluster_test.golden
@@ -17,4 +17,5 @@
                                                                                                
  OVERALL TOTAL                                                                          $49.84 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
@@ -22,4 +22,5 @@
                                                                                                                
  OVERALL TOTAL                                                                                         $275.88 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
@@ -49,4 +49,5 @@
                                                                                                               
  OVERALL TOTAL                                                                                    $176,130.67 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+7 cloud resources were detected:
+∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/redshift_cluster_test/redshift_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/redshift_cluster_test/redshift_cluster_test.golden
@@ -31,4 +31,5 @@
                                                                                                         
  OVERALL TOTAL                                                                               $42,976.77 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/route53_health_check_test/route53_health_check_test.golden
+++ b/internal/providers/terraform/aws/testdata/route53_health_check_test/route53_health_check_test.golden
@@ -40,3 +40,6 @@
  └─ Optional features                                                            2  months         $4.00 
                                                                                                          
  OVERALL TOTAL                                                                                    $36.25 
+----------------------------------
+10 cloud resources were detected:
+∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/route53_record_test/route53_record_test.golden
+++ b/internal/providers/terraform/aws/testdata/route53_record_test/route53_record_test.golden
@@ -22,4 +22,5 @@
                                                                                                    
  OVERALL TOTAL                                                                           $1,956.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/route53_resolver_endpoint_test/route53_resolver_endpoint_test.golden
+++ b/internal/providers/terraform/aws/testdata/route53_resolver_endpoint_test/route53_resolver_endpoint_test.golden
@@ -16,4 +16,5 @@
                                                                                                       
  OVERALL TOTAL                                                                              $1,187.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/route53_zone_test/route53_zone_test.golden
+++ b/internal/providers/terraform/aws/testdata/route53_zone_test/route53_zone_test.golden
@@ -5,3 +5,6 @@
  └─ Hosted zone                    1  months         $0.50 
                                                            
  OVERALL TOTAL                                       $0.50 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/s3_bucket_analytics_configuration_test/s3_bucket_analytics_configuration_test.golden
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_analytics_configuration_test/s3_bucket_analytics_configuration_test.golden
@@ -25,4 +25,5 @@
                                                                                                                           
  OVERALL TOTAL                                                                                                      $1.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/s3_bucket_inventory_test/s3_bucket_inventory_test.golden
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_inventory_test/s3_bucket_inventory_test.golden
@@ -41,4 +41,5 @@
                                                                                                       
  OVERALL TOTAL                                                                                  $0.03 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.golden
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.golden
@@ -133,4 +133,5 @@
                                                                                                     
  OVERALL TOTAL                                                                           $11,985.78 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/secretsmanager_secret_test/secretsmanager_secret_test.golden
+++ b/internal/providers/terraform/aws/testdata/secretsmanager_secret_test/secretsmanager_secret_test.golden
@@ -11,4 +11,5 @@
                                                                                                      
  OVERALL TOTAL                                                                                 $1.30 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/sns_topic_subscription_test/sns_topic_subscription_test.golden
+++ b/internal/providers/terraform/aws/testdata/sns_topic_subscription_test/sns_topic_subscription_test.golden
@@ -9,4 +9,5 @@
                                                                                                                          
  OVERALL TOTAL                                                                                                     $1.20 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/sns_topic_test/sns_topic_test.golden
+++ b/internal/providers/terraform/aws/testdata/sns_topic_test/sns_topic_test.golden
@@ -9,4 +9,5 @@
                                                                                          
  OVERALL TOTAL                                                                     $1.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/sqs_queue_test/sqs_queue_test.golden
+++ b/internal/providers/terraform/aws/testdata/sqs_queue_test/sqs_queue_test.golden
@@ -15,4 +15,5 @@
                                                                                                   
  OVERALL TOTAL                                                                              $1.30 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ssm_activation_test/ssm_activation_test.golden
+++ b/internal/providers/terraform/aws/testdata/ssm_activation_test/ssm_activation_test.golden
@@ -9,4 +9,5 @@
                                                                                                 
  OVERALL TOTAL                                                                          $507.35 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ssm_parameter_test/ssm_parameter_test.golden
+++ b/internal/providers/terraform/aws/testdata/ssm_parameter_test/ssm_parameter_test.golden
@@ -11,4 +11,5 @@
                                                                                                                
  OVERALL TOTAL                                                                                           $0.59 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/step_function_test/step_function_test.golden
+++ b/internal/providers/terraform/aws/testdata/step_function_test/step_function_test.golden
@@ -28,4 +28,5 @@
                                                                                                         
  OVERALL TOTAL                                                                                  $758.95 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
+++ b/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
@@ -25,4 +25,5 @@
                                                                                          
  OVERALL TOTAL                                                                    $95.80 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/vpn_connection_test/vpn_connection_test.golden
+++ b/internal/providers/terraform/aws/testdata/vpn_connection_test/vpn_connection_test.golden
@@ -19,4 +19,5 @@
                                                                                           
  OVERALL TOTAL                                                                    $221.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
+++ b/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
@@ -21,4 +21,8 @@
                                                                                     
  OVERALL TOTAL                                                               $38.20 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free
+  ∙ 1 x aws_waf_ipset
+  ∙ 1 x aws_waf_rule

--- a/internal/providers/terraform/aws/testdata/wafv2_web_acl_test/wafv2_web_acl_test.golden
+++ b/internal/providers/terraform/aws/testdata/wafv2_web_acl_test/wafv2_web_acl_test.golden
@@ -16,4 +16,9 @@
                                                                                       
  OVERALL TOTAL                                                                 $30.60 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 3 were free
+  ∙ 1 x aws_wafv2_ip_set
+  ∙ 1 x aws_wafv2_regex_pattern_set
+  ∙ 1 x aws_wafv2_rule_group

--- a/internal/providers/terraform/azure/synapse_spark_pool.go
+++ b/internal/providers/terraform/azure/synapse_spark_pool.go
@@ -93,7 +93,7 @@ func synapseSparkPoolCostComponent(region, name, start string, instances, vCores
 			Service:       strPtr("Azure Synapse Analytics"),
 			ProductFamily: strPtr("Analytics"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr("Azure Synapse Analytics Serverless Apache Spark Pool - Memory Optimized")},
+				{Key: "productName", Value: strPtr("Azure Synapse Analytics Serverless Apache Spark Pool - Memory Optimized")},
 				{Key: "skuName", Value: strPtr("vCore")},
 			},
 		},

--- a/internal/providers/terraform/azure/testdata/active_directory_domain_service_replica_set_test/active_directory_domain_service_replica_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/active_directory_domain_service_replica_set_test/active_directory_domain_service_replica_set_test.golden
@@ -8,3 +8,10 @@
  └─ Active directory domain service replica set (Enterprise)          730  hours       $292.00 
                                                                                                
  OVERALL TOTAL                                                                         $584.00 
+----------------------------------
+5 cloud resources were detected:
+∙ 2 were estimated
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/active_directory_domain_service_test/active_directory_domain_service_test.golden
+++ b/internal/providers/terraform/azure/testdata/active_directory_domain_service_test/active_directory_domain_service_test.golden
@@ -11,3 +11,10 @@
  └─ Active directory domain service (Standard)               730  hours       $109.50 
                                                                                       
  OVERALL TOTAL                                                              $1,569.50 
+----------------------------------
+6 cloud resources were detected:
+∙ 3 were estimated
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/api_management_test/api_management_test.golden
+++ b/internal/providers/terraform/azure/testdata/api_management_test/api_management_test.golden
@@ -26,4 +26,7 @@
                                                                                                        
  OVERALL TOTAL                                                                              $29,799.36 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+8 cloud resources were detected:
+∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/app_service_certificate_binding_test/app_service_certificate_binding_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_certificate_binding_test/app_service_certificate_binding_test.golden
@@ -5,3 +5,10 @@
  └─ IP SSL certificate                                      1  months        $39.00 
                                                                                     
  OVERALL TOTAL                                                               $39.00 
+----------------------------------
+4 cloud resources were detected:
+∙ 1 was estimated
+∙ 3 were free
+  ∙ 1 x azurerm_app_service_certificate
+  ∙ 1 x azurerm_app_service_certificate_binding
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/app_service_certificate_order_test/app_service_certificate_order_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_certificate_order_test/app_service_certificate_order_test.golden
@@ -8,3 +8,6 @@
  └─ SSL certificate (wildcard)                             0.0833  years        $25.00 
                                                                                        
  OVERALL TOTAL                                                                  $30.83 
+----------------------------------
+2 cloud resources were detected:
+∙ 2 were estimated

--- a/internal/providers/terraform/azure/testdata/app_service_custom_hostname_binding_test/app_service_custom_hostname_binding_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_custom_hostname_binding_test/app_service_custom_hostname_binding_test.golden
@@ -9,6 +9,10 @@
                                                                                         
  OVERALL TOTAL                                                                  $112.00 
 ----------------------------------
-1 resource type wasn't estimated as it's not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_app_service
+6 cloud resources were detected:
+∙ 2 were estimated
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_app_service
+∙ 3 were free
+  ∙ 2 x azurerm_app_service_custom_hostname_binding
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/app_service_environment_test/app_service_environment_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_environment_test/app_service_environment_test.golden
@@ -26,3 +26,10 @@
  └─ Instance usage (I2)                              730  hours       $416.10 
                                                                               
  OVERALL TOTAL                                                      $7,820.49 
+----------------------------------
+9 cloud resources were detected:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.golden
@@ -23,3 +23,8 @@
  └─ Instance usage (S1)                      3,650  hours       $365.00 
                                                                         
  OVERALL TOTAL                                                $5,095.27 
+----------------------------------
+8 cloud resources were detected:
+∙ 7 were estimated
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/application_gateway_test/application_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/application_gateway_test/application_gateway_test.golden
@@ -25,4 +25,9 @@
                                                                                        
  OVERALL TOTAL                                                               $2,505.26 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+9 cloud resources were detected:
+∙ 5 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 2 x azurerm_subnet
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/application_insights_test/application_insights_test.golden
+++ b/internal/providers/terraform/azure/testdata/application_insights_test/application_insights_test.golden
@@ -13,4 +13,7 @@
                                                                                           
  OVERALL TOTAL                                                                  $4,700.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/application_insights_web_t_test/application_insights_web_t_test.golden
+++ b/internal/providers/terraform/azure/testdata/application_insights_web_t_test/application_insights_web_t_test.golden
@@ -9,4 +9,8 @@
                                                                                              
  OVERALL TOTAL                                                                        $10.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 2 were estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free
+  ∙ 1 x azurerm_application_insights_web_test
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/automation_account_test/automation_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_account_test/automation_account_test.golden
@@ -17,4 +17,7 @@
                                                                                              
  OVERALL TOTAL                                                                        $12.10 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/automation_dsc_configuration_test/automation_dsc_configuration_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_dsc_configuration_test/automation_dsc_configuration_test.golden
@@ -14,4 +14,7 @@
                                                                                                        
  OVERALL TOTAL                                                                                  $30.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/automation_dsc_nodeconfiguration_test/automation_dsc_nodeconfiguration_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_dsc_nodeconfiguration_test/automation_dsc_nodeconfiguration_test.golden
@@ -17,4 +17,7 @@
                                                                                                           
  OVERALL TOTAL                                                                                     $30.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/automation_job_schedule_test/automation_job_schedule_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_job_schedule_test/automation_job_schedule_test.golden
@@ -9,4 +9,7 @@
                                                                                                  
  OVERALL TOTAL                                                                             $0.01 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/bastion_host_test/bastion_host_test.golden
+++ b/internal/providers/terraform/azure/testdata/bastion_host_test/bastion_host_test.golden
@@ -11,3 +11,10 @@
  └─ IP address (static)                          730  hours         $3.65 
                                                                           
  OVERALL TOTAL                                                  $8,872.35 
+----------------------------------
+5 cloud resources were detected:
+∙ 2 were estimated
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/cdn_endpoint_test/cdn_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/cdn_endpoint_test/cdn_endpoint_test.golden
@@ -40,4 +40,8 @@
                                                                                                            
  OVERALL TOTAL                                                                                 $609,769.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+10 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 5 were free
+  ∙ 4 x azurerm_cdn_profile
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/container_registry_test/container_registry_test.golden
+++ b/internal/providers/terraform/azure/testdata/container_registry_test/container_registry_test.golden
@@ -32,4 +32,7 @@
                                                                                                    
  OVERALL TOTAL                                                                             $652.98 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+7 cloud resources were detected:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.golden
@@ -46,4 +46,8 @@
                                                                                                                             
  OVERALL TOTAL                                                                                                    $5,155.73 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+9 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 3 x azurerm_cosmosdb_account
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.golden
@@ -91,12 +91,14 @@
                                                                                                                             
  OVERALL TOTAL                                                                                                    $5,455.03 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-2 x azurerm_cosmosdb_cassandra_table
-1 x azurerm_cosmosdb_cassandra_keyspace
+17 cloud resources were detected:
+∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
+∙ 3 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 2 x azurerm_cosmosdb_cassandra_table
+  ∙ 1 x azurerm_cosmosdb_cassandra_keyspace
+∙ 4 were free
+  ∙ 3 x azurerm_cosmosdb_account
+  ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_cosmosdb_cassandra_keyspace.no_account as its 'account_name' property could not be found."

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.golden
@@ -46,4 +46,8 @@
                                                                                                                           
  OVERALL TOTAL                                                                                                  $5,155.73 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+9 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 3 x azurerm_cosmosdb_account
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.golden
@@ -55,4 +55,8 @@
                                                                                                                        
  OVERALL TOTAL                                                                                               $5,155.73 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+10 cloud resources were detected:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 3 x azurerm_cosmosdb_account
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.golden
@@ -91,4 +91,8 @@
                                                                                                                           
  OVERALL TOTAL                                                                                                  $5,455.03 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+14 cloud resources were detected:
+∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 3 x azurerm_cosmosdb_account
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.golden
@@ -46,4 +46,8 @@
                                                                                                                         
  OVERALL TOTAL                                                                                                $5,155.73 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+9 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 3 x azurerm_cosmosdb_account
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_container_test/cosmosdb_sql_container_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_container_test/cosmosdb_sql_container_test.golden
@@ -57,4 +57,8 @@
                                                                                                                        
  OVERALL TOTAL                                                                                               $5,060.53 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+10 cloud resources were detected:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 3 x azurerm_cosmosdb_account
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.golden
@@ -46,4 +46,8 @@
                                                                                                                       
  OVERALL TOTAL                                                                                              $5,155.73 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+9 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 3 x azurerm_cosmosdb_account
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.golden
@@ -46,11 +46,13 @@
                                                                                                                  
  OVERALL TOTAL                                                                                         $5,155.73 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-1 resource type wasn't estimated as it's not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_cosmosdb_table
+10 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_cosmosdb_table
+∙ 4 were free
+  ∙ 3 x azurerm_cosmosdb_account
+  ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_cosmosdb_table.account-in-another-module as its 'account_name' property could not be found."

--- a/internal/providers/terraform/azure/testdata/databricks_workspace_test/databricks_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/databricks_workspace_test/databricks_workspace_test.golden
@@ -18,4 +18,8 @@
                                                                                               
  OVERALL TOTAL                                                                      $1,995.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free
+  ∙ 1 x azurerm_databricks_workspace
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_a_record_test/dns_a_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_a_record_test/dns_a_record_test.golden
@@ -16,4 +16,7 @@
                                                                                          
  OVERALL TOTAL                                                                   $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_aaaa_record_test/dns_aaaa_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_aaaa_record_test/dns_aaaa_record_test.golden
@@ -16,4 +16,7 @@
                                                                                             
  OVERALL TOTAL                                                                      $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_caa_record_test/dns_caa_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_caa_record_test/dns_caa_record_test.golden
@@ -16,4 +16,7 @@
                                                                                            
  OVERALL TOTAL                                                                     $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_cname_record_test/dns_cname_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_cname_record_test/dns_cname_record_test.golden
@@ -16,4 +16,7 @@
                                                                                              
  OVERALL TOTAL                                                                       $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_mx_record_test/dns_mx_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_mx_record_test/dns_mx_record_test.golden
@@ -16,4 +16,7 @@
                                                                                           
  OVERALL TOTAL                                                                    $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_ns_record_test/dns_ns_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_ns_record_test/dns_ns_record_test.golden
@@ -16,4 +16,7 @@
                                                                                           
  OVERALL TOTAL                                                                    $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_ptr_record_test/dns_ptr_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_ptr_record_test/dns_ptr_record_test.golden
@@ -16,4 +16,7 @@
                                                                                            
  OVERALL TOTAL                                                                     $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_srv_record_test/dns_srv_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_srv_record_test/dns_srv_record_test.golden
@@ -16,4 +16,7 @@
                                                                                            
  OVERALL TOTAL                                                                     $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_txt_record_test/dns_txt_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_txt_record_test/dns_txt_record_test.golden
@@ -16,4 +16,7 @@
                                                                                            
  OVERALL TOTAL                                                                     $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/dns_zone_test/dns_zone_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_zone_test/dns_zone_test.golden
@@ -8,3 +8,8 @@
  └─ Hosted zone                      1  months         $0.50 
                                                              
  OVERALL TOTAL                                         $1.04 
+----------------------------------
+4 cloud resources were detected:
+∙ 2 were estimated
+∙ 2 were free
+  ∙ 2 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/event_hubs_namespace_test/event_hubs_namespace_test.golden
+++ b/internal/providers/terraform/azure/testdata/event_hubs_namespace_test/event_hubs_namespace_test.golden
@@ -28,4 +28,7 @@
                                                                                                         
  OVERALL TOTAL                                                                               $16,954.19 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+7 cloud resources were detected:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.golden
+++ b/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.golden
@@ -26,9 +26,12 @@
                                                                                              
  OVERALL TOTAL                                                                     $6,256.15 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_virtual_hub
-1 x azurerm_virtual_wan
+11 cloud resources were detected:
+∙ 6 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_virtual_hub
+  ∙ 1 x azurerm_virtual_wan
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
+++ b/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
@@ -39,12 +39,14 @@
                                                                                                                             
  OVERALL TOTAL                                                                                                    $1,134.69 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_function_app
-1 x azurerm_storage_account
+16 cloud resources were detected:
+∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_function_app
+  ∙ 1 x azurerm_storage_account
+∙ 4 were free
+  ∙ 3 x azurerm_app_service_plan
+  ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_function_app.functionAppNoAvailableServicePlan. Could not find a way to get its cost components from the resource or usage file."

--- a/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
@@ -14,10 +14,13 @@
                                                                                  
  OVERALL TOTAL                                                         $3,967.55 
 ----------------------------------
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_storage_account
-1 x azurerm_storage_container
+5 cloud resources were detected:
+∙ 2 were estimated
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_storage_account
+  ∙ 1 x azurerm_storage_container
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
@@ -8,10 +8,13 @@
                                                                            
  OVERALL TOTAL                                                   $3,907.40 
 ----------------------------------
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_storage_account
-1 x azurerm_storage_container
+4 cloud resources were detected:
+∙ 1 was estimated
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_storage_account
+  ∙ 1 x azurerm_storage_container
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
@@ -8,10 +8,13 @@
                                                                                        
  OVERALL TOTAL                                                              $15,852.68 
 ----------------------------------
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_storage_account
-1 x azurerm_storage_container
+4 cloud resources were detected:
+∙ 1 was estimated
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_storage_account
+  ∙ 1 x azurerm_storage_container
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
@@ -24,12 +24,13 @@
                                                                                                           
  OVERALL TOTAL                                                                                 $27,535.31 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_storage_account
-1 x azurerm_storage_container
+6 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_storage_account
+  ∙ 1 x azurerm_storage_container
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
@@ -8,10 +8,13 @@
                                                                            
  OVERALL TOTAL                                                   $8,619.84 
 ----------------------------------
-2 resource types weren't estimated as they're not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_storage_account
-1 x azurerm_storage_container
+4 cloud resources were detected:
+∙ 1 was estimated
+∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_storage_account
+  ∙ 1 x azurerm_storage_container
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/integration_service_environment_test/integration_service_environment_test.golden
+++ b/internal/providers/terraform/azure/testdata/integration_service_environment_test/integration_service_environment_test.golden
@@ -12,3 +12,10 @@
  └─ Base units                                             730  hours       $749.71 
                                                                                     
  OVERALL TOTAL                                                           $17,714.91 
+----------------------------------
+9 cloud resources were detected:
+∙ 3 were estimated
+∙ 6 were free
+  ∙ 4 x azurerm_subnet
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.golden
@@ -15,4 +15,8 @@
                                                                                                      
  OVERALL TOTAL                                                                               $600.60 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 3 were free
+  ∙ 2 x azurerm_key_vault
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
@@ -53,4 +53,8 @@
                                                                                                    
  OVERALL TOTAL                                                                          $12,813.96 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+12 cloud resources were detected:
+∙ 9 were estimated, 9 include usage-based costs, see https://infracost.io/usage-file
+∙ 3 were free
+  ∙ 2 x azurerm_key_vault
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/key_vault_managed_hardware_security_module_test/key_vault_managed_hardware_security_module_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_managed_hardware_security_module_test/key_vault_managed_hardware_security_module_test.golden
@@ -5,3 +5,8 @@
  └─ HSM pools                                                          730  hours     $3,540.50 
                                                                                                 
  OVERALL TOTAL                                                                        $3,540.50 
+----------------------------------
+2 cloud resources were detected:
+∙ 1 was estimated
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
@@ -26,3 +26,8 @@
     └─ Storage (P1)                                              2  months         $1.20 
                                                                                          
  OVERALL TOTAL                                                                   $602.33 
+----------------------------------
+6 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
@@ -31,3 +31,8 @@
     └─ Hosted zone                                                1  months         $0.50 
                                                                                           
  OVERALL TOTAL                                                                  $1,478.51 
+----------------------------------
+5 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/lb_outbound_rule_test/lb_outbound_rule_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_outbound_rule_test/lb_outbound_rule_test.golden
@@ -8,3 +8,10 @@
  └─ IP address (static)                  730  hours         $2.63 
                                                                   
  OVERALL TOTAL                                              $9.93 
+----------------------------------
+5 cloud resources were detected:
+∙ 2 were estimated
+∙ 3 were free
+  ∙ 1 x azurerm_lb
+  ∙ 1 x azurerm_lb_backend_address_pool
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/lb_rule_test/lb_rule_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_rule_test/lb_rule_test.golden
@@ -8,3 +8,9 @@
  └─ IP address (static)             730  hours         $2.63 
                                                              
  OVERALL TOTAL                                         $9.93 
+----------------------------------
+4 cloud resources were detected:
+∙ 2 were estimated
+∙ 2 were free
+  ∙ 1 x azurerm_lb
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/lb_test/lb_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_test/lb_test.golden
@@ -9,4 +9,8 @@
                                                                          
  OVERALL TOTAL                                                     $0.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free
+  ∙ 1 x azurerm_lb
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_scale_set_test/linux_virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_scale_set_test/linux_virtual_machine_scale_set_test.golden
@@ -15,4 +15,5 @@
                                                                                                                     
  OVERALL TOTAL                                                                                              $414.44 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
@@ -27,4 +27,5 @@
                                                                                                                       
  OVERALL TOTAL                                                                                                $348.82 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/managed_disk_test/managed_disk_test.golden
+++ b/internal/providers/terraform/azure/testdata/managed_disk_test/managed_disk_test.golden
@@ -19,4 +19,5 @@
                                                                                                   
  OVERALL TOTAL                                                                            $534.36 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/mariadb_server_test/mariadb_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/mariadb_server_test/mariadb_server_test.golden
@@ -28,4 +28,7 @@
                                                                                  
  OVERALL TOTAL                                                         $5,041.69 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
@@ -70,7 +70,11 @@
                                                                                                             
  OVERALL TOTAL                                                                                   $28,382.88 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+14 cloud resources were detected:
+∙ 12 were estimated, 12 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_sql_server
 Logs:
 
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, BC_Gen5_8)' due to limitations in the Azure API."

--- a/internal/providers/terraform/azure/testdata/mysql_server_test/mysql_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/mysql_server_test/mysql_server_test.golden
@@ -28,4 +28,7 @@
                                                                                
  OVERALL TOTAL                                                       $5,041.69 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/nat_gateway_test/nat_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/nat_gateway_test/nat_gateway_test.golden
@@ -17,4 +17,7 @@
                                                                                   
  OVERALL TOTAL                                                             $74.18 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/notification_hub_namespace_test/notification_hub_namespace_test.golden
+++ b/internal/providers/terraform/azure/testdata/notification_hub_namespace_test/notification_hub_namespace_test.golden
@@ -35,4 +35,8 @@
                                                                                                                
  OVERALL TOTAL                                                                                       $2,815.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+10 cloud resources were detected:
+∙ 8 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free
+  ∙ 1 x azurerm_notification_hub_namespace
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
@@ -23,4 +23,7 @@
                                                                                                  
  OVERALL TOTAL                                                                         $3,294.05 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/postgresql_server_test/postgresql_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/postgresql_server_test/postgresql_server_test.golden
@@ -28,4 +28,7 @@
                                                                                     
  OVERALL TOTAL                                                            $5,041.69 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/private_dns_a_record_test/private_dns_a_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_a_record_test/private_dns_a_record_test.golden
@@ -16,4 +16,7 @@
                                                                                                  
  OVERALL TOTAL                                                                           $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/private_dns_aaaa_record_test/private_dns_aaaa_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_aaaa_record_test/private_dns_aaaa_record_test.golden
@@ -16,4 +16,7 @@
                                                                                                     
  OVERALL TOTAL                                                                              $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/private_dns_cname_record_test/private_dns_cname_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_cname_record_test/private_dns_cname_record_test.golden
@@ -16,4 +16,7 @@
                                                                                                      
  OVERALL TOTAL                                                                               $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/private_dns_mx_record_test/private_dns_mx_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_mx_record_test/private_dns_mx_record_test.golden
@@ -16,4 +16,7 @@
                                                                                                   
  OVERALL TOTAL                                                                            $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/private_dns_ptr_record_test/private_dns_ptr_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_ptr_record_test/private_dns_ptr_record_test.golden
@@ -16,4 +16,7 @@
                                                                                                    
  OVERALL TOTAL                                                                             $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/private_dns_srv_record_test/private_dns_srv_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_srv_record_test/private_dns_srv_record_test.golden
@@ -16,4 +16,7 @@
                                                                                                    
  OVERALL TOTAL                                                                             $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/private_dns_txt_record_test/private_dns_txt_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_txt_record_test/private_dns_txt_record_test.golden
@@ -16,4 +16,7 @@
                                                                                                    
  OVERALL TOTAL                                                                             $900.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/private_dns_zone_test/private_dns_zone_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_zone_test/private_dns_zone_test.golden
@@ -8,3 +8,8 @@
  └─ Hosted zone                              1  months         $0.50 
                                                                      
  OVERALL TOTAL                                                 $1.04 
+----------------------------------
+4 cloud resources were detected:
+∙ 2 were estimated
+∙ 2 were free
+  ∙ 2 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/private_endpoint_test/private_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_endpoint_test/private_endpoint_test.golden
@@ -29,4 +29,9 @@
                                                                                                          
  OVERALL TOTAL                                                                                    $23.90 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+7 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/public_ip_prefix_test/public_ip_prefix_test.golden
+++ b/internal/providers/terraform/azure/testdata/public_ip_prefix_test/public_ip_prefix_test.golden
@@ -5,3 +5,8 @@
  └─ IP prefix                              730  hours         $4.38 
                                                                     
  OVERALL TOTAL                                                $4.38 
+----------------------------------
+2 cloud resources were detected:
+∙ 1 was estimated
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/public_ip_test/public_ip_test.golden
+++ b/internal/providers/terraform/azure/testdata/public_ip_test/public_ip_test.golden
@@ -8,3 +8,8 @@
  └─ IP address (dynamic)             730  hours         $2.92 
                                                               
  OVERALL TOTAL                                          $6.57 
+----------------------------------
+3 cloud resources were detected:
+∙ 2 were estimated
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/redis_cache_test/redis_cache_test.golden
+++ b/internal/providers/terraform/azure/testdata/redis_cache_test/redis_cache_test.golden
@@ -11,3 +11,8 @@
  └─ Cache usage (Standard_C3)                1,460  hours       $657.00 
                                                                         
  OVERALL TOTAL                                                $3,241.20 
+----------------------------------
+4 cloud resources were detected:
+∙ 3 were estimated
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/search_service_test/search_service_test.golden
+++ b/internal/providers/terraform/azure/testdata/search_service_test/search_service_test.golden
@@ -23,4 +23,7 @@
                                                                                                       
  OVERALL TOTAL                                                                             $16,130.98 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -138,4 +138,7 @@
                                                                                                              
  OVERALL TOTAL                                                                                 $1,778,552.71 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+15 cloud resources were detected:
+∙ 14 were estimated, 14 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
@@ -22,11 +22,13 @@
                                                                                                                         
  OVERALL TOTAL                                                                                                   $97.66 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-1 resource type wasn't estimated as it's not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_storage_account
+6 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_storage_account
+∙ 2 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_storage_data_lake_gen2_filesystem
 Logs:
 
 level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
@@ -30,11 +30,13 @@
                                                                                                                         
  OVERALL TOTAL                                                                                                $6,771.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-1 resource type wasn't estimated as it's not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_storage_account
+7 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_storage_account
+∙ 2 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_storage_data_lake_gen2_filesystem
 Logs:
 
 level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
@@ -55,11 +55,13 @@
                                                                                                                         
  OVERALL TOTAL                                                                                                  $127.33 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
-
-1 resource type wasn't estimated as it's not supported yet.
-Please watch/star https://github.com/infracost/infracost as new resources are added regularly.
-1 x azurerm_storage_account
+7 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
+  ∙ 1 x azurerm_storage_account
+∙ 2 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_storage_data_lake_gen2_filesystem
 Logs:
 
 level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/virtual_machine_scale_set_test/virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_scale_set_test/virtual_machine_scale_set_test.golden
@@ -27,4 +27,9 @@
                                                                                                              
  OVERALL TOTAL                                                                                       $427.59 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
@@ -29,4 +29,10 @@
                                                                                                                 
  OVERALL TOTAL                                                                                          $385.16 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free
+  ∙ 1 x azurerm_network_interface
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/vpn_gateway_connection_test/vpn_gateway_connection_test.golden
+++ b/internal/providers/terraform/azure/testdata/vpn_gateway_connection_test/vpn_gateway_connection_test.golden
@@ -59,4 +59,11 @@
                                                                                                         
  OVERALL TOTAL                                                                                $5,964.83 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+25 cloud resources were detected:
+∙ 14 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file
+∙ 11 were free
+  ∙ 7 x azurerm_local_network_gateway
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network
+  ∙ 1 x azurerm_virtual_network_gateway_connection

--- a/internal/providers/terraform/azure/testdata/vpn_gateway_test/vpn_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/vpn_gateway_test/vpn_gateway_test.golden
@@ -41,4 +41,9 @@
                                                                                              
  OVERALL TOTAL                                                                    $49,247.27 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+11 cloud resources were detected:
+∙ 8 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file
+∙ 3 were free
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_scale_set_test/windows_virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_scale_set_test/windows_virtual_machine_scale_set_test.golden
@@ -15,4 +15,5 @@
                                                                                                                       
  OVERALL TOTAL                                                                                                $690.38 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
@@ -39,4 +39,5 @@
                                                                                                                            
  OVERALL TOTAL                                                                                                   $1,943.37 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/bigquery_dataset_test/bigquery_dataset_test.golden
+++ b/internal/providers/terraform/google/testdata/bigquery_dataset_test/bigquery_dataset_test.golden
@@ -9,4 +9,5 @@
                                                                                 
  OVERALL TOTAL                                                          $501.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/bigquery_table_test/bigquery_table_test.golden
+++ b/internal/providers/terraform/google/testdata/bigquery_table_test/bigquery_table_test.golden
@@ -20,4 +20,5 @@
                                                                                  
  OVERALL TOTAL                                                         $1,164.05 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/cloudfunctions_function_test/cloudfunctions_function_test.golden
+++ b/internal/providers/terraform/google/testdata/cloudfunctions_function_test/cloudfunctions_function_test.golden
@@ -15,4 +15,5 @@
                                                                                                         
  OVERALL TOTAL                                                                                   $29.88 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
@@ -12,3 +12,8 @@
  └─ IP address (if unused)                          730  hours         $7.30 
                                                                              
  OVERALL TOTAL                                                        $23.36 
+----------------------------------
+3 cloud resources were detected:
+∙ 2 were estimated
+∙ 1 was free
+  ∙ 1 x google_compute_address

--- a/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.golden
@@ -35,3 +35,6 @@
  └─ Storage                                              20  GB           $0.52 
                                                                                 
  OVERALL TOTAL                                                           $46.32 
+----------------------------------
+11 cloud resources were detected:
+∙ 11 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_external_vpn_gateway_test/compute_external_vpn_gateway_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_external_vpn_gateway_test/compute_external_vpn_gateway_test.golden
@@ -11,3 +11,6 @@
     └─ IPSec traffic to Australia (first 1TB)                                                             250  GB          $47.50 
                                                                                                                                   
  OVERALL TOTAL                                                                                                          $3,245.18 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_forwarding_rule_test/compute_forwarding_rule_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_forwarding_rule_test/compute_forwarding_rule_test.golden
@@ -15,4 +15,5 @@
                                                                                                
  OVERALL TOTAL                                                                          $23.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_ha_vpn_gateway_test/compute_ha_vpn_gateway_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_ha_vpn_gateway_test/compute_ha_vpn_gateway_test.golden
@@ -12,3 +12,8 @@
     └─ IPSec traffic between continents (excludes Oceania)          200  GB          $16.00 
                                                                                             
  OVERALL TOTAL                                                                       $38.90 
+----------------------------------
+2 cloud resources were detected:
+∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x google_compute_network

--- a/internal/providers/terraform/google/testdata/compute_image_test/compute_image_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_image_test/compute_image_test.golden
@@ -30,4 +30,5 @@
                                                                                             
  OVERALL TOTAL                                                                      $251.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+9 cloud resources were detected:
+∙ 9 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_instance_group_manager_test/compute_instance_group_manager_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_instance_group_manager_test/compute_instance_group_manager_test.golden
@@ -7,3 +7,8 @@
  └─ NVIDIA Tesla K80 (on-demand)                            5,840  hours     $1,839.60 
                                                                                        
  OVERALL TOTAL                                                               $2,110.13 
+----------------------------------
+2 cloud resources were detected:
+∙ 1 was estimated
+∙ 1 was free
+  ∙ 1 x google_compute_instance_template

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
@@ -34,3 +34,6 @@
  └─ Standard provisioned storage (pd-standard)                         10  GiB           $0.40 
                                                                                                
  OVERALL TOTAL                                                                       $1,638.42 
+----------------------------------
+7 cloud resources were detected:
+∙ 7 were estimated

--- a/internal/providers/terraform/google/testdata/compute_machine_image_test/compute_machine_image_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_machine_image_test/compute_machine_image_test.golden
@@ -13,4 +13,5 @@
                                                                                                    
  OVERALL TOTAL                                                                             $274.86 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_region_instance_group_manager_test/compute_region_instance_group_manager_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_region_instance_group_manager_test/compute_region_instance_group_manager_test.golden
@@ -6,3 +6,8 @@
  └─ Balanced provisioned storage (pd-balanced)                    1,200  GiB         $120.00 
                                                                                              
  OVERALL TOTAL                                                                     $1,285.07 
+----------------------------------
+2 cloud resources were detected:
+∙ 1 was estimated
+∙ 1 was free
+  ∙ 1 x google_compute_instance_template

--- a/internal/providers/terraform/google/testdata/compute_router_nat_test/compute_router_nat_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_router_nat_test/compute_router_nat_test.golden
@@ -14,4 +14,5 @@
                                                                                        
  OVERALL TOTAL                                                                 $126.79 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_snapshot_test/compute_snapshot_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_snapshot_test/compute_snapshot_test.golden
@@ -8,3 +8,6 @@
  └─ Storage                                             100  GB           $2.60 
                                                                                 
  OVERALL TOTAL                                                            $6.60 
+----------------------------------
+2 cloud resources were detected:
+∙ 2 were estimated, 1 includes usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_target_grpc_proxy_test/compute_target_grpc_proxy_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_target_grpc_proxy_test/compute_target_grpc_proxy_test.golden
@@ -35,4 +35,5 @@
                                                                                                      
  OVERALL TOTAL                                                                                 $7.39 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+8 cloud resources were detected:
+∙ 8 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_vpn_gateway_test/compute_vpn_gateway_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_vpn_gateway_test/compute_vpn_gateway_test.golden
@@ -12,3 +12,8 @@
     └─ IPSec traffic between continents (excludes Oceania)          200  GB          $16.00 
                                                                                             
  OVERALL TOTAL                                                                       $38.90 
+----------------------------------
+2 cloud resources were detected:
+∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+  ∙ 1 x google_compute_network

--- a/internal/providers/terraform/google/testdata/compute_vpn_tunnel_test/compute_vpn_tunnel_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_vpn_tunnel_test/compute_vpn_tunnel_test.golden
@@ -5,3 +5,6 @@
  └─ VPN Tunnel                              730  hours        $36.50 
                                                                      
  OVERALL TOTAL                                                $36.50 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
+++ b/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
@@ -118,3 +118,6 @@
     └─ Standard provisioned storage (pd-standard)                           400  GiB          $16.00 
                                                                                                      
  OVERALL TOTAL                                                                            $25,959.78 
+----------------------------------
+13 cloud resources were detected:
+∙ 13 were estimated, 13 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
@@ -102,3 +102,6 @@
  └─ Standard provisioned storage (pd-standard)                       400  GiB          $16.00 
                                                                                               
  OVERALL TOTAL                                                                      $7,944.86 
+----------------------------------
+21 cloud resources were detected:
+∙ 21 were estimated, 21 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.golden
+++ b/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.golden
@@ -28,4 +28,5 @@
                                                                                                                                               
  OVERALL TOTAL                                                                                                                      $1,561.29 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.tf
+++ b/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.tf
@@ -4,7 +4,7 @@ provider "google" {
 }
 
 resource "google_container_registry" "my_registry" {
-  project  = "my-project"
+  project = "my-project"
 }
 
 resource "google_container_registry" "my_registry_usage" {

--- a/internal/providers/terraform/google/testdata/dns_managed_zone_test/dns_managed_zone_test.golden
+++ b/internal/providers/terraform/google/testdata/dns_managed_zone_test/dns_managed_zone_test.golden
@@ -5,3 +5,6 @@
  └─ Managed zone                         1  months         $0.20 
                                                                  
  OVERALL TOTAL                                             $0.20 
+----------------------------------
+1 cloud resource was detected:
+∙ 1 was estimated

--- a/internal/providers/terraform/google/testdata/dns_record_set_test/dns_record_set_test.golden
+++ b/internal/providers/terraform/google/testdata/dns_record_set_test/dns_record_set_test.golden
@@ -9,4 +9,5 @@
                                                                                             
  OVERALL TOTAL                                                                        $0.04 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/kms_crypto_key_test/kms_crypto_key_test.golden
+++ b/internal/providers/terraform/google/testdata/kms_crypto_key_test/kms_crypto_key_test.golden
@@ -16,4 +16,5 @@
                                                                                                       
  OVERALL TOTAL                                                                              $8,001.74 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_billing_account_bucket_config_test/logging_billing_account_bucket_config_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_billing_account_bucket_config_test/logging_billing_account_bucket_config_test.golden
@@ -9,4 +9,5 @@
                                                                                                            
  OVERALL TOTAL                                                                                      $50.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_billing_account_sink_test/logging_billing_account_sink_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_billing_account_sink_test/logging_billing_account_sink_test.golden
@@ -9,4 +9,5 @@
                                                                                                     
  OVERALL TOTAL                                                                               $50.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_folder_bucket_config_test/logging_folder_bucket_config_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_folder_bucket_config_test/logging_folder_bucket_config_test.golden
@@ -9,4 +9,5 @@
                                                                                                   
  OVERALL TOTAL                                                                             $50.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_folder_sink_test/logging_folder_sink_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_folder_sink_test/logging_folder_sink_test.golden
@@ -9,4 +9,5 @@
                                                                                          
  OVERALL TOTAL                                                                    $50.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_organization_bucket_config_test/logging_organization_bucket_config_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_organization_bucket_config_test/logging_organization_bucket_config_test.golden
@@ -9,4 +9,5 @@
                                                                                                         
  OVERALL TOTAL                                                                                   $50.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_organization_sink_test/logging_organization_sink_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_organization_sink_test/logging_organization_sink_test.golden
@@ -9,4 +9,5 @@
                                                                                                
  OVERALL TOTAL                                                                          $50.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_project_bucket_config_test/logging_project_bucket_config_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_project_bucket_config_test/logging_project_bucket_config_test.golden
@@ -9,4 +9,5 @@
                                                                                                    
  OVERALL TOTAL                                                                              $50.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_project_sink_test/logging_project_sink_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_project_sink_test/logging_project_sink_test.golden
@@ -9,4 +9,5 @@
                                                                                           
  OVERALL TOTAL                                                                     $50.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/monitoring_metric_descriptor_test/monitoring_metric_descriptor_test.golden
+++ b/internal/providers/terraform/google/testdata/monitoring_metric_descriptor_test/monitoring_metric_descriptor_test.golden
@@ -13,4 +13,5 @@
                                                                                                      
  OVERALL TOTAL                                                                            $63,710.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/pubsub_subscription_test/pubsub_subscription_test.golden
+++ b/internal/providers/terraform/google/testdata/pubsub_subscription_test/pubsub_subscription_test.golden
@@ -13,4 +13,5 @@
                                                                                           
  OVERALL TOTAL                                                                    $413.50 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/pubsub_topic_test/pubsub_topic_test.golden
+++ b/internal/providers/terraform/google/testdata/pubsub_topic_test/pubsub_topic_test.golden
@@ -9,4 +9,5 @@
                                                                                
  OVERALL TOTAL                                                         $400.00 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/redis_instance_test/redis_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/redis_instance_test/redis_instance_test.golden
@@ -32,3 +32,6 @@
  └─ Redis instance (standard, M5)           105  GB           $3.15 
                                                                     
  OVERALL TOTAL                                                $9.50 
+----------------------------------
+10 cloud resources were detected:
+∙ 10 were estimated

--- a/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
@@ -66,4 +66,5 @@
                                                                                                    
  OVERALL TOTAL                                                                           $7,455.69 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+11 cloud resources were detected:
+∙ 11 were estimated, 11 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/storage_bucket_test/storage_bucket_test.golden
+++ b/internal/providers/terraform/google/testdata/storage_bucket_test/storage_bucket_test.golden
@@ -43,4 +43,5 @@
                                                                                                                                               
  OVERALL TOTAL                                                                                                                      $3,125.02 
 ----------------------------------
-To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -226,7 +226,10 @@ func GoldenFileResourceTestsWithOpts(t *testing.T, testName string, options *Gol
 	projects, err := RunCostCalculations(t, runCtx, tfProject, usageData)
 	require.NoError(t, err)
 
-	r := output.ToOutputFormat(projects)
+	r, err := output.ToOutputFormat(projects)
+	if err != nil {
+		require.NoError(t, err)
+	}
 	r.Currency = runCtx.Config.Currency
 
 	opts := output.Options{


### PR DESCRIPTION
This is done in two commits to make it easier to review and one for the golden tests.

There's more we could do for the HTML output, but I don't think this is worth doing until we get more feedback on this new summary:
1. Use a HTML list instead of the ASCII bullets
2. Parse and use href's for link text in the summary