### PR TITLE
feat(google): add Google Secret Manager resources

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -575,6 +575,14 @@ resource_usage:
   google_pubsub_topic.my_topic:
     monthly_message_data_tb: 7.416 # Monthly amount of message data published to the topic in TB.
 
+  google_secret_manager_secret.my_secret:
+    active_secret_versions: 10000       # Number of active secret versions in each month. NOTE: this is used only when secret versions are not defined.
+    monthly_access_operations: 20000    # Monthly number of access operations
+    monthly_rotation_notifications: 100 # Monthly number of rotation notifications
+
+  google_secret_manager_secret_version.my_secret_version:
+    monthly_access_operations: 25000 # Monthly number of access operations
+
   google_sql_database_instance.my_instance:
     backup_storage_gb: 1000 # Amount of backup storage in GB.
 

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -47,6 +47,8 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetPubSubSubscriptionRegistryItem(),
 	GetPubSubTopicRegistryItem(),
 	GetRedisInstanceRegistryItem(),
+	getSecretManagerSecretRegistryItem(),
+	getSecretManagerSecretVersionRegistryItem(),
 	GetSQLInstanceRegistryItem(),
 	GetStorageBucketRegistryItem(),
 }
@@ -164,6 +166,9 @@ var FreeResources = []string{
 	"google_pubsub_topic_iam_binding",
 	"google_pubsub_topic_iam_member",
 	"google_pubsub_topic_iam_policy",
+	"google_secret_manager_secret_iam_binding",
+	"google_secret_manager_secret_iam_member",
+	"google_secret_manager_secret_iam_policy",
 	"google_service_account",
 	"google_service_account_iam_binding",
 	"google_service_account_iam_member",

--- a/internal/providers/terraform/google/secret_manager_secret.go
+++ b/internal/providers/terraform/google/secret_manager_secret.go
@@ -1,0 +1,38 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/resources/google"
+	"github.com/infracost/infracost/internal/schema"
+
+	"github.com/tidwall/gjson"
+)
+
+func getSecretManagerSecretRegistryItem() *schema.RegistryItem {
+	rfunc := func(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+
+		r := newSecretManagerSecret(d)
+		r.PopulateUsage(u)
+
+		return r.BuildResource()
+	}
+
+	return &schema.RegistryItem{
+		Name:  "google_secret_manager_secret",
+		RFunc: rfunc,
+	}
+}
+
+func newSecretManagerSecret(d *schema.ResourceData) *google.SecretManagerSecret {
+	replicasCount := 1
+
+	replications := d.Get("replication.0.user_managed.0")
+	if replications.Type != gjson.Null && len(replications.Array()) > 0 {
+		replicasCount = len(replications.Get("replicas").Array())
+	}
+
+	return &google.SecretManagerSecret{
+		Address:              d.Address,
+		Region:               d.Get("region").String(),
+		ReplicationLocations: int64(replicasCount),
+	}
+}

--- a/internal/providers/terraform/google/secret_manager_secret_test.go
+++ b/internal/providers/terraform/google/secret_manager_secret_test.go
@@ -1,0 +1,16 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestSecretManagerSecretGoldenFile(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "secret_manager_secret_test")
+}

--- a/internal/providers/terraform/google/secret_manager_secret_version.go
+++ b/internal/providers/terraform/google/secret_manager_secret_version.go
@@ -1,0 +1,40 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/resources/google"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getSecretManagerSecretVersionRegistryItem() *schema.RegistryItem {
+	rfunc := func(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+
+		r := newSecretManagerSecretVersion(d)
+		r.PopulateUsage(u)
+
+		return r.BuildResource()
+	}
+
+	return &schema.RegistryItem{
+		Name:  "google_secret_manager_secret_version",
+		RFunc: rfunc,
+		ReferenceAttributes: []string{
+			"secret",
+		},
+	}
+}
+
+func newSecretManagerSecretVersion(d *schema.ResourceData) *google.SecretManagerSecretVersion {
+	replicasCount := int64(1)
+
+	secretReferences := d.References("secret")
+	if len(secretReferences) > 0 {
+		secret := newSecretManagerSecret(secretReferences[0])
+		replicasCount = secret.ReplicationLocations
+	}
+
+	return &google.SecretManagerSecretVersion{
+		Address:              d.Address,
+		Region:               d.Get("region").String(),
+		ReplicationLocations: replicasCount,
+	}
+}

