### PR TITLE
feat(azure): add resources for Azure Front Door service

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -739,6 +739,20 @@ resource_usage:
     throughput_or_capacity_units: 10  # Number of Throughput Units (for Basic and Standard) and Capacity units (for Dedicated) namespaces.
     capture_enabled: false            # Defines if capture is enabled for the Event Hub Standard namespaces, can be: true, false.
 
+  azurerm_frontdoor.my_frontdoor:
+    monthly_outbound_data_transfer_gb: # Monthly outbound data transfer from the following, in GB:
+      us_gov: 190000                       # US Gov
+      north_america_europe_africa: 200000  # North America, Europe and Africa
+      asia_pacific: 220000                 # Asia Pacific (including Japan)
+      south_america: 10000                 # South America
+      australia: 50000                     # Australia
+      india: 387000                        # India
+    monthly_inbound_data_transfer_gb: 1000 # Monthly inbound data transfer in GB
+
+  azurerm_frontdoor_firewall_policy.my_frontdoor_firewall_policy:
+    monthly_custom_rule_requests: 11000     # Monthly number of custom rule requests
+    monthly_managed_ruleset_requests: 10000 # Monthly number of managed ruleset requests
+
   azurerm_kubernetes_cluster.my_cluster:
     load_balancer:
       monthly_data_processed_gb: 100 # Monthly inbound and outbound data processed in GB.

--- a/internal/providers/terraform/azure/frontdoor.go
+++ b/internal/providers/terraform/azure/frontdoor.go
@@ -1,0 +1,49 @@
+package azure
+
+import (
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/tidwall/gjson"
+)
+
+// getAzureRMFrontdoorRegistryItem returns a registry item for the resource
+func getAzureRMFrontdoorRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_frontdoor",
+		RFunc: newFrontdoor,
+		ReferenceAttributes: []string{
+			"resource_group_name",
+		},
+	}
+}
+
+// newFrontdoor parses Terraform's data and uses it to build a new resource
+func newFrontdoor(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := lookupRegion(d, []string{"resource_group_name"})
+
+	if strings.HasPrefix(strings.ToLower(region), "usgov") {
+		region = "US Gov Zone 1"
+	} else {
+		region = regionToZone(region)
+	}
+
+	rulesCounter := 0
+	rules := d.Get("routing_rule").Array()
+	for _, rule := range rules {
+		if rule.Get("enabled").Type == gjson.True {
+			rulesCounter++
+		}
+	}
+
+	r := &azure.Frontdoor{
+		Address:       d.Address,
+		Region:        region,
+		FrontendHosts: len(d.Get("frontend_endpoint").Array()),
+		RoutingRules:  rulesCounter,
+	}
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/azure/frontdoor_firewall_policy.go
+++ b/internal/providers/terraform/azure/frontdoor_firewall_policy.go
@@ -1,0 +1,52 @@
+package azure
+
+import (
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+// getAzureRMFrontdoorFirewallPolicyRegistryItem returns a registry item for the
+// resource
+func getAzureRMFrontdoorFirewallPolicyRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_frontdoor_firewall_policy",
+		RFunc: newFrontdoorFirewallPolicy,
+		ReferenceAttributes: []string{
+			"resource_group_name",
+		},
+	}
+}
+
+// newFrontdoorFirewallPolicy parses Terraform's data and uses it to build
+// a new resource
+func newFrontdoorFirewallPolicy(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := lookupRegion(d, []string{"resource_group_name"})
+
+	if strings.HasPrefix(strings.ToLower(region), "usgov") {
+		region = "US Gov Zone 1"
+	} else {
+		region = regionToZone(region)
+	}
+
+	customRules := 0
+	if rules := d.Get("custom_rule"); rules.Exists() {
+		customRules = len(rules.Array())
+	}
+
+	managedRulesets := 0
+	if rules := d.Get("managed_rule"); rules.Exists() {
+		managedRulesets = len(rules.Array())
+	}
+
+	r := &azure.FrontdoorFirewallPolicy{
+		Address:         d.Address,
+		Region:          region,
+		CustomRules:     customRules,
+		ManagedRulesets: managedRulesets,
+	}
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/azure/frontdoor_firewall_policy_test.go
+++ b/internal/providers/terraform/azure/frontdoor_firewall_policy_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestFrontdoorFirewallPolicyGoldenFile(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "frontdoor_firewall_policy_test")
+}

--- a/internal/providers/terraform/azure/frontdoor_test.go
+++ b/internal/providers/terraform/azure/frontdoor_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestFrontdoorGoldenFile(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "frontdoor_test")
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -48,6 +48,8 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMDNSZoneRegistryItem(),
 	GetAzureRMEventHubsNamespaceRegistryItem(),
 	GetAzureRMFirewallRegistryItem(),
+	getAzureRMFrontdoorFirewallPolicyRegistryItem(),
+	getAzureRMFrontdoorRegistryItem(),
 	GetAzureRMHDInsightHadoopClusterRegistryItem(),
 	GetAzureRMHDInsightHBaseClusterRegistryItem(),
 	GetAzureRMHDInsightInteractiveQueryClusterRegistryItem(),
