### PR TITLE
feat(azure): add StorageV2 support to Azure Storage Account

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -855,18 +855,18 @@ resource_usage:
     monthly_images_extracted: 1000000 # Monthly number of extracted images
 
   azurerm_storage_account.my_account:
-    data_at_rest_storage_gb: 10000
-    early_deletion_gb: 1000
-    snapshots_storage_gb: 10000
-    metadata_at_rest_storage_gb: 10000
-    storage_gb: 1000000 # Total size of storage in GB.
-    monthly_write_operations: 1000000 # Monthly number of Write operations.
-    monthly_list_and_create_container_operations: 1000000 # Monthly number of List and Create Container operations. 
-    monthly_read_operations: 100000 # Monthly number of Read operations.
-    monthly_other_operations: 1000000 # Monthly number of  All other operations. 
-    monthly_data_retrieval_gb: 1000 # Monthly number of data retrieval in GB.
-    monthly_data_write_gb: 1000 # Monthly number of data write in GB.
-    blob_index_tags: 100000 # Total number of Blob indexes.
+    data_at_rest_storage_gb: 10000                        # Total size of Data at Rest in GB (File storage).
+    early_deletion_gb: 1000                               # Total size of Early deletion data in GB.
+    snapshots_storage_gb: 10000                           # Total size of Snapshots in GB (File storage).
+    metadata_at_rest_storage_gb: 10000                    # Total size of Metadata in GB (File storage).
+    storage_gb: 1000000                                   # Total size of storage in GB.
+    monthly_write_operations: 1000000                     # Monthly number of Write operations.
+    monthly_list_and_create_container_operations: 1000000 # Monthly number of List and Create Container operations.
+    monthly_read_operations: 100000                       # Monthly number of Read operations.
+    monthly_other_operations: 1000000                     # Monthly number of All other operations.
+    monthly_data_retrieval_gb: 1000                       # Monthly number of data retrieval in GB.
+    monthly_data_write_gb: 1000                           # Monthly number of data write in GB.
+    blob_index_tags: 100000                               # Total number of Blob indexes.
 
   azurerm_synapse_spark_pool.my_spark_pool:
     monthly_hours: 730 # Monthly number of hours used by each instance in the pool.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -860,8 +860,10 @@ resource_usage:
     snapshots_storage_gb: 10000                           # Total size of Snapshots in GB (File storage).
     metadata_at_rest_storage_gb: 10000                    # Total size of Metadata in GB (File storage).
     storage_gb: 1000000                                   # Total size of storage in GB.
+    monthly_iterative_write_operations: 170000            # Monthly number of Iterative write operations (GPv2).
     monthly_write_operations: 1000000                     # Monthly number of Write operations.
     monthly_list_and_create_container_operations: 1000000 # Monthly number of List and Create Container operations.
+    monthly_iterative_read_operations: 150000             # Monthly number of Iterative read operations (GPv2).
     monthly_read_operations: 100000                       # Monthly number of Read operations.
     monthly_other_operations: 1000000                     # Monthly number of All other operations.
     monthly_data_retrieval_gb: 1000                       # Monthly number of data retrieval in GB.

--- a/internal/providers/terraform/azure/hdinsight_hadoop_cluster_test.go
+++ b/internal/providers/terraform/azure/hdinsight_hadoop_cluster_test.go
@@ -11,7 +11,5 @@ func TestAzureRMHDInsightHadoopClusterGoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	opts := tftest.DefaultGoldenFileOptions()
-	opts.CaptureLogs = true
-	tftest.GoldenFileResourceTestsWithOpts(t, "hdinsight_hadoop_cluster_test", opts) //nolint:misspell
+	tftest.GoldenFileResourceTests(t, "hdinsight_hadoop_cluster_test") //nolint:misspell
 }

--- a/internal/providers/terraform/azure/hdinsight_hbase_cluster_test.go
+++ b/internal/providers/terraform/azure/hdinsight_hbase_cluster_test.go
@@ -11,7 +11,5 @@ func TestAzureRMHDInsightHBaseClusterGoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	opts := tftest.DefaultGoldenFileOptions()
-	opts.CaptureLogs = true
-	tftest.GoldenFileResourceTestsWithOpts(t, "hdinsight_hbase_cluster_test", opts) //nolint:misspell
+	tftest.GoldenFileResourceTests(t, "hdinsight_hbase_cluster_test") //nolint:misspell
 }

--- a/internal/providers/terraform/azure/hdinsight_interactive_query_cluster_test.go
+++ b/internal/providers/terraform/azure/hdinsight_interactive_query_cluster_test.go
@@ -11,7 +11,5 @@ func TestAzureRMHDInsightInteractiveQueryClusterGoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	opts := tftest.DefaultGoldenFileOptions()
-	opts.CaptureLogs = true
-	tftest.GoldenFileResourceTestsWithOpts(t, "hdinsight_interactive_query_cluster_test", opts) //nolint:misspell
+	tftest.GoldenFileResourceTests(t, "hdinsight_interactive_query_cluster_test") //nolint:misspell
 }

--- a/internal/providers/terraform/azure/hdinsight_kafka_cluster_test.go
+++ b/internal/providers/terraform/azure/hdinsight_kafka_cluster_test.go
@@ -11,7 +11,5 @@ func TestAzureRMHDInsightKafkaClusterGoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	opts := tftest.DefaultGoldenFileOptions()
-	opts.CaptureLogs = true
-	tftest.GoldenFileResourceTestsWithOpts(t, "hdinsight_kafka_cluster_test", opts) //nolint:misspell
+	tftest.GoldenFileResourceTests(t, "hdinsight_kafka_cluster_test") //nolint:misspell
 }

--- a/internal/providers/terraform/azure/hdinsight_spark_cluster_test.go
+++ b/internal/providers/terraform/azure/hdinsight_spark_cluster_test.go
@@ -11,7 +11,5 @@ func TestAzureRMHDInsightSparkClusterGoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	opts := tftest.DefaultGoldenFileOptions()
-	opts.CaptureLogs = true
-	tftest.GoldenFileResourceTestsWithOpts(t, "hdinsight_spark_cluster_test", opts) //nolint:misspell
+	tftest.GoldenFileResourceTests(t, "hdinsight_spark_cluster_test") //nolint:misspell
 }

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -84,7 +84,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMPublicIPPrefixRegistryItem(),
 	GetAzureRMSearchServiceRegistryItem(),
 	GetAzureRMRedisCacheRegistryItem(),
-	GetAzureRMStorageAccountRegistryItem(),
+	getAzureRMStorageAccountRegistryItem(),
 	GetAzureRMSynapseSparkPoolRegistryItem(),
 	GetAzureRMSynapseSQLPoolRegistryItem(),
 	GetAzureRMSynapseWorkspacRegistryItem(),

--- a/internal/providers/terraform/azure/storage_account.go
+++ b/internal/providers/terraform/azure/storage_account.go
@@ -1,442 +1,51 @@
 package azure
 
 import (
-	"fmt"
 	"strings"
 
+	"github.com/infracost/infracost/internal/resources/azure"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/infracost/infracost/internal/usage"
-	"github.com/shopspring/decimal"
-	log "github.com/sirupsen/logrus"
-	"github.com/tidwall/gjson"
 )
 
-func GetAzureRMStorageAccountRegistryItem() *schema.RegistryItem {
+func getAzureRMStorageAccountRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "azurerm_storage_account",
-		RFunc: NewAzureRMStorageAccount,
+		RFunc: newAzureRMStorageAccount,
 	}
 }
 