--- a/internal/providers/terraform/google/secret_manager_secret_version_test.go
+++ b/internal/providers/terraform/google/secret_manager_secret_version_test.go
@@ -1,0 +1,16 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestSecretManagerSecretVersionGoldenFile(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "secret_manager_secret_version_test")
+}

--- a/internal/providers/terraform/google/testdata/secret_manager_secret_test/secret_manager_secret_test.golden
+++ b/internal/providers/terraform/google/testdata/secret_manager_secret_test/secret_manager_secret_test.golden
@@ -1,0 +1,22 @@
+
+ Name                                                           Monthly Qty  Unit                    Monthly Cost 
+                                                                                                                  
+ google_secret_manager_secret.secret_example                                                                      
+ ├─ Active secret versions                                Monthly cost depends on usage: $0.06 per versions       
+ ├─ Access operations                                     Monthly cost depends on usage: $0.03 per 10K requests   
+ └─ Rotation notifications                                Monthly cost depends on usage: $0.05 per rotations      
+                                                                                                                  
+ google_secret_manager_secret.secret_replicas_with_usage                                                          
+ ├─ Active secret versions                                            3,000  versions                     $180.00 
+ ├─ Access operations                                                   0.2  10K requests                   $0.01 
+ └─ Rotation notifications                                               10  rotations                      $0.50 
+                                                                                                                  
+ google_secret_manager_secret.secret_with_usage                                                                   
+ ├─ Active secret versions                                           10,000  versions                     $600.00 
+ ├─ Access operations                                                     2  10K requests                   $0.06 
+ └─ Rotation notifications                                              100  rotations                      $5.00 
+                                                                                                                  
+ OVERALL TOTAL                                                                                            $785.57 
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/secret_manager_secret_test/secret_manager_secret_test.tf
+++ b/internal/providers/terraform/google/testdata/secret_manager_secret_test/secret_manager_secret_test.tf
@@ -1,0 +1,57 @@
+provider "google" {
+  credentials = "{\"type\":\"service_account\"}"
+  region      = "us-central1"
+}
+
+resource "google_secret_manager_secret" "secret_example" {
+  secret_id = "secret"
+
+  labels = {
+    label = "example"
+  }
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret" "secret_with_usage" {
+  secret_id = "secret-with-usage"
+
+  labels = {
+    label = "example-with-usage"
+  }
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret" "secret_replicas_with_usage" {
+  secret_id = "secret-with-usage"
+
+  labels = {
+    label = "example-replicas-wth-usage"
+  }
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+      replicas {
+        location = "us-east2"
+      }
+    }
+  }
+}

--- a/internal/providers/terraform/google/testdata/secret_manager_secret_test/secret_manager_secret_test.usage.yml
+++ b/internal/providers/terraform/google/testdata/secret_manager_secret_test/secret_manager_secret_test.usage.yml
@@ -1,0 +1,10 @@
+version: 0.1
+resource_usage:
+  google_secret_manager_secret.secret_with_usage:
+    active_secret_versions: 10000       # Number of active secret versions in each month. NOTE: this is used only when secret versions are not defined.
+    monthly_access_operations: 20000    # Monthly number of access operations
+    monthly_rotation_notifications: 100 # Monthly number of rotation notifications
+  google_secret_manager_secret.secret_replicas_with_usage:
+    active_secret_versions: 1000        # Number of active secret versions in each month. NOTE: this is used only when secret versions are not defined.
+    monthly_access_operations: 2000     # Monthly number of access operations
+    monthly_rotation_notifications: 10  # Monthly number of rotation notifications

