### PR TITLE
chore(aws): fix double products for aws_data_transfer resource

### DIFF
--- a/internal/providers/cloudformation/aws/registry.go
+++ b/internal/providers/cloudformation/aws/registry.go
@@ -19,7 +19,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	// GetConfigurationRecorderItem(),
 	// GetConfigOrganizationCustomRuleItem(),
 	// GetConfigOrganizationManagedRuleItem(),
-	// GetDataTransferRegistryItem(),
+	// getDataTransferRegistryItem(),
 	// GetDBInstanceRegistryItem(),
 	// GetDMSRegistryItem(),
 	// GetDocDBClusterInstanceRegistryItem(),

--- a/internal/providers/terraform/aws/data_transfer.go
+++ b/internal/providers/terraform/aws/data_transfer.go
@@ -1,243 +1,27 @@
 package aws
 
 import (
-	"fmt"
 	"strings"
-
-	"github.com/shopspring/decimal"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/infracost/infracost/internal/resources/aws"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/infracost/infracost/internal/usage"
 )
 
-type dataTransferRegionUsageFilterData struct {
-	usageName      string
-	tierCapacity   int64
-	endUsageNumber int64
-}
-
-type UsageStepsFilterData struct {
-	usageName   string
-	usageFilter string
-	quantity    *decimal.Decimal
-}
-
-func GetDataTransferRegistryItem() *schema.RegistryItem {
+func getDataTransferRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_data_transfer",
-		RFunc: NewDataTransfer,
+		RFunc: newDataTransfer,
 	}
 }
 
-func NewDataTransfer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+func newDataTransfer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := strings.ToLower(u.Get("region").String())
-	fromLocation, ok := aws.RegionMapping[region]
 