-func NewAzureRMStorageAccount(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+func newAzureRMStorageAccount(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := lookupRegion(d, []string{})
 
-	var costComponents []*schema.CostComponent
-	var productName string
-
 	accountKind := "StorageV2"
-	if d.Get("account_kind").Type != gjson.Null {
+	if !d.IsEmpty("account_kind") {
 		accountKind = d.Get("account_kind").String()
 	}
 
-	if accountKind != "BlockBlobStorage" && accountKind != "FileStorage" {
-		log.Warnf("Skipping resource %s. Infracost only supports BlockBlobStorage and FileStorage account kinds", d.Address)
-		return nil
+	accountReplicationType := d.Get("account_replication_type").String()
+	switch strings.ToLower(accountReplicationType) {
+	case "ragrs":
+		accountReplicationType = "RA-GRS"
+	case "ragzrs":
+		accountReplicationType = "RA-GZRS"
 	}
 
-	accountReplicationType := d.Get("account_replication_type").String()
 	accountTier := d.Get("account_tier").String()
+
 	accessTier := "Hot"
-	if d.Get("access_tier").Type != gjson.Null {
+	if !d.IsEmpty("access_tier") {
 		accessTier = d.Get("access_tier").String()
 	}
 
-	if strings.ToLower(accountKind) == "blockblobstorage" {
-		productName = map[string]string{
-			"Standard": "Blob Storage",
-			"Premium":  "Premium Block Blob",
-		}[accountTier]
-
-		if productName == "" {
-			log.Warnf("Unrecognized account tier for resource %s: %s", d.Address, accountTier)
-			return nil
-		}
-
-		validPremiumReplicationTypes := []string{"ZRS", "LRS"}
-		validStandardReplicationTypes := []string{"LRS", "GRS", "RAGRS"}
-
-		if strings.ToLower(accessTier) == "premium" && (!Contains(validPremiumReplicationTypes, accountReplicationType) || !Contains(validStandardReplicationTypes, accountReplicationType)) {
-			log.Warnf("%s redundancy does not supports for %s performance tier", accountReplicationType, accountTier)
-		}
-
-		var capacity, writeOperations, listOperations, readOperations, otherOperations, dataRetrieval, dataWrite, blobIndex *decimal.Decimal
-
-		if strings.ToLower(accountReplicationType) == "ragrs" {
-			accountReplicationType = "RA-GRS"
-		}
-
-		skuName := fmt.Sprintf("%s %s", accessTier, accountReplicationType)
-		if strings.ToLower(accountTier) == "premium" {
-			skuName = fmt.Sprintf("%s %s", accountTier, accountReplicationType)
-		}
-
-		if u != nil && u.Get("storage_gb").Type != gjson.Null {
-			capacity = decimalPtr(decimal.NewFromInt(u.Get("storage_gb").Int()))
-
-			if strings.ToLower(accessTier) == "hot" && strings.ToLower(accountTier) != "premium" {
-				dataStorageTiers := []int{51200, 512000}
-				dataStorageQuantities := usage.CalculateTierBuckets(*capacity, dataStorageTiers)
-
-				costComponents = append(costComponents, blobDataStorageCostComponent(
-					region,
-					"Capacity (first 50TB)",
-					skuName,
-					"0",
-					productName,
-					&dataStorageQuantities[0]))
-
-				if dataStorageQuantities[1].GreaterThan(decimal.Zero) {
-					costComponents = append(costComponents, blobDataStorageCostComponent(
-						region,
-						"Capacity (next 450TB)",
-						skuName,
-						"51200",
-						productName,
-						&dataStorageQuantities[1]))
-				}
-
-				if dataStorageQuantities[2].GreaterThan(decimal.Zero) {
-					costComponents = append(costComponents, blobDataStorageCostComponent(
-						region,
-						"Capacity (over 500TB)",
-						skuName,
-						"512000",
-						productName,
-						&dataStorageQuantities[2]))
-				}
-			} else {
-				costComponents = append(costComponents, blobDataStorageCostComponent(region, "Capacity", skuName, "0", productName, capacity))
-			}
-		} else {
-			var unknown *decimal.Decimal
-
-			costComponents = append(costComponents, blobDataStorageCostComponent(region, "Capacity", skuName, "0", productName, unknown))
-		}
-
-		if u != nil && u.Get("monthly_write_operations").Type != gjson.Null {
-			writeOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_write_operations").Int()))
-		}
-
-		costComponents = append(costComponents, blobOperationsCostComponent(
-			region,
-			"Write operations",
-			"10K operations",
-			skuName,
-			"Write Operations",
-			productName,
-			writeOperations,
-			10000))
-
-		if u != nil && u.Get("monthly_list_and_create_container_operations").Type != gjson.Null {
-			listOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_list_and_create_container_operations").Int()))
-		}
-		costComponents = append(costComponents, blobOperationsCostComponent(
-			region,
-			"List and create container operations",
-			"10K operations",
-			skuName,
-			"List and Create Container Operations",
-			productName,
-			listOperations,
-			10000))
-
-		if u != nil && u.Get("monthly_read_operations").Type != gjson.Null {
-			readOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_read_operations").Int()))
-		}
-		costComponents = append(costComponents, blobOperationsCostComponent(
-			region,
-			"Read operations",
-			"10K operations",
-			skuName,
-			"Read Operations",
-			productName,
-			readOperations,
-			10000))
-
-		if u != nil && u.Get("monthly_other_operations").Type != gjson.Null {
-			otherOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_other_operations").Int()))
-		}
-		costComponents = append(costComponents, blobOperationsCostComponent(
-			region,
-			"All other operations",
-			"10K operations",
-			skuName,
-			"All Other Operations",
-			productName,
-			otherOperations,
-			10000))
-
-		if accountTier != "Premium" {
-			if u != nil && u.Get("monthly_data_retrieval_gb").Type != gjson.Null {
-				dataRetrieval = decimalPtr(decimal.NewFromInt(u.Get("monthly_data_retrieval_gb").Int()))
-			}
-			costComponents = append(costComponents, blobOperationsCostComponent(
-				region,
-				"Data retrieval",
-				"GB",
-				skuName,
-				"Data Retrieval",
-				productName,
-				dataRetrieval,
-				1))
-
-			if u != nil && u.Get("monthly_data_write_gb").Type != gjson.Null {
-				dataWrite = decimalPtr(decimal.NewFromInt(u.Get("monthly_data_write_gb").Int()))
-			}
-			costComponents = append(costComponents, blobOperationsCostComponent(
-				region,
-				"Data write",
-				"GB",
-				skuName,
-				"Data Write",
-				productName,
-				dataWrite,
-				1))
-
-			if u != nil && u.Get("blob_index_tags").Type != gjson.Null {
-				blobIndex = decimalPtr(decimal.NewFromInt(u.Get("blob_index_tags").Int()))
-			}
-			costComponents = append(costComponents, blobOperationsCostComponent(
-				region,
-				"Blob index",
-				"10K tags",
-				skuName,
-				"Index Tags",
-				productName,
-				blobIndex,
-				10000))
-		}
+	r := &azure.StorageAccount{
+		Address:                d.Address,
+		Region:                 region,
+		AccessTier:             accessTier,
+		AccountKind:            accountKind,
+		AccountReplicationType: accountReplicationType,
+		AccountTier:            accountTier,
 	}
-	if strings.ToLower(accountKind) == "filestorage" {
-		var dataAtRest, snapshotsStorageGb, metadataAtRestStorageGb, monthlyWriteOperations, listOperations, monthlyReadOperations, monthlyOtherOperations, monthlyDataRetrievalGb, earlyDeletionGb *decimal.Decimal
-		validHotCoolReplicationTypes := []string{"LRS", "GRS", "ZRS"}
+	r.PopulateUsage(u)
 
-		if strings.ToLower(accessTier) == "hot" && (!Contains(validHotCoolReplicationTypes, accountReplicationType)) {
-			log.Warnf("%s redundancy does not supports for %s performance tier", accountReplicationType, accessTier)
-		}
-		if strings.ToLower(accessTier) == "cool" && (!Contains(validHotCoolReplicationTypes, accountReplicationType)) {
-			log.Warnf("%s redundancy does not supports for %s performance tier", accountReplicationType, accessTier)
-		}
-
-		skuName := fmt.Sprintf("%s %s", accessTier, accountReplicationType)
-
-		if u != nil && u.Get("data_at_rest_storage_gb").Type != gjson.Null {
-			dataAtRest = decimalPtr(decimal.NewFromInt(u.Get("data_at_rest_storage_gb").Int()))
-		}
-		costComponents = append(costComponents, fileDataStorageCostComponent(
-			region,
-			"Data at rest",
-			skuName,
-			"/Data Stored$/",
-			dataAtRest,
-		))
-
-		if u != nil && u.Get("snapshots_storage_gb").Type != gjson.Null {
-			snapshotsStorageGb = decimalPtr(decimal.NewFromInt(u.Get("snapshots_storage_gb").Int()))
-		}
-		costComponents = append(costComponents, fileDataStorageCostComponent(
-			region,
-			"Snapshots",
-			skuName,
-			"/Data Stored$/",
-			snapshotsStorageGb,
-		))
-
-		if u != nil && u.Get("metadata_at_rest_storage_gb").Type != gjson.Null {
-			metadataAtRestStorageGb = decimalPtr(decimal.NewFromInt(u.Get("metadata_at_rest_storage_gb").Int()))
-		}
-		costComponents = append(costComponents, fileDataStorageCostComponent(
-			region,
-			"Metadata at rest",
-			skuName,
-			"/Metadata$/",
-			metadataAtRestStorageGb,
-		))
-
-		if u != nil && u.Get("monthly_write_operations").Type != gjson.Null {
-			monthlyWriteOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_write_operations").Int()))
-		}
-		costComponents = append(costComponents, fileOperationStorageCostComponent(
-			region,
-			"10k operations",
-			"Write operations",
-			skuName,
-			"/Write Operations$/",
-			monthlyWriteOperations,
-			10000,
-		))
-
-		if u != nil && u.Get("monthly_list_and_create_container_operations").Type != gjson.Null {
-			listOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_list_and_create_container_operations").Int()))
-		}
-		costComponents = append(costComponents, fileOperationStorageCostComponent(
-			region,
-			"10k operations",
-			"List operations",
-			skuName,
-			"/List Operations$/",
-			listOperations,
-			10000,
-		))
-
-		if u != nil && u.Get("monthly_read_operations").Type != gjson.Null {
-			monthlyReadOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_read_operations").Int()))
-		}
-		costComponents = append(costComponents, fileOperationStorageCostComponent(
-			region,
-			"10k operations",
-			"Read operations",
-			skuName,
-			"/Read Operations$/",
-			monthlyReadOperations,
-			10000,
-		))
-
-		if u != nil && u.Get("monthly_other_operations").Type != gjson.Null {
-			monthlyOtherOperations = decimalPtr(decimal.NewFromInt(u.Get("monthly_other_operations").Int()))
-		}
-		costComponents = append(costComponents, fileOperationStorageCostComponent(
-			region,
-			"10k operations",
-			"All other operations",
-			skuName,
-			"/Other Operations$/",
-			monthlyOtherOperations,
-			10000,
-		))
-
-		if strings.ToLower(accessTier) == "cool" {
-			if u != nil && u.Get("monthly_data_retrieval_gb").Type != gjson.Null {
-				monthlyDataRetrievalGb = decimalPtr(decimal.NewFromInt(u.Get("monthly_data_retrieval_gb").Int()))
-			}
-			costComponents = append(costComponents, fileOperationStorageCostComponent(
-				region,
-				"GB",
-				"Data retrieval",
-				skuName,
-				"/Data Retrieval$/",
-				monthlyDataRetrievalGb,
-				1,
-			))
-
-			if u != nil && u.Get("early_deletion_gb").Type != gjson.Null {
-				earlyDeletionGb = decimalPtr(decimal.NewFromInt(u.Get("early_deletion_gb").Int()))
-			}
-			costComponents = append(costComponents, fileOperationStorageCostComponent(
-				region,
-				"GB",
-				"Early deletion",
-				skuName,
-				"/Early Delete$/",
-				earlyDeletionGb,
-				1,
-			))
-		}
-	}
-	return &schema.Resource{
-		Name:           d.Address,
-		CostComponents: costComponents,
-	}
-}
-
-func blobDataStorageCostComponent(region, name, skuName, startUsage, productName string, quantity *decimal.Decimal) *schema.CostComponent {
-	return &schema.CostComponent{
-		Name:                 name,
-		Unit:                 "GB",
-		UnitMultiplier:       decimal.NewFromInt(1),
-		MonthlyQuantity:      quantity,
-		IgnoreIfMissingPrice: true,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("azure"),
-			Region:        strPtr(region),
-			Service:       strPtr("Storage"),
-			ProductFamily: strPtr("Storage"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr(productName)},
-				{Key: "skuName", Value: strPtr(skuName)},
-				{Key: "meterName", ValueRegex: strPtr("/Data Stored$/i")},
-			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			PurchaseOption:   strPtr("Consumption"),
-			StartUsageAmount: strPtr(startUsage),
-		},
-	}
-}
-
-func blobOperationsCostComponent(region, name, unit, skuName, meterName, productName string, quantity *decimal.Decimal, multi int) *schema.CostComponent {
-	if quantity != nil {
-		quantity = decimalPtr(quantity.Div(decimal.NewFromInt(int64(multi))))
-	}
-
-	return &schema.CostComponent{
-		Name:                 name,
-		Unit:                 unit,
-		UnitMultiplier:       decimal.NewFromInt(1),
-		MonthlyQuantity:      quantity,
-		IgnoreIfMissingPrice: true,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("azure"),
-			Region:        strPtr(region),
-			Service:       strPtr("Storage"),
-			ProductFamily: strPtr("Storage"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr(productName)},
-				{Key: "skuName", Value: strPtr(skuName)},
-				{Key: "meterName", ValueRegex: strPtr(fmt.Sprintf("/%s$/i", meterName))},
-			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			PurchaseOption: strPtr("Consumption"),
-		},
-	}
-}
-func fileDataStorageCostComponent(region, name, skuName, meterName string, quantity *decimal.Decimal) *schema.CostComponent {
-	return &schema.CostComponent{
-		Name:                 name,
-		Unit:                 "GB",
-		UnitMultiplier:       decimal.NewFromInt(1),
-		MonthlyQuantity:      quantity,
-		IgnoreIfMissingPrice: true,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("azure"),
-			Region:        strPtr(region),
-			Service:       strPtr("Storage"),
-			ProductFamily: strPtr("Storage"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr("Files v2")},
-				{Key: "skuName", Value: strPtr(skuName)},
-				{Key: "meterName", ValueRegex: strPtr(meterName)},
-			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			PurchaseOption: strPtr("Consumption"),
-		},
-	}
-}
-func fileOperationStorageCostComponent(region, unit, name, skuName, meterName string, quantity *decimal.Decimal, multi int) *schema.CostComponent {
-	if quantity != nil {
-		quantity = decimalPtr(quantity.Div(decimal.NewFromInt(int64(multi))))
-	}
-	return &schema.CostComponent{
-		Name:                 name,
-		Unit:                 unit,
-		UnitMultiplier:       decimal.NewFromInt(1),
-		MonthlyQuantity:      quantity,
-		IgnoreIfMissingPrice: true,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("azure"),
-			Region:        strPtr(region),
-			Service:       strPtr("Storage"),
-			ProductFamily: strPtr("Storage"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr("Files v2")},
-				{Key: "skuName", Value: strPtr(skuName)},
-				{Key: "meterName", ValueRegex: strPtr(meterName)},
-			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			PurchaseOption: strPtr("Consumption"),
-		},
-	}
+	return r.BuildResource()
 }

--- a/internal/providers/terraform/azure/storage_account.go
+++ b/internal/providers/terraform/azure/storage_account.go
@@ -37,6 +37,11 @@ func newAzureRMStorageAccount(d *schema.ResourceData, u *schema.UsageData) *sche
 		accessTier = d.Get("access_tier").String()
 	}
 
+	nfsv3 := false
+	if !d.IsEmpty("nfsv3_enabled") {
+		nfsv3 = d.Get("nfsv3_enabled").Bool()
+	}
+
 	r := &azure.StorageAccount{
 		Address:                d.Address,
 		Region:                 region,
@@ -44,6 +49,7 @@ func newAzureRMStorageAccount(d *schema.ResourceData, u *schema.UsageData) *sche
 		AccountKind:            accountKind,
 		AccountReplicationType: accountReplicationType,
 		AccountTier:            accountTier,
+		NFSv3:                  nfsv3,
 	}
 	r.PopulateUsage(u)
 