@@ -213,6 +215,10 @@ var FreeResources = []string{
 	"azurerm_firewall_network_rule_collection",
 	"azurerm_firewall_policy",
 	"azurerm_firewall_policy_rule_collection_group",
+
+	// Azure Front Door
+	"azurerm_frontdoor_custom_https_configuration",
+	"azurerm_frontdoor_rules_engine",
 
 	// Azure Key Vault
 	"azurerm_key_vault",

--- a/internal/providers/terraform/azure/testdata/frontdoor_firewall_policy_test/frontdoor_firewall_policy_test.golden
+++ b/internal/providers/terraform/azure/testdata/frontdoor_firewall_policy_test/frontdoor_firewall_policy_test.golden
@@ -1,0 +1,23 @@
+
+ Name                                                               Monthly Qty  Unit                  Monthly Cost 
+                                                                                                                    
+ azurerm_frontdoor_firewall_policy.firewall_policy_example                                                          
+ ├─ Policy                                                                    1  months                       $5.00 
+ ├─ Custom rules                                                              2  rules                        $2.00 
+ ├─ Custom rule requests                                       Monthly cost depends on usage: $0.60 per 1M requests 
+ ├─ Managed rulesets                                                          2  rulesets                    $40.00 
+ └─ Managed ruleset requests                                   Monthly cost depends on usage: $1.00 per 1M requests 
+                                                                                                                    
+ azurerm_frontdoor_firewall_policy.firewall_policy_with_usage                                                       
+ ├─ Policy                                                                    1  months                       $5.00 
+ ├─ Custom rules                                                              2  rules                        $2.00 
+ ├─ Custom rule requests                                                   0.11  1M requests                  $0.07 
+ ├─ Managed rulesets                                                          2  rulesets                    $40.00 
+ └─ Managed ruleset requests                                                  1  1M requests                  $1.00 
+                                                                                                                    
+ OVERALL TOTAL                                                                                               $95.07 
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free:
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/frontdoor_firewall_policy_test/frontdoor_firewall_policy_test.tf
+++ b/internal/providers/terraform/azure/testdata/frontdoor_firewall_policy_test/frontdoor_firewall_policy_test.tf
@@ -1,0 +1,95 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "westus"
+}
+
+resource "azurerm_frontdoor_firewall_policy" "firewall_policy_example" {
+  name                = "Example"
+  resource_group_name = azurerm_resource_group.example.name
+
+  custom_rule {
+    name     = "Rule1"
+    enabled  = true
+    priority = 1
+    type     = "MatchRule"
+    action   = "Block"
+
+    match_condition {
+      match_variable = "RemoteAddr"
+      operator       = "IPMatch"
+      match_values   = ["192.168.1.0/24", "10.0.0.0/24"]
+    }
+  }
+
+  custom_rule {
+    name     = "Rule2"
+    enabled  = false
+    priority = 2
+    type     = "MatchRule"
+    action   = "Block"
+
+    match_condition {
+      match_variable = "RemoteAddr"
+      operator       = "IPMatch"
+      match_values   = ["192.168.1.0/24"]
+    }
+  }
+
+  managed_rule {
+    type    = "DefaultRuleSet"
+    version = "1.0"
+  }
+
+  managed_rule {
+    type    = "RuleSet2"
+    version = "1.0"
+  }
+}
+
+resource "azurerm_frontdoor_firewall_policy" "firewall_policy_with_usage" {
+  name                = "ExampleWithUsage"
+  resource_group_name = azurerm_resource_group.example.name
+
+  custom_rule {
+    name     = "Rule1"
+    enabled  = true
+    priority = 1
+    type     = "MatchRule"
+    action   = "Block"
+
+    match_condition {
+      match_variable = "RemoteAddr"
+      operator       = "IPMatch"
+      match_values   = ["192.168.1.0/24", "10.0.0.0/24"]
+    }
+  }
+
+  custom_rule {
+    name     = "Rule2"
+    enabled  = false
+    priority = 2
+    type     = "MatchRule"
+    action   = "Block"
+
+    match_condition {
+      match_variable = "RemoteAddr"
+      operator       = "IPMatch"
+      match_values   = ["192.168.1.0/24"]
+    }
+  }
+
+  managed_rule {
+    type    = "DefaultRuleSet"
+    version = "1.0"
+  }
+
+  managed_rule {
+    type    = "RuleSet2"
+    version = "1.0"
+  }
+}

--- a/internal/providers/terraform/azure/testdata/frontdoor_firewall_policy_test/frontdoor_firewall_policy_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/frontdoor_firewall_policy_test/frontdoor_firewall_policy_test.usage.yml
@@ -1,0 +1,5 @@
+version: 0.1
+resource_usage:
+  azurerm_frontdoor_firewall_policy.firewall_policy_with_usage:
+    monthly_custom_rule_requests: 110000      # Monthly number of custom rule requests
+    monthly_managed_ruleset_requests: 1000000 # Monthly number of managed ruleset requests

