### PR TITLE
Show one line in diff when cost component labels change

### DIFF
--- a/cmd/infracost/testdata/breakdown_format_table/breakdown_format_table.golden
+++ b/cmd/infracost/testdata/breakdown_format_table/breakdown_format_table.golden
@@ -24,6 +24,6 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                             25,000,000  GB-seconds        $416.67 
                                                                                                
  OVERALL TOTAL                                                                       $1,361.31 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_directory/breakdown_terraform_directory.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_directory/breakdown_terraform_directory.golden
@@ -16,6 +16,6 @@ Project: infracost/infracost/examples/terraform
  └─ Duration                                            Monthly cost depends on usage: $0.0000166667 per GB-seconds   
                                                                                                                       
  OVERALL TOTAL                                                                                                $742.64 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_fields_all/breakdown_terraform_fields_all.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_fields_all/breakdown_terraform_fields_all.golden
@@ -24,6 +24,6 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                            $0.0000166667   25,000,000  GB-seconds         $0.57       $416.67 
                                                                                                                            
  OVERALL TOTAL                                                                                                   $1,361.31 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_fields_invalid/breakdown_terraform_fields_invalid.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_fields_invalid/breakdown_terraform_fields_invalid.golden
@@ -24,7 +24,7 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                            $0.0000166667        $0.57 
                                                                                    
  OVERALL TOTAL                                                           $1,361.31 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 

--- a/cmd/infracost/testdata/breakdown_terraform_plan_json/breakdown_terraform_plan_json.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_plan_json/breakdown_terraform_plan_json.golden
@@ -24,6 +24,6 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                             25,000,000  GB-seconds        $416.67 
                                                                                                
  OVERALL TOTAL                                                                       $1,361.31 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_show_skipped/breakdown_terraform_show_skipped.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_show_skipped/breakdown_terraform_show_skipped.golden
@@ -27,7 +27,7 @@ Project: infracost/infracost/cmd/infracost/testdata/azure_firewall_plan.json
  └─ IP address (static)                                  730  hours                    $3.65 
                                                                                              
  OVERALL TOTAL                                                                     $5,296.15 
-----------------------------------
+──────────────────────────────────
 11 cloud resources were detected:
 ∙ 6 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/cmd/infracost/testdata/breakdown_terraform_sync_usage_file/breakdown_terraform_sync_usage_file.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_sync_usage_file/breakdown_terraform_sync_usage_file.golden
@@ -30,7 +30,7 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_terraform_sync_usa
  └─ Data processed                                                2  GB                       $0.09 
                                                                                                     
  OVERALL TOTAL                                                                              $251.12 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
 

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file/breakdown_terraform_usage_file.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file/breakdown_terraform_usage_file.golden
@@ -24,6 +24,6 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
  └─ Duration                                             25,000,000  GB-seconds        $416.67 
                                                                                                
  OVERALL TOTAL                                                                       $1,361.31 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file_invalid_key/breakdown_terraform_usage_file_invalid_key.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file_invalid_key/breakdown_terraform_usage_file_invalid_key.golden
@@ -36,7 +36,7 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
     └─ Select data returned                             Monthly cost depends on usage: $0.0007 per GB                 
                                                                                                                       
  OVERALL TOTAL                                                                                              $1,921.95 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 

--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
@@ -38,7 +38,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_state.json
     └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
                                                                                                     
  OVERALL TOTAL                                                                               $40.56 
-----------------------------------
+──────────────────────────────────
 14 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 7 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost

--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
@@ -38,7 +38,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_state.json
     └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
                                                                                                     
  OVERALL TOTAL                                                                               $40.56 
-----------------------------------
+──────────────────────────────────
 14 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 7 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost

--- a/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
@@ -72,7 +72,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
     └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
                                                                                                     
  OVERALL TOTAL                                                                               $81.12 
-----------------------------------
+──────────────────────────────────
 26 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
@@ -72,7 +72,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
     └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
                                                                                                     
  OVERALL TOTAL                                                                               $81.12 
-----------------------------------
+──────────────────────────────────
 26 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/cmd/infracost/testdata/breakdown_terragrunt/breakdown_terragrunt.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt/breakdown_terragrunt.golden
@@ -17,7 +17,7 @@ Project: infracost/infracost/examples/terragrunt/dev
                                                                                                                     
  Project total                                                                                               $51.97 
 
-----------------------------------
+──────────────────────────────────
 Project: infracost/infracost/examples/terragrunt/prod
 
  Name                                                           Monthly Qty  Unit                        Monthly Cost 
@@ -37,6 +37,6 @@ Project: infracost/infracost/examples/terragrunt/prod
  Project total                                                                                                $747.64 
 
  OVERALL TOTAL                                                                                                $799.61 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terragrunt_nested/breakdown_terragrunt_nested.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_nested/breakdown_terragrunt_nested.golden
@@ -17,7 +17,7 @@ Project: infracost/infracost/examples/terragrunt/dev
                                                                                                                     
  Project total                                                                                               $51.97 
 
-----------------------------------
+──────────────────────────────────
 Project: infracost/infracost/examples/terragrunt/prod
 
  Name                                                           Monthly Qty  Unit                        Monthly Cost 
@@ -37,6 +37,6 @@ Project: infracost/infracost/examples/terragrunt/prod
  Project total                                                                                                $747.64 
 
  OVERALL TOTAL                                                                                                $799.61 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/diff_terraform_directory/diff_terraform_directory.golden
+++ b/cmd/infracost/testdata/diff_terraform_directory/diff_terraform_directory.golden
@@ -32,9 +32,9 @@ Project: infracost/infracost/examples/terraform
         +$0.0000166667 per GB-seconds
 
 Monthly cost change for infracost/infracost/examples/terraform
-Amount:  +$743 ($0.00 -> $743)
+Amount:  +$743 ($0.00 → $743)
 
-----------------------------------
+──────────────────────────────────
 Key: ~ changed, + added, - removed
 
 2 cloud resources were detected, rerun with --show-skipped to see details:

--- a/cmd/infracost/testdata/diff_terraform_plan_json/diff_terraform_plan_json.golden
+++ b/cmd/infracost/testdata/diff_terraform_plan_json/diff_terraform_plan_json.golden
@@ -78,9 +78,9 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
           $0.00
 
 Monthly cost change for infracost/infracost/cmd/infracost/testdata/example_plan.json
-Amount:  +$1,361 ($0.00 -> $1,361)
+Amount:  +$1,361 ($0.00 → $1,361)
 
-----------------------------------
+──────────────────────────────────
 Key: ~ changed, + added, - removed
 
 5 cloud resources were detected, rerun with --show-skipped to see details:

--- a/cmd/infracost/testdata/diff_terraform_show_skipped/diff_terraform_show_skipped.golden
+++ b/cmd/infracost/testdata/diff_terraform_show_skipped/diff_terraform_show_skipped.golden
@@ -58,9 +58,9 @@ Project: infracost/infracost/cmd/infracost/testdata/azure_firewall_plan.json
       +$3.65
 
 Monthly cost change for infracost/infracost/cmd/infracost/testdata/azure_firewall_plan.json
-Amount:  +$5,296 ($0.00 -> $5,296)
+Amount:  +$5,296 ($0.00 → $5,296)
 
-----------------------------------
+──────────────────────────────────
 Key: ~ changed, + added, - removed
 
 11 cloud resources were detected:

--- a/cmd/infracost/testdata/diff_terraform_usage_file/diff_terraform_usage_file.golden
+++ b/cmd/infracost/testdata/diff_terraform_usage_file/diff_terraform_usage_file.golden
@@ -78,9 +78,9 @@ Project: infracost/infracost/cmd/infracost/testdata/example_plan.json
           $0.00
 
 Monthly cost change for infracost/infracost/cmd/infracost/testdata/example_plan.json
-Amount:  +$1,361 ($0.00 -> $1,361)
+Amount:  +$1,361 ($0.00 → $1,361)
 
-----------------------------------
+──────────────────────────────────
 Key: ~ changed, + added, - removed
 
 5 cloud resources were detected, rerun with --show-skipped to see details:

--- a/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
@@ -95,10 +95,10 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
           +$0.80
 
 Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
-Amount:  +$40.56 ($40.56 -> $81.12)
+Amount:  +$40.56 ($40.56 → $81.12)
 Percent: +100%
 
-----------------------------------
+──────────────────────────────────
 Key: ~ changed, + added, - removed
 
 26 cloud resources were detected, rerun with --show-skipped to see details:

--- a/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
@@ -95,10 +95,10 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
           +$0.80
 
 Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
-Amount:  +$40.56 ($40.56 -> $81.12)
+Amount:  +$40.56 ($40.56 → $81.12)
 Percent: +100%
 
-----------------------------------
+──────────────────────────────────
 Key: ~ changed, + added, - removed
 
 26 cloud resources were detected, rerun with --show-skipped to see details:

--- a/cmd/infracost/testdata/diff_terragrunt/diff_terragrunt.golden
+++ b/cmd/infracost/testdata/diff_terragrunt/diff_terragrunt.golden
@@ -32,9 +32,9 @@ Project: infracost/infracost/examples/terragrunt/dev
         +$0.0000166667 per GB-seconds
 
 Monthly cost change for infracost/infracost/examples/terragrunt/dev
-Amount:  +$51.97 ($0.00 -> $51.97)
+Amount:  +$51.97 ($0.00 → $51.97)
 
-----------------------------------
+──────────────────────────────────
 Project: infracost/infracost/examples/terragrunt/prod
 
 + aws_instance.web_app
@@ -68,9 +68,9 @@ Project: infracost/infracost/examples/terragrunt/prod
         +$0.0000166667 per GB-seconds
 
 Monthly cost change for infracost/infracost/examples/terragrunt/prod
-Amount:  +$748 ($0.00 -> $748)
+Amount:  +$748 ($0.00 → $748)
 
-----------------------------------
+──────────────────────────────────
 Key: ~ changed, + added, - removed
 
 4 cloud resources were detected, rerun with --show-skipped to see details:

--- a/cmd/infracost/testdata/diff_terragrunt_nested/diff_terragrunt_nested.golden
+++ b/cmd/infracost/testdata/diff_terragrunt_nested/diff_terragrunt_nested.golden
@@ -32,9 +32,9 @@ Project: infracost/infracost/examples/terragrunt/dev
         +$0.0000166667 per GB-seconds
 
 Monthly cost change for infracost/infracost/examples/terragrunt/dev
-Amount:  +$51.97 ($0.00 -> $51.97)
+Amount:  +$51.97 ($0.00 → $51.97)
 
-----------------------------------
+──────────────────────────────────
 Project: infracost/infracost/examples/terragrunt/prod
 
 + aws_instance.web_app
@@ -68,9 +68,9 @@ Project: infracost/infracost/examples/terragrunt/prod
         +$0.0000166667 per GB-seconds
 
 Monthly cost change for infracost/infracost/examples/terragrunt/prod
-Amount:  +$748 ($0.00 -> $748)
+Amount:  +$748 ($0.00 → $748)
 
-----------------------------------
+──────────────────────────────────
 Key: ~ changed, + added, - removed
 
 4 cloud resources were detected, rerun with --show-skipped to see details:

--- a/cmd/infracost/testdata/flag_errors_config_file_and_terraform_workspace_env/flag_errors_config_file_and_terraform_workspace_env.golden
+++ b/cmd/infracost/testdata/flag_errors_config_file_and_terraform_workspace_env/flag_errors_config_file_and_terraform_workspace_env.golden
@@ -16,6 +16,6 @@ Project: infracost/infracost/examples/terraform (dev)
  └─ Duration                                            Monthly cost depends on usage: $0.0000166667 per GB-seconds   
                                                                                                                       
  OVERALL TOTAL                                                                                                $742.64 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/flag_errors_terraform_workspace_flag_and_env/flag_errors_terraform_workspace_flag_and_env.golden
+++ b/cmd/infracost/testdata/flag_errors_terraform_workspace_flag_and_env/flag_errors_terraform_workspace_flag_and_env.golden
@@ -16,6 +16,6 @@ Project: infracost/infracost/examples/terraform (prod)
  └─ Duration                                            Monthly cost depends on usage: $0.0000166667 per GB-seconds   
                                                                                                                       
  OVERALL TOTAL                                                                                                $742.64 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected, rerun with --show-skipped to see details:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/output_format_table/output_format_table.golden
+++ b/cmd/infracost/testdata/output_format_table/output_format_table.golden
@@ -24,7 +24,7 @@ Project: infracost/infracost/cmd/infracost/testdata
                                                                                                
  Project total                                                                       $1,361.31 
 
-----------------------------------
+──────────────────────────────────
 Project: infracost/infracost/cmd/infracost/testdata/azure_firewall_plan.json
 
  Name                                            Monthly Qty  Unit              Monthly Cost 

--- a/cmd/infracost/testdata/output_terraform_fields_all/output_terraform_fields_all.golden
+++ b/cmd/infracost/testdata/output_terraform_fields_all/output_terraform_fields_all.golden
@@ -24,7 +24,7 @@ Project: infracost/infracost/cmd/infracost/testdata
                                                                                                                            
  Project total                                                                                                   $1,361.31 
 