--- a/internal/providers/terraform/azure/storage_account_test.go
+++ b/internal/providers/terraform/azure/storage_account_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func TestAzureStorageAccountGoldenFile(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "storage_account_test")
+	opts := tftest.DefaultGoldenFileOptions()
+	opts.CaptureLogs = true
+	tftest.GoldenFileResourceTestsWithOpts(t, "storage_account_test", opts)
 }

--- a/internal/providers/terraform/azure/synapse_spark_pool_test.go
+++ b/internal/providers/terraform/azure/synapse_spark_pool_test.go
@@ -11,7 +11,5 @@ func TestNewAzureRMSynapseSparkPool(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTestsWithOpts(t, "synapse_spark_pool_test", &tftest.GoldenFileOptions{
-		CaptureLogs: true,
-	})
+	tftest.GoldenFileResourceTests(t, "synapse_spark_pool_test")
 }

--- a/internal/providers/terraform/azure/synapse_sql_pool_test.go
+++ b/internal/providers/terraform/azure/synapse_sql_pool_test.go
@@ -11,7 +11,5 @@ func TestNewAzureRMSynapseSQLPool(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	opts := tftest.DefaultGoldenFileOptions()
-	opts.CaptureLogs = true
-	tftest.GoldenFileResourceTestsWithOpts(t, "synapse_sql_pool_test", opts)
+	tftest.GoldenFileResourceTests(t, "synapse_sql_pool_test")
 }

--- a/internal/providers/terraform/azure/synapse_workspace_test.go
+++ b/internal/providers/terraform/azure/synapse_workspace_test.go
@@ -11,7 +11,5 @@ func TestNewAzureRMSynapseWorkspace(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTestsWithOpts(t, "synapse_workspace_test", &tftest.GoldenFileOptions{
-		CaptureLogs: true,
-	})
+	tftest.GoldenFileResourceTests(t, "synapse_workspace_test")
 }

--- a/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
+++ b/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
@@ -1,53 +1,58 @@
 
- Name                                                                     Monthly Qty  Unit                    Monthly Cost 
-                                                                                                                            
- azurerm_function_app.elasticFunction                                                                                       
- ├─ vCPU (EP2)                                                                      2  vCPU                         $252.58 
- └─ Memory (EP2)                                                                    7  GB                            $62.85 
-                                                                                                                            
- azurerm_function_app.elasticFunctionWithUsage                                                                              
- ├─ vCPU (EP2)                                                                      4  vCPU                         $505.16 
- └─ Memory (EP2)                                                                   14  GB                           $125.71 
-                                                                                                                            
- azurerm_function_app.elasticPremiumFunction                                                                                
- ├─ vCPU (EP1)                                                                      1  vCPU                         $126.29 
- └─ Memory (EP1)                                                                  3.5  GB                            $31.43 
-                                                                                                                            
- azurerm_function_app.functionApp                                                                                           
- ├─ Execution time                                                  Monthly cost depends on usage: $0.000016 per GB-seconds 
- └─ Executions                                                      Monthly cost depends on usage: $0.20 per 1M requests    
-                                                                                                                            
- azurerm_function_app.functionAppNoAvailableServicePlanButHasUsage                                                          
- ├─ Execution time                                                       876,180.4425  GB-seconds                    $14.02 
- └─ Executions                                                                 3.5401  1M requests                    $0.71 
-                                                                                                                            
- azurerm_function_app.functionAppWithAllUsage                                                                               
- ├─ Execution time                                                       876,180.4425  GB-seconds                    $14.02 
- └─ Executions                                                                 3.5401  1M requests                    $0.71 
-                                                                                                                            
- azurerm_function_app.functionAppWithLessThanMins                                                                           
- ├─ Execution time                                                             37,500  GB-seconds                     $0.60 
- └─ Executions                                                                      3  1M requests                    $0.60 
-                                                                                                                            
- azurerm_function_app.functionAppWithMissingExecutions                                                                      
- ├─ Execution time                                                  Monthly cost depends on usage: $0.000016 per GB-seconds 
- └─ Executions                                                      Monthly cost depends on usage: $0.20 per 1M requests    
-                                                                                                                            
- azurerm_function_app.functionAppWithOnlyExecutions                                                                         
- ├─ Execution time                                                  Monthly cost depends on usage: $0.000016 per GB-seconds 
- └─ Executions                                                                    0.1  1M requests                    $0.02 
-                                                                                                                            
- OVERALL TOTAL                                                                                                    $1,134.69 
+ Name                                                                      Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                               
+ azurerm_function_app.elasticFunction                                                                                          
+ ├─ vCPU (EP2)                                                                       2  vCPU                           $252.58 
+ └─ Memory (EP2)                                                                     7  GB                              $62.85 
+                                                                                                                               
+ azurerm_function_app.elasticFunctionWithUsage                                                                                 
+ ├─ vCPU (EP2)                                                                       4  vCPU                           $505.16 
+ └─ Memory (EP2)                                                                    14  GB                             $125.71 
+                                                                                                                               
+ azurerm_function_app.elasticPremiumFunction                                                                                   
+ ├─ vCPU (EP1)                                                                       1  vCPU                           $126.29 
+ └─ Memory (EP1)                                                                   3.5  GB                              $31.43 
+                                                                                                                               
+ azurerm_function_app.functionApp                                                                                              
+ ├─ Execution time                                                  Monthly cost depends on usage: $0.000016 per GB-seconds    
+ └─ Executions                                                      Monthly cost depends on usage: $0.20 per 1M requests       
+                                                                                                                               
+ azurerm_function_app.functionAppNoAvailableServicePlanButHasUsage                                                             
+ ├─ Execution time                                                        876,180.4425  GB-seconds                      $14.02 
+ └─ Executions                                                                  3.5401  1M requests                      $0.71 
+                                                                                                                               
+ azurerm_function_app.functionAppWithAllUsage                                                                                  
+ ├─ Execution time                                                        876,180.4425  GB-seconds                      $14.02 
+ └─ Executions                                                                  3.5401  1M requests                      $0.71 
+                                                                                                                               
+ azurerm_function_app.functionAppWithLessThanMins                                                                              
+ ├─ Execution time                                                              37,500  GB-seconds                       $0.60 
+ └─ Executions                                                                       3  1M requests                      $0.60 
+                                                                                                                               
+ azurerm_function_app.functionAppWithMissingExecutions                                                                         
+ ├─ Execution time                                                  Monthly cost depends on usage: $0.000016 per GB-seconds    
+ └─ Executions                                                      Monthly cost depends on usage: $0.20 per 1M requests       
+                                                                                                                               
+ azurerm_function_app.functionAppWithOnlyExecutions                                                                            
+ ├─ Execution time                                                  Monthly cost depends on usage: $0.000016 per GB-seconds    
+ └─ Executions                                                                     0.1  1M requests                      $0.02 
+                                                                                                                               
+ azurerm_storage_account.example                                                                                               
+ ├─ Capacity                                                        Monthly cost depends on usage: $0.0208 per GB              
+ ├─ List and create container operations                            Monthly cost depends on usage: $0.05 per 10k operations    
+ ├─ Read operations                                                 Monthly cost depends on usage: $0.004 per 10k operations   
+ ├─ All other operations                                            Monthly cost depends on usage: $0.004 per 10k operations   
+ └─ Blob index                                                      Monthly cost depends on usage: $0.03 per 10k tags          
+                                                                                                                               
+ OVERALL TOTAL                                                                                                       $1,134.69 
 ──────────────────────────────────
 16 cloud resources were detected:
-∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
-∙ 2 weren't estimated, report them in https://github.com/infracost/infracost:
+∙ 11 were estimated, 11 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
   ∙ 1 x azurerm_function_app
-  ∙ 1 x azurerm_storage_account
 ∙ 4 were free:
   ∙ 3 x azurerm_app_service_plan
   ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_function_app.functionAppNoAvailableServicePlan. Could not find a way to get its cost components from the resource or usage file."
-level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
@@ -1,26 +1,29 @@
 
- Name                                           Monthly Qty  Unit   Monthly Cost 
-                                                                                 
- azurerm_hdinsight_hadoop_cluster.with_edge                                      
- ├─ Head node (Standard_D3)                           1,460  hours       $430.70 
- ├─ Worker node (Standard_D4)                         2,190  hours     $1,292.10 
- ├─ Zookeeper node (Standard_D3)                      2,190  hours       $646.05 
- └─ Edge node (Standard_A5)                           2,190  hours       $554.07 
-                                                                                 
- azurerm_hdinsight_hadoop_cluster.without_edge                                   
- ├─ Head node (Standard_A4m_V2)                       1,460  hours       $446.76 
- ├─ Worker node (Standard_A1_V2)                        730  hours        $43.80 
- └─ Zookeeper node (Standard_A5)                      2,190  hours       $554.07 
-                                                                                 
- OVERALL TOTAL                                                         $3,967.55 
+ Name                                                  Monthly Qty  Unit                      Monthly Cost 
+                                                                                                           
+ azurerm_hdinsight_hadoop_cluster.with_edge                                                                
+ ├─ Head node (Standard_D3)                                  1,460  hours                          $430.70 
+ ├─ Worker node (Standard_D4)                                2,190  hours                        $1,292.10 
+ ├─ Zookeeper node (Standard_D3)                             2,190  hours                          $646.05 
+ └─ Edge node (Standard_A5)                                  2,190  hours                          $554.07 
+                                                                                                           
+ azurerm_hdinsight_hadoop_cluster.without_edge                                                             
+ ├─ Head node (Standard_A4m_V2)                              1,460  hours                          $446.76 
+ ├─ Worker node (Standard_A1_V2)                               730  hours                           $43.80 
+ └─ Zookeeper node (Standard_A5)                             2,190  hours                          $554.07 
+                                                                                                           
+ azurerm_storage_account.example                                                                           
+ ├─ Capacity                                    Monthly cost depends on usage: $0.0196 per GB              
+ ├─ List and create container operations        Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                             Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ All other operations                        Monthly cost depends on usage: $0.0043 per 10k operations  
+ └─ Blob index                                  Monthly cost depends on usage: $0.039 per 10k tags         
+                                                                                                           
+ OVERALL TOTAL                                                                                   $3,967.55 
 ──────────────────────────────────
 5 cloud resources were detected:
-∙ 2 were estimated
-∙ 2 weren't estimated, report them in https://github.com/infracost/infracost:
-  ∙ 1 x azurerm_storage_account
+∙ 3 were estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
   ∙ 1 x azurerm_storage_container
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
-Logs:
-
-level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
@@ -1,20 +1,23 @@
 
- Name                                     Monthly Qty  Unit   Monthly Cost 
-                                                                           
- azurerm_hdinsight_hbase_cluster.example                                   
- ├─ Head node (Standard_D1)                     1,460  hours       $107.31 
- ├─ Region node (Standard_D14)                  2,190  hours     $3,274.49 
- └─ Zookeeper node (Standard_D4a V4)            2,190  hours       $525.60 
-                                                                           
- OVERALL TOTAL                                                   $3,907.40 
+ Name                                            Monthly Qty  Unit                      Monthly Cost 
+                                                                                                     
+ azurerm_hdinsight_hbase_cluster.example                                                             
+ ├─ Head node (Standard_D1)                            1,460  hours                          $107.31 
+ ├─ Region node (Standard_D14)                         2,190  hours                        $3,274.49 
+ └─ Zookeeper node (Standard_D4a V4)                   2,190  hours                          $525.60 
+                                                                                                     
+ azurerm_storage_account.example                                                                     
+ ├─ Capacity                              Monthly cost depends on usage: $0.0196 per GB              
+ ├─ List and create container operations  Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                       Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ All other operations                  Monthly cost depends on usage: $0.0043 per 10k operations  
+ └─ Blob index                            Monthly cost depends on usage: $0.039 per 10k tags         
+                                                                                                     
+ OVERALL TOTAL                                                                             $3,907.40 
 ──────────────────────────────────
 4 cloud resources were detected:
-∙ 1 was estimated
-∙ 2 weren't estimated, report them in https://github.com/infracost/infracost:
-  ∙ 1 x azurerm_storage_account
+∙ 2 were estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
   ∙ 1 x azurerm_storage_container
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
-Logs:
-
-level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
@@ -1,20 +1,23 @@
 
- Name                                                 Monthly Qty  Unit   Monthly Cost 
-                                                                                       
- azurerm_hdinsight_interactive_query_cluster.example                                   
- ├─ Head node (Standard_E2_V3)                              1,460  hours       $277.40 
- ├─ Worker node (Standard_E16_V3)                           2,190  hours     $3,328.80 
- └─ Zookeeper node (Standard_E64i_V3)                       2,190  hours    $12,246.48 
-                                                                                       
- OVERALL TOTAL                                                              $15,852.68 
+ Name                                                        Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                 
+ azurerm_hdinsight_interactive_query_cluster.example                                                             
+ ├─ Head node (Standard_E2_V3)                                     1,460  hours                          $277.40 
+ ├─ Worker node (Standard_E16_V3)                                  2,190  hours                        $3,328.80 
+ └─ Zookeeper node (Standard_E64i_V3)                              2,190  hours                       $12,246.48 
+                                                                                                                 
+ azurerm_storage_account.example                                                                                 
+ ├─ Capacity                                          Monthly cost depends on usage: $0.0196 per GB              
+ ├─ List and create container operations              Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                                   Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ All other operations                              Monthly cost depends on usage: $0.0043 per 10k operations  
+ └─ Blob index                                        Monthly cost depends on usage: $0.039 per 10k tags         
+                                                                                                                 
+ OVERALL TOTAL                                                                                        $15,852.68 
 ──────────────────────────────────
 4 cloud resources were detected:
-∙ 1 was estimated
-∙ 2 weren't estimated, report them in https://github.com/infracost/infracost:
-  ∙ 1 x azurerm_storage_account
+∙ 2 were estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
   ∙ 1 x azurerm_storage_container
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
-Logs:
-
-level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
@@ -22,15 +22,18 @@
  ├─ Managed OS disks                                          4  months                           $163.84 
  └─ Disk operations                                          40  100K operations                    $0.01 
                                                                                                           
+ azurerm_storage_account.example                                                                          
+ ├─ Capacity                                Monthly cost depends on usage: $0.0196 per GB                 
+ ├─ List and create container operations    Monthly cost depends on usage: $0.054 per 10k operations      
+ ├─ Read operations                         Monthly cost depends on usage: $0.0043 per 10k operations     
+ ├─ All other operations                    Monthly cost depends on usage: $0.0043 per 10k operations     
+ └─ Blob index                              Monthly cost depends on usage: $0.039 per 10k tags            
+                                                                                                          
  OVERALL TOTAL                                                                                 $27,535.31 
 ──────────────────────────────────
 6 cloud resources were detected:
-∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
-∙ 2 weren't estimated, report them in https://github.com/infracost/infracost:
-  ∙ 1 x azurerm_storage_account
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
   ∙ 1 x azurerm_storage_container
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
-Logs:
-
-level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
@@ -1,20 +1,23 @@
 
- Name                                     Monthly Qty  Unit   Monthly Cost 
-                                                                           
- azurerm_hdinsight_spark_cluster.example                                   
- ├─ Head node (Standard_G2)                     1,460  hours     $2,154.96 
- ├─ Worker node (Standard_G2)                   2,190  hours     $3,232.44 
- └─ Zookeeper node (Standard_G2)                2,190  hours     $3,232.44 
-                                                                           
- OVERALL TOTAL                                                   $8,619.84 
+ Name                                            Monthly Qty  Unit                      Monthly Cost 
+                                                                                                     
+ azurerm_hdinsight_spark_cluster.example                                                             
+ ├─ Head node (Standard_G2)                            1,460  hours                        $2,154.96 
+ ├─ Worker node (Standard_G2)                          2,190  hours                        $3,232.44 
+ └─ Zookeeper node (Standard_G2)                       2,190  hours                        $3,232.44 
+                                                                                                     
+ azurerm_storage_account.example                                                                     
+ ├─ Capacity                              Monthly cost depends on usage: $0.0196 per GB              
+ ├─ List and create container operations  Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                       Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ All other operations                  Monthly cost depends on usage: $0.0043 per 10k operations  
+ └─ Blob index                            Monthly cost depends on usage: $0.039 per 10k tags         
+                                                                                                     
+ OVERALL TOTAL                                                                             $8,619.84 
 ──────────────────────────────────
 4 cloud resources were detected:
-∙ 1 was estimated
-∙ 2 weren't estimated, report them in https://github.com/infracost/infracost:
-  ∙ 1 x azurerm_storage_account
+∙ 2 were estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
   ∙ 1 x azurerm_storage_container
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
-Logs:
-
-level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/private_endpoint_test/private_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_endpoint_test/private_endpoint_test.golden
@@ -29,10 +29,10 @@
  ├─ Data at rest                               Monthly cost depends on usage: $0.0228 per GB              
  ├─ Snapshots                                  Monthly cost depends on usage: $0.0228 per GB              
  ├─ Metadata at rest                           Monthly cost depends on usage: $0.0297 per GB              
- ├─ Write operations                           Monthly cost depends on usage: $0.13 per 10K operations    
- ├─ List operations                            Monthly cost depends on usage: $0.0715 per 10K operations  
- ├─ Read operations                            Monthly cost depends on usage: $0.013 per 10K operations   
- ├─ All other operations                       Monthly cost depends on usage: $0.00572 per 10K operations 
+ ├─ Write operations                           Monthly cost depends on usage: $0.13 per 10k operations    
+ ├─ List operations                            Monthly cost depends on usage: $0.0715 per 10k operations  
+ ├─ Read operations                            Monthly cost depends on usage: $0.013 per 10k operations   
+ ├─ All other operations                       Monthly cost depends on usage: $0.00572 per 10k operations 
  ├─ Data retrieval                             Monthly cost depends on usage: $0.01 per GB                
  └─ Early deletion                             Monthly cost depends on usage: $0.0228 per GB              
                                                                                                           

--- a/internal/providers/terraform/azure/testdata/private_endpoint_test/private_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_endpoint_test/private_endpoint_test.golden
@@ -29,10 +29,10 @@
  ├─ Data at rest                               Monthly cost depends on usage: $0.0228 per GB              
  ├─ Snapshots                                  Monthly cost depends on usage: $0.0228 per GB              
  ├─ Metadata at rest                           Monthly cost depends on usage: $0.0297 per GB              
- ├─ Write operations                           Monthly cost depends on usage: $0.13 per 10k operations    
- ├─ List operations                            Monthly cost depends on usage: $0.0715 per 10k operations  
- ├─ Read operations                            Monthly cost depends on usage: $0.013 per 10k operations   
- ├─ All other operations                       Monthly cost depends on usage: $0.00572 per 10k operations 
+ ├─ Write operations                           Monthly cost depends on usage: $0.13 per 10K operations    
+ ├─ List operations                            Monthly cost depends on usage: $0.0715 per 10K operations  
+ ├─ Read operations                            Monthly cost depends on usage: $0.013 per 10K operations   
+ ├─ All other operations                       Monthly cost depends on usage: $0.00572 per 10K operations 
  ├─ Data retrieval                             Monthly cost depends on usage: $0.01 per GB                
  └─ Early deletion                             Monthly cost depends on usage: $0.0228 per GB              
                                                                                                           

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -144,12 +144,91 @@
  ├─ Data retrieval                                Monthly cost depends on usage: $0.01 per GB                
  └─ Early deletion                                Monthly cost depends on usage: $0.0228 per GB              
                                                                                                              
- OVERALL TOTAL                                                                                 $1,781,812.71 
+ azurerm_storage_account.v2_cool_gzrs                                                                        
+ ├─ Read operations                                               10  10k operations                   $0.10 
+ ├─ All other operations                                         100  10k operations                   $0.44 
+ └─ Data retrieval                                             1,000  GB                              $10.00 
+                                                                                                             
+ azurerm_storage_account.v2_cool_lrs                                                                         
+ ├─ Capacity                                               1,000,000  GB                          $15,200.00 
+ ├─ Write operations                                             100  10k operations                  $10.00 
+ ├─ List and create container operations                         100  10k operations                   $5.50 
+ ├─ Read operations                                               10  10k operations                   $0.10 
+ ├─ All other operations                                         100  10k operations                   $0.44 
+ ├─ Data retrieval                                             1,000  GB                              $10.00 
+ ├─ Blob index                                                    10  10k tags                         $0.39 
+ └─ Early deletion                                             1,000  GB                              $15.20 
+                                                                                                             
+ azurerm_storage_account.v2_cool_lrs_nfsv3                                                                   
+ ├─ Capacity                                               1,000,000  GB                          $15,000.00 
+ ├─ Iterative write operations                                 1,700  100 operations                 $221.00 
+ ├─ Write operations                                             100  10k operations                  $13.00 
+ ├─ Iterative read operations                                     15  10k operations                   $1.08 
+ ├─ Read operations                                               10  10k operations                   $0.13 
+ ├─ All other operations                                         100  10k operations                   $0.60 
+ ├─ Data retrieval                                             1,000  GB                              $10.00 
+ └─ Early deletion                                             1,000  GB                              $15.00 
+                                                                                                             
+ azurerm_storage_account.v2_cool_ragzrs                                                                      
+ ├─ Read operations                                               10  10k operations                   $0.10 
+ ├─ All other operations                                         100  10k operations                   $0.44 
+ └─ Data retrieval                                             1,000  GB                              $10.00 
+                                                                                                             
+ azurerm_storage_account.v2_hot_gzrs                                                                         
+ ├─ Read operations                                               10  10k operations                   $0.04 
+ └─ All other operations                                         100  10k operations                   $0.44 
+                                                                                                             
+ azurerm_storage_account.v2_hot_lrs                                                                          
+ ├─ Capacity (first 50TB)                                     51,200  GB                           $1,064.96 
+ ├─ Capacity (next 450TB)                                    512,000  GB                          $10,223.62 
+ ├─ Capacity (over 500TB)                                    436,800  GB                           $8,358.60 
+ ├─ Write operations                                             100  10k operations                   $5.50 
+ ├─ Read operations                                               10  10k operations                   $0.04 
+ ├─ All other operations                                         100  10k operations                   $0.44 
+ └─ Blob index                                                    10  10k tags                         $0.39 
+                                                                                                             
+ azurerm_storage_account.v2_hot_lrs_nfsv3                                                                    
+ ├─ Capacity (first 50TB)                                     51,200  GB                           $1,075.20 
+ ├─ Capacity (next 450TB)                                    512,000  GB                          $10,240.00 
+ ├─ Capacity (over 500TB)                                    436,800  GB                           $8,342.88 
+ ├─ Iterative write operations                                 1,700  100 operations                 $122.40 
+ ├─ Write operations                                             100  10k operations                   $7.20 
+ ├─ Iterative read operations                                     15  10k operations                   $1.08 
+ ├─ Read operations                                               10  10k operations                   $0.06 
+ └─ All other operations                                         100  10k operations                   $0.60 
+                                                                                                             
+ azurerm_storage_account.v2_hot_ragzrs                                                                       
+ ├─ Read operations                                               10  10k operations                   $0.04 
+ └─ All other operations                                         100  10k operations                   $0.44 
+                                                                                                             
+ azurerm_storage_account.v2_premium_lrs                                                                      
+ ├─ Capacity                                               1,000,000  GB                         $195,000.00 
+ ├─ Write operations                                             100  10k operations                   $2.28 
+ ├─ List and create container operations                         100  10k operations                   $6.50 
+ ├─ Read operations                                               10  10k operations                   $0.02 
+ └─ All other operations                                         100  10k operations                   $0.18 
+                                                                                                             
+ azurerm_storage_account.v2_premium_lrs_nfsv3                                                                
+ ├─ Capacity                                               1,000,000  GB                         $195,000.00 
+ ├─ Write operations                                             100  10k operations                   $2.96 
+ ├─ List and create container operations                         100  10k operations                   $8.45 
+ ├─ Read operations                                               10  10k operations                   $0.02 
+ └─ All other operations                                         100  10k operations                   $0.24 
+                                                                                                             
+ azurerm_storage_account.v2_without_usage                                                                    
+ ├─ Capacity                                      Monthly cost depends on usage: $0.021 per GB               
+ ├─ Iterative write operations                    Monthly cost depends on usage: $0.072 per 100 operations   
+ ├─ Write operations                              Monthly cost depends on usage: $0.072 per 10k operations   
+ ├─ Iterative read operations                     Monthly cost depends on usage: $0.072 per 10k operations   
+ ├─ Read operations                               Monthly cost depends on usage: $0.006 per 10k operations   
+ └─ All other operations                          Monthly cost depends on usage: $0.006 per 10k operations   
+                                                                                                             
+ OVERALL TOTAL                                                                                 $2,241,800.82 
 ──────────────────────────────────