--- a/internal/providers/terraform/google/testdata/secret_manager_secret_version_test/secret_manager_secret_version_test.golden
+++ b/internal/providers/terraform/google/testdata/secret_manager_secret_version_test/secret_manager_secret_version_test.golden
@@ -1,0 +1,29 @@
+
+ Name                                                                           Monthly Qty  Unit                    Monthly Cost 
+                                                                                                                                  
+ google_secret_manager_secret.secret_automatic                                                                                    
+ ├─ Active secret versions                                                Monthly cost depends on usage: $0.06 per versions       
+ ├─ Access operations                                                     Monthly cost depends on usage: $0.03 per 10K requests   
+ └─ Rotation notifications                                                Monthly cost depends on usage: $0.05 per rotations      
+                                                                                                                                  
+ google_secret_manager_secret.secret_example                                                                                      
+ ├─ Active secret versions                                                Monthly cost depends on usage: $0.06 per versions       
+ ├─ Access operations                                                     Monthly cost depends on usage: $0.03 per 10K requests   
+ └─ Rotation notifications                                                Monthly cost depends on usage: $0.05 per rotations      
+                                                                                                                                  
+ google_secret_manager_secret_version.secret_version                                                                              
+ ├─ Active secret versions                                                                2  versions                       $0.12 
+ └─ Access operations                                                     Monthly cost depends on usage: $0.03 per 10K requests   
+                                                                                                                                  
+ google_secret_manager_secret_version.secret_version_replicas_with_usage                                                          
+ ├─ Active secret versions                                                                2  versions                       $0.12 
+ └─ Access operations                                                                   0.2  10K requests                   $0.01 
+                                                                                                                                  
+ google_secret_manager_secret_version.secret_version_with_usage                                                                   
+ ├─ Active secret versions                                                                1  versions                       $0.06 
+ └─ Access operations                                                                   2.5  10K requests                   $0.08 
+                                                                                                                                  
+ OVERALL TOTAL                                                                                                              $0.38 
+──────────────────────────────────
+5 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/secret_manager_secret_version_test/secret_manager_secret_version_test.tf
+++ b/internal/providers/terraform/google/testdata/secret_manager_secret_version_test/secret_manager_secret_version_test.tf
@@ -1,0 +1,53 @@
+provider "google" {
+  credentials = "{\"type\":\"service_account\"}"
+  region      = "us-central1"
+}
+
+resource "google_secret_manager_secret" "secret_example" {
+  secret_id = "secret"
+
+  labels = {
+    label = "example"
+  }
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret" "secret_automatic" {
+  secret_id = "secret-with-usage"
+
+  labels = {
+    label = "example-with-usage"
+  }
+
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  secret = google_secret_manager_secret.secret_example.id
+
+  secret_data = "secret-data"
+}
+
+resource "google_secret_manager_secret_version" "secret_version_with_usage" {
+  secret = google_secret_manager_secret.secret_automatic.id
+
+  secret_data = "secret-data"
+}
+
+resource "google_secret_manager_secret_version" "secret_version_replicas_with_usage" {
+  secret = google_secret_manager_secret.secret_example.id
+
+  secret_data = "secret-data"
+}

--- a/internal/providers/terraform/google/testdata/secret_manager_secret_version_test/secret_manager_secret_version_test.usage.yml
+++ b/internal/providers/terraform/google/testdata/secret_manager_secret_version_test/secret_manager_secret_version_test.usage.yml
@@ -1,0 +1,6 @@
+version: 0.1
+resource_usage:
+  google_secret_manager_secret_version.secret_version_with_usage:
+    monthly_access_operations: 25000 # Monthly number of access operations
+  google_secret_manager_secret_version.secret_version_replicas_with_usage:
+    monthly_access_operations: 2000 # Monthly number of access operations

