### PR TITLE
feat(aws): Add AWS Transfer Family resources

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -345,6 +345,10 @@ resource_usage:
     instance_tier: standard # Instance tier being used, can be: standard, advanced.
     instances: 100          # Number of instances being managed.
 
+  aws_transfer_server.my_transfer_server:
+    monthly_data_downloaded_gb: 50 # Monthly data downloaded over enabled protocols in GB.
+    monthly_data_uploaded_gb: 10 # Monthly data uploaded over enabled protocols in GB.
+
   aws_vpc_endpoint.my_endpoint:
     monthly_data_processed_gb: 1000 # Monthly data processed by the VPC endpoint(s) in GB.
 

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -91,6 +91,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetWafWebACLRegistryItem(),
 	GetStepFunctionRegistryItem(),
 	getDirectoryServiceDirectory(),
+	getTransferServerRegistryItem(),
 }
 
 // FreeResources grouped alphabetically
@@ -341,6 +342,11 @@ var FreeResources = []string{
 	"aws_ssm_patch_baseline",
 	"aws_ssm_patch_group",
 	"aws_ssm_resource_data_sync",
+
+	// AWS Transfer Family
+	"aws_transfer_access",
+	"aws_transfer_ssh_key",
+	"aws_transfer_user",
 
 	// AWS VPC
 	"aws_customer_gateway",

--- a/internal/providers/terraform/aws/testdata/transfer_server_test/transfer_server_test.golden
+++ b/internal/providers/terraform/aws/testdata/transfer_server_test/transfer_server_test.golden
@@ -1,0 +1,19 @@
+
+ Name                                                 Monthly Qty  Unit            Monthly Cost 
+                                                                                                
+ aws_transfer_server.default_no_protocols                                                       
+ ├─ FTPS protocol enabled                                     730  hours                $219.00 
+ ├─ Data downloaded                                 Monthly cost depends on usage: $0.04 per GB 
+ └─ Data uploaded                                   Monthly cost depends on usage: $0.04 per GB 
+                                                                                                
+ aws_transfer_server.multiple_protocols_with_usage                                              
+ ├─ FTP protocol enabled                                      730  hours                $219.00 
+ ├─ FTPS protocol enabled                                     730  hours                $219.00 
+ ├─ SFTP protocol enabled                                     730  hours                $219.00 
+ ├─ Data downloaded                                            50  GB                     $2.00 
+ └─ Data uploaded                                              10  GB                     $0.40 
+                                                                                                
+ OVERALL TOTAL                                                                          $878.40 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/transfer_server_test/transfer_server_test.tf
+++ b/internal/providers/terraform/aws/testdata/transfer_server_test/transfer_server_test.tf
@@ -1,0 +1,24 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_transfer_server" "default_no_protocols" {
+  tags = {
+    Name = "No protocols"
+  }
+}
+
+resource "aws_transfer_server" "multiple_protocols_with_usage" {
+  protocols = ["SFTP", "FTPS", "FTP"]
+
+  tags = {
+    Name = "Multiple protocols with usage"
+  }
+}

--- a/internal/providers/terraform/aws/testdata/transfer_server_test/transfer_server_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/transfer_server_test/transfer_server_test.usage.yml
@@ -1,0 +1,5 @@
+version: 0.1
+resource_usage:
+  aws_transfer_server.multiple_protocols_with_usage:
+    monthly_data_downloaded_gb: 50
+    monthly_data_uploaded_gb: 10

--- a/internal/providers/terraform/aws/transfer_server.go
+++ b/internal/providers/terraform/aws/transfer_server.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/resources/aws"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getTransferServerRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_transfer_server",
+		RFunc: newTransferServer,
+	}
+}
+
+func newTransferServer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+	protocols := []string{}
+
+	if d.Get("protocols").Exists() {
+		for _, data := range d.Get("protocols").Array() {
+			protocols = append(protocols, data.String())
+		}
+	} else {
+		defaultProtocol := "FTPS"
+		protocols = append(protocols, defaultProtocol)
+	}
+
+	t := &aws.TransferServer{
+		Address:   d.Address,
+		Region:    region,
+		Protocols: protocols,
+	}
+	t.PopulateUsage(u)
+
+	return t.BuildResource()
+}