-22 cloud resources were detected:
-∙ 16 were estimated, 16 include usage-based costs, see https://infracost.io/usage-file
-∙ 5 weren't estimated, report them in https://github.com/infracost/infracost:
-  ∙ 5 x azurerm_storage_account
+34 cloud resources were detected:
+∙ 27 were estimated, 27 include usage-based costs, see https://infracost.io/usage-file
+∙ 6 weren't estimated, report them in https://github.com/infracost/infracost:
+  ∙ 6 x azurerm_storage_account
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
 Logs:
@@ -158,4 +237,5 @@ level=warning msg="Skipping resource azurerm_storage_account.bb_Premium_unsuppor
 level=warning msg="Skipping resource azurerm_storage_account.bb_Standard_unsupported_access_tier. BlockBlobStorage Standard doesn't support RA-GZRS redundancy"
 level=warning msg="Skipping resource azurerm_storage_account.file_premium_unsupported_access_tier. FileStorage Premium doesn't support GZRS redundancy"
 level=warning msg="Skipping resource azurerm_storage_account.file_unsupported_access_tier. FileStorage Standard doesn't support GZRS redundancy"
-level=warning msg="Skipping resource azurerm_storage_account.unsupported. Infracost only supports BlockBlobStorage and FileStorage account kinds"
+level=warning msg="Skipping resource azurerm_storage_account.unsupported. Infracost only supports StorageV2, BlockBlobStorage and FileStorage account kinds"
+level=warning msg="Skipping resource azurerm_storage_account.v2_premium_unsupported_access_tier. StorageV2 Premium doesn't support GZRS redundancy"

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -138,7 +138,13 @@
                                                                                                              
  OVERALL TOTAL                                                                                 $1,778,552.71 
 ──────────────────────────────────
-15 cloud resources were detected:
-∙ 14 were estimated, 14 include usage-based costs, see https://infracost.io/usage-file
+18 cloud resources were detected:
+∙ 16 were estimated, 16 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
+  ∙ 1 x azurerm_storage_account
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
+Logs:
+
+level=warning msg="GZRS redundancy does not supports for Cool performance tier"
+level=warning msg="Skipping resource azurerm_storage_account.unsupported. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -125,6 +125,14 @@
  ├─ Read operations                                               10  10k operations                   $0.06 
  └─ All other operations                                         100  10k operations                   $0.57 
                                                                                                              
+ azurerm_storage_account.file_premium_lrs                                                                    
+ ├─ Data at rest                                              10,000  GB                           $1,760.00 
+ └─ Snapshots                                                 10,000  GB                           $1,500.00 
+                                                                                                             
+ azurerm_storage_account.file_premium_zrs                                                                    
+ ├─ Data at rest                                  Monthly cost depends on usage: $0.22 per GB                
+ └─ Snapshots                                     Monthly cost depends on usage: $0.19 per GB                
+                                                                                                             
  azurerm_storage_account.file_without_usage_file                                                             
  ├─ Data at rest                                  Monthly cost depends on usage: $0.0228 per GB              
  ├─ Snapshots                                     Monthly cost depends on usage: $0.0228 per GB              
@@ -136,17 +144,18 @@
  ├─ Data retrieval                                Monthly cost depends on usage: $0.01 per GB                
  └─ Early deletion                                Monthly cost depends on usage: $0.0228 per GB              
                                                                                                              
- OVERALL TOTAL                                                                                 $1,778,552.71 
+ OVERALL TOTAL                                                                                 $1,781,812.71 
 ──────────────────────────────────
-19 cloud resources were detected:
-∙ 14 were estimated, 14 include usage-based costs, see https://infracost.io/usage-file
-∙ 4 weren't estimated, report them in https://github.com/infracost/infracost:
-  ∙ 4 x azurerm_storage_account
+22 cloud resources were detected:
+∙ 16 were estimated, 16 include usage-based costs, see https://infracost.io/usage-file
+∙ 5 weren't estimated, report them in https://github.com/infracost/infracost:
+  ∙ 5 x azurerm_storage_account
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
 Logs:
 
 level=warning msg="Skipping resource azurerm_storage_account.bb_Premium_unsupported_access_tier. BlockBlobStorage Premium doesn't support RA-GZRS redundancy"
 level=warning msg="Skipping resource azurerm_storage_account.bb_Standard_unsupported_access_tier. BlockBlobStorage Standard doesn't support RA-GZRS redundancy"
+level=warning msg="Skipping resource azurerm_storage_account.file_premium_unsupported_access_tier. FileStorage Premium doesn't support GZRS redundancy"
 level=warning msg="Skipping resource azurerm_storage_account.file_unsupported_access_tier. FileStorage Standard doesn't support GZRS redundancy"
 level=warning msg="Skipping resource azurerm_storage_account.unsupported. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -3,87 +3,87 @@
                                                                                                              
  azurerm_storage_account.bb_Premium_LRS                                                                      
  ├─ Capacity                                               1,000,000  GB                         $195,000.00 
- ├─ Write operations                                             100  10K operations                   $2.28 
- ├─ List and create container operations                         100  10K operations                   $6.50 
- ├─ Read operations                                               10  10K operations                   $0.02 
- └─ All other operations                                         100  10K operations                   $0.18 
+ ├─ Write operations                                             100  10k operations                   $2.28 
+ ├─ List and create container operations                         100  10k operations                   $6.50 
+ ├─ Read operations                                               10  10k operations                   $0.02 
+ └─ All other operations                                         100  10k operations                   $0.18 
                                                                                                              
  azurerm_storage_account.bb_Premium_ZRS                                                                      
  ├─ Capacity                                               2,000,000  GB                         $518,000.00 
- ├─ Write operations                                             200  10K operations                   $6.06 
- ├─ List and create container operations                         200  10K operations                  $17.20 
- ├─ Read operations                                               20  10K operations                   $0.05 
- └─ All other operations                                         200  10K operations                   $0.48 
+ ├─ Write operations                                             200  10k operations                   $6.06 
+ ├─ List and create container operations                         200  10k operations                  $17.20 
+ ├─ Read operations                                               20  10k operations                   $0.05 
+ └─ All other operations                                         200  10k operations                   $0.48 
                                                                                                              
  azurerm_storage_account.bb_Standard_GRS_Cool                                                                
  ├─ Capacity                                               3,000,000  GB                         $100,200.00 
- ├─ Write operations                                             300  10K operations                  $60.00 
- ├─ List and create container operations                         300  10K operations                  $33.00 
- ├─ Read operations                                               30  10K operations                   $0.30 
- ├─ All other operations                                         300  10K operations                   $1.32 
+ ├─ Write operations                                             300  10k operations                  $60.00 
+ ├─ List and create container operations                         300  10k operations                  $33.00 
+ ├─ Read operations                                               30  10k operations                   $0.30 
+ ├─ All other operations                                         300  10k operations                   $1.32 
  ├─ Data retrieval                                             3,000  GB                              $30.00 
  ├─ Data write                                                 3,000  GB                              $15.00 
- └─ Blob index                                                    30  10K tags                         $2.07 
+ └─ Blob index                                                    30  10k tags                         $2.07 
                                                                                                              
  azurerm_storage_account.bb_Standard_GRS_Hot                                                                 
  ├─ Capacity (first 50TB)                                     51,200  GB                           $2,344.96 
  ├─ Capacity (next 450TB)                                    512,000  GB                          $22,511.62 
  ├─ Capacity (over 500TB)                                  3,436,800  GB                         $144,813.00 
- ├─ Write operations                                             400  10K operations                  $44.00 
- ├─ List and create container operations                         400  10K operations                  $44.00 
- ├─ Read operations                                               40  10K operations                   $0.18 
- ├─ All other operations                                         400  10K operations                   $1.76 
- └─ Blob index                                                    40  10K tags                         $2.76 
+ ├─ Write operations                                             400  10k operations                  $44.00 
+ ├─ List and create container operations                         400  10k operations                  $44.00 
+ ├─ Read operations                                               40  10k operations                   $0.18 
+ ├─ All other operations                                         400  10k operations                   $1.76 
+ └─ Blob index                                                    40  10k tags                         $2.76 
                                                                                                              
  azurerm_storage_account.bb_Standard_LRS_Cool                                                                
  ├─ Capacity                                               5,000,000  GB                          $76,000.00 
- ├─ Write operations                                             500  10K operations                  $50.00 
- ├─ List and create container operations                          50  10K operations                   $2.75 
- ├─ Read operations                                               50  10K operations                   $0.50 
- ├─ All other operations                                         500  10K operations                   $2.20 
+ ├─ Write operations                                             500  10k operations                  $50.00 
+ ├─ List and create container operations                          50  10k operations                   $2.75 
+ ├─ Read operations                                               50  10k operations                   $0.50 
+ ├─ All other operations                                         500  10k operations                   $2.20 
  ├─ Data retrieval                                             5,000  GB                              $50.00 
  ├─ Data write                                                 5,000  GB                              $12.50 
- └─ Blob index                                                    50  10K tags                         $1.95 
+ └─ Blob index                                                    50  10k tags                         $1.95 
                                                                                                              
  azurerm_storage_account.bb_Standard_LRS_Hot                                                                 
  ├─ Capacity (first 50TB)                                     51,200  GB                           $1,064.96 
  ├─ Capacity (next 450TB)                                    512,000  GB                          $10,223.62 
  ├─ Capacity (over 500TB)                                  5,436,800  GB                         $104,038.60 
- ├─ Write operations                                             600  10K operations                  $33.00 
- ├─ List and create container operations                         600  10K operations                  $33.00 
- ├─ Read operations                                               60  10K operations                   $0.26 
- ├─ All other operations                                         600  10K operations                   $2.64 
- └─ Blob index                                                    60  10K tags                         $2.34 
+ ├─ Write operations                                             600  10k operations                  $33.00 
+ ├─ List and create container operations                         600  10k operations                  $33.00 
+ ├─ Read operations                                               60  10k operations                   $0.26 
+ ├─ All other operations                                         600  10k operations                   $2.64 
+ └─ Blob index                                                    60  10k tags                         $2.34 
                                                                                                              
  azurerm_storage_account.bb_Standard_RAGRS_Cool                                                              
  ├─ Capacity                                               7,000,000  GB                         $245,000.00 
- ├─ Write operations                                             700  10K operations                 $140.00 
- ├─ List and create container operations                         700  10K operations                  $77.00 
- ├─ Read operations                                               70  10K operations                   $0.70 
- ├─ All other operations                                         700  10K operations                   $3.08 
+ ├─ Write operations                                             700  10k operations                 $140.00 
+ ├─ List and create container operations                         700  10k operations                  $77.00 
+ ├─ Read operations                                               70  10k operations                   $0.70 
+ ├─ All other operations                                         700  10k operations                   $3.08 
  ├─ Data retrieval                                             7,000  GB                              $70.00 
  ├─ Data write                                                 7,000  GB                              $35.00 
