### PR TITLE
Use consistent ordering for Terragrunt projects

### DIFF
--- a/examples/terragrunt/prod/terragrunt.hcl
+++ b/examples/terragrunt/prod/terragrunt.hcl
@@ -2,11 +2,6 @@ include {
   path = find_in_parent_folders()
 }
 
-# Add dependency on dev to make output consistent order
-dependencies {
-  paths = ["../dev"]
-}
-
 terraform {
   source = "..//modules/example"
 }


### PR DESCRIPTION
terragrunt run-all doesn't have consistent ordering, so this sorts the projects so our tests are consistent