### PR TITLE
fix(azure): param can include an empty string in TF plan JSON

### DIFF
--- a/internal/providers/terraform/azure/event_hubs_namespace.go
+++ b/internal/providers/terraform/azure/event_hubs_namespace.go
@@ -34,7 +34,7 @@ func NewAzureRMEventHubs(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 		capacity = decimal.NewFromInt(d.Get("capacity").Int())
 	}
 
-	if d.Get("dedicated_cluster_id").Type != gjson.Null {
+	if d.Get("dedicated_cluster_id").Type != gjson.Null && len(d.Get("dedicated_cluster_id").String()) > 0 {
 		sku = "Dedicated"
 		meterName = "Capacity Unit"
 	}
@@ -56,7 +56,6 @@ func NewAzureRMEventHubs(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 	}
 
 	costComponents = append(costComponents, eventHubsThroughPutCostComponent(region, sku, meterName, capacity))
-
 	if strings.ToLower(sku) == "dedicated" {
 		if u != nil && u.Get("retention_storage_gb").Type != gjson.Null {
 			retention := decimalPtr(decimal.NewFromInt(u.Get("retention_storage_gb").Int()))
@@ -68,7 +67,6 @@ func NewAzureRMEventHubs(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 		} else {
 			costComponents = append(costComponents, eventHubsExtensionRetentionCostComponent(region, sku, unknown))
 		}
-
 	}
 
 	return &schema.Resource{


### PR DESCRIPTION
The empty string wasn’t being checked before thus the resource could be estimated as a dedicated cluster, which is a lot more expensive. 

Big thanks to @fernandomatsuosantos for helping us debug this. It was hard to track down as two identical projects were showing different cost estimates.

---

There's no easy way to write a test for this resource combo as the same TF version was producing slightly different plan JSONs (maybe the azure provider version was different). So I'm wondering if we should create an issue to review other places we use `d.Get("...").Type != gjson.Null`. Maybe we should have a helper function that can be used as there are 3 cases we need to handle when processing params in TF plan JSONs: param is not present, param is present but it's set to `null`, param is present and set to `""`. We switched from `.Exists()` to `d.Get("value_name").Type != gjson.Null` but that's still not enough.