- └─ Blob index                                                    70  10K tags                         $4.83 
+ └─ Blob index                                                    70  10k tags                         $4.83 
                                                                                                              
  azurerm_storage_account.bb_Standard_RAGRS_Hot                                                               
  ├─ Capacity (first 50TB)                                     51,200  GB                           $2,447.36 
  ├─ Capacity (next 450TB)                                    512,000  GB                          $23,494.66 
  ├─ Capacity (over 500TB)                                  7,436,800  GB                         $327,040.72 
- ├─ Write operations                                             800  10K operations                  $88.00 
- ├─ List and create container operations                         800  10K operations                  $88.00 
- ├─ Read operations                                               80  10K operations                   $0.35 
- ├─ All other operations                                         800  10K operations                   $3.52 
- └─ Blob index                                                    80  10K tags                         $5.52 
+ ├─ Write operations                                             800  10k operations                  $88.00 
+ ├─ List and create container operations                         800  10k operations                  $88.00 
+ ├─ Read operations                                               80  10k operations                   $0.35 
+ ├─ All other operations                                         800  10k operations                   $3.52 
+ └─ Blob index                                                    80  10k tags                         $5.52 
                                                                                                              
  azurerm_storage_account.bb_without_usage_file                                                               
  ├─ Capacity                                      Monthly cost depends on usage: $0.035 per GB               
- ├─ Write operations                              Monthly cost depends on usage: $0.20 per 10K operations    
- ├─ List and create container operations          Monthly cost depends on usage: $0.11 per 10K operations    
- ├─ Read operations                               Monthly cost depends on usage: $0.01 per 10K operations    
- ├─ All other operations                          Monthly cost depends on usage: $0.0044 per 10K operations  
+ ├─ Write operations                              Monthly cost depends on usage: $0.20 per 10k operations    
+ ├─ List and create container operations          Monthly cost depends on usage: $0.11 per 10k operations    
+ ├─ Read operations                               Monthly cost depends on usage: $0.01 per 10k operations    
+ ├─ All other operations                          Monthly cost depends on usage: $0.0044 per 10k operations  
  ├─ Data retrieval                                Monthly cost depends on usage: $0.01 per GB                
  ├─ Data write                                    Monthly cost depends on usage: $0.005 per GB               
- └─ Blob index                                    Monthly cost depends on usage: $0.069 per 10K tags         
+ └─ Blob index                                    Monthly cost depends on usage: $0.069 per 10k tags         
                                                                                                              
  azurerm_storage_account.file_cool_grs                                                                       
  ├─ Data at rest                                              10,000  GB                             $501.00 
@@ -138,13 +138,15 @@
                                                                                                              
  OVERALL TOTAL                                                                                 $1,778,552.71 
 ──────────────────────────────────
-18 cloud resources were detected:
-∙ 16 were estimated, 16 include usage-based costs, see https://infracost.io/usage-file
-∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
-  ∙ 1 x azurerm_storage_account
+19 cloud resources were detected:
+∙ 14 were estimated, 14 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 weren't estimated, report them in https://github.com/infracost/infracost:
+  ∙ 4 x azurerm_storage_account
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
 Logs:
 
-level=warning msg="GZRS redundancy does not supports for Cool performance tier"
+level=warning msg="Skipping resource azurerm_storage_account.bb_Premium_unsupported_access_tier. BlockBlobStorage Premium doesn't support RA-GZRS redundancy"
+level=warning msg="Skipping resource azurerm_storage_account.bb_Standard_unsupported_access_tier. BlockBlobStorage Standard doesn't support RA-GZRS redundancy"
+level=warning msg="Skipping resource azurerm_storage_account.file_unsupported_access_tier. FileStorage Standard doesn't support GZRS redundancy"
 level=warning msg="Skipping resource azurerm_storage_account.unsupported. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
@@ -44,6 +44,15 @@ resource "azurerm_storage_account" "bb_Premium_LRS" {
   account_replication_type = "LRS"
 }
 
+resource "azurerm_storage_account" "bb_Standard_unsupported_access_tier" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "BlockBlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "RAGZRS"
+}
+
 resource "azurerm_storage_account" "bb_Standard_LRS_Hot" {
   name                     = "storageaccountname"
   resource_group_name      = azurerm_resource_group.example.name
@@ -110,6 +119,7 @@ resource "azurerm_storage_account" "bb_without_usage_file" {
   account_replication_type = "RAGRS"
   access_tier              = "Cool"
 }
+
 resource "azurerm_storage_account" "file_without_usage_file" {
   name                     = "storageaccountname"
   resource_group_name      = azurerm_resource_group.example.name
@@ -119,6 +129,7 @@ resource "azurerm_storage_account" "file_without_usage_file" {
   account_replication_type = "LRS"
   access_tier              = "Cool"
 }
+
 resource "azurerm_storage_account" "file_unsupported_access_tier" {
   name                     = "storageaccountname"
   resource_group_name      = azurerm_resource_group.example.name
@@ -128,6 +139,7 @@ resource "azurerm_storage_account" "file_unsupported_access_tier" {
   account_replication_type = "GZRS"
   access_tier              = "Cool"
 }
+
 resource "azurerm_storage_account" "file_cool_lrs" {
   name                     = "storageaccountname"
   resource_group_name      = azurerm_resource_group.example.name
@@ -137,6 +149,7 @@ resource "azurerm_storage_account" "file_cool_lrs" {
   account_replication_type = "LRS"
   access_tier              = "Cool"
 }
+
 resource "azurerm_storage_account" "file_hot_lrs" {
   name                     = "storageaccountname"
   resource_group_name      = azurerm_resource_group.example.name
@@ -146,6 +159,7 @@ resource "azurerm_storage_account" "file_hot_lrs" {
   account_replication_type = "LRS"
   access_tier              = "Hot"
 }
+
 resource "azurerm_storage_account" "file_cool_grs" {
   name                     = "storageaccountname"
   resource_group_name      = azurerm_resource_group.example.name
@@ -155,6 +169,7 @@ resource "azurerm_storage_account" "file_cool_grs" {
   account_replication_type = "GRS"
   access_tier              = "Cool"
 }
+
 resource "azurerm_storage_account" "file_hot_grs" {
   name                     = "storageaccountname"
   resource_group_name      = azurerm_resource_group.example.name

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
@@ -179,3 +179,30 @@ resource "azurerm_storage_account" "file_hot_grs" {
   account_replication_type = "GRS"
   access_tier              = "Hot"
 }
+
+resource "azurerm_storage_account" "file_premium_unsupported_access_tier" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "FileStorage"
+  account_tier             = "Premium"
+  account_replication_type = "GZRS"
+}
+
+resource "azurerm_storage_account" "file_premium_lrs" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "FileStorage"
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_account" "file_premium_zrs" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "FileStorage"
+  account_tier             = "Premium"
+  account_replication_type = "ZRS"
+}

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
@@ -206,3 +206,124 @@ resource "azurerm_storage_account" "file_premium_zrs" {
   account_tier             = "Premium"
   account_replication_type = "ZRS"
 }
+
+resource "azurerm_storage_account" "v2_without_usage" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  access_tier              = "Hot"
+  nfsv3_enabled            = true
+}
+
+resource "azurerm_storage_account" "v2_cool_lrs" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  access_tier              = "Cool"
+}
+
+resource "azurerm_storage_account" "v2_cool_lrs_nfsv3" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  access_tier              = "Cool"
+  nfsv3_enabled            = true
+}
+
+resource "azurerm_storage_account" "v2_hot_lrs" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  access_tier              = "Hot"
+}
+
+resource "azurerm_storage_account" "v2_hot_lrs_nfsv3" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  access_tier              = "Hot"
+  nfsv3_enabled            = true
+}
+
+resource "azurerm_storage_account" "v2_cool_gzrs" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "GZRS"
+  access_tier              = "Cool"
+}
+
+resource "azurerm_storage_account" "v2_hot_gzrs" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "GZRS"
+  access_tier              = "Hot"
+}
+
+resource "azurerm_storage_account" "v2_cool_ragzrs" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "RAGZRS"
+  access_tier              = "Cool"
+}
+
+resource "azurerm_storage_account" "v2_hot_ragzrs" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "RAGZRS"
+  access_tier              = "Hot"
+}
+
+resource "azurerm_storage_account" "v2_premium_unsupported_access_tier" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Premium"
+  account_replication_type = "GZRS"
+}
+
+resource "azurerm_storage_account" "v2_premium_lrs" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_account" "v2_premium_lrs_nfsv3" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+  nfsv3_enabled            = true
+}

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
@@ -8,6 +8,24 @@ resource "azurerm_resource_group" "example" {
   location = "westus"
 }
 