-	if !ok {
-		log.Warnf("Skipping resource %s. Could not find mapping for region %s", d.Address, region)
-		return nil
+	r := &aws.DataTransfer{
+		Address: d.Address,
+		Region:  region,
 	}
+	r.PopulateUsage(u)
 
-	usEastRegion := aws.RegionMapping["us-east-1"]
-	otherRegion := aws.RegionMapping["us-west-1"]
-
-	if region == "us-east-1" {
-		usEastRegion = aws.RegionMapping["us-east-2"]
-		otherRegion = aws.RegionMapping["us-west-2"]
-	} else if region == "us-west-1" {
-		otherRegion = aws.RegionMapping["us-west-2"]
-	} else if region == "cn-north-1" {
-		otherRegion = aws.RegionMapping["cn-northwest-1"]
-	} else if region == "cn-northwest-1" {
-		otherRegion = aws.RegionMapping["cn-north-1"]
-	}
-
-	var intraRegionGb *decimal.Decimal
-	if u != nil && u.Get("monthly_intra_region_gb").Exists() {
-		intraRegionGb = decimalPtr(decimal.NewFromFloat(u.Get("monthly_intra_region_gb").Float()))
-	}
-
-	var outboundInternetGb *decimal.Decimal
-	if u != nil && u.Get("monthly_outbound_internet_gb").Exists() {
-		outboundInternetGb = decimalPtr(decimal.NewFromFloat(u.Get("monthly_outbound_internet_gb").Float()))
-	}
-
-	var outboundUsEastGb *decimal.Decimal
-	if u != nil && u.Get("monthly_outbound_us_east_to_us_east_gb").Exists() {
-		outboundUsEastGb = decimalPtr(decimal.NewFromFloat(u.Get("monthly_outbound_us_east_to_us_east_gb").Float()))
-	}
-
-	var outboundOtherRegionsGb *decimal.Decimal
-	if u != nil && u.Get("monthly_outbound_other_regions_gb").Exists() {
-		outboundOtherRegionsGb = decimalPtr(decimal.NewFromFloat(u.Get("monthly_outbound_other_regions_gb").Float()))
-	}
-
-	costComponents := make([]*schema.CostComponent, 0)
-
-	if intraRegionGb != nil {
-		costComponents = append(costComponents, &schema.CostComponent{
-			Name:            "Intra-region data transfer",
-			Unit:            "GB",
-			UnitMultiplier:  decimal.NewFromInt(1),
-			MonthlyQuantity: decimalPtr(intraRegionGb.Mul(decimal.NewFromInt(2))),
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Service:       strPtr("AWSDataTransfer"),
-				ProductFamily: strPtr("Data Transfer"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "transferType", Value: strPtr("IntraRegion")},
-					{Key: "fromLocation", Value: strPtr(fromLocation)},
-				},
-			},
-		})
-	}
-
-	if outboundInternetGb != nil {
-		costComponents = append(costComponents, outboundInternet(fromLocation, outboundInternetGb.IntPart())...)
-	}
-
-	if outboundUsEastGb != nil {
-		costComponents = append(costComponents, &schema.CostComponent{
-			Name:            "Outbound data transfer to US East regions",
-			Unit:            "GB",
-			UnitMultiplier:  decimal.NewFromInt(1),
-			MonthlyQuantity: outboundUsEastGb,
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Service:       strPtr("AWSDataTransfer"),
-				ProductFamily: strPtr("Data Transfer"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "transferType", Value: strPtr("InterRegion Outbound")},
-					{Key: "fromLocation", Value: strPtr(fromLocation)},
-					{Key: "toLocation", Value: strPtr(usEastRegion)},
-				},
-			},
-		})
-	}
-
-	if outboundOtherRegionsGb != nil {
-		costComponents = append(costComponents, &schema.CostComponent{
-			Name:            "Outbound data transfer to other regions",
-			Unit:            "GB",
-			UnitMultiplier:  decimal.NewFromInt(1),
-			MonthlyQuantity: outboundOtherRegionsGb,
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Service:       strPtr("AWSDataTransfer"),
-				ProductFamily: strPtr("Data Transfer"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "transferType", Value: strPtr("InterRegion Outbound")},
-					{Key: "fromLocation", Value: strPtr(fromLocation)},
-					{Key: "toLocation", Value: strPtr(otherRegion)},
-				},
-			},
-		})
-	}
-
-	return &schema.Resource{
-		Name:           d.Address,
-		CostComponents: costComponents,
-	}
-}
-
-func usageStepsFilterHelper(usageFiltersData []*dataTransferRegionUsageFilterData, usageAmount int64) []*UsageStepsFilterData {
-	results := make([]*UsageStepsFilterData, 0)
-	if len(usageFiltersData) == 1 {
-		quantity := decimal.NewFromInt(usageAmount)
-		results = append(results, &UsageStepsFilterData{
-			usageName:   usageFiltersData[0].usageName,
-			usageFilter: "Inf",
-			quantity:    &quantity,
-		})
-		return results
-	}
-	tierLimits := make([]int, len(usageFiltersData)-1)
-	for idx, usageFilter := range usageFiltersData {
-		if usageFilter.tierCapacity > 0 {
-			tierLimits[idx] = int(usageFilter.tierCapacity)
-		}
-	}
-	tiers := usage.CalculateTierBuckets(decimal.NewFromInt(usageAmount), tierLimits)
-	for idx, usageFilter := range usageFiltersData {
-		if tiers[idx].Equals(decimal.Zero) {
-			break
-		}
-		filter := fmt.Sprint(usageFilter.endUsageNumber)
-		if usageFilter.endUsageNumber == 0 {
-			filter = "Inf"
-		}
-		results = append(results, &UsageStepsFilterData{
-			usageName:   usageFilter.usageName,
-			usageFilter: filter,
-			quantity:    &tiers[idx],
-		})
-	}
-	return results
-}
-
-func outboundInternet(fromLocation string, networkUsage int64) []*schema.CostComponent {
-	costComponents := make([]*schema.CostComponent, 0)
-	defaultUsageFiltersData := []*dataTransferRegionUsageFilterData{
-		{
-			usageName:      "first 10TB",
-			tierCapacity:   10240,
-			endUsageNumber: 10240,
-		},
-		{
-			usageName:      "next 40TB",
-			tierCapacity:   40960,
-			endUsageNumber: 51200,
-		},
-		{
-			usageName:      "next 100TB",
-			tierCapacity:   102400,
-			endUsageNumber: 153600,
-		},
-		{
-			usageName:      "over 150TB",
-			tierCapacity:   0,
-			endUsageNumber: 0,
-		},
-	}
-	chinaUsageFiltersData := []*dataTransferRegionUsageFilterData{
-		{
-			usageName:      "",
-			tierCapacity:   0,
-			endUsageNumber: 0,
-		},
-	}
-	usageFiltersData := defaultUsageFiltersData
-	chinaLocations := map[string]struct{}{"China (Beijing)": {}, "China (Ningxia)": {}}
-	if _, ok := chinaLocations[fromLocation]; ok {
-		usageFiltersData = chinaUsageFiltersData
-	}
-	for _, usageStep := range usageStepsFilterHelper(usageFiltersData, networkUsage) {
-		var name string
-		if usageStep.usageName == "" {
-			name = "Outbound data transfer to Internet"
-		} else {
-			name = fmt.Sprintf("Outbound data transfer to Internet (%s)", usageStep.usageName)
-		}
-		costComponents = append(costComponents, &schema.CostComponent{
-			Name:            name,
-			Unit:            "GB",
-			UnitMultiplier:  decimal.NewFromInt(1),
-			MonthlyQuantity: usageStep.quantity,
-			ProductFilter: &schema.ProductFilter{
-				VendorName:    strPtr("aws"),
-				Service:       strPtr("AWSDataTransfer"),
-				ProductFamily: strPtr("Data Transfer"),
-				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "transferType", Value: strPtr("AWS Outbound")},
-					{Key: "fromLocation", Value: strPtr(fromLocation)},
-				},
-			},
-			PriceFilter: &schema.PriceFilter{
-				EndUsageAmount: strPtr(usageStep.usageFilter),
-			},
-		})
-	}
-	return costComponents
+	return r.BuildResource()
 }

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -22,7 +22,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetConfigurationRecorderItem(),
 	GetConfigOrganizationCustomRuleItem(),
 	GetConfigOrganizationManagedRuleItem(),