--- a/internal/providers/terraform/aws/transfer_server_test.go
+++ b/internal/providers/terraform/aws/transfer_server_test.go
@@ -1,0 +1,16 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestTransferServerGoldenFile(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "transfer_server_test")
+}

--- a/internal/resources/aws/transfer_server.go
+++ b/internal/resources/aws/transfer_server.go
@@ -1,0 +1,138 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+// TransferServer defines a AWS Transfer Server resource from Transfer Family
+// service. It supports multiple transfer protocols like FTP/FTPS/SFTP and
+// each is billed hourly when enabled. It also bills the amount of data
+// being downloaded/uploaded over those protocols.
+//
+// See more resource information here: https://aws.amazon.com/aws-transfer-family/.
+//
+// See the pricing information here: https://aws.amazon.com/aws-transfer-family/pricing/.
+type TransferServer struct {
+	Address   string
+	Region    string
+	Protocols []string
+
+	// "usage" args
+	MonthlyDataDownloadedGB *float64 `infracost_usage:"monthly_data_downloaded_gb"`
+	MonthlyDataUploadedGB   *float64 `infracost_usage:"monthly_data_uploaded_gb"`
+}
+
+// TransferServerUsageSchema defines a list of usage items for TransferServer.
+var TransferServerUsageSchema = []*schema.UsageItem{
+	{Key: "monthly_data_downloaded_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "monthly_data_uploaded_gb", DefaultValue: 0, ValueType: schema.Float64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the TransferServer.
+// It uses the `infracost_usage` struct tags to populate data into the TransferServer.
+func (t *TransferServer) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(t, u)
+}
+
+// BuildResource builds a schema.Resource from a valid TransferServer struct.
+// This method is called after the resource is initialised by an IaC provider.
+func (t *TransferServer) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{}
+
+	service := "AWSTransfer"
+	productFamily := "AWS Transfer Family"
+
+	for _, protocol := range t.Protocols {
+		costComponents = append(costComponents,
+			newProtocolCostComponent(
+				protocol,
+				"[A-Z0-9]*-ProtocolHours",
+				t.Region,
+				service,
+				productFamily,
+			),
+		)
+	}
+
+	costComponents = append(costComponents,
+		newDataTransferCostComponent(
+			"Data downloaded",
+			t.MonthlyDataDownloadedGB,
+			"[A-Z0-9]*-DownloadBytes",
+			t.Region,
+			service,
+			productFamily,
+		),
+		newDataTransferCostComponent(
+			"Data uploaded",
+			t.MonthlyDataUploadedGB,
+			"[A-Z0-9]*-UploadBytes",
+			t.Region,
+			service,
+			productFamily,
+		),
+	)
+
+	return &schema.Resource{
+		Name:           t.Address,
+		UsageSchema:    TransferServerUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+func newProtocolCostComponent(protocol string, usageType string, region string, service string, productFamily string) *schema.CostComponent {
+	// This value can be used for any storage type as their pricing is
+	// identical, but for some protocols EFS prices are missing in the pricing API.
+	storageType := "S3"
+
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("%s protocol enabled", protocol),
+		Unit:           "hours",
+		UnitMultiplier: decimal.NewFromInt(1),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr(service),
+			ProductFamily: strPtr(productFamily),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", usageType))},
+				{Key: "operation", ValueRegex: strPtr(fmt.Sprintf("/^%s:%s$/i", protocol, storageType))},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("on_demand"),
+		},
+	}
+}
+
+func newDataTransferCostComponent(name string, quantity *float64, usageType string, region string, service string, productFamily string) *schema.CostComponent {
+	// This value can be used for any protocol/storage type as their pricing is
+	// identical, but for some protocols EFS prices are missing in the pricing API.
+	storageType := "FTP:S3"
+
+	return &schema.CostComponent{
+		Name:            name,
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: floatPtrToDecimalPtr(quantity),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(region),
+			Service:       strPtr(service),
+			ProductFamily: strPtr(productFamily),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", usageType))},
+				{Key: "operation", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", storageType))},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("on_demand"),
+		},
+	}
+}