+resource "azurerm_storage_account" "unsupported" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "BlobStorage"
+  account_tier             = "Premium"
+  account_replication_type = "ZRS"
+}
+
+resource "azurerm_storage_account" "bb_Premium_unsupported_access_tier" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "BlockBlobStorage"
+  account_tier             = "Premium"
+  account_replication_type = "RAGZRS"
+}
+
 resource "azurerm_storage_account" "bb_Premium_ZRS" {
   name                     = "storageaccountname"
   resource_group_name      = azurerm_resource_group.example.name
@@ -99,6 +117,15 @@ resource "azurerm_storage_account" "file_without_usage_file" {
   account_kind             = "FileStorage"
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  access_tier              = "Cool"
+}
+resource "azurerm_storage_account" "file_unsupported_access_tier" {
+  name                     = "storageaccountname"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "FileStorage"
+  account_tier             = "Standard"
+  account_replication_type = "GZRS"
   access_tier              = "Cool"
 }
 resource "azurerm_storage_account" "file_cool_lrs" {

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.usage.yml
@@ -79,12 +79,12 @@ resource_usage:
     monthly_data_retrieval_gb: 8000
     monthly_data_write_gb: 8000
     blob_index_tags: 800000
-  
+
   azurerm_storage_account.file_cool_lrs:
     data_at_rest_storage_gb: 10000
     early_deletion_gb: 1000
     snapshots_storage_gb: 10000
-    metadata_at_rest_storage_gb: 10000  
+    metadata_at_rest_storage_gb: 10000
     monthly_data_retrieval_gb: 1000
     monthly_write_operations: 1000000
     monthly_list_and_create_container_operations: 1000000
@@ -95,7 +95,7 @@ resource_usage:
     data_at_rest_storage_gb: 10000
     early_deletion_gb: 1000
     snapshots_storage_gb: 10000
-    metadata_at_rest_storage_gb: 10000  
+    metadata_at_rest_storage_gb: 10000
     monthly_data_retrieval_gb: 1000
     monthly_write_operations: 1000000
     monthly_list_and_create_container_operations: 1000000
@@ -106,7 +106,7 @@ resource_usage:
     data_at_rest_storage_gb: 10000
     early_deletion_gb: 1000
     snapshots_storage_gb: 10000
-    metadata_at_rest_storage_gb: 10000  
+    metadata_at_rest_storage_gb: 10000
     monthly_data_retrieval_gb: 1000
     monthly_write_operations: 1000000
     monthly_list_and_create_container_operations: 1000000
@@ -117,7 +117,7 @@ resource_usage:
     data_at_rest_storage_gb: 10000
     early_deletion_gb: 1000
     snapshots_storage_gb: 10000
-    metadata_at_rest_storage_gb: 10000  
+    metadata_at_rest_storage_gb: 10000
     monthly_data_retrieval_gb: 1000
     monthly_write_operations: 1000000
     monthly_list_and_create_container_operations: 1000000

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.usage.yml
@@ -123,3 +123,14 @@ resource_usage:
     monthly_list_and_create_container_operations: 1000000
     monthly_read_operations: 100000
     monthly_other_operations: 1000000
+
+  azurerm_storage_account.file_premium_lrs:
+    data_at_rest_storage_gb: 10000
+    early_deletion_gb: 1000
+    snapshots_storage_gb: 10000
+    metadata_at_rest_storage_gb: 10000
+    monthly_data_retrieval_gb: 1000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.usage.yml
@@ -134,3 +134,146 @@ resource_usage:
     monthly_list_and_create_container_operations: 1000000
     monthly_read_operations: 100000
     monthly_other_operations: 1000000
+
+  azurerm_storage_account.v2_cool_lrs:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_cool_lrs_nfsv3:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_hot_lrs:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_hot_lrs_nfsv3:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_cool_gzrs:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_hot_gzrs:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_cool_ragzrs:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_hot_ragzrs:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_premium_unsupported_access_tier:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_premium_lrs:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000
+
+  azurerm_storage_account.v2_premium_lrs_nfsv3:
+    storage_gb: 1000000
+    monthly_iterative_write_operations: 170000
+    monthly_write_operations: 1000000
+    monthly_list_and_create_container_operations: 1000000
+    monthly_iterative_read_operations: 150000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    monthly_data_write_gb: 1000
+    blob_index_tags: 100000
+    early_deletion_gb: 1000

--- a/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
@@ -1,6 +1,13 @@
 
  Name                                                               Monthly Qty  Unit                      Monthly Cost 
                                                                                                                         
+ azurerm_storage_account.example                                                                                        
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.0196 per GB              
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                                          Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ All other operations                                     Monthly cost depends on usage: $0.0043 per 10k operations  
+ └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+                                                                                                                        
  azurerm_synapse_spark_pool.autoscale                                                                                   
  └─ small (4 nodes)                                                         144  vCore-hours                     $22.26 
                                                                                                                         
@@ -23,12 +30,7 @@
  OVERALL TOTAL                                                                                                   $97.66 
 ──────────────────────────────────
 6 cloud resources were detected:
-∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
-∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
-  ∙ 1 x azurerm_storage_account
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free:
   ∙ 1 x azurerm_resource_group
   ∙ 1 x azurerm_storage_data_lake_gen2_filesystem
-Logs:
-
-level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
@@ -1,6 +1,13 @@
 
  Name                                                               Monthly Qty  Unit                      Monthly Cost 
                                                                                                                         
+ azurerm_storage_account.example                                                                                        
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.0196 per GB              
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                                          Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ All other operations                                     Monthly cost depends on usage: $0.0043 per 10k operations  
+ └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+                                                                                                                        
  azurerm_synapse_sql_pool.default                                                                                       
  ├─ DWU blocks (DW200c)                                                     730  hours                        $2,204.60 
  ├─ Storage                                                  Monthly cost depends on usage: $23.00 per TB               
@@ -31,12 +38,7 @@
  OVERALL TOTAL                                                                                                $6,771.00 
 ──────────────────────────────────
 7 cloud resources were detected:
-∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
-∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
-  ∙ 1 x azurerm_storage_account
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free:
   ∙ 1 x azurerm_resource_group
   ∙ 1 x azurerm_storage_data_lake_gen2_filesystem
-Logs:
-
-level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
@@ -1,6 +1,13 @@
 
  Name                                                               Monthly Qty  Unit                      Monthly Cost 
                                                                                                                         
+ azurerm_storage_account.example                                                                                        
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.0196 per GB              
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                                          Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ All other operations                                     Monthly cost depends on usage: $0.0043 per 10k operations  
+ └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+                                                                                                                        
  azurerm_synapse_workspace.dataflows                                                                                    
  ├─ Serverless SQL pool size                                 Monthly cost depends on usage: $5.00 per TB                
  ├─ Data flow (basic)                                                         8  vCore-hours                      $2.14 
@@ -56,12 +63,7 @@
  OVERALL TOTAL                                                                                                  $127.33 
 ──────────────────────────────────
 7 cloud resources were detected:
-∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
-∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
-  ∙ 1 x azurerm_storage_account
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free:
   ∙ 1 x azurerm_resource_group
   ∙ 1 x azurerm_storage_data_lake_gen2_filesystem
-Logs:
-
-level=warning msg="Skipping resource azurerm_storage_account.example. Infracost only supports BlockBlobStorage and FileStorage account kinds"

--- a/internal/resources/azure/storage_account.go
+++ b/internal/resources/azure/storage_account.go
@@ -120,7 +120,10 @@ func (r *StorageAccount) buildProductFilter(meterName string) *schema.ProductFil
 			"Premium":  "Premium Block Blob",
 		}[r.AccountTier]
 	case r.isFileStorage():
-		productName = "Files v2"
+		productName = map[string]string{
+			"Standard": "Files v2",
+			"Premium":  "Premium Files",
+		}[r.AccountTier]
 	}
 
 	skuName := fmt.Sprintf("%s %s", r.AccessTier, r.AccountReplicationType)