-	GetDataTransferRegistryItem(),
+	getDataTransferRegistryItem(),
 	GetDBInstanceRegistryItem(),
 	GetDMSRegistryItem(),
 	GetDocDBClusterInstanceRegistryItem(),

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -198,15 +198,3 @@
 ──────────────────────────────────
 24 cloud resources were detected:
 ∙ 24 were estimated, 24 include usage-based costs, see https://infracost.io/usage-file
-Logs:
-
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to Internet (first 10TB), using the first product"
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to Internet (first 10TB), using the first product"
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to Internet (next 100TB), using the first product"
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to Internet (next 100TB), using the first product"
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to Internet (next 40TB), using the first product"
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to Internet (next 40TB), using the first product"
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to Internet (over 150TB), using the first product"
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to Internet (over 150TB), using the first product"
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to other regions, using the first product"
-level=warning msg="Multiple products found for aws_data_transfer.ap-southeast-1 Outbound data transfer to other regions, using the first product"

--- a/internal/resources/aws/data_transfer.go
+++ b/internal/resources/aws/data_transfer.go
@@ -1,0 +1,270 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/shopspring/decimal"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
+)
+
+// DataTransfer represents data transferred "in" to and "out" of Amazon EC2.
+//
+// Pricing information here: https://aws.amazon.com/ec2/pricing/on-demand/
+type DataTransfer struct {
+	Address string
+	Region  string
+
+	// "usage" args
+	MonthlyInfraRegionGB            *float64 `infracost_usage:"monthly_intra_region_gb"`
+	MonthlyOutboundInternetGB       *float64 `infracost_usage:"monthly_outbound_internet_gb"`
+	MonthlyOutboundUsEastToUsEastGB *float64 `infracost_usage:"monthly_outbound_us_east_to_us_east_gb"`
+	MonthlyOutboundOtherRegionsGB   *float64 `infracost_usage:"monthly_outbound_other_regions_gb"`
+}
+
+// DataTransferUsageSchema defines a list which represents the usage schema of DataTransfer.
+var DataTransferUsageSchema = []*schema.UsageItem{
+	{Key: "monthly_intra_region_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "monthly_outbound_internet_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "monthly_outbound_us_east_to_us_east_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "monthly_outbound_other_regions_gb", DefaultValue: 0, ValueType: schema.Float64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the DataTransfer.
+// It uses the `infracost_usage` struct tags to populate data into the DataTransfer.
+func (r *DataTransfer) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid DataTransfer.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *DataTransfer) BuildResource() *schema.Resource {
+	_, ok := RegionMapping[r.Region]
+
+	if !ok {
+		log.Warnf("Skipping resource %s. Could not find mapping for region %s", r.Address, r.Region)
+		return nil
+	}
+
+	costComponents := []*schema.CostComponent{}
+
+	costComponents = append(costComponents, r.intraRegionCostComponents()...)
+	costComponents = append(costComponents, r.outboundInternetCostComponents()...)
+	costComponents = append(costComponents, r.outboundUsEastCostComponents()...)
+	costComponents = append(costComponents, r.outboundOtherRegionsCostComponents()...)
+
+	return &schema.Resource{
+		Name:           r.Address,
+		CostComponents: costComponents,
+	}
+}
+
+// intraRegionCostComponents returns a cost component for Intra-region data
+// transfer only when its usage is specified.
+func (r *DataTransfer) intraRegionCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if r.MonthlyInfraRegionGB == nil {
+		return costComponents
+	}
+
+	intraRegionGb := decimalPtr(decimal.NewFromFloat(*r.MonthlyInfraRegionGB))
+
+	if intraRegionGb != nil {
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            "Intra-region data transfer",
+			Unit:            "GB",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: decimalPtr(intraRegionGb.Mul(decimal.NewFromInt(2))),
+			ProductFilter:   r.buildProductFilter("IntraRegion", nil),
+		})
+	}
+
+	return costComponents
+}
+
+// intraRegionCostComponents returns a cost component for outbound data
+// transfer to the Internet only when its usage is specified.
+// China regions are calculated without tiers.
+func (r *DataTransfer) outboundInternetCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if r.MonthlyOutboundInternetGB == nil {
+		return costComponents
+	}
+
+	outboundInternetGb := decimalPtr(decimal.NewFromFloat(*r.MonthlyOutboundInternetGB))
+	networkUsage := outboundInternetGb.IntPart()
+
+	if r.Region == "cn-north-1" || r.Region == "cn-northwest-1" {
+		costComponents = append(costComponents, r.buildOutboundInternetCostComponent(
+			"Outbound data transfer to Internet",
+			decimal.NewFromInt(networkUsage),
+			"Inf",
+		))
+		return costComponents
+	}
+
+	type dataTransferRegionUsageFilterData struct {
+		usageName      string
+		tierCapacity   int64
+		endUsageNumber int64
+	}
+
+	usageFiltersData := []*dataTransferRegionUsageFilterData{
+		{
+			usageName:      "first 10TB",
+			tierCapacity:   10240,
+			endUsageNumber: 10240,
+		},
+		{
+			usageName:      "next 40TB",
+			tierCapacity:   40960,
+			endUsageNumber: 51200,
+		},
+		{
+			usageName:      "next 100TB",
+			tierCapacity:   102400,
+			endUsageNumber: 153600,
+		},
+		{
+			usageName:      "over 150TB",
+			tierCapacity:   0,
+			endUsageNumber: 0,
+		},
+	}
+
+	tierLimits := make([]int, len(usageFiltersData)-1)
+	for i, usageFilter := range usageFiltersData {
+		if usageFilter.tierCapacity > 0 {
+			tierLimits[i] = int(usageFilter.tierCapacity)
+		}
+	}
+
+	tiers := usage.CalculateTierBuckets(decimal.NewFromInt(networkUsage), tierLimits)
+	for i, usageFilter := range usageFiltersData {
+		quantity := tiers[i]
+
+		if quantity.Equals(decimal.Zero) {
+			break
+		}
+
+		filter := fmt.Sprint(usageFilter.endUsageNumber)
+		if usageFilter.endUsageNumber == 0 {
+			filter = "Inf"
+		}
+
+		name := fmt.Sprintf("Outbound data transfer to Internet (%s)", usageFilter.usageName)
+		costComponents = append(costComponents, r.buildOutboundInternetCostComponent(
+			name,
+			quantity,
+			filter,
+		))
+	}
+
+	return costComponents
+}
+
+// buildOutboundInternetCostComponent builds a cost component for
+// outbound data transfer to Internet.
+func (r *DataTransfer) buildOutboundInternetCostComponent(name string, networkUsage decimal.Decimal, endUsageAmount string) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            name,
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(networkUsage),
+		ProductFilter:   r.buildProductFilter("AWS Outbound", nil),
+		PriceFilter: &schema.PriceFilter{
+			EndUsageAmount: strPtr(endUsageAmount),
+		},
+	}
+}
+
+// outboundUsEastCostComponents returns a cost component for outbound data
+// transfer to US East regions only when its usage is specified.
+func (r *DataTransfer) outboundUsEastCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if r.MonthlyOutboundUsEastToUsEastGB == nil {
+		return costComponents
+	}
+
+	toRegion := "us-east-1"
+
+	if r.Region == "us-east-1" {
+		toRegion = "us-east-2"
+	}
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Outbound data transfer to US East regions",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyOutboundUsEastToUsEastGB)),
+		ProductFilter:   r.buildProductFilter("InterRegion Outbound", &toRegion),
+	})
+
+	return costComponents
+}
+
+// outboundOtherRegionsCostComponents returns a cost component for outbound data
+// transfer to other regions only when its usage is specified.
+func (r *DataTransfer) outboundOtherRegionsCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if r.MonthlyOutboundOtherRegionsGB == nil {
+		return costComponents
+	}
+
+	toRegion := "us-west-1"
+
+	switch r.Region {
+	case "us-east-1":
+		toRegion = "us-west-2"
+	case "us-west-1":
+		toRegion = "us-west-2"
+	case "cn-north-1":
+		toRegion = "cn-northwest-1"
+	case "cn-northwest-1":
+		toRegion = "cn-north-1"
+	}
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Outbound data transfer to other regions",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyOutboundOtherRegionsGB)),
+		ProductFilter:   r.buildProductFilter("InterRegion Outbound", &toRegion),
+	})
+
+	return costComponents
+}
+
+// buildProductFilter returns a filter for data transfer products. Desctination
+// region is optional.
+func (r *DataTransfer) buildProductFilter(transferType string, toRegion *string) *schema.ProductFilter {
+	fromLocation := RegionMapping[r.Region]
+
+	attributeFilters := []*schema.AttributeFilter{
+		{Key: "transferType", Value: strPtr(transferType)},
+		{Key: "fromLocation", Value: strPtr(fromLocation)},
+	}
+
+	if toRegion != nil {
+		toLocation := RegionMapping[*toRegion]
+		attributeFilters = append(attributeFilters, &schema.AttributeFilter{
+			Key:   "toLocation",
+			Value: strPtr(toLocation),
+		})
+	}
+
+	return &schema.ProductFilter{
+		VendorName:       strPtr("aws"),
+		Service:          strPtr("AWSDataTransfer"),
+		ProductFamily:    strPtr("Data Transfer"),
+		AttributeFilters: attributeFilters,
+	}
+}

