### PR TITLE
 fix: add missing resource to the usage file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,7 +319,7 @@ Terraform supports multiple provider blocks (e.g. `provider "aws"`) so you can t
 Finally, generate the golden file by running the test with the `-update` flag. You should **verify** that these cost calculations are correct by manually checking them, or comparing them against cost calculators from the cloud vendors. You should also ensure that there are **no warnings** about "Multiple products found", "No products found for" or "No prices found for" in the logs. These warnings indicate that the price filters have an issue.
 
 ```sh
-ARGS="--run TestNewAzureRMSynapseSQLPool -update" make test_azure # or test_aws or test_google
+ARGS="--run TestNewAzureRMSynapseSQLPool -update" make test_azure # or test_aws or test_google or test_shared_int
 ```
 
 Please use the following pull request description template as a guide on the level of details to include in your PR, including required integration tests.

--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
@@ -39,6 +39,6 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_state.json
  OVERALL TOTAL                                                                               $40.56 
 ──────────────────────────────────
 14 cloud resources were detected, rerun with --show-skipped to see details:
-∙ 7 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 7 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
 ∙ 6 were free

--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
@@ -39,6 +39,6 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_state.json
  OVERALL TOTAL                                                                               $40.56 
 ──────────────────────────────────
 14 cloud resources were detected, rerun with --show-skipped to see details:
-∙ 7 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+∙ 7 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost
 ∙ 6 were free

--- a/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
@@ -73,6 +73,6 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
  OVERALL TOTAL                                                                               $81.12 
 ──────────────────────────────────
 26 cloud resources were detected, rerun with --show-skipped to see details:
-∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+∙ 14 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
 ∙ 10 were free

--- a/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
@@ -73,6 +73,6 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
  OVERALL TOTAL                                                                               $81.12 
 ──────────────────────────────────
 26 cloud resources were detected, rerun with --show-skipped to see details:
-∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+∙ 14 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
 ∙ 10 were free

--- a/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
@@ -101,6 +101,6 @@ Percent: +100%
 Key: ~ changed, + added, - removed
 
 26 cloud resources were detected, rerun with --show-skipped to see details:
-∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+∙ 14 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
 ∙ 10 were free

--- a/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
@@ -101,6 +101,6 @@ Percent: +100%
 Key: ~ changed, + added, - removed
 
 26 cloud resources were detected, rerun with --show-skipped to see details:
-∙ 14 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+∙ 14 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost
 ∙ 10 were free

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -86,6 +86,9 @@ resource_usage:
     monthly_outbound_other_regions_gb: 750      # Monthly data transferred to other AWS regions.
     monthly_outbound_internet_gb: 5000          # Monthly data transferred to the Internet.
 
+  aws_db_instance.my_db:
+    monthly_standard_io_requests: 10000 # Monthly number of input/output requests for database.
+
   aws_directory_service_directory.my_directory:
     additional_domain_controllers: 3 # The number of domain controllers in the directory service provisioned in addition to the minimum 2 controllers
     shared_accounts: 8 # Number of accounts that Microsoft AD directory is shared with

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
@@ -96,4 +96,4 @@
  OVERALL TOTAL                                                                                         $5,293.39 
 ──────────────────────────────────
 22 cloud resources were detected:
-∙ 22 were estimated
+∙ 22 were estimated, 22 include usage-based costs, see https://infracost.io/usage-file


### PR DESCRIPTION
The example file is used by the sync-usage-file feature so it’s important
that it remains uptodate