@@ -505,7 +508,7 @@ func (r *StorageAccount) blobIndexTagsCostComponents() []*schema.CostComponent {
 // FileStorage:
 //   Standard Hot:  cost exists
 //   Standard Cool: cost exists
-//   Premium:       cost exists (TODO)
+//   Premium:       cost exists
 func (r *StorageAccount) dataAtRestCostComponents() []*schema.CostComponent {
 	costComponents := []*schema.CostComponent{}
 
@@ -520,6 +523,9 @@ func (r *StorageAccount) dataAtRestCostComponents() []*schema.CostComponent {
 	}
 
 	meterName := "Data Stored"
+	if r.isPremium() {
+		meterName = "Provisioned"
+	}
 
 	costComponents = append(costComponents, &schema.CostComponent{
 		Name:            "Data at rest",
@@ -542,7 +548,7 @@ func (r *StorageAccount) dataAtRestCostComponents() []*schema.CostComponent {
 // FileStorage:
 //   Standard Hot:  cost exists
 //   Standard Cool: cost exists
-//   Premium:       cost exists (TODO)
+//   Premium:       cost exists
 func (r *StorageAccount) snapshotsCostComponents() []*schema.CostComponent {
 	costComponents := []*schema.CostComponent{}
 
@@ -557,6 +563,9 @@ func (r *StorageAccount) snapshotsCostComponents() []*schema.CostComponent {
 	}
 
 	meterName := "Data Stored"
+	if r.isPremium() {
+		meterName = "Snapshots"
+	}
 
 	costComponents = append(costComponents, &schema.CostComponent{
 		Name:            "Snapshots",

--- a/internal/resources/azure/storage_account.go
+++ b/internal/resources/azure/storage_account.go
@@ -1,0 +1,703 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
+	"github.com/shopspring/decimal"
+	log "github.com/sirupsen/logrus"
+)
+
+// StorageAccount represents Azure data storage services.
+//
+// More resource information here:
+//   Block Blob Storage: https://azure.microsoft.com/en-us/services/storage/blobs/
+//   File Storage: https://azure.microsoft.com/en-us/services/storage/files/
+// Pricing information here:
+//   Block Blob Storage: https://azure.microsoft.com/en-us/pricing/details/storage/blobs/
+//   File Storage: https://azure.microsoft.com/en-us/pricing/details/storage/files/
+type StorageAccount struct {
+	Address string
+	Region  string
+
+	AccessTier             string
+	AccountKind            string
+	AccountReplicationType string
+	AccountTier            string
+
+	// "usage" args
+	MonthlyStorageGB                        *float64 `infracost_usage:"storage_gb"`
+	MonthlyReadOperations                   *int64   `infracost_usage:"monthly_read_operations"`
+	MonthlyWriteOperations                  *int64   `infracost_usage:"monthly_write_operations"`
+	MonthlyListAndCreateContainerOperations *int64   `infracost_usage:"monthly_list_and_create_container_operations"`
+	MonthlyOtherOperations                  *int64   `infracost_usage:"monthly_other_operations"`
+	MonthlyDataRetrievalGB                  *float64 `infracost_usage:"monthly_data_retrieval_gb"`
+	MonthlyDataWriteGB                      *float64 `infracost_usage:"monthly_data_write_gb"`
+	BlobIndexTags                           *int64   `infracost_usage:"blob_index_tags"`
+	DataAtRestStorageGB                     *float64 `infracost_usage:"data_at_rest_storage_gb"`
+	SnapshotsStorageGB                      *float64 `infracost_usage:"snapshots_storage_gb"`
+	MetadataAtRestStorageGB                 *float64 `infracost_usage:"metadata_at_rest_storage_gb"`
+	EarlyDeletionGB                         *float64 `infracost_usage:"early_deletion_gb"`
+}
+
+// StorageAccountUsageSchema defines a list which represents the usage schema of StorageAccount.
+var StorageAccountUsageSchema = []*schema.UsageItem{
+	{Key: "storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "monthly_read_operations", DefaultValue: 0, ValueType: schema.Int64},
+	{Key: "monthly_write_operations", DefaultValue: 0, ValueType: schema.Int64},
+	{Key: "monthly_list_and_create_container_operations", DefaultValue: 0, ValueType: schema.Int64},
+	{Key: "monthly_other_operations", DefaultValue: 0, ValueType: schema.Int64},
+	{Key: "monthly_data_retrieval_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "monthly_data_write_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "blob_index_tags", DefaultValue: 0, ValueType: schema.Int64},
+	{Key: "data_at_rest_storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "snapshots_storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "metadata_at_rest_storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "early_deletion_gb", DefaultValue: 0, ValueType: schema.Float64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the StorageAccount.
+// It uses the `infracost_usage` struct tags to populate data into the StorageAccount.
+func (r *StorageAccount) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from valid StorageAccount data.
+// This method is called after the resource is initialised by an IaC provider.
+func (r *StorageAccount) BuildResource() *schema.Resource {
+	if !r.isBlockBlobStorage() && !r.isFileStorage() {
+		log.Warnf("Skipping resource %s. Infracost only supports BlockBlobStorage and FileStorage account kinds", r.Address)
+		return nil
+	}
+
+	if !r.isReplicationTypeSupported() {
+		log.Warnf("Skipping resource %s. %s %s doesn't support %s redundancy", r.Address, r.AccountKind, r.AccountTier, r.AccountReplicationType)
+		return nil
+	}
+
+	if r.isPremium() {
+		// Premium tier doesn't differentiate between Hot or Cool storage. This
+		// helps to simplify skuName search.
+		r.AccessTier = "Premium"
+	}
+
+	costComponents := []*schema.CostComponent{}
+
+	costComponents = append(costComponents, r.storageCostComponents()...)
+
+	costComponents = append(costComponents, r.dataAtRestCostComponents()...)
+	costComponents = append(costComponents, r.snapshotsCostComponents()...)
+	costComponents = append(costComponents, r.metadataAtRestCostComponents()...)
+
+	costComponents = append(costComponents, r.writeOperationsCostComponents()...)
+	costComponents = append(costComponents, r.listAndCreateContainerOperationsCostComponents()...)
+	costComponents = append(costComponents, r.readOperationsCostComponents()...)
+	costComponents = append(costComponents, r.otherOperationsCostComponents()...)
+	costComponents = append(costComponents, r.dataRetrievalCostComponents()...)
+	costComponents = append(costComponents, r.dataWriteCostComponents()...)
+	costComponents = append(costComponents, r.blobIndexTagsCostComponents()...)
+
+	costComponents = append(costComponents, r.earlyDeletionCostComponents()...)
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    StorageAccountUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+// buildProductFilter returns a product filter for the Storage Account's products.
+func (r *StorageAccount) buildProductFilter(meterName string) *schema.ProductFilter {
+	var productName string
+
+	switch {
+	case r.isBlockBlobStorage():
+		productName = map[string]string{
+			"Standard": "Blob Storage",
+			"Premium":  "Premium Block Blob",
+		}[r.AccountTier]
+	case r.isFileStorage():
+		productName = "Files v2"
+	}
+
+	skuName := fmt.Sprintf("%s %s", r.AccessTier, r.AccountReplicationType)
+
+	return &schema.ProductFilter{
+		VendorName:    strPtr("azure"),
+		Region:        strPtr(r.Region),
+		Service:       strPtr("Storage"),
+		ProductFamily: strPtr("Storage"),
+		AttributeFilters: []*schema.AttributeFilter{
+			{Key: "productName", Value: strPtr(productName)},
+			{Key: "skuName", Value: strPtr(skuName)},
+			{Key: "meterName", ValueRegex: regexPtr(fmt.Sprintf("%s$", meterName))},
+		},
+	}
+}
+
+// storageCostComponents returns one or several tier cost components for monthly
+// storage capacity in Blob Storage.
+//
+// BlockBlobStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       cost exists
+// FileStorage: see dataAtRestCostComponents()
+func (r *StorageAccount) storageCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if !r.isBlockBlobStorage() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+	name := "Capacity"
+
+	if r.MonthlyStorageGB == nil {
+		costComponents = append(costComponents, r.buildStorageCostComponent(
+			name,
+			"0",
+			quantity,
+		))
+		return costComponents
+	}
+
+	quantity = decimalPtr(decimal.NewFromFloat(*r.MonthlyStorageGB))
+
+	// Only Hot storage has pricing tiers, others have a single price for any
+	// amount.
+	if !r.isHot() {
+		costComponents = append(costComponents, r.buildStorageCostComponent(
+			name,
+			"0",
+			quantity,
+		))
+		return costComponents
+	}
+
+	type dataTier struct {
+		name       string
+		startUsage string
+	}
+
+	data := []dataTier{
+		{name: fmt.Sprintf("%s (first 50TB)", name), startUsage: "0"},
+		{name: fmt.Sprintf("%s (next 450TB)", name), startUsage: "51200"},
+		{name: fmt.Sprintf("%s (over 500TB)", name), startUsage: "512000"},
+	}
+
+	tierLimits := []int{51200, 512000}
+	tiers := usage.CalculateTierBuckets(*quantity, tierLimits)
+
+	for i, d := range data {
+		if i < len(tiers) && tiers[i].GreaterThan(decimal.Zero) {
+			costComponents = append(costComponents, r.buildStorageCostComponent(
+				d.name,
+				d.startUsage,
+				decimalPtr(tiers[i]),
+			))
+		}
+	}
+
+	return costComponents
+}
+
+// writeOperationsCostComponents returns a cost component for Write Operations.
+//
+// BlockBlobStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       cost exists
+// FileStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       no cost
+func (r *StorageAccount) writeOperationsCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if r.isFileStorage() && r.isPremium() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+	itemsPerCost := 10000
+
+	if r.MonthlyWriteOperations != nil {
+		value := decimal.NewFromInt(*r.MonthlyWriteOperations)
+		quantity = decimalPtr(value.Div(decimal.NewFromInt(int64(itemsPerCost))))
+	}
+
+	meterName := "Write Operations"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Write operations",
+		Unit:            "10k operations",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// listAndCreateContainerOperationsCostComponents returns a cost component for
+// List and Create Container Operations (List Operations for File storage).
+//
+// BlockBlobStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       cost exists
+// FileStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       no cost
+func (r *StorageAccount) listAndCreateContainerOperationsCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if r.isFileStorage() && r.isPremium() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+	itemsPerCost := 10000
+
+	if r.MonthlyListAndCreateContainerOperations != nil {
+		value := decimal.NewFromInt(*r.MonthlyListAndCreateContainerOperations)
+		quantity = decimalPtr(value.Div(decimal.NewFromInt(int64(itemsPerCost))))
+	}
+
+	name := "List and create container operations"
+	meterName := "List and Create Container Operations"
+
+	if r.isFileStorage() {
+		name = "List operations"
+		meterName = "List Operations"
+	}
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            name,
+		Unit:            "10k operations",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// readOperationsCostComponents returns a cost component for Read Operations.
+//
+// BlockBlobStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       cost exists
+// FileStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       no cost
+func (r *StorageAccount) readOperationsCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if r.isFileStorage() && r.isPremium() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+	itemsPerCost := 10000
+
+	if r.MonthlyReadOperations != nil {
+		value := decimal.NewFromInt(*r.MonthlyReadOperations)
+		quantity = decimalPtr(value.Div(decimal.NewFromInt(int64(itemsPerCost))))
+	}
+
+	meterName := "Read Operations"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Read operations",
+		Unit:            "10k operations",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// otherOperationsCostComponents returns a cost component for All Other Operations.
+//
+// BlockBlobStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       cost exists
+// FileStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       no cost
+func (r *StorageAccount) otherOperationsCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if r.isFileStorage() && r.isPremium() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+	itemsPerCost := 10000
+
+	if r.MonthlyOtherOperations != nil {
+		value := decimal.NewFromInt(*r.MonthlyOtherOperations)
+		quantity = decimalPtr(value.Div(decimal.NewFromInt(int64(itemsPerCost))))
+	}
+
+	meterName := "Other Operations"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "All other operations",
+		Unit:            "10k operations",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// dataRetrievalCostComponents returns a cost component for Data Retrieval
+// amount.
+//
+// BlockBlobStorage:
+//   Standard Hot:  no cost
+//   Standard Cool: cost exists
+//   Premium:       no cost
+// FileStorage:
+//   Standard Hot:  no cost
+//   Standard Cool: cost exists
+//   Premium:       no cost
+func (r *StorageAccount) dataRetrievalCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if !r.isCool() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+
+	if r.MonthlyDataRetrievalGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.MonthlyDataRetrievalGB))
+	}
+
+	meterName := "Data Retrieval"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Data retrieval",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// dataWriteCostComponents returns a cost component for Data Write amount.
+//
+// BlockBlobStorage:
+//   Standard Hot:  no cost
+//   Standard Cool: cost exists
+//   Premium:       no cost
+// FileStorage:
+//   Standard Hot:  no cost
+//   Standard Cool: no cost
+//   Premium:       no cost
+func (r *StorageAccount) dataWriteCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if !r.isBlockBlobStorage() || !r.isCool() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+
+	if r.MonthlyDataWriteGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.MonthlyDataWriteGB))
+	}
+
+	meterName := "Data Write"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Data write",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// blobIndexTagsCostComponents returns a cost component for Blob Index
+// subresources amount.
+//
+// BlockBlobStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       no cost
+// FileStorage:
+//   Standard Hot:  no cost
+//   Standard Cool: no cost
+//   Premium:       no cost
+func (r *StorageAccount) blobIndexTagsCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	isBlockPremium := r.isBlockBlobStorage() && r.isPremium()
+	if isBlockPremium || r.isFileStorage() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+	itemsPerCost := 10000
+
+	if r.BlobIndexTags != nil {
+		value := decimal.NewFromInt(*r.BlobIndexTags)
+		quantity = decimalPtr(value.Div(decimal.NewFromInt(int64(itemsPerCost))))
+	}
+
+	meterName := "Index Tags"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Blob index",
+		Unit:            "10k tags",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// dataAtRestCostComponents returns a cost component for Data at Rest amount in
+// File Storage.
+//
+// BlockBlobStorage: n/a
+// FileStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       cost exists (TODO)
+func (r *StorageAccount) dataAtRestCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if !r.isFileStorage() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+
+	if r.DataAtRestStorageGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.DataAtRestStorageGB))
+	}
+
+	meterName := "Data Stored"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Data at rest",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// snapshotsCostComponents returns a cost component for Snapshots amount in
+// File Storage.
+//
+// BlockBlobStorage: n/a
+// FileStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       cost exists (TODO)
+func (r *StorageAccount) snapshotsCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if !r.isFileStorage() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+
+	if r.SnapshotsStorageGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.SnapshotsStorageGB))
+	}
+
+	meterName := "Data Stored"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Snapshots",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// metadataAtRestCostComponents returns a cost component for Metadata at-rest amount in
+// File Storage.
+//
+// BlockBlobStorage: n/a
+// FileStorage:
+//   Standard Hot:  cost exists
+//   Standard Cool: cost exists
+//   Premium:       no cost
+func (r *StorageAccount) metadataAtRestCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if !r.isFileStorage() || r.isPremium() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+
+	if r.MetadataAtRestStorageGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.MetadataAtRestStorageGB))
+	}
+
+	meterName := "Metadata"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Metadata at rest",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// earlyDeletionCostComponents returns a cost component for Metadata at-rest amount in
+// File Storage.
+//
+// BlockBlobStorage: n/a
+// FileStorage:
+//   Standard Hot:  no cost
+//   Standard Cool: cost exists
+//   Premium:       no cost
+func (r *StorageAccount) earlyDeletionCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{}
+
+	if !r.isFileStorage() || !r.isCool() {
+		return costComponents
+	}
+
+	var quantity *decimal.Decimal
+
+	if r.EarlyDeletionGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.EarlyDeletionGB))
+	}
+
+	meterName := "Early Delete"
+
+	costComponents = append(costComponents, &schema.CostComponent{
+		Name:            "Early deletion",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	})
+
+	return costComponents
+}
+
+// buildStorageCostComponent builds one cost component for storage amount costs.
+func (r *StorageAccount) buildStorageCostComponent(name string, startUsage string, quantity *decimal.Decimal) *schema.CostComponent {
+	meterName := "Data Stored"
+
+	return &schema.CostComponent{
+		Name:            name,
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter:   r.buildProductFilter(meterName),
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr(startUsage),
+		},
+	}
+}
+
+func (r *StorageAccount) isBlockBlobStorage() bool {
+	return strings.EqualFold(r.AccountKind, "blockblobstorage")
+}
+
+func (r *StorageAccount) isFileStorage() bool {
+	return strings.EqualFold(r.AccountKind, "filestorage")
+}
+
+func (r *StorageAccount) isHot() bool {
+	return strings.EqualFold(r.AccessTier, "hot")
+}
+
+func (r *StorageAccount) isCool() bool {
+	return strings.EqualFold(r.AccessTier, "cool")
+}
+
+func (r *StorageAccount) isPremium() bool {
+	return strings.EqualFold(r.AccountTier, "premium")
+}
+
+func (r *StorageAccount) isReplicationTypeSupported() bool {
+	var validReplicationTypes []string
+
+	switch {
+	case r.isPremium():
+		validReplicationTypes = []string{"LRS", "ZRS"}
+	case r.isBlockBlobStorage():
+		validReplicationTypes = []string{"LRS", "GRS", "RA-GRS", "ZRS"}
+	case r.isFileStorage():
+		validReplicationTypes = []string{"LRS", "GRS", "ZRS"}
+	}
+
+	if validReplicationTypes != nil {
+		return contains(validReplicationTypes, r.AccountReplicationType)
+	}
+
+	return true
+}

--- a/internal/resources/azure/util.go
+++ b/internal/resources/azure/util.go
@@ -1,6 +1,8 @@
 package azure
 
 import (
+	"fmt"
+
 	"github.com/shopspring/decimal"
 )
 
@@ -17,4 +19,17 @@ func floatPtrToDecimalPtr(f *float64) *decimal.Decimal {
 		return nil
 	}
 	return decimalPtr(decimal.NewFromFloat(*f))
+}
+
+func contains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}
+
+func regexPtr(regex string) *string {
+	return strPtr(fmt.Sprintf("/%s/i", regex))
 }


### PR DESCRIPTION
## Objective:

Add support for StorageV2 in `azurerm_storage_account`.  Fixes #951.

## Pricing details:

- Pricing differs when NFSv3 is enabled.
- Not all regions support GZRS and RA-GZRS redundancy types. Also some regions don't have pricing for redundancy types that are common everywhere else. More [info](https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy).
- For some regions Azure Pricing page can show prices that are not matched in Pricing API thus CLI won't show such cost components.

## Status:

- [x] Added to resource_registry.go
- [x] Added internal/resources file
- [x] Added internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator.
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/123))

## Issues:

None