--- a/internal/providers/terraform/azure/testdata/frontdoor_test/frontdoor_test.golden
+++ b/internal/providers/terraform/azure/testdata/frontdoor_test/frontdoor_test.golden
@@ -1,0 +1,25 @@
+
+ Name                                                   Monthly Qty  Unit            Monthly Cost 
+                                                                                                  
+ azurerm_frontdoor.frontdoor_with_usage                                                           
+ ├─ Routing rules (first 5 rules)                             3,650  hours                $109.50 
+ ├─ Routing rules (per additional rule)                         730  hours                  $8.76 
+ ├─ Frontend hosts (over 100)                                    10  hosts                 $50.00 
+ ├─ Inbound data transfer                                     1,000  GB                    $10.00 
+ └─ Outbound data transfer                                                                        
+    ├─ North America, Europe and Africa (first 10TB)         10,000  GB                 $1,700.00 
+    ├─ North America, Europe and Africa (next 40TB)          40,000  GB                 $6,000.00 
+    └─ North America, Europe and Africa (over 50TB)         150,000  GB                $19,500.00 
+                                                                                                  
+ azurerm_frontdoor.frontdoor_without_usage                                                        
+ ├─ Routing rules (first 5 rules)                               730  hours                 $21.90 
+ ├─ Inbound data transfer                             Monthly cost depends on usage: $0.01 per GB 
+ └─ Outbound data transfer                                                                        
+    └─ North America, Europe and Africa (first 10TB)  Monthly cost depends on usage: $0.17 per GB 
+                                                                                                  
+ OVERALL TOTAL                                                                         $27,400.16 
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free:
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/frontdoor_test/frontdoor_test.tf
+++ b/internal/providers/terraform/azure/testdata/frontdoor_test/frontdoor_test.tf
@@ -1,0 +1,721 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "FrontDoorExampleResourceGroup"
+  location = "West Europe"
+}
+
+resource "azurerm_frontdoor" "frontdoor_without_usage" {
+  name                                         = "exampleFrontdoor"
+  resource_group_name                          = azurerm_resource_group.example.name
+  enforce_backend_pools_certificate_name_check = false
+
+  routing_rule {
+    name               = "exampleRoutingRule1"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["exampleFrontendEndpoint1"]
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = "exampleBackendBing"
+    }
+  }
+
+  routing_rule {
+    name               = "exampleDisabledRoutingRule"
+    enabled            = false
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["exampleFrontendEndpoint1"]
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = "exampleBackendBing"
+    }
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint1"
+    host_name = "example-frontdoor1.example.net"
+  }
+
+  # --- Required attributes ---
+  backend_pool_load_balancing {
+    name = "exampleLoadBalancingSettings1"
+  }
+
+  backend_pool_health_probe {
+    name = "exampleHealthProbeSetting1"
+  }
+
+  backend_pool {
+    name = "exampleBackendBing"
+    backend {
+      host_header = "www.bing.com"
+      address     = "www.bing.com"
+      http_port   = 80
+      https_port  = 443
+    }
+
+    load_balancing_name = "exampleLoadBalancingSettings1"
+    health_probe_name   = "exampleHealthProbeSetting1"
+  }
+}
+
+resource "azurerm_frontdoor" "frontdoor_with_usage" {
+  name                                         = "exampleFrontdoorWithUsage"
+  resource_group_name                          = azurerm_resource_group.example.name
+  enforce_backend_pools_certificate_name_check = false
+
+  routing_rule {
+    name               = "exampleRoutingRule1"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["exampleFrontendEndpoint1"]
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = "exampleBackendBing"
+    }
+  }
+
+  routing_rule {
+    name               = "exampleRoutingRule2"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["exampleFrontendEndpoint1"]
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = "exampleBackendBing"
+    }
+  }
+
+  routing_rule {
+    name               = "exampleRoutingRule3"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["exampleFrontendEndpoint1"]
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = "exampleBackendBing"
+    }
+  }
+
+  routing_rule {
+    name               = "exampleRoutingRule4"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["exampleFrontendEndpoint1"]
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = "exampleBackendBing"
+    }
+  }
+
+  routing_rule {
+    name               = "exampleRoutingRule5"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["exampleFrontendEndpoint1"]
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = "exampleBackendBing"
+    }
+  }
+
+  routing_rule {
+    name               = "exampleRoutingRule6"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["exampleFrontendEndpoint1"]
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = "exampleBackendBing"
+    }
+  }
+
+  routing_rule {
+    name               = "exampleDisabledRoutingRule"
+    enabled            = false
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = ["exampleFrontendEndpoint1"]
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = "exampleBackendBing"
+    }
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint1"
+    host_name = "example-frontdoor1.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint2"
+    host_name = "example-frontdoor2.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint3"
+    host_name = "example-frontdoor3.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint4"
+    host_name = "example-frontdoor4.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint5"
+    host_name = "example-frontdoor5.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint6"
+    host_name = "example-frontdoor6.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint7"
+    host_name = "example-frontdoor7.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint8"
+    host_name = "example-frontdoor8.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint9"
+    host_name = "example-frontdoor9.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint10"
+    host_name = "example-frontdoor10.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint11"
+    host_name = "example-frontdoor11.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint12"
+    host_name = "example-frontdoor12.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint13"
+    host_name = "example-frontdoor13.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint14"
+    host_name = "example-frontdoor14.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint15"
+    host_name = "example-frontdoor15.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint16"
+    host_name = "example-frontdoor16.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint17"
+    host_name = "example-frontdoor17.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint18"
+    host_name = "example-frontdoor18.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint19"
+    host_name = "example-frontdoor19.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint20"
+    host_name = "example-frontdoor20.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint21"
+    host_name = "example-frontdoor21.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint22"
+    host_name = "example-frontdoor22.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint23"
+    host_name = "example-frontdoor23.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint24"
+    host_name = "example-frontdoor24.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint25"
+    host_name = "example-frontdoor25.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint26"
+    host_name = "example-frontdoor26.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint27"
+    host_name = "example-frontdoor27.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint28"
+    host_name = "example-frontdoor28.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint29"
+    host_name = "example-frontdoor29.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint30"
+    host_name = "example-frontdoor30.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint31"
+    host_name = "example-frontdoor31.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint32"
+    host_name = "example-frontdoor32.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint33"
+    host_name = "example-frontdoor33.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint34"
+    host_name = "example-frontdoor34.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint35"
+    host_name = "example-frontdoor35.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint36"
+    host_name = "example-frontdoor36.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint37"
+    host_name = "example-frontdoor37.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint38"
+    host_name = "example-frontdoor38.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint39"
+    host_name = "example-frontdoor39.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint40"
+    host_name = "example-frontdoor40.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint41"
+    host_name = "example-frontdoor41.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint42"
+    host_name = "example-frontdoor42.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint43"
+    host_name = "example-frontdoor43.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint44"
+    host_name = "example-frontdoor44.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint45"
+    host_name = "example-frontdoor45.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint46"
+    host_name = "example-frontdoor46.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint47"
+    host_name = "example-frontdoor47.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint48"
+    host_name = "example-frontdoor48.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint49"
+    host_name = "example-frontdoor49.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint50"
+    host_name = "example-frontdoor50.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint51"
+    host_name = "example-frontdoor51.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint52"
+    host_name = "example-frontdoor52.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint53"
+    host_name = "example-frontdoor53.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint54"
+    host_name = "example-frontdoor54.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint55"
+    host_name = "example-frontdoor55.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint56"
+    host_name = "example-frontdoor56.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint57"
+    host_name = "example-frontdoor57.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint58"
+    host_name = "example-frontdoor58.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint59"
+    host_name = "example-frontdoor59.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint60"
+    host_name = "example-frontdoor60.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint61"
+    host_name = "example-frontdoor61.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint62"
+    host_name = "example-frontdoor62.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint63"
+    host_name = "example-frontdoor63.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint64"
+    host_name = "example-frontdoor64.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint65"
+    host_name = "example-frontdoor65.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint66"
+    host_name = "example-frontdoor66.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint67"
+    host_name = "example-frontdoor67.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint68"
+    host_name = "example-frontdoor68.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint69"
+    host_name = "example-frontdoor69.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint70"
+    host_name = "example-frontdoor70.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint71"
+    host_name = "example-frontdoor71.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint72"
+    host_name = "example-frontdoor72.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint73"
+    host_name = "example-frontdoor73.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint74"
+    host_name = "example-frontdoor74.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint75"
+    host_name = "example-frontdoor75.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint76"
+    host_name = "example-frontdoor76.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint77"
+    host_name = "example-frontdoor77.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint78"
+    host_name = "example-frontdoor78.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint79"
+    host_name = "example-frontdoor79.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint80"
+    host_name = "example-frontdoor80.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint81"
+    host_name = "example-frontdoor81.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint82"
+    host_name = "example-frontdoor82.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint83"
+    host_name = "example-frontdoor83.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint84"
+    host_name = "example-frontdoor84.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint85"
+    host_name = "example-frontdoor85.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint86"
+    host_name = "example-frontdoor86.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint87"
+    host_name = "example-frontdoor87.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint88"
+    host_name = "example-frontdoor88.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint89"
+    host_name = "example-frontdoor89.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint90"
+    host_name = "example-frontdoor90.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint91"
+    host_name = "example-frontdoor91.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint92"
+    host_name = "example-frontdoor92.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint93"
+    host_name = "example-frontdoor93.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint94"
+    host_name = "example-frontdoor94.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint95"
+    host_name = "example-frontdoor95.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint96"
+    host_name = "example-frontdoor96.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint97"
+    host_name = "example-frontdoor97.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint98"
+    host_name = "example-frontdoor98.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint99"
+    host_name = "example-frontdoor99.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint100"
+    host_name = "example-frontdoor100.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint101"
+    host_name = "example-frontdoor101.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint102"
+    host_name = "example-frontdoor102.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint103"
+    host_name = "example-frontdoor103.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint104"
+    host_name = "example-frontdoor104.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint105"
+    host_name = "example-frontdoor105.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint106"
+    host_name = "example-frontdoor106.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint107"
+    host_name = "example-frontdoor107.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint108"
+    host_name = "example-frontdoor108.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint109"
+    host_name = "example-frontdoor109.example.net"
+  }
+
+  frontend_endpoint {
+    name      = "exampleFrontendEndpoint110"
+    host_name = "example-frontdoor110.example.net"
+  }
+
+  # --- Required attributes ---
+  backend_pool_load_balancing {
+    name = "exampleLoadBalancingSettings1"
+  }
+
+  backend_pool_health_probe {
+    name = "exampleHealthProbeSetting1"
+  }
+
+  backend_pool {
+    name = "exampleBackendBing"
+    backend {
+      host_header = "www.bing.com"
+      address     = "www.bing.com"
+      http_port   = 80
+      https_port  = 443
+    }
+
+    load_balancing_name = "exampleLoadBalancingSettings1"
+    health_probe_name   = "exampleHealthProbeSetting1"
+  }
+}