-----------------------------------
+──────────────────────────────────
 Project: infracost/infracost/cmd/infracost/testdata/azure_firewall_plan.json
 
  Name                                                  Price     Monthly Qty  Unit            Hourly Cost  Monthly Cost 

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -33,7 +33,7 @@ func ToDiff(out Root, opts Options) ([]byte, error) {
 		}
 
 		if i != 0 {
-			s += "----------------------------------\n"
+			s += "──────────────────────────────────\n"
 		}
 
 		s += fmt.Sprintf("%s %s\n\n",
@@ -63,7 +63,7 @@ func ToDiff(out Root, opts Options) ([]byte, error) {
 			ui.BoldString("Monthly cost change for"),
 			ui.BoldString(project.Label(opts.DashboardEnabled)),
 			formatTitleWithCurrency(formatCostChange(out.Currency, project.Diff.TotalMonthlyCost), out.Currency),
-			ui.FaintStringf("(%s -> %s)", formatCost(out.Currency, oldCost), formatCost(out.Currency, newCost)),
+			ui.FaintStringf("(%s → %s)", formatCost(out.Currency, oldCost), formatCost(out.Currency, newCost)),
 		)
 
 		percent := formatPercentChange(oldCost, newCost)
@@ -79,12 +79,12 @@ func ToDiff(out Root, opts Options) ([]byte, error) {
 	}
 
 	if len(noDiffProjects) > 0 {
-		s += "----------------------------------\n"
+		s += "──────────────────────────────────\n"
 		s += fmt.Sprintf("\nThe following projects have no cost estimate changes: %s", strings.Join(noDiffProjects, ", "))
 		s += fmt.Sprintf("\nRun %s to see their full breakdown.", ui.PrimaryString("infracost breakdown"))
 	}
 
-	s += "\n\n----------------------------------\n"
+	s += "\n\n──────────────────────────────────\n"
 	if len(noDiffProjects) != len(out.Projects) {
 		s += fmt.Sprintf("Key: %s changed, %s added, %s removed",
 			opChar(UPDATED),
@@ -215,7 +215,7 @@ func costComponentToDiff(currency string, diffComponent CostComponent, oldCompon
 
 // colorizeDiffName colorizes any arrows in the name
 func colorizeDiffName(name string) string {
-	return strings.ReplaceAll(name, " -> ", fmt.Sprintf(" %s ", color.YellowString("->")))
+	return strings.ReplaceAll(name, " → ", fmt.Sprintf(" %s ", color.YellowString("→")))
 }
 
 func opChar(op int) string {
@@ -273,7 +273,7 @@ func formatCostChangeDetails(currency string, oldCost *decimal.Decimal, newCost 
 		return ""
 	}
 
-	return fmt.Sprintf(" (%s -> %s)", formatCost(currency, oldCost), formatCost(currency, newCost))
+	return fmt.Sprintf(" (%s → %s)", formatCost(currency, oldCost), formatCost(currency, newCost))
 }
 
 func formatPriceChange(currency string, d decimal.Decimal) string {
@@ -286,7 +286,7 @@ func formatPriceChangeDetails(currency string, oldPrice *decimal.Decimal, newPri
 		return ""
 	}
 
-	return fmt.Sprintf(" (%s -> %s)", formatPrice(currency, *oldPrice), formatPrice(currency, *newPrice))
+	return fmt.Sprintf(" (%s → %s)", formatPrice(currency, *oldPrice), formatPrice(currency, *newPrice))
 }
 
 func formatPercentChange(oldCost *decimal.Decimal, newCost *decimal.Decimal) string {

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -27,7 +27,7 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 		}
 
 		if i != 0 {
-			s += "----------------------------------\n"
+			s += "──────────────────────────────────\n"
 		}
 
 		s += fmt.Sprintf("%s %s\n\n",
@@ -66,7 +66,7 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 	summaryMsg := out.summaryMessage(opts.ShowSkipped)
 
 	if summaryMsg != "" {
-		s += "\n----------------------------------\n" + summaryMsg
+		s += "\n──────────────────────────────────\n" + summaryMsg
 	}
 
 	return []byte(s), nil

--- a/internal/providers/terraform/aws/testdata/acm_certificate_test/acm_certificate_test.golden
+++ b/internal/providers/terraform/aws/testdata/acm_certificate_test/acm_certificate_test.golden
@@ -5,6 +5,6 @@
  └─ Certificate                              1  requests         $0.75 
                                                                        
  OVERALL TOTAL                                                   $0.75 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/acmpca_certificate_authority_test/acmpca_certificate_authority_test.golden
+++ b/internal/providers/terraform/aws/testdata/acmpca_certificate_authority_test/acmpca_certificate_authority_test.golden
@@ -21,6 +21,6 @@
  └─ Certificates (next 9K)                                          9,000  requests               $3,150.00 
                                                                                                             
  OVERALL TOTAL                                                                                   $10,160.00 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/api_gateway_rest_api_test/api_gateway_rest_api_test.golden
+++ b/internal/providers/terraform/aws/testdata/api_gateway_rest_api_test/api_gateway_rest_api_test.golden
@@ -11,6 +11,6 @@
  └─ Requests (over 20B)                           1,000  1M requests              $1,510.00 
                                                                                             
  OVERALL TOTAL                                                                   $49,763.10 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/api_gateway_stage_test/api_gateway_stage_test.golden
+++ b/internal/providers/terraform/aws/testdata/api_gateway_stage_test/api_gateway_stage_test.golden
@@ -8,6 +8,6 @@
  └─ Cache memory (237 GB)               730  hours     $2,774.00 
                                                                  
  OVERALL TOTAL                                         $2,788.60 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/apigatewayv2_api_test/apigatewayv2_api_test.golden
+++ b/internal/providers/terraform/aws/testdata/apigatewayv2_api_test/apigatewayv2_api_test.golden
@@ -18,6 +18,6 @@
  └─ Connection duration                              10  1M minutes                   $2.50 
                                                                                             
  OVERALL TOTAL                                                                    $2,332.50 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
@@ -113,7 +113,7 @@
     └─ Instance usage (Linux/UNIX, on-demand, t2.large)            2,190  hours            $203.23 
                                                                                                    
  OVERALL TOTAL                                                                           $3,133.01 
-----------------------------------
+──────────────────────────────────
 40 cloud resources were detected:
 ∙ 18 were estimated, 18 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.golden
+++ b/internal/providers/terraform/aws/testdata/backup_vault_test/backup_vault_test.golden
@@ -30,6 +30,6 @@
  └─ FSx for lustre backup              10,000  GB                       $550.00 
                                                                                 
  OVERALL TOTAL                                                       $12,960.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudformation_stack_set_test/cloudformation_stack_set_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudformation_stack_set_test/cloudformation_stack_set_test.golden
@@ -9,7 +9,7 @@
  └─ Durations above 30s                         Monthly cost depends on usage: $0.00008 per seconds     
                                                                                                         
  OVERALL TOTAL                                                                                    $9.00 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/aws/testdata/cloudformation_stack_test/cloudformation_stack_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudformation_stack_test/cloudformation_stack_test.golden
@@ -9,7 +9,7 @@
  └─ Durations above 30s                     Monthly cost depends on usage: $0.00008 per seconds     
                                                                                                     
  OVERALL TOTAL                                                                                $9.00 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/aws/testdata/cloudfront_distribution_test/cloudfront_distribution_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudfront_distribution_test/cloudfront_distribution_test.golden
@@ -175,6 +175,6 @@
     └─ Select data returned                                                 Monthly cost depends on usage: $0.0007 per GB           
                                                                                                                                     
  OVERALL TOTAL                                                                                                       $21,684,502.45 
-----------------------------------
+──────────────────────────────────
 9 cloud resources were detected:
 ∙ 9 were estimated, 9 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudwatch_dashboard_test/cloudwatch_dashboard_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudwatch_dashboard_test/cloudwatch_dashboard_test.golden
@@ -5,6 +5,6 @@
  └─ Dashboard                                  1  months         $3.00 
                                                                        
  OVERALL TOTAL                                                   $3.00 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/cloudwatch_event_bus_test/cloudwatch_event_bus_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudwatch_event_bus_test/cloudwatch_event_bus_test.golden
@@ -16,6 +16,6 @@
  └─ Schema discovery                                          1  1M events                    $0.10 
                                                                                                     
  OVERALL TOTAL                                                                               $17.70 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudwatch_log_group_test/cloudwatch_log_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudwatch_log_group_test/cloudwatch_log_group_test.golden
@@ -27,6 +27,6 @@
  └─ Insights queries data scanned                             250  GB                       $1.25 
                                                                                                   
  OVERALL TOTAL                                                                          $2,065.00 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudwatch_metric_alarm_test/cloudwatch_metric_alarm_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudwatch_metric_alarm_test/cloudwatch_metric_alarm_test.golden
@@ -14,6 +14,6 @@
  └─ Standard resolution                                   1  alarm metrics         $0.10 
                                                                                          
  OVERALL TOTAL                                                                     $1.50 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated

--- a/internal/providers/terraform/aws/testdata/codebuild_project_test/codebuild_project_test.golden
+++ b/internal/providers/terraform/aws/testdata/codebuild_project_test/codebuild_project_test.golden
@@ -17,6 +17,6 @@
  └─ Linux (general1.small)                                 1,000  minutes                    $5.00 
                                                                                                    
  OVERALL TOTAL                                                                           $5,705.00 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/config_config_rule_test/config_config_rule_test.golden
+++ b/internal/providers/terraform/aws/testdata/config_config_rule_test/config_config_rule_test.golden
@@ -10,6 +10,6 @@
  └─ Rule evaluations (over 500K)                       500,000  evaluations                  $250.00 
                                                                                                      
  OVERALL TOTAL                                                                               $670.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/config_configuration_recorder_test/config_configuration_recorder_test.golden
+++ b/internal/providers/terraform/aws/testdata/config_configuration_recorder_test/config_configuration_recorder_test.golden
@@ -10,7 +10,7 @@
  └─ Custom config items                                                              2,000  records                    $6.00 
                                                                                                                              
  OVERALL TOTAL                                                                                                         $9.00 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free

--- a/internal/providers/terraform/aws/testdata/config_organization_custom_rule_test/config_organization_custom_rule_test.golden
+++ b/internal/providers/terraform/aws/testdata/config_organization_custom_rule_test/config_organization_custom_rule_test.golden
@@ -10,6 +10,6 @@
  └─ Rule evaluations (over 500K)                                                         100,000  evaluations                   $50.00 
                                                                                                                                        
  OVERALL TOTAL                                                                                                                 $470.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/config_organization_managed_rule_test/config_organization_managed_rule_test.golden
+++ b/internal/providers/terraform/aws/testdata/config_organization_managed_rule_test/config_organization_managed_rule_test.golden
@@ -10,6 +10,6 @@
  └─ Rule evaluations (over 500K)                                                           100,000  evaluations                   $50.00 
                                                                                                                                          
  OVERALL TOTAL                                                                                                                   $470.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -195,6 +195,6 @@
  └─ Outbound data transfer to other regions                  750  GB          $15.00 
                                                                                      
  OVERALL TOTAL                                                           $325,124.38 
-----------------------------------
+──────────────────────────────────
 24 cloud resources were detected:
 ∙ 24 were estimated, 24 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
@@ -94,6 +94,6 @@
  └─ Storage (general purpose SSD, gp2)                                    20  GB                           $2.30 
                                                                                                                  
  OVERALL TOTAL                                                                                         $5,293.39 
-----------------------------------
+──────────────────────────────────
 22 cloud resources were detected:
 ∙ 22 were estimated

--- a/internal/providers/terraform/aws/testdata/directory_service_directory_test/directory_service_directory_test.golden
+++ b/internal/providers/terraform/aws/testdata/directory_service_directory_test/directory_service_directory_test.golden
@@ -26,6 +26,6 @@
  └─ Additional domain controllers                                   3  controllers       $109.50 
                                                                                                  
  OVERALL TOTAL                                                                         $1,295.02 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/dms_test/dms_test.golden
+++ b/internal/providers/terraform/aws/testdata/dms_test/dms_test.golden
@@ -9,6 +9,6 @@
  └─ Instance (t2.micro)                                                               730  hours        $13.14 
                                                                                                                
  OVERALL TOTAL                                                                                          $44.02 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/docdb_cluster_instance_test/docdb_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/docdb_cluster_instance_test/docdb_cluster_instance_test.golden
@@ -19,6 +19,6 @@
  └─ CPU credits                                                 10  vCPU-hours                   $0.90 
                                                                                                        
  OVERALL TOTAL                                                                               $1,936.46 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/docdb_cluster_snapshot_test/docdb_cluster_snapshot_test.golden
+++ b/internal/providers/terraform/aws/testdata/docdb_cluster_snapshot_test/docdb_cluster_snapshot_test.golden
@@ -8,6 +8,6 @@
  └─ Backup storage                                                        1,000  GB                      $21.00 
                                                                                                                 
  OVERALL TOTAL                                                                                           $21.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/docdb_cluster_test/docdb_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/docdb_cluster_test/docdb_cluster_test.golden
@@ -8,6 +8,6 @@
  └─ Backup storage                         10,000  GB                     $210.00 
                                                                                   
  OVERALL TOTAL                                                            $210.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/dx_connection_test/dx_connection_test.golden
+++ b/internal/providers/terraform/aws/testdata/dx_connection_test/dx_connection_test.golden
@@ -14,7 +14,7 @@
  └─ Outbound data transfer (from us-east-1, to EqDC2)               200  GB            $4.00 
                                                                                              
  OVERALL TOTAL                                                                       $959.20 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 Logs:

--- a/internal/providers/terraform/aws/testdata/dx_gateway_association_test/dx_gateway_association_test.golden
+++ b/internal/providers/terraform/aws/testdata/dx_gateway_association_test/dx_gateway_association_test.golden
@@ -10,6 +10,6 @@
  └─ Transit gateway attachment                                             730  hours                 $36.50 
                                                                                                              
  OVERALL TOTAL                                                                                        $75.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/dynamodb_table_test/dynamodb_table_test.golden
+++ b/internal/providers/terraform/aws/testdata/dynamodb_table_test/dynamodb_table_test.golden
@@ -28,6 +28,6 @@
     └─ Replicated write request unit (rWRU)             4,109.5890  rWRU                         $6.27 
                                                                                                        
  OVERALL TOTAL                                                                                 $658.50 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ebs_snapshot_copy_test/ebs_snapshot_copy_test.golden
+++ b/internal/providers/terraform/aws/testdata/ebs_snapshot_copy_test/ebs_snapshot_copy_test.golden
@@ -15,6 +15,6 @@
  └─ Storage (general purpose SSD, gp2)                                    10  GB                                 $1.00 
                                                                                                                        
  OVERALL TOTAL                                                                                                   $2.00 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ebs_snapshot_test/ebs_snapshot_test.golden
+++ b/internal/providers/terraform/aws/testdata/ebs_snapshot_test/ebs_snapshot_test.golden
@@ -19,6 +19,6 @@
  └─ Storage (general purpose SSD, gp2)                                    10  GB                                 $1.00 
                                                                                                                        
  OVERALL TOTAL                                                                                                  $78.40 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ebs_volume_test/ebs_volume_test.golden
+++ b/internal/providers/terraform/aws/testdata/ebs_volume_test/ebs_volume_test.golden
@@ -32,6 +32,6 @@
  └─ I/O requests                                            1  1M request                   $0.05 
                                                                                                   
  OVERALL TOTAL                                                                             $60.50 
-----------------------------------
+──────────────────────────────────
 8 cloud resources were detected:
 ∙ 8 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ec2_client_vpn_endpoint_test/ec2_client_vpn_endpoint_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_client_vpn_endpoint_test/ec2_client_vpn_endpoint_test.golden
@@ -5,6 +5,6 @@
  └─ Connection                                 730  hours        $36.50 
                                                                         
  OVERALL TOTAL                                                   $36.50 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/ec2_client_vpn_network_association_test/ec2_client_vpn_network_association_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_client_vpn_network_association_test/ec2_client_vpn_network_association_test.golden
@@ -5,6 +5,6 @@
  └─ Endpoint association                                     730  hours        $73.00 
                                                                                       
  OVERALL TOTAL                                                                 $73.00 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/ec2_traffic_mirror_session_test/ec2_traffic_mirror_session_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_traffic_mirror_session_test/ec2_traffic_mirror_session_test.golden
@@ -5,6 +5,6 @@
  └─ Traffic mirror                               730  hours        $10.95 
                                                                           
  OVERALL TOTAL                                                     $10.95 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/ec2_transit_gateway_peering_attachment_test/ec2_transit_gateway_peering_attachment_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_transit_gateway_peering_attachment_test/ec2_transit_gateway_peering_attachment_test.golden
@@ -5,6 +5,6 @@
  └─ Transit gateway attachment                               730  hours        $36.50 
                                                                                       
  OVERALL TOTAL                                                                 $36.50 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/ec2_transit_gateway_vpc_attachment_test/ec2_transit_gateway_vpc_attachment_test.golden
+++ b/internal/providers/terraform/aws/testdata/ec2_transit_gateway_vpc_attachment_test/ec2_transit_gateway_vpc_attachment_test.golden
@@ -6,6 +6,6 @@
  └─ Data processed                                      Monthly cost depends on usage: $0.02 per GB 
                                                                                                     
  OVERALL TOTAL                                                                               $36.50 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ecr_repository_test/ecr_repository_test.golden
+++ b/internal/providers/terraform/aws/testdata/ecr_repository_test/ecr_repository_test.golden
@@ -8,6 +8,6 @@
  └─ Storage                Monthly cost depends on usage: $0.10 per GB 
                                                                        
  OVERALL TOTAL                                                   $0.10 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.golden
+++ b/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.golden
@@ -7,7 +7,7 @@
  └─ Inference accelerator (eia2.medium)        1,460  hours       $175.20 
                                                                           
  OVERALL TOTAL                                                    $247.28 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 5 were free

--- a/internal/providers/terraform/aws/testdata/efs_file_system_test/efs_file_system_test.golden
+++ b/internal/providers/terraform/aws/testdata/efs_file_system_test/efs_file_system_test.golden
@@ -21,6 +21,6 @@
  └─ Write requests (infrequent access)               100  GB                     $1.00 
                                                                                        
  OVERALL TOTAL                                                                 $712.63 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/eip_test/eip_test.golden
+++ b/internal/providers/terraform/aws/testdata/eip_test/eip_test.golden
@@ -5,6 +5,6 @@
  └─ IP address (if unused)          730  hours         $3.65 
                                                              
  OVERALL TOTAL                                         $3.65 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
@@ -5,7 +5,7 @@
  └─ EKS cluster                              730  hours        $73.00 
                                                                       
  OVERALL TOTAL                                                 $73.00 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 1 was estimated
 ∙ 3 were free

--- a/internal/providers/terraform/aws/testdata/eks_fargate_profile_test/eks_fargate_profile_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_fargate_profile_test/eks_fargate_profile_test.golden
@@ -9,6 +9,6 @@
  └─ Per vCPU per hour                       1  CPU          $29.55 
                                                                    
  OVERALL TOTAL                                             $105.80 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
@@ -58,7 +58,7 @@
  └─ Storage (general purpose SSD, gp2)                             20  GB                 $2.00 
                                                                                                 
  OVERALL TOTAL                                                                        $2,590.80 
-----------------------------------
+──────────────────────────────────
 14 cloud resources were detected:
 ∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/aws/testdata/elasticache_cluster_test/elasticache_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/elasticache_cluster_test/elasticache_cluster_test.golden
@@ -16,6 +16,6 @@
  └─ Backup storage                                       10,000  GB                     $850.00 
                                                                                                 
  OVERALL TOTAL                                                                        $8,867.59 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.golden
@@ -12,6 +12,6 @@
  └─ Backup storage                                       Monthly cost depends on usage: $0.085 per GB   
                                                                                                         
  OVERALL TOTAL                                                                               $13,387.47 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated

--- a/internal/providers/terraform/aws/testdata/elasticsearch_domain_test/elasticsearch_domain_test.golden
+++ b/internal/providers/terraform/aws/testdata/elasticsearch_domain_test/elasticsearch_domain_test.golden
@@ -17,6 +17,6 @@
  └─ Storage (standard)                                                       123  GB            $8.24 
                                                                                                       
  OVERALL TOTAL                                                                              $6,149.50 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated

--- a/internal/providers/terraform/aws/testdata/elb_test/elb_test.golden
+++ b/internal/providers/terraform/aws/testdata/elb_test/elb_test.golden
@@ -10,6 +10,6 @@
  └─ Data processed                 10,000  GB                      $80.00 
                                                                           
  OVERALL TOTAL                                                    $116.50 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/fsx_windows_file_system_test/fsx_windows_file_system_test.golden
+++ b/internal/providers/terraform/aws/testdata/fsx_windows_file_system_test/fsx_windows_file_system_test.golden
@@ -12,6 +12,6 @@
  └─ Backup storage                                  10,000  GB                   $500.00 
                                                                                          
  OVERALL TOTAL                                                                 $9,731.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
@@ -128,7 +128,7 @@
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
  OVERALL TOTAL                                                                                      $992.14 
-----------------------------------
+──────────────────────────────────
 23 cloud resources were detected:
 ∙ 22 were estimated, 22 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost

--- a/internal/providers/terraform/aws/testdata/kinesis_firehose_delivery_stream_test/kinesis_firehose_delivery_stream_test.golden
+++ b/internal/providers/terraform/aws/testdata/kinesis_firehose_delivery_stream_test/kinesis_firehose_delivery_stream_test.golden
@@ -44,7 +44,7 @@
     └─ Select data returned                             Monthly cost depends on usage: $0.0008 per GB           
                                                                                                                 
  OVERALL TOTAL                                                                                      $687,286.50 
-----------------------------------
+──────────────────────────────────
 8 cloud resources were detected:
 ∙ 7 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/aws/testdata/kinesisanalytics_application_test/kinesisanalytics_application_test.golden
+++ b/internal/providers/terraform/aws/testdata/kinesisanalytics_application_test/kinesisanalytics_application_test.golden
@@ -8,6 +8,6 @@
  └─ Processing (stream)                          Monthly cost depends on usage: $92.71 per KPU  
                                                                                                 
  OVERALL TOTAL                                                                          $927.10 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/kinesisanalyticsv2_application_snapshot_test/kinesisanalyticsv2_application_snapshot_test.golden
+++ b/internal/providers/terraform/aws/testdata/kinesisanalyticsv2_application_snapshot_test/kinesisanalyticsv2_application_snapshot_test.golden
@@ -20,7 +20,7 @@
  └─ Backup                                                 Monthly cost depends on usage: $0.024 per GB   
                                                                                                           
  OVERALL TOTAL                                                                                    $187.82 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/aws/testdata/kinesisanalyticsv2_application_test/kinesisanalyticsv2_application_test.golden
+++ b/internal/providers/terraform/aws/testdata/kinesisanalyticsv2_application_test/kinesisanalyticsv2_application_test.golden
@@ -17,7 +17,7 @@
  └─ Backup                                        Monthly cost depends on usage: $0.024 per GB   
                                                                                                  
  OVERALL TOTAL                                                                         $2,100.02 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/aws/testdata/kms_external_key_test/kms_external_key_test.golden
+++ b/internal/providers/terraform/aws/testdata/kms_external_key_test/kms_external_key_test.golden
@@ -5,6 +5,6 @@
  └─ Customer master key              1  months         $1.00 
                                                              
  OVERALL TOTAL                                         $1.00 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/kms_key_test/kms_key_test.golden
+++ b/internal/providers/terraform/aws/testdata/kms_key_test/kms_key_test.golden
@@ -16,6 +16,6 @@
  └─ Requests (asymmetric)             Monthly cost depends on usage: $0.15 per 10k requests   
                                                                                               
  OVERALL TOTAL                                                                          $3.00 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated

--- a/internal/providers/terraform/aws/testdata/lambda_function_test/lambda_function_test.golden
+++ b/internal/providers/terraform/aws/testdata/lambda_function_test/lambda_function_test.golden
@@ -14,6 +14,6 @@
  └─ Duration                                              17,500  GB-seconds                         $0.29 
                                                                                                            
  OVERALL TOTAL                                                                                       $0.40 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/lb_test/lb_test.golden
+++ b/internal/providers/terraform/aws/testdata/lb_test/lb_test.golden
@@ -22,6 +22,6 @@
  └─ Load balancer capacity units          1.3698  LCU                      $6.00 
                                                                                  
  OVERALL TOTAL                                                            $96.13 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
@@ -8,6 +8,6 @@
  └─ Virtual server (Windows)             730  hours        $19.62 
                                                                   
  OVERALL TOTAL                                             $98.12 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/mq_broker_test/mq_broker_test.golden
+++ b/internal/providers/terraform/aws/testdata/mq_broker_test/mq_broker_test.golden
@@ -22,7 +22,7 @@
  └─ Storage (RabbitMQ, EBS)                                          Monthly cost depends on usage: $0.10 per GB 
                                                                                                                  
  OVERALL TOTAL                                                                                         $2,149.20 
-----------------------------------
+──────────────────────────────────
 8 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free

--- a/internal/providers/terraform/aws/testdata/msk_cluster_test/msk_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/msk_cluster_test/msk_cluster_test.golden
@@ -10,6 +10,6 @@
  └─ Storage                             4,000  GB          $400.00 
                                                                    
  OVERALL TOTAL                                          $30,000.18 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated

--- a/internal/providers/terraform/aws/testdata/mwaa_environment_test/mwaa_environment_test.golden
+++ b/internal/providers/terraform/aws/testdata/mwaa_environment_test/mwaa_environment_test.golden
@@ -28,7 +28,7 @@
     └─ Select data returned                      Monthly cost depends on usage: $0.0007 per GB           
                                                                                                          
  OVERALL TOTAL                                                                                 $2,603.90 
-----------------------------------
+──────────────────────────────────
 8 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/aws/testdata/nat_gateway_test/nat_gateway_test.golden
+++ b/internal/providers/terraform/aws/testdata/nat_gateway_test/nat_gateway_test.golden
@@ -10,6 +10,6 @@
  └─ Data processed                         100  GB                       $4.50 
                                                                                
  OVERALL TOTAL                                                          $70.20 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/neptune_cluster_instance_test/neptune_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/neptune_cluster_instance_test/neptune_cluster_instance_test.golden
@@ -20,6 +20,6 @@
  └─ CPU credits                                   Monthly cost depends on usage: $0.15 per vCPU-hours  
                                                                                                        
  OVERALL TOTAL                                                                               $1,854.20 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/neptune_cluster_snapshot_test/neptune_cluster_snapshot_test.golden
+++ b/internal/providers/terraform/aws/testdata/neptune_cluster_snapshot_test/neptune_cluster_snapshot_test.golden
@@ -25,7 +25,7 @@
  └─ Backup storage                                 Monthly cost depends on usage: $0.022 per GB         
                                                                                                         
  OVERALL TOTAL                                                                                   $22.00 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/aws/testdata/neptune_cluster_test/neptune_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/neptune_cluster_test/neptune_cluster_test.golden
@@ -16,6 +16,6 @@
  └─ Backup storage                        Monthly cost depends on usage: $0.022 per GB         
                                                                                                
  OVERALL TOTAL                                                                          $49.84 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
@@ -21,6 +21,6 @@
  └─ CPU credits                                                   48  vCPU-hours                         $4.32 
                                                                                                                
  OVERALL TOTAL                                                                                         $275.88 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
@@ -48,6 +48,6 @@
  └─ Snapshot export                             Monthly cost depends on usage: $0.01 per GB                   
                                                                                                               
  OVERALL TOTAL                                                                                    $176,130.67 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/redshift_cluster_test/redshift_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/redshift_cluster_test/redshift_cluster_test.golden
@@ -30,6 +30,6 @@
  └─ Backup storage (first 50 TB)             Monthly cost depends on usage: $0.023 per GB               
                                                                                                         
  OVERALL TOTAL                                                                               $42,976.77 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/route53_health_check_test/route53_health_check_test.golden
+++ b/internal/providers/terraform/aws/testdata/route53_health_check_test/route53_health_check_test.golden
@@ -40,6 +40,6 @@
  └─ Optional features                                                            2  months         $4.00 
                                                                                                          
  OVERALL TOTAL                                                                                    $36.25 
-----------------------------------
+──────────────────────────────────
 10 cloud resources were detected:
 ∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/route53_record_test/route53_record_test.golden
+++ b/internal/providers/terraform/aws/testdata/route53_record_test/route53_record_test.golden
@@ -21,6 +21,6 @@
  └─ Hosted zone                                              1  months                       $0.50 
                                                                                                    
  OVERALL TOTAL                                                                           $1,956.00 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/route53_resolver_endpoint_test/route53_resolver_endpoint_test.golden
+++ b/internal/providers/terraform/aws/testdata/route53_resolver_endpoint_test/route53_resolver_endpoint_test.golden
@@ -15,6 +15,6 @@
  └─ DNS queries (over 1B)                                   1,000  1M queries                 $200.00 
                                                                                                       
  OVERALL TOTAL                                                                              $1,187.50 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/route53_zone_test/route53_zone_test.golden
+++ b/internal/providers/terraform/aws/testdata/route53_zone_test/route53_zone_test.golden
@@ -5,6 +5,6 @@
  └─ Hosted zone                    1  months         $0.50 
                                                            
  OVERALL TOTAL                                       $0.50 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/aws/testdata/s3_bucket_analytics_configuration_test/s3_bucket_analytics_configuration_test.golden
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_analytics_configuration_test/s3_bucket_analytics_configuration_test.golden
@@ -24,6 +24,6 @@
  └─ Objects monitored                                             Monthly cost depends on usage: $0.10 per 1M objects     
                                                                                                                           
  OVERALL TOTAL                                                                                                      $1.00 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/s3_bucket_inventory_test/s3_bucket_inventory_test.golden
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_inventory_test/s3_bucket_inventory_test.golden
@@ -40,6 +40,6 @@
  └─ Objects listed                                           10  1M objects                     $0.03 
                                                                                                       
  OVERALL TOTAL                                                                                  $0.03 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.golden
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.golden
@@ -132,6 +132,6 @@
     └─ Early delete (within 180 days)                  60,000  GB                            $59.40 
                                                                                                     
  OVERALL TOTAL                                                                           $11,985.78 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/secretsmanager_secret_test/secretsmanager_secret_test.golden
+++ b/internal/providers/terraform/aws/testdata/secretsmanager_secret_test/secretsmanager_secret_test.golden
@@ -10,6 +10,6 @@
  └─ API requests                                            10  10k requests                   $0.50 
                                                                                                      
  OVERALL TOTAL                                                                                 $1.30 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/sns_topic_subscription_test/sns_topic_subscription_test.golden
+++ b/internal/providers/terraform/aws/testdata/sns_topic_subscription_test/sns_topic_subscription_test.golden
@@ -8,6 +8,6 @@
  └─ HTTP notifications                                                         2  1M notifications                 $1.20 
                                                                                                                          
  OVERALL TOTAL                                                                                                     $1.20 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/sns_topic_test/sns_topic_test.golden
+++ b/internal/providers/terraform/aws/testdata/sns_topic_test/sns_topic_test.golden
@@ -8,6 +8,6 @@
  └─ Requests                                       2  1M requests                  $1.00 
                                                                                          
  OVERALL TOTAL                                                                     $1.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/sqs_queue_test/sqs_queue_test.golden
+++ b/internal/providers/terraform/aws/testdata/sqs_queue_test/sqs_queue_test.golden
@@ -14,6 +14,6 @@
  └─ Requests                                                2  1M requests                  $0.80 
                                                                                                   
  OVERALL TOTAL                                                                              $1.30 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ssm_activation_test/ssm_activation_test.golden
+++ b/internal/providers/terraform/aws/testdata/ssm_activation_test/ssm_activation_test.golden
@@ -8,6 +8,6 @@
  └─ On-prem managed instances (advanced)               73,000  hours                    $507.35 
                                                                                                 
  OVERALL TOTAL                                                                          $507.35 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/ssm_parameter_test/ssm_parameter_test.golden
+++ b/internal/providers/terraform/aws/testdata/ssm_parameter_test/ssm_parameter_test.golden
@@ -10,6 +10,6 @@
  └─ API interactions (advanced)                                     10  10k interactions                 $0.50 
                                                                                                                
  OVERALL TOTAL                                                                                           $0.59 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/step_function_test/step_function_test.golden
+++ b/internal/providers/terraform/aws/testdata/step_function_test/step_function_test.golden
@@ -27,6 +27,6 @@
  └─ Transitions                              Monthly cost depends on usage: $0.00005 per 1K transitions 
                                                                                                         
  OVERALL TOTAL                                                                                  $758.95 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
+++ b/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
@@ -24,6 +24,6 @@
  └─ Endpoint (Interface)                           1,460  hours                   $14.60 
                                                                                          
  OVERALL TOTAL                                                                    $95.80 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/vpn_connection_test/vpn_connection_test.golden
+++ b/internal/providers/terraform/aws/testdata/vpn_connection_test/vpn_connection_test.golden
@@ -18,6 +18,6 @@
  └─ VPN connection                                      730  hours                 $36.50 
                                                                                           
  OVERALL TOTAL                                                                    $221.00 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
+++ b/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
@@ -20,7 +20,7 @@
  └─ Requests                   Monthly cost depends on usage: $0.60 per 1M requests 
                                                                                     
  OVERALL TOTAL                                                               $38.20 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free

--- a/internal/providers/terraform/aws/testdata/wafv2_web_acl_test/wafv2_web_acl_test.golden
+++ b/internal/providers/terraform/aws/testdata/wafv2_web_acl_test/wafv2_web_acl_test.golden
@@ -15,7 +15,7 @@
  └─ Requests                     Monthly cost depends on usage: $0.60 per 1M requests 
                                                                                       
  OVERALL TOTAL                                                                 $30.60 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/active_directory_domain_service_replica_set_test/active_directory_domain_service_replica_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/active_directory_domain_service_replica_set_test/active_directory_domain_service_replica_set_test.golden
@@ -8,7 +8,7 @@
  └─ Active directory domain service replica set (Enterprise)          730  hours       $292.00 
                                                                                                
  OVERALL TOTAL                                                                         $584.00 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/active_directory_domain_service_test/active_directory_domain_service_test.golden
+++ b/internal/providers/terraform/azure/testdata/active_directory_domain_service_test/active_directory_domain_service_test.golden
@@ -11,7 +11,7 @@
  └─ Active directory domain service (Standard)               730  hours       $109.50 
                                                                                       
  OVERALL TOTAL                                                              $1,569.50 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 3 were estimated
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/api_management_test/api_management_test.golden
+++ b/internal/providers/terraform/azure/testdata/api_management_test/api_management_test.golden
@@ -25,7 +25,7 @@
  └─ API management (standard)                                  3  units                      $2,060.13 
                                                                                                        
  OVERALL TOTAL                                                                              $29,799.36 
-----------------------------------
+──────────────────────────────────
 8 cloud resources were detected:
 ∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/app_service_certificate_binding_test/app_service_certificate_binding_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_certificate_binding_test/app_service_certificate_binding_test.golden
@@ -5,7 +5,7 @@
  └─ IP SSL certificate                                      1  months        $39.00 
                                                                                     
  OVERALL TOTAL                                                               $39.00 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 1 was estimated
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/app_service_certificate_order_test/app_service_certificate_order_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_certificate_order_test/app_service_certificate_order_test.golden
@@ -8,6 +8,6 @@
  └─ SSL certificate (wildcard)                             0.0833  years        $25.00 
                                                                                        
  OVERALL TOTAL                                                                  $30.83 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated

--- a/internal/providers/terraform/azure/testdata/app_service_custom_hostname_binding_test/app_service_custom_hostname_binding_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_custom_hostname_binding_test/app_service_custom_hostname_binding_test.golden
@@ -8,7 +8,7 @@
  └─ Instance usage (S1)                                       730  hours         $73.00 
                                                                                         
  OVERALL TOTAL                                                                  $112.00 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/app_service_environment_test/app_service_environment_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_environment_test/app_service_environment_test.golden
@@ -26,7 +26,7 @@
  └─ Instance usage (I2)                              730  hours       $416.10 
                                                                               
  OVERALL TOTAL                                                      $7,820.49 
-----------------------------------
+──────────────────────────────────
 9 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.golden
@@ -23,7 +23,7 @@
  └─ Instance usage (S1)                      3,650  hours       $365.00 
                                                                         
  OVERALL TOTAL                                                $5,095.27 
-----------------------------------
+──────────────────────────────────
 8 cloud resources were detected:
 ∙ 7 were estimated
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/application_gateway_test/application_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/application_gateway_test/application_gateway_test.golden
@@ -24,7 +24,7 @@
  └─ IP address (dynamic)                             730  hours                  $2.92 
                                                                                        
  OVERALL TOTAL                                                               $2,505.26 
-----------------------------------
+──────────────────────────────────
 9 cloud resources were detected:
 ∙ 5 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/azure/testdata/application_insights_test/application_insights_test.golden
+++ b/internal/providers/terraform/azure/testdata/application_insights_test/application_insights_test.golden
@@ -12,7 +12,7 @@
  └─ Data retention (120 days)                         1,000  GB                   $100.00 
                                                                                           
  OVERALL TOTAL                                                                  $4,700.00 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/application_insights_web_t_test/application_insights_web_t_test.golden
+++ b/internal/providers/terraform/azure/testdata/application_insights_web_t_test/application_insights_web_t_test.golden
@@ -8,7 +8,7 @@
  └─ Multi-step web test                                      1  test                  $10.00 
                                                                                              
  OVERALL TOTAL                                                                        $10.00 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 2 were estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free

--- a/internal/providers/terraform/azure/testdata/automation_account_test/automation_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_account_test/automation_account_test.golden
@@ -16,7 +16,7 @@
  └─ Watchers                               Monthly cost depends on usage: $0.002 per hours   
                                                                                              
  OVERALL TOTAL                                                                        $12.10 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/automation_dsc_configuration_test/automation_dsc_configuration_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_dsc_configuration_test/automation_dsc_configuration_test.golden
@@ -13,7 +13,7 @@
  └─ Non-azure config nodes                           Monthly cost depends on usage: $6.00 per nodes    
                                                                                                        
  OVERALL TOTAL                                                                                  $30.00 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/automation_dsc_nodeconfiguration_test/automation_dsc_nodeconfiguration_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_dsc_nodeconfiguration_test/automation_dsc_nodeconfiguration_test.golden
@@ -16,7 +16,7 @@
  └─ Non-azure config nodes                              Monthly cost depends on usage: $6.00 per nodes    
                                                                                                           
  OVERALL TOTAL                                                                                     $30.00 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/automation_job_schedule_test/automation_job_schedule_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_job_schedule_test/automation_job_schedule_test.golden
@@ -8,7 +8,7 @@
  └─ Job run time                               Monthly cost depends on usage: $0.002 per minutes 
                                                                                                  
  OVERALL TOTAL                                                                             $0.01 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/bastion_host_test/bastion_host_test.golden
+++ b/internal/providers/terraform/azure/testdata/bastion_host_test/bastion_host_test.golden
@@ -11,7 +11,7 @@
  └─ IP address (static)                          730  hours         $3.65 
                                                                           
  OVERALL TOTAL                                                  $8,872.35 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/cdn_endpoint_test/cdn_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/cdn_endpoint_test/cdn_endpoint_test.golden
@@ -39,7 +39,7 @@
  └─ Acceleration outbound data transfer (over 1000TB)            1,000,000  GB                 $102,000.00 
                                                                                                            
  OVERALL TOTAL                                                                                 $609,769.00 
-----------------------------------
+──────────────────────────────────
 10 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 5 were free

--- a/internal/providers/terraform/azure/testdata/container_registry_test/container_registry_test.golden
+++ b/internal/providers/terraform/azure/testdata/container_registry_test/container_registry_test.golden
@@ -31,7 +31,7 @@
  └─ Build vCPU                                Monthly cost depends on usage: $0.0001 per seconds   
                                                                                                    
  OVERALL TOTAL                                                                             $652.98 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.golden
@@ -45,7 +45,7 @@
  └─ Restored data                                                             3,000  GB                             $450.00 
                                                                                                                             
  OVERALL TOTAL                                                                                                    $5,155.73 
-----------------------------------
+──────────────────────────────────
 9 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.golden
@@ -90,7 +90,7 @@
  └─ Restored data                                                             3,000  GB                             $450.00 
                                                                                                                             
  OVERALL TOTAL                                                                                                    $5,455.03 
-----------------------------------
+──────────────────────────────────
 17 cloud resources were detected:
 ∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 weren't estimated, report them in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.golden
@@ -45,7 +45,7 @@
  └─ Restored data                                                           3,000  GB                             $450.00 
                                                                                                                           
  OVERALL TOTAL                                                                                                  $5,155.73 
-----------------------------------
+──────────────────────────────────
 9 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.golden
@@ -54,7 +54,7 @@
  └─ Restored data                                                        3,000  GB                             $450.00 
                                                                                                                        
  OVERALL TOTAL                                                                                               $5,155.73 
-----------------------------------
+──────────────────────────────────
 10 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.golden
@@ -90,7 +90,7 @@
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                
                                                                                                                           
  OVERALL TOTAL                                                                                                  $5,455.03 
-----------------------------------
+──────────────────────────────────
 14 cloud resources were detected:
 ∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.golden
@@ -45,7 +45,7 @@
  └─ Restored data                                                         3,000  GB                             $450.00 
                                                                                                                         
  OVERALL TOTAL                                                                                                $5,155.73 
-----------------------------------
+──────────────────────────────────
 9 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_container_test/cosmosdb_sql_container_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_container_test/cosmosdb_sql_container_test.golden
@@ -56,7 +56,7 @@
  └─ Restored data                                           Monthly cost depends on usage: $0.15 per GB                
                                                                                                                        
  OVERALL TOTAL                                                                                               $5,060.53 
-----------------------------------
+──────────────────────────────────
 10 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.golden
@@ -45,7 +45,7 @@
  └─ Restored data                                                       3,000  GB                             $450.00 
                                                                                                                       
  OVERALL TOTAL                                                                                              $5,155.73 
-----------------------------------
+──────────────────────────────────
 9 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.golden
@@ -45,7 +45,7 @@
  └─ Restored data                                                  3,000  GB                             $450.00 
                                                                                                                  
  OVERALL TOTAL                                                                                         $5,155.73 
-----------------------------------
+──────────────────────────────────
 10 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/databricks_workspace_test/databricks_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/databricks_workspace_test/databricks_workspace_test.golden
@@ -17,7 +17,7 @@
  └─ Jobs light compute DBUs                         4,000  DBU-hours                  $280.00 
                                                                                               
  OVERALL TOTAL                                                                      $1,995.00 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free

--- a/internal/providers/terraform/azure/testdata/dns_a_record_test/dns_a_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_a_record_test/dns_a_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                    1  months                       $0.50 
                                                                                          
  OVERALL TOTAL                                                                   $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/dns_aaaa_record_test/dns_aaaa_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_aaaa_record_test/dns_aaaa_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                       1  months                       $0.50 
                                                                                             
  OVERALL TOTAL                                                                      $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/dns_caa_record_test/dns_caa_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_caa_record_test/dns_caa_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                      1  months                       $0.50 
                                                                                            
  OVERALL TOTAL                                                                     $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/dns_cname_record_test/dns_cname_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_cname_record_test/dns_cname_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                        1  months                       $0.50 
                                                                                              
  OVERALL TOTAL                                                                       $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/dns_mx_record_test/dns_mx_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_mx_record_test/dns_mx_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                     1  months                       $0.50 
                                                                                           
  OVERALL TOTAL                                                                    $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/dns_ns_record_test/dns_ns_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_ns_record_test/dns_ns_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                     1  months                       $0.50 
                                                                                           
  OVERALL TOTAL                                                                    $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/dns_ptr_record_test/dns_ptr_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_ptr_record_test/dns_ptr_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                      1  months                       $0.50 
                                                                                            
  OVERALL TOTAL                                                                     $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/dns_srv_record_test/dns_srv_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_srv_record_test/dns_srv_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                      1  months                       $0.50 
                                                                                            
  OVERALL TOTAL                                                                     $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/dns_txt_record_test/dns_txt_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_txt_record_test/dns_txt_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                      1  months                       $0.50 
                                                                                            
  OVERALL TOTAL                                                                     $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/dns_zone_test/dns_zone_test.golden
+++ b/internal/providers/terraform/azure/testdata/dns_zone_test/dns_zone_test.golden
@@ -8,7 +8,7 @@
  └─ Hosted zone                      1  months         $0.50 
                                                              
  OVERALL TOTAL                                         $1.04 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 2 were free

--- a/internal/providers/terraform/azure/testdata/event_hubs_namespace_test/event_hubs_namespace_test.golden
+++ b/internal/providers/terraform/azure/testdata/event_hubs_namespace_test/event_hubs_namespace_test.golden
@@ -27,7 +27,7 @@
  └─ Throughput                                                    1  units                       $21.90 
                                                                                                         
  OVERALL TOTAL                                                                               $16,954.19 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.golden
+++ b/internal/providers/terraform/azure/testdata/firewall_test/firewall_test.golden
@@ -25,7 +25,7 @@
  └─ IP address (static)                                  730  hours                    $3.65 
                                                                                              
  OVERALL TOTAL                                                                     $6,256.15 
-----------------------------------
+──────────────────────────────────
 11 cloud resources were detected:
 ∙ 6 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
+++ b/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
@@ -38,7 +38,7 @@
  └─ Executions                                                                    0.1  1M requests                    $0.02 
                                                                                                                             
  OVERALL TOTAL                                                                                                    $1,134.69 
-----------------------------------
+──────────────────────────────────
 16 cloud resources were detected:
 ∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
@@ -13,7 +13,7 @@
  └─ Zookeeper node (Standard_A5)                      2,190  hours       $554.07 
                                                                                  
  OVERALL TOTAL                                                         $3,967.55 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
@@ -7,7 +7,7 @@
  └─ Zookeeper node (Standard_D4a V4)            2,190  hours       $525.60 
                                                                            
  OVERALL TOTAL                                                   $3,907.40 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 1 was estimated
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
@@ -7,7 +7,7 @@
  └─ Zookeeper node (Standard_E64i_V3)                       2,190  hours    $12,246.48 
                                                                                        
  OVERALL TOTAL                                                              $15,852.68 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 1 was estimated
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
@@ -23,7 +23,7 @@
  └─ Disk operations                                          40  100K operations                    $0.01 
                                                                                                           
  OVERALL TOTAL                                                                                 $27,535.31 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
@@ -7,7 +7,7 @@
  └─ Zookeeper node (Standard_G2)                2,190  hours     $3,232.44 
                                                                            
  OVERALL TOTAL                                                   $8,619.84 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 1 was estimated
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/integration_service_environment_test/integration_service_environment_test.golden
+++ b/internal/providers/terraform/azure/testdata/integration_service_environment_test/integration_service_environment_test.golden
@@ -12,7 +12,7 @@
  └─ Base units                                             730  hours       $749.71 
                                                                                     
  OVERALL TOTAL                                                           $17,714.91 
-----------------------------------
+──────────────────────────────────
 9 cloud resources were detected:
 ∙ 3 were estimated
 ∙ 6 were free

--- a/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_certificate_test/key_vault_certificate_test.golden
@@ -14,7 +14,7 @@
  └─ Certificate operations                                10  10K transactions                 $0.30 
                                                                                                      
  OVERALL TOTAL                                                                               $600.60 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_key_test/key_vault_key_test.golden
@@ -52,7 +52,7 @@
  └─ Software-protected keys                            600  10K transactions                $90.00 
                                                                                                    
  OVERALL TOTAL                                                                          $12,813.96 
-----------------------------------
+──────────────────────────────────
 12 cloud resources were detected:
 ∙ 9 were estimated, 9 include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/key_vault_managed_hardware_security_module_test/key_vault_managed_hardware_security_module_test.golden
+++ b/internal/providers/terraform/azure/testdata/key_vault_managed_hardware_security_module_test/key_vault_managed_hardware_security_module_test.golden
@@ -5,7 +5,7 @@
  └─ HSM pools                                                          730  hours     $3,540.50 
                                                                                                 
  OVERALL TOTAL                                                                        $3,540.50 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
@@ -26,7 +26,7 @@
     └─ Storage (P1)                                              2  months         $1.20 
                                                                                          
  OVERALL TOTAL                                                                   $602.33 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
@@ -31,7 +31,7 @@
     └─ Hosted zone                                                1  months         $0.50 
                                                                                           
  OVERALL TOTAL                                                                  $1,478.51 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/lb_outbound_rule_test/lb_outbound_rule_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_outbound_rule_test/lb_outbound_rule_test.golden
@@ -8,7 +8,7 @@
  └─ IP address (static)                  730  hours         $2.63 
                                                                   
  OVERALL TOTAL                                              $9.93 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/lb_rule_test/lb_rule_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_rule_test/lb_rule_test.golden
@@ -8,7 +8,7 @@
  └─ IP address (static)             730  hours         $2.63 
                                                              
  OVERALL TOTAL                                         $9.93 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 2 were free

--- a/internal/providers/terraform/azure/testdata/lb_test/lb_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_test/lb_test.golden
@@ -8,7 +8,7 @@
  └─ Data processed        Monthly cost depends on usage: $0.005 per GB   
                                                                          
  OVERALL TOTAL                                                     $0.50 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_scale_set_test/linux_virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_scale_set_test/linux_virtual_machine_scale_set_test.golden
@@ -14,6 +14,6 @@
     └─ Disk operations                                   Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                     
  OVERALL TOTAL                                                                                              $414.44 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
@@ -26,6 +26,6 @@
     └─ Storage (P4)                                                         1  months                           $5.28 
                                                                                                                       
  OVERALL TOTAL                                                                                                $348.82 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/managed_disk_test/managed_disk_test.golden
+++ b/internal/providers/terraform/azure/testdata/managed_disk_test/managed_disk_test.golden
@@ -18,6 +18,6 @@
  └─ Throughput                                         20  MB/s                             $6.99 
                                                                                                   
  OVERALL TOTAL                                                                            $534.36 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/mariadb_server_test/mariadb_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/mariadb_server_test/mariadb_server_test.golden
@@ -27,7 +27,7 @@
  └─ Additional backup storage                2,000  GB                   $200.00 
                                                                                  
  OVERALL TOTAL                                                         $5,041.69 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
@@ -69,7 +69,7 @@
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
                                                                                                             
  OVERALL TOTAL                                                                                   $28,382.88 
-----------------------------------
+──────────────────────────────────
 14 cloud resources were detected:
 ∙ 12 were estimated, 12 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free

--- a/internal/providers/terraform/azure/testdata/mysql_server_test/mysql_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/mysql_server_test/mysql_server_test.golden
@@ -27,7 +27,7 @@
  └─ Additional backup storage              2,000  GB                   $200.00 
                                                                                
  OVERALL TOTAL                                                       $5,041.69 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/nat_gateway_test/nat_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/nat_gateway_test/nat_gateway_test.golden
@@ -16,7 +16,7 @@
  └─ IP prefix                                 730  hours                    $4.38 
                                                                                   
  OVERALL TOTAL                                                             $74.18 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/notification_hub_namespace_test/notification_hub_namespace_test.golden
+++ b/internal/providers/terraform/azure/testdata/notification_hub_namespace_test/notification_hub_namespace_test.golden
@@ -34,7 +34,7 @@
  └─ Namespace usage (Standard)                                           1  months                     $200.00 
                                                                                                                
  OVERALL TOTAL                                                                                       $2,815.00 
-----------------------------------
+──────────────────────────────────
 10 cloud resources were detected:
 ∙ 8 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free

--- a/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
@@ -22,7 +22,7 @@
  └─ Additional backup storage                     Monthly cost depends on usage: $0.095 per GB   
                                                                                                  
  OVERALL TOTAL                                                                         $3,294.05 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/postgresql_server_test/postgresql_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/postgresql_server_test/postgresql_server_test.golden
@@ -27,7 +27,7 @@
  └─ Additional backup storage                   2,000  GB                   $200.00 
                                                                                     
  OVERALL TOTAL                                                            $5,041.69 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/private_dns_a_record_test/private_dns_a_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_a_record_test/private_dns_a_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                            1  months                       $0.50 
                                                                                                  
  OVERALL TOTAL                                                                           $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/private_dns_aaaa_record_test/private_dns_aaaa_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_aaaa_record_test/private_dns_aaaa_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                               1  months                       $0.50 
                                                                                                     
  OVERALL TOTAL                                                                              $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/private_dns_cname_record_test/private_dns_cname_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_cname_record_test/private_dns_cname_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                                1  months                       $0.50 
                                                                                                      
  OVERALL TOTAL                                                                               $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/private_dns_mx_record_test/private_dns_mx_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_mx_record_test/private_dns_mx_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                             1  months                       $0.50 
                                                                                                   
  OVERALL TOTAL                                                                            $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/private_dns_ptr_record_test/private_dns_ptr_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_ptr_record_test/private_dns_ptr_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                              1  months                       $0.50 
                                                                                                    
  OVERALL TOTAL                                                                             $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/private_dns_srv_record_test/private_dns_srv_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_srv_record_test/private_dns_srv_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                              1  months                       $0.50 
                                                                                                    
  OVERALL TOTAL                                                                             $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/private_dns_txt_record_test/private_dns_txt_record_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_txt_record_test/private_dns_txt_record_test.golden
@@ -15,7 +15,7 @@
  └─ Hosted zone                                              1  months                       $0.50 
                                                                                                    
  OVERALL TOTAL                                                                             $900.50 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/private_dns_zone_test/private_dns_zone_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_zone_test/private_dns_zone_test.golden
@@ -8,7 +8,7 @@
  └─ Hosted zone                              1  months         $0.50 
                                                                      
  OVERALL TOTAL                                                 $1.04 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 2 were free

--- a/internal/providers/terraform/azure/testdata/private_endpoint_test/private_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_endpoint_test/private_endpoint_test.golden
@@ -28,7 +28,7 @@
  └─ Early deletion                            Monthly cost depends on usage: $0.0228 per GB              
                                                                                                          
  OVERALL TOTAL                                                                                    $23.90 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/public_ip_prefix_test/public_ip_prefix_test.golden
+++ b/internal/providers/terraform/azure/testdata/public_ip_prefix_test/public_ip_prefix_test.golden
@@ -5,7 +5,7 @@
  └─ IP prefix                              730  hours         $4.38 
                                                                     
  OVERALL TOTAL                                                $4.38 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/public_ip_test/public_ip_test.golden
+++ b/internal/providers/terraform/azure/testdata/public_ip_test/public_ip_test.golden
@@ -8,7 +8,7 @@
  └─ IP address (dynamic)             730  hours         $2.92 
                                                               
  OVERALL TOTAL                                          $6.57 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/redis_cache_test/redis_cache_test.golden
+++ b/internal/providers/terraform/azure/testdata/redis_cache_test/redis_cache_test.golden
@@ -11,7 +11,7 @@
  └─ Cache usage (Standard_C3)                1,460  hours       $657.00 
                                                                         
  OVERALL TOTAL                                                $3,241.20 
-----------------------------------
+──────────────────────────────────
 4 cloud resources were detected:
 ∙ 3 were estimated
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/search_service_test/search_service_test.golden
+++ b/internal/providers/terraform/azure/testdata/search_service_test/search_service_test.golden
@@ -22,7 +22,7 @@
  └─ Image extraction (next 4M)                              1,000  1000 images                $800.00 
                                                                                                       
  OVERALL TOTAL                                                                             $16,130.98 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -137,7 +137,7 @@
  └─ Early deletion                                Monthly cost depends on usage: $0.0228 per GB              
                                                                                                              
  OVERALL TOTAL                                                                                 $1,778,552.71 
-----------------------------------
+──────────────────────────────────
 15 cloud resources were detected:
 ∙ 14 were estimated, 14 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
@@ -21,7 +21,7 @@
  └─ Data pipeline self hosted external integration runtime   Monthly cost depends on usage: $0.0001 per hours           
                                                                                                                         
  OVERALL TOTAL                                                                                                   $97.66 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
@@ -29,7 +29,7 @@
  └─ Data pipeline self hosted external integration runtime   Monthly cost depends on usage: $0.0001 per hours           
                                                                                                                         
  OVERALL TOTAL                                                                                                $6,771.00 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
@@ -54,7 +54,7 @@
  └─ Data pipeline self hosted external integration runtime   Monthly cost depends on usage: $0.0001 per hours           
                                                                                                                         
  OVERALL TOTAL                                                                                                  $127.33 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost

--- a/internal/providers/terraform/azure/testdata/virtual_machine_scale_set_test/virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_scale_set_test/virtual_machine_scale_set_test.golden
@@ -26,7 +26,7 @@
     └─ Disk operations                                           200  10k operations                   $0.10 
                                                                                                              
  OVERALL TOTAL                                                                                       $427.59 
-----------------------------------
+──────────────────────────────────
 5 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
@@ -28,7 +28,7 @@
     └─ Throughput                                                     8  MB/s                             $2.80 
                                                                                                                 
  OVERALL TOTAL                                                                                          $385.16 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free

--- a/internal/providers/terraform/azure/testdata/vpn_gateway_connection_test/vpn_gateway_connection_test.golden
+++ b/internal/providers/terraform/azure/testdata/vpn_gateway_connection_test/vpn_gateway_connection_test.golden
@@ -58,7 +58,7 @@
  └─ VPN gateway (VpnGw5)                                          730  hours                     $10.95 
                                                                                                         
  OVERALL TOTAL                                                                                $5,964.83 
-----------------------------------
+──────────────────────────────────
 25 cloud resources were detected:
 ∙ 14 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file
 ∙ 11 were free

--- a/internal/providers/terraform/azure/testdata/vpn_gateway_test/vpn_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/vpn_gateway_test/vpn_gateway_test.golden
@@ -40,7 +40,7 @@
  └─ VPN gateway data tranfer               Monthly cost depends on usage: $0.035 per GB      
                                                                                              
  OVERALL TOTAL                                                                    $49,247.27 
-----------------------------------
+──────────────────────────────────
 11 cloud resources were detected:
 ∙ 8 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_scale_set_test/windows_virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_scale_set_test/windows_virtual_machine_scale_set_test.golden
@@ -14,6 +14,6 @@
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
  OVERALL TOTAL                                                                                                $690.38 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
@@ -38,6 +38,6 @@
     └─ Storage (P4)                                                              1  months                           $5.28 
                                                                                                                            
  OVERALL TOTAL                                                                                                   $1,943.37 
-----------------------------------
+──────────────────────────────────
 6 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/bigquery_dataset_test/bigquery_dataset_test.golden
+++ b/internal/providers/terraform/google/testdata/bigquery_dataset_test/bigquery_dataset_test.golden
@@ -8,6 +8,6 @@
  └─ Queries (on-demand)                     100.3  TB                   $501.50 
                                                                                 
  OVERALL TOTAL                                                          $501.50 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/bigquery_table_test/bigquery_table_test.golden
+++ b/internal/providers/terraform/google/testdata/bigquery_table_test/bigquery_table_test.golden
@@ -19,6 +19,6 @@
  └─ Storage read API                       1,000  TB                   $1,100.00 
                                                                                  
  OVERALL TOTAL                                                         $1,164.05 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/cloudfunctions_function_test/cloudfunctions_function_test.golden
+++ b/internal/providers/terraform/google/testdata/cloudfunctions_function_test/cloudfunctions_function_test.golden
@@ -14,6 +14,6 @@
  └─ Outbound data transfer                                  100  GB                              $12.00 
                                                                                                         
  OVERALL TOTAL                                                                                   $29.88 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
@@ -12,7 +12,7 @@
  └─ IP address (if unused)                          730  hours         $7.30 
                                                                              
  OVERALL TOTAL                                                        $23.36 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 2 were estimated
 ∙ 1 was free

--- a/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.golden
@@ -35,6 +35,6 @@
  └─ Storage                                              20  GB           $0.52 
                                                                                 
  OVERALL TOTAL                                                           $46.32 
-----------------------------------
+──────────────────────────────────
 11 cloud resources were detected:
 ∙ 11 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_external_vpn_gateway_test/compute_external_vpn_gateway_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_external_vpn_gateway_test/compute_external_vpn_gateway_test.golden
@@ -11,6 +11,6 @@
     └─ IPSec traffic to Australia (first 1TB)                                                             250  GB          $47.50 
                                                                                                                                   
  OVERALL TOTAL                                                                                                          $3,245.18 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_forwarding_rule_test/compute_forwarding_rule_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_forwarding_rule_test/compute_forwarding_rule_test.golden
@@ -14,6 +14,6 @@
  └─ Ingress data                                           100  GB                       $0.80 
                                                                                                
  OVERALL TOTAL                                                                          $23.50 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_ha_vpn_gateway_test/compute_ha_vpn_gateway_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_ha_vpn_gateway_test/compute_ha_vpn_gateway_test.golden
@@ -12,7 +12,7 @@
     └─ IPSec traffic between continents (excludes Oceania)          200  GB          $16.00 
                                                                                             
  OVERALL TOTAL                                                                       $38.90 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/google/testdata/compute_image_test/compute_image_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_image_test/compute_image_test.golden
@@ -29,6 +29,6 @@
  └─ Storage                                             1,000  GB                    $26.00 
                                                                                             
  OVERALL TOTAL                                                                      $251.00 
-----------------------------------
+──────────────────────────────────
 9 cloud resources were detected:
 ∙ 9 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_instance_group_manager_test/compute_instance_group_manager_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_instance_group_manager_test/compute_instance_group_manager_test.golden
@@ -7,7 +7,7 @@
  └─ NVIDIA Tesla K80 (on-demand)                            5,840  hours     $1,839.60 
                                                                                        
  OVERALL TOTAL                                                               $2,110.13 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated
 ∙ 1 was free

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
@@ -34,6 +34,6 @@
  └─ Standard provisioned storage (pd-standard)                         10  GiB           $0.40 
                                                                                                
  OVERALL TOTAL                                                                       $1,638.42 
-----------------------------------
+──────────────────────────────────
 7 cloud resources were detected:
 ∙ 7 were estimated

--- a/internal/providers/terraform/google/testdata/compute_machine_image_test/compute_machine_image_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_machine_image_test/compute_machine_image_test.golden
@@ -12,6 +12,6 @@
  └─ Storage                                                    5,000  GB                   $250.00 
                                                                                                    
  OVERALL TOTAL                                                                             $274.86 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_region_instance_group_manager_test/compute_region_instance_group_manager_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_region_instance_group_manager_test/compute_region_instance_group_manager_test.golden
@@ -6,7 +6,7 @@
  └─ Balanced provisioned storage (pd-balanced)                    1,200  GiB         $120.00 
                                                                                              
  OVERALL TOTAL                                                                     $1,285.07 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated
 ∙ 1 was free

--- a/internal/providers/terraform/google/testdata/compute_router_nat_test/compute_router_nat_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_router_nat_test/compute_router_nat_test.golden
@@ -13,6 +13,6 @@
  └─ Data processed                               1,000  GB                      $45.00 
                                                                                        
  OVERALL TOTAL                                                                 $126.79 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_snapshot_test/compute_snapshot_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_snapshot_test/compute_snapshot_test.golden
@@ -8,6 +8,6 @@
  └─ Storage                                             100  GB           $2.60 
                                                                                 
  OVERALL TOTAL                                                            $6.60 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 1 includes usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_target_grpc_proxy_test/compute_target_grpc_proxy_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_target_grpc_proxy_test/compute_target_grpc_proxy_test.golden
@@ -34,6 +34,6 @@
  └─ Data processed                                             100  GB                         $0.80 
                                                                                                      
  OVERALL TOTAL                                                                                 $7.39 
-----------------------------------
+──────────────────────────────────
 8 cloud resources were detected:
 ∙ 8 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_vpn_gateway_test/compute_vpn_gateway_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_vpn_gateway_test/compute_vpn_gateway_test.golden
@@ -12,7 +12,7 @@
     └─ IPSec traffic between continents (excludes Oceania)          200  GB          $16.00 
                                                                                             
  OVERALL TOTAL                                                                       $38.90 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free

--- a/internal/providers/terraform/google/testdata/compute_vpn_tunnel_test/compute_vpn_tunnel_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_vpn_tunnel_test/compute_vpn_tunnel_test.golden
@@ -5,6 +5,6 @@
  └─ VPN Tunnel                              730  hours        $36.50 
                                                                      
  OVERALL TOTAL                                                $36.50 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
+++ b/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
@@ -118,6 +118,6 @@
     └─ Standard provisioned storage (pd-standard)                           400  GiB          $16.00 
                                                                                                      
  OVERALL TOTAL                                                                            $25,959.78 
-----------------------------------
+──────────────────────────────────
 13 cloud resources were detected:
 ∙ 13 were estimated, 13 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
@@ -102,6 +102,6 @@
  └─ Standard provisioned storage (pd-standard)                       400  GiB          $16.00 
                                                                                               
  OVERALL TOTAL                                                                      $7,944.86 
-----------------------------------
+──────────────────────────────────
 21 cloud resources were detected:
 ∙ 21 were estimated, 21 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.golden
+++ b/internal/providers/terraform/google/testdata/container_registry_test/container_registry_test.golden
@@ -27,6 +27,6 @@
     └─ Data transfer to Australia (first 1TB)                                                     250  GB                              $47.50 
                                                                                                                                               
  OVERALL TOTAL                                                                                                                      $1,561.29 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/dns_managed_zone_test/dns_managed_zone_test.golden
+++ b/internal/providers/terraform/google/testdata/dns_managed_zone_test/dns_managed_zone_test.golden
@@ -5,6 +5,6 @@
  └─ Managed zone                         1  months         $0.20 
                                                                  
  OVERALL TOTAL                                             $0.20 
-----------------------------------
+──────────────────────────────────
 1 cloud resource was detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/google/testdata/dns_record_set_test/dns_record_set_test.golden
+++ b/internal/providers/terraform/google/testdata/dns_record_set_test/dns_record_set_test.golden
@@ -8,6 +8,6 @@
  └─ Queries                                         0.1  1M queries                   $0.04 
                                                                                             
  OVERALL TOTAL                                                                        $0.04 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/kms_crypto_key_test/kms_crypto_key_test.golden
+++ b/internal/providers/terraform/google/testdata/kms_crypto_key_test/kms_crypto_key_test.golden
@@ -15,6 +15,6 @@
  └─ Operations                                                1  10k operations                 $0.03 
                                                                                                       
  OVERALL TOTAL                                                                              $8,001.74 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_billing_account_bucket_config_test/logging_billing_account_bucket_config_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_billing_account_bucket_config_test/logging_billing_account_bucket_config_test.golden
@@ -8,6 +8,6 @@
  └─ Logging data                                                         100  GB                    $50.00 
                                                                                                            
  OVERALL TOTAL                                                                                      $50.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_billing_account_sink_test/logging_billing_account_sink_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_billing_account_sink_test/logging_billing_account_sink_test.golden
@@ -8,6 +8,6 @@
  └─ Logging data                                                  100  GB                    $50.00 
                                                                                                     
  OVERALL TOTAL                                                                               $50.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_folder_bucket_config_test/logging_folder_bucket_config_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_folder_bucket_config_test/logging_folder_bucket_config_test.golden
@@ -8,6 +8,6 @@
  └─ Logging data                                                100  GB                    $50.00 
                                                                                                   
  OVERALL TOTAL                                                                             $50.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_folder_sink_test/logging_folder_sink_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_folder_sink_test/logging_folder_sink_test.golden
@@ -8,6 +8,6 @@
  └─ Logging data                                       100  GB                    $50.00 
                                                                                          
  OVERALL TOTAL                                                                    $50.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_organization_bucket_config_test/logging_organization_bucket_config_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_organization_bucket_config_test/logging_organization_bucket_config_test.golden
@@ -8,6 +8,6 @@
  └─ Logging data                                                      100  GB                    $50.00 
                                                                                                         
  OVERALL TOTAL                                                                                   $50.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_organization_sink_test/logging_organization_sink_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_organization_sink_test/logging_organization_sink_test.golden
@@ -8,6 +8,6 @@
  └─ Logging data                                             100  GB                    $50.00 
                                                                                                
  OVERALL TOTAL                                                                          $50.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_project_bucket_config_test/logging_project_bucket_config_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_project_bucket_config_test/logging_project_bucket_config_test.golden
@@ -8,6 +8,6 @@
  └─ Logging data                                                 100  GB                    $50.00 
                                                                                                    
  OVERALL TOTAL                                                                              $50.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/logging_project_sink_test/logging_project_sink_test.golden
+++ b/internal/providers/terraform/google/testdata/logging_project_sink_test/logging_project_sink_test.golden
@@ -8,6 +8,6 @@
  └─ Logging data                                        100  GB                    $50.00 
                                                                                           
  OVERALL TOTAL                                                                     $50.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/monitoring_metric_descriptor_test/monitoring_metric_descriptor_test.golden
+++ b/internal/providers/terraform/google/testdata/monitoring_metric_descriptor_test/monitoring_metric_descriptor_test.golden
@@ -12,6 +12,6 @@
  └─ API calls                                              1,000  1 k calls                   $10.00 
                                                                                                      
  OVERALL TOTAL                                                                            $63,710.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/pubsub_subscription_test/pubsub_subscription_test.golden
+++ b/internal/providers/terraform/google/testdata/pubsub_subscription_test/pubsub_subscription_test.golden
@@ -12,6 +12,6 @@
  └─ Snapshot message backlog storage                   30  GiB                      $8.10 
                                                                                           
  OVERALL TOTAL                                                                    $413.50 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/pubsub_topic_test/pubsub_topic_test.golden
+++ b/internal/providers/terraform/google/testdata/pubsub_topic_test/pubsub_topic_test.golden
@@ -8,6 +8,6 @@
  └─ Message ingestion data                  10  TiB                    $400.00 
                                                                                
  OVERALL TOTAL                                                         $400.00 
-----------------------------------
+──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/redis_instance_test/redis_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/redis_instance_test/redis_instance_test.golden
@@ -32,6 +32,6 @@
  └─ Redis instance (standard, M5)           105  GB           $3.15 
                                                                     
  OVERALL TOTAL                                                $9.50 
-----------------------------------
+──────────────────────────────────
 10 cloud resources were detected:
 ∙ 10 were estimated

--- a/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
@@ -65,6 +65,6 @@
     └─ Storage (SSD, zonal)                                      500  GB                    $85.00 
                                                                                                    
  OVERALL TOTAL                                                                           $7,455.69 
-----------------------------------
+──────────────────────────────────
 11 cloud resources were detected:
 ∙ 11 were estimated, 11 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/storage_bucket_test/storage_bucket_test.golden
+++ b/internal/providers/terraform/google/testdata/storage_bucket_test/storage_bucket_test.golden
@@ -42,6 +42,6 @@
     └─ Data transfer to Australia (first 1TB)                                                     250  GB                              $47.50 
                                                                                                                                               
  OVERALL TOTAL                                                                                                                      $3,125.02 
-----------------------------------
+──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/schema/diff.go
+++ b/internal/schema/diff.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"fmt"
-	"math"
 	"regexp"
 	"strings"
 
@@ -269,7 +268,12 @@ func diffName(current string, past string) string {
 	pastLabels := strings.Split(pastM[2], ", ")
 	currentLabels := strings.Split(currentM[2], ", ")
 
-	labelCount := int(math.Max(float64(len(pastLabels)), float64(len(currentLabels))))
+	// If the names don't have the same label count then return the labels in the format `(old, labels) → (new, labels)`
+	if len(pastLabels) != len(currentLabels) {
+		return fmt.Sprintf("%s (%s) → (%s)", currentM[1], pastM[2], currentM[2])
+	}
+
+	labelCount := len(currentLabels)
 	labels := make([]string, 0, labelCount)
 
 	for i := 0; i < labelCount; i++ {

--- a/internal/schema/diff.go
+++ b/internal/schema/diff.go
@@ -280,7 +280,7 @@ func diffName(current string, past string) string {
 		} else if pastLabels[i] == currentLabels[i] {
 			labels = append(labels, currentLabels[i])
 		} else {
-			labels = append(labels, fmt.Sprintf("%s -> %s", pastLabels[i], currentLabels[i]))
+			labels = append(labels, fmt.Sprintf("%s → %s", pastLabels[i], currentLabels[i]))
 		}
 	}
 

--- a/internal/schema/diff_test.go
+++ b/internal/schema/diff_test.go
@@ -393,6 +393,16 @@ func TestDiffName(t *testing.T) {
 			past:     "Instance usage (Linux/UNIX, on-demand, t3.small)",
 			expected: "Instance usage (Linux/UNIX, on-demand → reserved, t3.small → t3.medium)",
 		},
+		{
+			current:  "Instance usage (Linux/UNIX, reserved, t3.medium)",
+			past:     "Instance usage (Linux/UNIX, on-demand)",
+			expected: "Instance usage (Linux/UNIX, on-demand) → (Linux/UNIX, reserved, t3.medium)",
+		},
+		{
+			current:  "Instance usage (Linux/UNIX, reserved)",
+			past:     "Instance usage (Linux/UNIX, on-demand, t3.small)",
+			expected: "Instance usage (Linux/UNIX, on-demand, t3.small) → (Linux/UNIX, reserved)",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I originally did this by separating the cost component name from the labels, but this modified the JSON output. After discussing with @alikhajeh1 we agreed not to change the JSON output format at the moment, so this change parses the labels from the name instead. The one change to the JSON output is we update the name of the diff cost components to 
be show something like `Instance usage (Linux/UNIX, on-demand, t3.small → t3.large)`.

This also updates the output to replace `->` with `→` and `-` with `─` (so the line is continuous).

Before:
```
~ module.base.module.eks.module.node_groups.aws_eks_node_group.workers["default"]
  +$207 ($75.55 -> $283)

    - Instance usage (Linux/UNIX, on-demand, t3.small)
      -$45.55

    + Instance usage (Linux/UNIX, on-demand, t3.large)
      +$243
```

After:
```
~ module.base.module.eks.module.node_groups.aws_eks_node_group.workers["default"]
  +$207 ($75.55 → $283)

    ~ Instance usage (Linux/UNIX, on-demand, t3.small → t3.large)
      +$197 ($45.55 → $243)
```