### PR TITLE
Fix diff symbol

### DIFF
--- a/cmd/infracost/testdata/output_format_github_comment/output_format_github_comment.golden
+++ b/cmd/infracost/testdata/output_format_github_comment/output_format_github_comment.golden
@@ -12,19 +12,19 @@
       <td>infracost/infracost/cmd/infracost/testdata</td>
       <td align="right">$0</td>
       <td align="right">$1,361</td>
-      <td>$1,361</td>
+      <td>+$1,361</td>
     </tr>
     <tr>
       <td>infracost/infracost/cmd/infraco.../testdata/terraform_v0.14_plan.json</td>
       <td align="right">$40.56</td>
       <td align="right">$81.12</td>
-      <td>$40.56 (+100%)</td>
+      <td>+$40.56 (+100%)</td>
     </tr>
     <tr>
       <td>All projects</td>
       <td align="right">$81.12</td>
       <td align="right">$1,483</td>
-      <td>$1,402 (+1,728%)</td>
+      <td>+$1,402 (+1,728%)</td>
     </tr>
   </tbody>
 </table> 

--- a/scripts/ci/diff.sh
+++ b/scripts/ci/diff.sh
@@ -215,14 +215,12 @@ build_project_row () {
     percent_display=$(percent_display "$past_monthly_cost" "$monthly_cost")
   fi
 
-  sym=$(change_symbol "$past_monthly_cost" "$monthly_cost")
-
   local row=""
   row+="    <tr>\n"
   row+="      <td>$name</td>\n"
   row+="      <td align=\"right\">$(format_cost "$past_monthly_cost")</td>\n"
   row+="      <td align=\"right\">$(format_cost "$monthly_cost")</td>\n"
-  row+="      <td>$sym$(format_cost "$diff_monthly_cost")$percent_display</td>\n"
+  row+="      <td>$(format_cost "$diff_monthly_cost" true)$percent_display</td>\n"
   row+="    </tr>\n"
   
   printf "%s" "$row"
@@ -236,14 +234,12 @@ build_overall_row () {
     percent_display=$(percent_display "$past_total_monthly_cost" "$total_monthly_cost")
   fi
 
-  sym=$(change_symbol "$past_total_monthly_cost" "$total_monthly_cost")
-
   local row=""
   row+="    <tr>\n"
   row+="      <td>All projects</td>\n"
   row+="      <td align=\"right\">$(format_cost "$past_total_monthly_cost")</td>\n"
   row+="      <td align=\"right\">$(format_cost "$total_monthly_cost")</td>\n"
-  row+="      <td>$sym$(format_cost "$diff_total_monthly_cost")$percent_display</td>\n"
+  row+="      <td>$(format_cost "$diff_total_monthly_cost" true)$percent_display</td>\n"
   row+="    </tr>\n"
 
   printf "%s" "$row"
@@ -251,13 +247,29 @@ build_overall_row () {
 
 format_cost () {
   cost=$1
+  include_plus=$2
+
+  sym=""
+  if [ "$(echo "$cost < 0" | bc -l)" = 1 ]; then
+    sym="-"
+  elif [ "$include_plus" = true ] && [ "$(echo "$cost > 0" | bc -l)" = 1 ]; then
+    sym="+"
+  fi
 
   if [ -z "$cost" ] || [ "$cost" = "null" ] || [ "$cost" = "0" ]; then
-    printf "$currency%s" "0"
-  elif [ "$(echo "$cost < 100" | bc -l)" = 1 ]; then
-    printf "$currency%0.2f" "$cost"
+    cost="0"
+  elif [ "$(echo "${cost#-} < 100" | bc -l)" = 1 ]; then
+    cost="$(printf "%'0.2f" "$cost")"
   else
-    printf "$currency%0.0f" "$cost"
+    cost="$(printf "%'0.0f" "$cost")"
+  fi
+
+  # If the currency length is greater than 1, assume it's a currency code and display `INR -22.78`
+  if [ ${#currency} -gt 1 ]; then
+    printf "%s" "$currency$sym${cost#-}"
+  # If currency length is 1, assume it's a symbol and display it like `-$22.78`
+  else
+    printf "%s" "$sym$currency${cost#-}"
   fi
 }
 


### PR DESCRIPTION
Should change depending on if we're using a symbol or currency code, e.g. `-$22.78` and `INR -22.78`. This also fixes displaying 2dp for all negative values, and adds thousands separators.