--- a/internal/providers/terraform/azure/testdata/frontdoor_test/frontdoor_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/frontdoor_test/frontdoor_test.usage.yml
@@ -1,0 +1,11 @@
+version: 0.1
+resource_usage:
+  azurerm_frontdoor.frontdoor_with_usage:
+    monthly_outbound_data_transfer_gb: # Monthly outbound data transfer from the following, in GB:
+      us_gov: 190000                       # US Gov
+      north_america_europe_africa: 200000  # North America, Europe and Africa
+      asia_pacific: 220000                 # Asia Pacific (including Japan)
+      south_america: 10000                 # South America
+      australia: 50000                     # Australia
+      india: 387000                        # India
+    monthly_inbound_data_transfer_gb: 1000 # Monthly inbound data transfer in GB

--- a/internal/resources/azure/frontdoor.go
+++ b/internal/resources/azure/frontdoor.go
@@ -1,0 +1,324 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
+	"github.com/shopspring/decimal"
+)
+
+// Frontdoor struct represents Azure's Front Door network service.
+//
+// More resource information here: https://docs.microsoft.com/en-us/azure/frontdoor/front-door-overview
+// Pricing information here: https://azure.microsoft.com/en-us/pricing/details/frontdoor/ (Azure Front Door tab)
+type Frontdoor struct {
+	Address string
+	Region  string
+
+	FrontendHosts int
+	RoutingRules  int
+
+	// "usage" args
+	MonthlyInboundDataTransferGB  *float64                            `infracost_usage:"monthly_inbound_data_transfer_gb"`
+	MonthlyOutboundDataTransferGB *frontdoorOutboundDataTransferUsage `infracost_usage:"monthly_outbound_data_transfer_gb"`
+}
+
+// frontdoorOutboundDataTransferUsage represents outbound transfer usage group per
+// region.
+type frontdoorOutboundDataTransferUsage struct {
+	USGovZone1MonthlyTransferGB *float64 `infracost_usage:"us_gov"`
+	Zone1MonthlyTransferGB      *float64 `infracost_usage:"north_america_europe_africa"`
+	Zone2MonthlyTransferGB      *float64 `infracost_usage:"asia_pacific"`
+	Zone3MonthlyTransferGB      *float64 `infracost_usage:"south_america"`
+	Zone4MonthlyTransferGB      *float64 `infracost_usage:"australia"`
+	Zone5MonthlyTransferGB      *float64 `infracost_usage:"india"`
+}
+
+// FrontdoorUsageSchema defines a list which represents the usage schema of Frontdoor.
+var FrontdoorUsageSchema = []*schema.UsageItem{
+	{Key: "monthly_inbound_data_transfer_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{
+		Key:          "monthly_outbound_data_transfer_gb",
+		DefaultValue: &usage.ResourceUsage{Name: "monthly_outbound_data_transfer_gb", Items: frontdoorOutboundDataUsageSchema},
+		ValueType:    schema.SubResourceUsage,
+	},
+}
+
+// frontdoorOutboundDataUsageSchema defines a nested list of outbound data
+// transfer usage per region.
+var frontdoorOutboundDataUsageSchema = []*schema.UsageItem{
+	{Key: "us_gov", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "north_america_europe_africa", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "asia_pacific", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "south_america", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "australia", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "india", DefaultValue: 0, ValueType: schema.Float64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the Frontdoor.
+// It uses the `infracost_usage` struct tags to populate data into the Frontdoor.
+func (r *Frontdoor) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from valid Frontdoor data.
+// This method is called after the resource is initialised by an IaC provider.
+func (r *Frontdoor) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{}
+
+	costComponents = append(costComponents, r.routingRulesCostComponents()...)
+	costComponents = append(costComponents, r.frontendHostsCostComponents()...)
+	costComponents = append(costComponents, r.inboundDataTransferCostComponents()...)
+
+	// Subresource is used because the cost component has nested tier items
+	outboundTransferSubResource := &schema.Resource{
+		Name:           "Outbound data transfer",
+		CostComponents: r.outboundDataTransferCostComponents(),
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    FrontdoorUsageSchema,
+		CostComponents: costComponents,
+		SubResources:   []*schema.Resource{outboundTransferSubResource},
+	}
+}
+
+// routingRulesCostComponents returns cost components for defined routing rules.
+// The pricing depends on rules quantity.
+func (r *Frontdoor) routingRulesCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	name := "Routing rules"
+	firstBatchThreshold := 5
+	quantity := r.RoutingRules
+
+	type dataTier struct {
+		name       string
+		meterName  string
+		startUsage string
+	}
+
+	// For Zones 1 - 5 the price with startUsage 0 in API is free, but Azure
+	// pricing calculator bills first rules.
+	// US Gov Zone 1 has only one price
+	firstRulesStartUsage := "5"
+	if r.isGovZone(r.Region) {
+		firstRulesStartUsage = "0"
+	}
+
+	data := []dataTier{
+		{
+			name:       fmt.Sprintf("%s (first %d rules)", name, firstBatchThreshold),
+			meterName:  "Included Routing Rules",
+			startUsage: firstRulesStartUsage,
+		}, {
+			name:       fmt.Sprintf("%s (per additional rule)", name),
+			meterName:  "Overage Routing Rules",
+			startUsage: "0",
+		},
+	}
+
+	tierLimits := []int{firstBatchThreshold}
+	tiers := usage.CalculateTierBuckets(decimal.NewFromInt(int64(quantity)), tierLimits)
+	for i, d := range data {
+		if i < len(tiers) && tiers[i].GreaterThan(decimal.Zero) {
+			costComponents = append(costComponents, &schema.CostComponent{
+				Name:           d.name,
+				Unit:           "hours",
+				UnitMultiplier: decimal.NewFromInt(1),
+				HourlyQuantity: decimalPtr(tiers[i]),
+				ProductFilter:  r.buildProductFilter(d.meterName),
+				PriceFilter: &schema.PriceFilter{
+					PurchaseOption:   strPtr("Consumption"),
+					StartUsageAmount: strPtr(d.startUsage),
+				},
+			})
+		}
+	}
+
+	return costComponents
+}
+
+// frontendHostsCostComponents returns a cost component for frontend hosts.
+// Only additional hosts above free limit are billed.
+func (r *Frontdoor) frontendHostsCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	freeQuantity := 100
+	quantity := r.FrontendHosts
+
+	if quantity <= freeQuantity {
+		return costComponents
+	}
+
+	name := fmt.Sprintf("Frontend hosts (over %d)", freeQuantity)
+	billedHostsQuantity := quantity - freeQuantity
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            name,
+		Unit:            "hosts",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromInt(int64(billedHostsQuantity))),
+		ProductFilter:   r.buildProductFilter("Custom Domains"),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// inboundDataTransferCostComponents returns a cost component for amount of
+// transferred inbound data.
+func (r *Frontdoor) inboundDataTransferCostComponents() []*schema.CostComponent {
+	return []*schema.CostComponent{
+		{
+			Name:            "Inbound data transfer",
+			Unit:            "GB",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: floatPtrToDecimalPtr(r.MonthlyInboundDataTransferGB),
+			ProductFilter:   r.buildProductFilter("Data Transfer In"),
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+}
+
+// outboundDataTransferCostComponents returns cost components for amount of
+// transferred outbound data. There are several tiers that are billed
+// differently. The pricing depends on the region.
+func (r *Frontdoor) outboundDataTransferCostComponents() []*schema.CostComponent {
+	if r.isGovZone(r.Region) {
+		return r.govOutboundDataTransferCostComponents()
+	}
+
+	costComponents := []*schema.CostComponent{}
+
+	resourceUsage := &frontdoorOutboundDataTransferUsage{}
+	if r.MonthlyOutboundDataTransferGB != nil {
+		resourceUsage = r.MonthlyOutboundDataTransferGB
+	}
+
+	type zoneUsage struct {
+		zone     string
+		name     string
+		quantity *float64
+	}
+
+	zones := []zoneUsage{
+		{zone: "Zone 1", quantity: resourceUsage.Zone1MonthlyTransferGB, name: "North America, Europe and Africa"},
+		{zone: "Zone 2", quantity: resourceUsage.Zone2MonthlyTransferGB, name: "Asia Pacific (including Japan)"},
+		{zone: "Zone 3", quantity: resourceUsage.Zone3MonthlyTransferGB, name: "South America"},
+		{zone: "Zone 4", quantity: resourceUsage.Zone4MonthlyTransferGB, name: "Australia"},
+		{zone: "Zone 5", quantity: resourceUsage.Zone5MonthlyTransferGB, name: "India"},
+	}
+
+	currentZone := zones[0]
+	for _, item := range zones {
+		if strings.EqualFold(item.zone, r.Region) {
+			currentZone = item
+			break
+		}
+	}
+
+	type dataTier struct {
+		name       string
+		startUsage string
+	}
+	data := []dataTier{
+		{name: fmt.Sprintf("%s (first 10TB)", currentZone.name), startUsage: "0"},
+		{name: fmt.Sprintf("%s (next 40TB)", currentZone.name), startUsage: "10000"},
+		{name: fmt.Sprintf("%s (over 50TB)", currentZone.name), startUsage: "50000"},
+	}
+
+	if currentZone.quantity != nil {
+		quantity := decimal.NewFromFloat(*currentZone.quantity)
+
+		tierLimits := []int{10000, 40000}
+		tiers := usage.CalculateTierBuckets(quantity, tierLimits)
+
+		for i, d := range data {
+			if i < len(tiers) && tiers[i].GreaterThan(decimal.Zero) {
+				costComponents = append(costComponents, r.buildOutboundDataTransferCostComponent(
+					d.name,
+					d.startUsage,
+					decimalPtr(tiers[i]),
+				))
+			}
+		}
+	} else {
+		costComponents = append(costComponents, r.buildOutboundDataTransferCostComponent(
+			data[0].name,
+			data[0].startUsage,
+			nil,
+		))
+	}
+	return costComponents
+}
+
+// govOutboundDataTransferCostComponents returns a cost component for outbound
+// data transfer in US Gov zone. This zone doesn't have tiers.
+func (r *Frontdoor) govOutboundDataTransferCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	var quantity *decimal.Decimal
+
+	if r.MonthlyOutboundDataTransferGB != nil {
+		transferAmount := r.MonthlyOutboundDataTransferGB.USGovZone1MonthlyTransferGB
+		if transferAmount != nil {
+			quantity = decimalPtr(decimal.NewFromFloat(*transferAmount))
+		}
+	}
+
+	costComponents = append(costComponents, r.buildOutboundDataTransferCostComponent(
+		"US Gov",
+		"0",
+		quantity,
+	))
+
+	return costComponents
+}
+
+// buildOutboundDataTransferCostComponent returns a cost component for one tier
+// of outbound data transfer usage.
+func (r *Frontdoor) buildOutboundDataTransferCostComponent(name, startUsage string, quantity *decimal.Decimal) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            name,
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter("Data Transfer Out"),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr(startUsage),
+		},
+	}
+}
+
+// buildProductFilter returns a product filter for the Front Door's products.
+//
+// skuName and productName define the original Front Door service (not
+// Standard/Premium).
+func (r *Frontdoor) buildProductFilter(meterName string) *schema.ProductFilter {
+	return &schema.ProductFilter{
+		VendorName:    strPtr("azure"),
+		Region:        strPtr(r.Region),
+		Service:       strPtr("Azure Front Door Service"),
+		ProductFamily: strPtr("Networking"),
+		AttributeFilters: []*schema.AttributeFilter{
+			{Key: "skuName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", "Standard"))},
+			{Key: "meterName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", meterName))},
+			{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", "Azure Front Door Service"))},
+		},
+	}
+}
+
+// isGovZone checks if the region/zone is US Gov
+func (r *Frontdoor) isGovZone(zone string) bool {
+	return strings.EqualFold(zone, "US Gov Zone 1")
+}