--- a/internal/resources/google/secret_manager_secret.go
+++ b/internal/resources/google/secret_manager_secret.go
@@ -1,0 +1,137 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// SecretManagerSecret represents Google Secret Manager's Secret resource.
+//
+// The cost of active secret versions depends on the number of replication
+// locations. If it's more than one then the price is multiplied by the
+// locations' quantity. Pricing API includes Free Tier, but it's not used.
+//
+// More resource information here: https://cloud.google.com/secret-manager
+// Pricing information here: https://cloud.google.com/secret-manager/pricing
+type SecretManagerSecret struct {
+	Address              string
+	Region               string
+	ReplicationLocations int64
+
+	// "usage" args
+	ActiveSecretVersions         *int64 `infracost_usage:"active_secret_versions"`
+	MonthlyAccessOperations      *int64 `infracost_usage:"monthly_access_operations"`
+	MonthlyRotationNotifications *int64 `infracost_usage:"monthly_rotation_notifications"`
+}
+
+// SecretManagerSecretUsageSchema defines a list which represents the usage schema of SecretManagerSecret.
+var SecretManagerSecretUsageSchema = []*schema.UsageItem{
+	{Key: "active_secret_versions", DefaultValue: 0, ValueType: schema.Int64},
+	{Key: "monthly_access_operations", DefaultValue: 0, ValueType: schema.Int64},
+	{Key: "monthly_rotation_notifications", DefaultValue: 0, ValueType: schema.Int64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the SecretManagerSecret.
+// It uses the `infracost_usage` struct tags to populate data into the SecretManagerSecret.
+func (r *SecretManagerSecret) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid SecretManagerSecret.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *SecretManagerSecret) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{}
+
+	costComponents = append(costComponents, r.activeSecretVersionsCostComponents()...)
+	costComponents = append(costComponents, r.accessOperationsCostComponents()...)
+	costComponents = append(costComponents, r.rotationNotificationsCostComponents()...)
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    SecretManagerSecretUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+// activeSecretVersionsCostComponents returns a cost component for Active Secret
+// Versions.
+// The cost is multiplied by the number of replication locations. Free tier
+// pricing is excluded.
+func (r *SecretManagerSecret) activeSecretVersionsCostComponents() []*schema.CostComponent {
+	var quantity *int64
+
+	if r.ActiveSecretVersions != nil {
+		multiplied := r.ReplicationLocations * *r.ActiveSecretVersions
+		quantity = &multiplied
+	}
+
+	return []*schema.CostComponent{
+		{
+			Name:            "Active secret versions",
+			Unit:            "versions",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: intPtrToDecimalPtr(quantity),
+			ProductFilter:   r.buildProductFilter("Secret version replica storage"),
+			PriceFilter:     r.buildPriceFilter("6"),
+		},
+	}
+}
+
+// accessOperationsCostComponents returns a cost component for Secret's Access
+// Operations. Free tier pricing is excluded.
+func (r *SecretManagerSecret) accessOperationsCostComponents() []*schema.CostComponent {
+	multiplier := 10000
+
+	return []*schema.CostComponent{
+		{
+			Name:            "Access operations",
+			Unit:            "10K requests",
+			UnitMultiplier:  decimal.NewFromInt(int64(multiplier)),
+			MonthlyQuantity: intPtrToDecimalPtr(r.MonthlyAccessOperations),
+			ProductFilter:   r.buildProductFilter("Secret access operations"),
+			PriceFilter:     r.buildPriceFilter(fmt.Sprint(multiplier)),
+		},
+	}
+}
+
+// rotationNotificationsCostComponents returns a cost component for Secret's
+// Rotation Notifications. Free tier pricing is excluded.
+func (r *SecretManagerSecret) rotationNotificationsCostComponents() []*schema.CostComponent {
+	return []*schema.CostComponent{
+		{
+			Name:            "Rotation notifications",
+			Unit:            "rotations",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: intPtrToDecimalPtr(r.MonthlyRotationNotifications),
+			ProductFilter:   r.buildProductFilter("Secret rotate operations"),
+			PriceFilter:     r.buildPriceFilter("3"),
+		},
+	}
+}
+
+// buildProductFilter creates a product filter for Secret Manager's Secret
+// product.
+func (r *SecretManagerSecret) buildProductFilter(description string) *schema.ProductFilter {
+	return &schema.ProductFilter{
+		VendorName:    strPtr("gcp"),
+		Region:        strPtr(r.Region),
+		Service:       strPtr("Secret Manager"),
+		ProductFamily: strPtr("ApplicationServices"),
+		AttributeFilters: []*schema.AttributeFilter{
+			{Key: "description", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", description))},
+		},
+	}
+}
+
+// buildPriceFilter creates a price filter based on start usage amount to ignore
+// free tier pricing.
+func (r *SecretManagerSecret) buildPriceFilter(startUsageAmount string) *schema.PriceFilter {
+	return &schema.PriceFilter{
+		PurchaseOption:   strPtr("OnDemand"),
+		StartUsageAmount: strPtr(startUsageAmount),
+	}
+}

--- a/internal/resources/google/secret_manager_secret_version.go
+++ b/internal/resources/google/secret_manager_secret_version.go
@@ -1,0 +1,112 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+// SecretManagerSecretVersion represents one Google Secret Manager Secret's Version resource.
+//
+// The cost of active secret version depends on the number of replication
+// locations specified by its parent secret. If it's more than one then the price
+// is multiplied by the locations' quantity.
+// Pricing API includes Free Tier, but it's not used.
+//
+// More resource information here: https://cloud.google.com/secret-manager
+// Pricing information here: https://cloud.google.com/secret-manager/pricing
+type SecretManagerSecretVersion struct {
+	Address              string
+	Region               string
+	ReplicationLocations int64
+
+	// "usage" args
+	MonthlyAccessOperations *int64 `infracost_usage:"monthly_access_operations"`
+}
+
+// SecretManagerSecretVersionUsageSchema defines a list which represents the usage schema of SecretManagerSecretVersion.
+var SecretManagerSecretVersionUsageSchema = []*schema.UsageItem{
+	{Key: "monthly_access_operations", DefaultValue: 0, ValueType: schema.Int64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the SecretManagerSecretVersion.
+// It uses the `infracost_usage` struct tags to populate data into the SecretManagerSecretVersion.
+func (r *SecretManagerSecretVersion) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid SecretManagerSecretVersion.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *SecretManagerSecretVersion) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{}
+
+	costComponents = append(costComponents, r.activeSecretVersionsCostComponents()...)
+	costComponents = append(costComponents, r.accessOperationsCostComponents()...)
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    SecretManagerSecretVersionUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+// activeSecretVersionsCostComponents returns a cost component for the Active Secret
+// Version. By default it represents one version.
+// The cost is multiplied by the number of replication locations. Free tier
+// pricing is excluded.
+func (r *SecretManagerSecretVersion) activeSecretVersionsCostComponents() []*schema.CostComponent {
+	return []*schema.CostComponent{
+		{
+			Name:            "Active secret versions",
+			Unit:            "versions",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: intPtrToDecimalPtr(&r.ReplicationLocations),
+			ProductFilter:   r.buildProductFilter("Secret version replica storage"),
+			PriceFilter:     r.buildPriceFilter("6"),
+		},
+	}
+}
+
+// accessOperationsCostComponents returns a cost component for Secret Version's Access
+// Operations. Free tier pricing is excluded.
+func (r *SecretManagerSecretVersion) accessOperationsCostComponents() []*schema.CostComponent {
+	multiplier := 10000
+
+	return []*schema.CostComponent{
+		{
+			Name:            "Access operations",
+			Unit:            "10K requests",
+			UnitMultiplier:  decimal.NewFromInt(int64(multiplier)),
+			MonthlyQuantity: intPtrToDecimalPtr(r.MonthlyAccessOperations),
+			ProductFilter:   r.buildProductFilter("Secret access operations"),
+			PriceFilter:     r.buildPriceFilter(fmt.Sprint(multiplier)),
+		},
+	}
+}
+
+// buildProductFilter creates a product filter for Secret Manager's Secret
+// product.
+func (r *SecretManagerSecretVersion) buildProductFilter(description string) *schema.ProductFilter {
+	return &schema.ProductFilter{
+		VendorName:    strPtr("gcp"),
+		Region:        strPtr(r.Region),
+		Service:       strPtr("Secret Manager"),
+		ProductFamily: strPtr("ApplicationServices"),
+		AttributeFilters: []*schema.AttributeFilter{
+			{Key: "description", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", description))},
+		},
+	}
+}
+
+// buildPriceFilter creates a price filter based on start usage amount to ignore
+// free tier pricing.
+func (r *SecretManagerSecretVersion) buildPriceFilter(startUsageAmount string) *schema.PriceFilter {
+	return &schema.PriceFilter{
+		PurchaseOption:   strPtr("OnDemand"),
+		StartUsageAmount: strPtr(startUsageAmount),
+	}
+}

--- a/internal/resources/google/util.go
+++ b/internal/resources/google/util.go
@@ -1,0 +1,20 @@
+package google
+
+import (
+	"github.com/shopspring/decimal"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func decimalPtr(d decimal.Decimal) *decimal.Decimal {
+	return &d
+}
+
+func intPtrToDecimalPtr(i *int64) *decimal.Decimal {
+	if i == nil {
+		return nil
+	}
+	return decimalPtr(decimal.NewFromInt(*i))
+}


### PR DESCRIPTION
## Objective:

Add support for Google Secret Manager resources.  Fixes #1023.

## Pricing details:

- Free Tier pricing is excluded.
- The cost of active secret versions depends on the number of replication locations. If it's more than one then the price is multiplied by the locations' quantity.
- Both enabled and disabled secret versions are treated as "active".

## Status:

- [x] Added to resource_registry.go
- [x] Added internal/resources file
- [x] Added internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator.
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/122))

## Issues:

None
