### PR TITLE
fix(google): add default location to container registry

### DIFF
--- a/internal/providers/terraform/google/storage_bucket.go
+++ b/internal/providers/terraform/google/storage_bucket.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/schema"
 )
 
 func GetStorageBucketRegistryItem() *schema.RegistryItem {
@@ -80,6 +81,10 @@ func getDSRegionResourceGroup(location, storageClass string) (string, string) {
 
 func dataStorage(d *schema.ResourceData, u *schema.UsageData) *schema.CostComponent {
 	location := d.Get("location").String()
+	if location == "" {
+		location = "US"
+	}
+
 	var quantity *decimal.Decimal
 	if u != nil && u.Get("storage_gb").Exists() {
 		quantity = decimalPtr(decimal.NewFromInt(u.Get("storage_gb").Int()))

--- a/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.golden
+++ b/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.golden
@@ -1,18 +1,31 @@
 
- Name                                                                              Monthly Qty  Unit            Monthly Cost 
-                                                                                                                             
- google_container_registry.my_registry                                                                                       
- ├─ Storage (standard)                                                                     150  GiB                    $3.90 
- ├─ Object adds, bucket/object list (class A)                                                4  10k operations         $0.20 
- ├─ Object gets, retrieve bucket/object metadata (class B)                                   2  10k operations         $0.01 
- └─ Network egress                                                                                                           
-    ├─ Data transfer in same continent                                                     550  GB                     $5.50 
-    ├─ Data transfer to worldwide excluding Asia, Australia (first 1TB)                  1,024  GB                   $122.88 
-    ├─ Data transfer to worldwide excluding Asia, Australia (next 9TB)                   9,216  GB                 $1,013.76 
-    ├─ Data transfer to worldwide excluding Asia, Australia (over 10TB)                  2,260  GB                   $180.80 
-    ├─ Data transfer to Asia excluding China, but including Hong Kong (first 1TB)        1,024  GB                   $122.88 
-    ├─ Data transfer to Asia excluding China, but including Hong Kong (next 9TB)           476  GB                    $52.36 
-    ├─ Data transfer to China excluding Hong Kong (first 1TB)                               50  GB                    $11.50 
-    └─ Data transfer to Australia (first 1TB)                                              250  GB                    $47.50 
-                                                                                                                             
- OVERALL TOTAL                                                                                                     $1,561.29 
+ Name                                                                                     Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                                              
+ google_container_registry.my_registry                                                                                                        
+ ├─ Storage (standard)                                                             Monthly cost depends on usage: $0.026 per GiB              
+ ├─ Object adds, bucket/object list (class A)                                      Monthly cost depends on usage: $0.05 per 10k operations    
+ ├─ Object gets, retrieve bucket/object metadata (class B)                         Monthly cost depends on usage: $0.004 per 10k operations   
+ └─ Network egress                                                                                                                            
+    ├─ Data transfer in same continent                                             Monthly cost depends on usage: $0.01 per GB                
+    ├─ Data transfer to worldwide excluding Asia, Australia (first 1TB)            Monthly cost depends on usage: $0.12 per GB                
+    ├─ Data transfer to Asia excluding China, but including Hong Kong (first 1TB)  Monthly cost depends on usage: $0.12 per GB                
+    ├─ Data transfer to China excluding Hong Kong (first 1TB)                      Monthly cost depends on usage: $0.23 per GB                
+    └─ Data transfer to Australia (first 1TB)                                      Monthly cost depends on usage: $0.19 per GB                
+                                                                                                                                              
+ google_container_registry.my_registry_usage                                                                                                  
+ ├─ Storage (standard)                                                                            150  GiB                              $3.90 
+ ├─ Object adds, bucket/object list (class A)                                                       4  10k operations                   $0.20 
+ ├─ Object gets, retrieve bucket/object metadata (class B)                                          2  10k operations                   $0.01 
+ └─ Network egress                                                                                                                            
+    ├─ Data transfer in same continent                                                            550  GB                               $5.50 
+    ├─ Data transfer to worldwide excluding Asia, Australia (first 1TB)                         1,024  GB                             $122.88 
+    ├─ Data transfer to worldwide excluding Asia, Australia (next 9TB)                          9,216  GB                           $1,013.76 
+    ├─ Data transfer to worldwide excluding Asia, Australia (over 10TB)                         2,260  GB                             $180.80 
+    ├─ Data transfer to Asia excluding China, but including Hong Kong (first 1TB)               1,024  GB                             $122.88 
+    ├─ Data transfer to Asia excluding China, but including Hong Kong (next 9TB)                  476  GB                              $52.36 
+    ├─ Data transfer to China excluding Hong Kong (first 1TB)                                      50  GB                              $11.50 
+    └─ Data transfer to Australia (first 1TB)                                                     250  GB                              $47.50 
+                                                                                                                                              
+ OVERALL TOTAL                                                                                                                      $1,561.29 
+----------------------------------
+To estimate usage-based resources use --usage-file, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.tf
+++ b/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.tf
@@ -5,5 +5,10 @@ provider "google" {
 
 resource "google_container_registry" "my_registry" {
   project  = "my-project"
+}
+
+resource "google_container_registry" "my_registry_usage" {
+  project  = "my-project"
   location = "EU"
 }
+

--- a/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.usage.yml
+++ b/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.usage.yml
@@ -1,6 +1,6 @@
 version: 0.1
 resource_usage:
-  google_container_registry.my_registry:
+  google_container_registry.my_registry_usage:
     storage_gb: 150
     monthly_class_a_operations: 40000
     monthly_class_b_operations: 20000


### PR DESCRIPTION
Closes: #1026

---

Fixes issue where a `google_container_registry` resource without a specified location fails to get pricing for storage.

e.g.

```
resource "google_container_registry" "registry" {
  project   = "my-project"
}
```

will give an output of:

```
 google_container_registry.registry
 ├─ Storage (standard).          Monthly cost depends on usage: $0.00 per GiB   # <- note 0 cost
 ...
```

---

`location` resource output is listed in [terraform docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_registry) as:

> (Optional) The location of the registry. One of ASIA, EU, US or not specified. See the official documentation for more information on registry locations.

The default registry is `gcr.io` which [google references](https://cloud.google.com/container-registry/docs/pushing-and-pulling#pushing_an_image_to_a_registry) as:

> **gcr.io** hosts images in data centers in the **United States**, but the location may change in the future

 Thus I have now altered the `dataStorage` function to default to **US** if no location attribute is specified.