--- a/internal/resources/azure/frontdoor_firewall_policy.go
+++ b/internal/resources/azure/frontdoor_firewall_policy.go
@@ -1,0 +1,171 @@
+package azure
+
+import (
+	"fmt"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// FrontdoorFirewallPolicy represents a policy for Web Application Firewall (WAF)
+// with Azure Front Door.
+//
+// More resource information here: https://docs.microsoft.com/en-us/azure/web-application-firewall/afds/waf-front-door-drs
+// Pricing information here: https://azure.microsoft.com/en-us/pricing/details/frontdoor/#overview
+type FrontdoorFirewallPolicy struct {
+	Address string
+	Region  string
+
+	CustomRules     int
+	ManagedRulesets int
+
+	// "usage" args
+	MonthlyCustomRuleRequests     *int64 `infracost_usage:"monthly_custom_rule_requests"`
+	MonthlyManagedRulesetRequests *int64 `infracost_usage:"monthly_managed_ruleset_requests"`
+}
+
+// FrontdoorFirewallPolicyUsageSchema defines a list which represents the usage schema of FrontdoorFirewallPolicy.
+var FrontdoorFirewallPolicyUsageSchema = []*schema.UsageItem{
+	{Key: "monthly_custom_rule_requests", DefaultValue: 0, ValueType: schema.Int64},
+	{Key: "monthly_managed_ruleset_requests", DefaultValue: 0, ValueType: schema.Int64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the FrontdoorFirewallPolicy.
+func (r *FrontdoorFirewallPolicy) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid FrontdoorFirewallPolicy.
+// This method is called after the resource is initialised by an IaC provider.
+func (r *FrontdoorFirewallPolicy) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{}
+
+	costComponents = append(costComponents, r.policyCostComponents()...)
+	costComponents = append(costComponents, r.customRulesCostComponents()...)
+	costComponents = append(costComponents, r.customRuleRequestsCostComponents()...)
+	costComponents = append(costComponents, r.managedRulesetsCostComponents()...)
+	costComponents = append(costComponents, r.managedRulesetRequestsCostComponents()...)
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    FrontdoorFirewallPolicyUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+// policyCostComponents returns cost components for Policy usage
+func (r *FrontdoorFirewallPolicy) policyCostComponents() []*schema.CostComponent {
+	return []*schema.CostComponent{
+		{
+			Name:            "Policy",
+			Unit:            "months",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			ProductFilter:   r.buildProductFilter("Policies"),
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+}
+
+// customRulesCostComponents returns a cost component for the total number of custom
+// rules in the policy.
+func (r *FrontdoorFirewallPolicy) customRulesCostComponents() []*schema.CostComponent {
+	return []*schema.CostComponent{
+		{
+			Name:            "Custom rules",
+			Unit:            "rules",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(int64(r.CustomRules))),
+			ProductFilter:   r.buildProductFilter("Rules"),
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+}
+
+// customRuleRequestsCostComponents returns a usage based cost component for the
+// number of custom rules' requests.
+func (r *FrontdoorFirewallPolicy) customRuleRequestsCostComponents() []*schema.CostComponent {
+	return []*schema.CostComponent{
+		{
+			Name:            "Custom rule requests",
+			Unit:            "1M requests",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: r.monthlyRequestsQuantity(r.MonthlyCustomRuleRequests),
+			ProductFilter:   r.buildProductFilter("Requests"),
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+}
+
+// managedRulesetsCostComponents returns a cost component for the total number
+// of managed rulesets in the policy.
+func (r *FrontdoorFirewallPolicy) managedRulesetsCostComponents() []*schema.CostComponent {
+	return []*schema.CostComponent{
+		{
+			Name:            "Managed rulesets",
+			Unit:            "rulesets",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(int64(r.ManagedRulesets))),
+			ProductFilter:   r.buildProductFilter("Default Rulesets"),
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+}
+
+// managedRulesetRequestsCostComponents returns a usage based cost component for
+// the number of managed rulesets' requests.
+func (r *FrontdoorFirewallPolicy) managedRulesetRequestsCostComponents() []*schema.CostComponent {
+	return []*schema.CostComponent{
+		{
+			Name:            "Managed ruleset requests",
+			Unit:            "1M requests",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: r.monthlyRequestsQuantity(r.MonthlyManagedRulesetRequests),
+			ProductFilter:   r.buildProductFilter("Default Requests"),
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+}
+
+// buildProductFilter returns a product filter for the Front Door's products.
+//
+// skuName and productName define the original Front Door service (not
+// Standard/Premium).
+func (r *FrontdoorFirewallPolicy) buildProductFilter(meterName string) *schema.ProductFilter {
+	return &schema.ProductFilter{
+		VendorName:    strPtr("azure"),
+		Region:        strPtr(r.Region),
+		Service:       strPtr("Azure Front Door Service"),
+		ProductFamily: strPtr("Networking"),
+		AttributeFilters: []*schema.AttributeFilter{
+			{Key: "skuName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", "Standard"))},
+			{Key: "meterName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", meterName))},
+			{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", "Azure Front Door Service"))},
+		},
+	}
+}
+
+// monthlyRequestsQuantity converts the monthly requests usage number as
+// Azure's requests pricing is 1M requests/month.
+func (r *FrontdoorFirewallPolicy) monthlyRequestsQuantity(requestsNumber *int64) *decimal.Decimal {
+	var monthlyRequests *decimal.Decimal
+	divider := decimal.NewFromInt(1000000)
+
+	if requestsNumber != nil {
+		requests := decimal.NewFromInt(*requestsNumber)
+		monthlyRequests = decimalPtr(requests.Div(divider))
+	}
+
+	return monthlyRequests
+}

--- a/internal/resources/azure/util.go
+++ b/internal/resources/azure/util.go
@@ -1,0 +1,20 @@
+package azure
+
+import (
+	"github.com/shopspring/decimal"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func decimalPtr(d decimal.Decimal) *decimal.Decimal {
+	return &d
+}
+
+func floatPtrToDecimalPtr(f *float64) *decimal.Decimal {
+	if f == nil {
+		return nil
+	}
+	return decimalPtr(decimal.NewFromFloat(*f))
+}


### PR DESCRIPTION
## Objective:

Add support for `azurerm_frontdoor` and `azurerm_frontdoor_firewall_policy`.  Fixes #909

## Pricing details:

- Azure has two Front Door services: "Standard" and newer "Standard/Premium (Preview)". This PR introduces the "Standard" one.
- Pricing for outbound data transfer depends on the region, in the Pricing API the regions are represented as zones (Zone 1 - Zone 5, US Gov Zone 1).
- Pricing API has 2 prices for Routing rules quantity. The item with `startUsage: 0` is free (for first 5 rules), however Azure's pricing page bills all the rules. Using the price with `startUsage: 5` instead.

## Status:

- [x] Added to resource_registry.go
- [x] Added internal/resources file
- [x] Added internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator.
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/119)

## Issues:

None