--- a/internal/resources/aws/transfer_server.go
+++ b/internal/resources/aws/transfer_server.go
@@ -33,12 +33,6 @@ var TransferServerUsageSchema = []*schema.UsageItem{
 	{Key: "monthly_data_uploaded_gb", DefaultValue: 0, ValueType: schema.Float64},
 }
 
-// Names of resource's service/product family to use in price search
-var (
-	resourceService       = strPtr("AWSTransfer")
-	resourceProductFamily = strPtr("AWS Transfer Family")
-)
-
 // PopulateUsage parses the u schema.UsageData into the TransferServer.
 // It uses the `infracost_usage` struct tags to populate data into the TransferServer.
 func (t *TransferServer) PopulateUsage(u *schema.UsageData) {
@@ -88,8 +82,8 @@ func (t *TransferServer) newProtocolCostComponent(protocol string, usageType str
 		ProductFilter: &schema.ProductFilter{
 			VendorName:       strPtr("aws"),
 			Region:           strPtr(t.Region),
-			Service:          resourceService,
-			ProductFamily:    resourceProductFamily,
+			Service:          strPtr(t.serviceName()),
+			ProductFamily:    strPtr(t.productFamilyName()),
 			AttributeFilters: t.getAttributeFilters(protocol, usageType),
 		},
 		PriceFilter: &schema.PriceFilter{
@@ -110,8 +104,8 @@ func (t *TransferServer) newDataTransferCostComponent(name string, quantity *flo
 		ProductFilter: &schema.ProductFilter{
 			VendorName:       strPtr("aws"),
 			Region:           strPtr(t.Region),
-			Service:          resourceService,
-			ProductFamily:    resourceProductFamily,
+			Service:          strPtr(t.serviceName()),
+			ProductFamily:    strPtr(t.productFamilyName()),
 			AttributeFilters: t.getAttributeFilters(transferProtocol, usageType),
 		},
 		PriceFilter: &schema.PriceFilter{
@@ -119,6 +113,15 @@ func (t *TransferServer) newDataTransferCostComponent(name string, quantity *flo
 		},
 	}
 }
+
+func (t *TransferServer) serviceName() string {
+	return "AWSTransfer"
+}
+
+func (t *TransferServer) productFamilyName() string {
+	return "AWS Transfer Family"
+}
+
 func (t *TransferServer) getAttributeFilters(protocol string, usageType string) []*schema.AttributeFilter {
 	// The pricing for all storage types is identical, but for some protocols
 	// EFS prices are missing in the pricing API.


### PR DESCRIPTION
## Objective:

Add support for AWS Transfer Family resources.  Fixes #1030 

## Pricing details:

The main resource which contains cost components is `aws_transfer_server`:
- Supports 3 protocols `FTP`/`FTPS`/`SFTP`, each is billed hourly when enabled, if no protocols are defined the default is `FTPS`.
- Has 2 usage-based components for downloaded and uploaded data, measured in GB.
- Both S3 and EFS storage types have same pricing, however the Pricing API includes EFS prices only for SFTP protocol. For that reason the Infracost resource uses "S3" to match the prices.
- Pricing details: https://aws.amazon.com/aws-transfer-family/pricing/

## Status:

- [x] Added to resource_registry.go
- [x] Added internal/resources file
- [x] Added internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator.
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/blob/master/docs/supported_resources.md))

## Issues:

None