--- a/internal/resources/aws/data_transfer.go
+++ b/internal/resources/aws/data_transfer.go
@@ -261,6 +261,13 @@ func (r *DataTransfer) buildProductFilter(transferType string, toRegion *string)
 		})
 	}
 
+	if regionCode, ok := RegionCodeMapping[r.Region]; ok {
+		attributeFilters = append(attributeFilters, &schema.AttributeFilter{
+			Key:        "usagetype",
+			ValueRegex: strPtr(fmt.Sprintf("/^%s-/i", regionCode)),
+		})
+	}
+
 	return &schema.ProductFilter{
 		VendorName:       strPtr("aws"),
 		Service:          strPtr("AWSDataTransfer"),

--- a/internal/resources/aws/util.go
+++ b/internal/resources/aws/util.go
@@ -113,6 +113,12 @@ var RegionMapping = map[string]string{
 	"af-south-1":      "Africa (Cape Town)",
 }
 
+// RegionCodeMapping helps to find region's abbreviated code for a more granular
+// filtering when resources may have multiple products for the same region.
+var RegionCodeMapping = map[string]string{
+	"ap-southeast-1": "APS1",
+}
+
 // RegionsUsage is a reusable type that represents a usage cost map.
 // This can be used in resources that define a usage parameter that's
 // changed on a per-region basis. e.g.


### PR DESCRIPTION
The previous fix to the golden file tried to resolve double products
found for `ap-southeast-1` region. First product has `APS1` prefix (correct)
and the second one has `APS4` (incorrect one). The fix worked until
the product results order returned `APS1` records first. But it was not
guaranteed. Mostly like it's an issue on AWS side.
Introducing an additional filter with the prefix should match exactly
the correct product. It might not work for regions that don't have such
prefix in `usagetype`.