### PR TITLE
Add support for a post header in ci

### DIFF
--- a/internal/config/run_context.go
+++ b/internal/config/run_context.go
@@ -112,6 +112,7 @@ func (c *RunContext) loadInitialContextValues() {
 	c.SetContextValue("os", runtime.GOOS)
 	c.SetContextValue("ciPlatform", ciPlatform())
 	c.SetContextValue("ciScript", ciScript())
+	c.SetContextValue("ciPostHeader", os.Getenv("INFRACOST_CI_POST_HEADER"))
 	c.SetContextValue("ciPostCondition", os.Getenv("INFRACOST_CI_POST_CONDITION"))
 	c.SetContextValue("ciPercentageThreshold", os.Getenv("INFRACOST_CI_PERCENTAGE_THRESHOLD"))
 }

--- a/scripts/ci/atlantis_diff.sh
+++ b/scripts/ci/atlantis_diff.sh
@@ -104,7 +104,11 @@ build_msg () {
     percent_display=" (${change_sym}${percent_display}%%)"
   fi
 
-  msg="##### Infracost estimate #####"
+  msg=""
+  if [ ! -z "$post_header" ]; then
+    msg="${msg}${post_header}\n"
+  fi
+  msg="${msg}##### Infracost estimate #####"
   msg="${msg}\n\n"
   msg="${msg}Monthly cost will ${change_word} by $(format_cost $diff_cost)$percent_display\n"
   msg="${msg}\n"

--- a/scripts/ci/diff.sh
+++ b/scripts/ci/diff.sh
@@ -18,6 +18,7 @@ process_args () {
   post_condition=${7:-$post_condition}
   show_skipped=${8:-$show_skipped}
   sync_usage_file=${9:-$sync_usage_file}
+  post_header=${10:-$post_header}
 
   # Validate post_condition
   if ! echo "$post_condition" | jq empty; then
@@ -126,7 +127,11 @@ build_msg () {
     percent_display=" (${change_sym}${percent_display}%%)"
   fi
   
-  msg="${MSG_START} **monthly cost will ${change_word} by $(format_cost "$diff_cost")$percent_display** ${change_emoji}\n"
+  msg=""
+  if [ ! -z "$post_header" ]; then
+    msg="${msg}${post_header}\n"
+  fi
+  msg="${msg}${MSG_START} **monthly cost will ${change_word} by $(format_cost "$diff_cost")$percent_display** ${change_emoji}\n"
   msg="${msg}\n"
   msg="${msg}Previous monthly cost: $(format_cost "$past_total_monthly_cost")\n"
   msg="${msg}New monthly cost: $(format_cost "$total_monthly_cost")\n"

--- a/scripts/ci/jenkins_diff.sh
+++ b/scripts/ci/jenkins_diff.sh
@@ -14,6 +14,7 @@ fix_env_vars () {
     config_file=${config_file:-$CONFIG_FILE}
     fail_condition=${fail_condition:-$FAIL_CONDITION}
     show_skipped=${show_skipped:-$SHOW_SKIPPED}
+    post_header=${post_header:-$POST_HEADER}
 }
 
 process_args () {
@@ -103,6 +104,10 @@ build_msg () {
     percent_display=" (${change_sym}${percent_display}%%)"
   fi
 
+  msg=""
+  if [ ! -z "$post_header" ]; then
+    msg="${msg}${post_header}\n"
+  fi
   msg="${msg}\n##### Infracost estimate #####"
   msg="${msg}\n\n"
   msg="${msg}Monthly cost will ${change_word} by $(format_cost $diff_cost)$percent_display\n"


### PR DESCRIPTION
Allows setting a header on CI posts -- Useful for when a PR triggers multiple infracost runs.