### PR TITLE
fix: fix diff showing all resources when `-target` is used with Terrarform.

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -137,6 +137,10 @@ func TestBreakdownTerraformWrapper(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "./testdata/plan_with_terraform_wrapper.json"}, nil)
 }
 
+func TestBreakdownWithTarget(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "./testdata/plan_with_target.json"}, nil)
+}
+
 func TestBreakdownTerraform_v0_12(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "./testdata/terraform_v0.12_plan.json"}, nil)
 }

--- a/cmd/infracost/diff_test.go
+++ b/cmd/infracost/diff_test.go
@@ -57,6 +57,10 @@ func TestDiffTerragruntNested(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"diff", "--path", "../../examples"}, nil)
 }
 
+func TestDiffWithTarget(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"diff", "--path", "./testdata/plan_with_target.json"}, nil)
+}
+
 func TestDiffTerraform_v0_12(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"diff", "--path", "./testdata/terraform_v0.12_plan.json"}, nil)
 }

--- a/cmd/infracost/testdata/breakdown_with_target/breakdown_with_target.golden
+++ b/cmd/infracost/testdata/breakdown_with_target/breakdown_with_target.golden
@@ -1,0 +1,13 @@
+Project: infracost/infracost/cmd/infracost/testdata/plan_with_target.json
+
+ Name                                                 Monthly Qty  Unit   Monthly Cost 
+                                                                                       
+ aws_instance.web_app_1                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.small)          730  hours        $15.18 
+ └─ root_block_device                                                                  
+    └─ Storage (general purpose SSD, gp2)                      10  GB            $1.00 
+                                                                                       
+ OVERALL TOTAL                                                                  $16.18 
+──────────────────────────────────
+1 cloud resource was detected, rerun with --show-skipped to see details:
+∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/diff_with_target/diff_with_target.golden
+++ b/cmd/infracost/testdata/diff_with_target/diff_with_target.golden
@@ -1,0 +1,17 @@
+Project: infracost/infracost/cmd/infracost/testdata/plan_with_target.json
+
+~ aws_instance.web_app_1
+  +$7.59 ($8.59 → $16.18)
+
+    ~ Instance usage (Linux/UNIX, on-demand, t3.micro → t3.small)
+      +$7.59 ($7.59 → $15.18)
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata/plan_with_target.json
+Amount:  +$7.59 ($8.59 → $16.18)
+Percent: +88%
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+1 cloud resource was detected, rerun with --show-skipped to see details:
+∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/plan_with_target.json
+++ b/cmd/infracost/testdata/plan_with_target.json
@@ -1,0 +1,990 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.0.11",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web_app_1",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web_app_1",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 1,
+          "values": {
+            "ami": "ami-0ff8a91507f77f867",
+            "arn": "arn:aws:ec2:us-east-1:111111111111:instance/i-01ba2abb329c4eec0",
+            "associate_public_ip_address": true,
+            "availability_zone": "us-east-1b",
+            "capacity_reservation_specification": [
+              {
+                "capacity_reservation_preference": "open",
+                "capacity_reservation_target": []
+              }
+            ],
+            "cpu_core_count": 1,
+            "cpu_threads_per_core": 2,
+            "credit_specification": [
+              {
+                "cpu_credits": "unlimited"
+              }
+            ],
+            "disable_api_termination": false,
+            "ebs_block_device": [],
+            "ebs_optimized": false,
+            "enclave_options": [
+              {
+                "enabled": false
+              }
+            ],
+            "ephemeral_block_device": [],
+            "get_password_data": false,
+            "hibernation": false,
+            "host_id": null,
+            "iam_instance_profile": "",
+            "id": "i-01ba2abb329c4eec0",
+            "instance_initiated_shutdown_behavior": "stop",
+            "instance_state": "running",
+            "instance_type": "t3.small",
+            "ipv6_address_count": 0,
+            "ipv6_addresses": [],
+            "key_name": "",
+            "launch_template": [],
+            "metadata_options": [
+              {
+                "http_endpoint": "enabled",
+                "http_put_response_hop_limit": 1,
+                "http_tokens": "optional"
+              }
+            ],
+            "monitoring": false,
+            "network_interface": [],
+            "outpost_arn": "",
+            "password_data": "",
+            "placement_group": "",
+            "placement_partition_number": null,
+            "primary_network_interface_id": "eni-0d35141d50c10c8c9",
+            "private_dns": "ip-172-31-1-12.ec2.internal",
+            "private_ip": "172.31.1.12",
+            "public_dns": "ec2-11-11-11-11.compute-1.amazonaws.com",
+            "public_ip": "11.11.11.11",
+            "root_block_device": [
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/xvda",
+                "encrypted": false,
+                "iops": 100,
+                "kms_key_id": "",
+                "tags": {},
+                "throughput": 0,
+                "volume_id": "vol-0537652153568b7fc",
+                "volume_size": 10,
+                "volume_type": "gp2"
+              }
+            ],
+            "secondary_private_ips": [],
+            "security_groups": [
+              "default"
+            ],
+            "source_dest_check": true,
+            "subnet_id": "subnet-286f234e",
+            "tags": {},
+            "tags_all": {},
+            "tenancy": "default",
+            "timeouts": null,
+            "user_data": null,
+            "user_data_base64": null,
+            "volume_tags": null,
+            "vpc_security_group_ids": [
+              "sg-5277e14a"
+            ]
+          },
+          "sensitive_values": {
+            "capacity_reservation_specification": [
+              {
+                "capacity_reservation_target": []
+              }
+            ],
+            "credit_specification": [
+              {}
+            ],
+            "ebs_block_device": [],
+            "enclave_options": [
+              {}
+            ],
+            "ephemeral_block_device": [],
+            "ipv6_addresses": [],
+            "launch_template": [],
+            "metadata_options": [
+              {}
+            ],
+            "network_interface": [],
+            "root_block_device": [
+              {
+                "tags": {}
+              }
+            ],
+            "secondary_private_ips": [],
+            "security_groups": [
+              false
+            ],
+            "tags": {},
+            "tags_all": {},
+            "vpc_security_group_ids": [
+              false
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "resource_drift": [
+    {
+      "address": "aws_instance.web_app_1",
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "web_app_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "ami": "ami-0ff8a91507f77f867",
+          "arn": "arn:aws:ec2:us-east-1:111111111111:instance/i-01ba2abb329c4eec0",
+          "associate_public_ip_address": true,
+          "availability_zone": "us-east-1b",
+          "capacity_reservation_specification": [
+            {
+              "capacity_reservation_preference": "open",
+              "capacity_reservation_target": []
+            }
+          ],
+          "cpu_core_count": 1,
+          "cpu_threads_per_core": 2,
+          "credit_specification": [
+            {
+              "cpu_credits": "unlimited"
+            }
+          ],
+          "disable_api_termination": false,
+          "ebs_block_device": [],
+          "ebs_optimized": false,
+          "enclave_options": [
+            {
+              "enabled": false
+            }
+          ],
+          "ephemeral_block_device": [],
+          "get_password_data": false,
+          "hibernation": false,
+          "host_id": null,
+          "iam_instance_profile": "",
+          "id": "i-01ba2abb329c4eec0",
+          "instance_initiated_shutdown_behavior": "stop",
+          "instance_state": "running",
+          "instance_type": "t3.micro",
+          "ipv6_address_count": 0,
+          "ipv6_addresses": [],
+          "key_name": "",
+          "launch_template": [],
+          "metadata_options": [
+            {
+              "http_endpoint": "enabled",
+              "http_put_response_hop_limit": 1,
+              "http_tokens": "optional"
+            }
+          ],
+          "monitoring": false,
+          "network_interface": [],
+          "outpost_arn": "",
+          "password_data": "",
+          "placement_group": "",
+          "placement_partition_number": null,
+          "primary_network_interface_id": "eni-0d35141d50c10c8c9",
+          "private_dns": "ip-172-31-1-12.ec2.internal",
+          "private_ip": "172.31.1.12",
+          "public_dns": "ec2-11-11-11-11.compute-1.amazonaws.com",
+          "public_ip": "11.11.11.11",
+          "root_block_device": [
+            {
+              "delete_on_termination": true,
+              "device_name": "/dev/xvda",
+              "encrypted": false,
+              "iops": 100,
+              "kms_key_id": "",
+              "tags": null,
+              "throughput": 0,
+              "volume_id": "vol-0537652153568b7fc",
+              "volume_size": 10,
+              "volume_type": "gp2"
+            }
+          ],
+          "secondary_private_ips": [],
+          "security_groups": [
+            "default"
+          ],
+          "source_dest_check": true,
+          "subnet_id": "subnet-286f234e",
+          "tags": null,
+          "tags_all": {},
+          "tenancy": "default",
+          "timeouts": null,
+          "user_data": null,
+          "user_data_base64": null,
+          "volume_tags": null,
+          "vpc_security_group_ids": [
+            "sg-5277e14a"
+          ]
+        },
+        "after": {
+          "ami": "ami-0ff8a91507f77f867",
+          "arn": "arn:aws:ec2:us-east-1:111111111111:instance/i-01ba2abb329c4eec0",
+          "associate_public_ip_address": true,
+          "availability_zone": "us-east-1b",
+          "capacity_reservation_specification": [
+            {
+              "capacity_reservation_preference": "open",
+              "capacity_reservation_target": []
+            }
+          ],
+          "cpu_core_count": 1,
+          "cpu_threads_per_core": 2,
+          "credit_specification": [
+            {
+              "cpu_credits": "unlimited"
+            }
+          ],
+          "disable_api_termination": false,
+          "ebs_block_device": [],
+          "ebs_optimized": false,
+          "enclave_options": [
+            {
+              "enabled": false
+            }
+          ],
+          "ephemeral_block_device": [],
+          "get_password_data": false,
+          "hibernation": false,
+          "host_id": null,
+          "iam_instance_profile": "",
+          "id": "i-01ba2abb329c4eec0",
+          "instance_initiated_shutdown_behavior": "stop",
+          "instance_state": "running",
+          "instance_type": "t3.micro",
+          "ipv6_address_count": 0,
+          "ipv6_addresses": [],
+          "key_name": "",
+          "launch_template": [],
+          "metadata_options": [
+            {
+              "http_endpoint": "enabled",
+              "http_put_response_hop_limit": 1,
+              "http_tokens": "optional"
+            }
+          ],
+          "monitoring": false,
+          "network_interface": [],
+          "outpost_arn": "",
+          "password_data": "",
+          "placement_group": "",
+          "placement_partition_number": null,
+          "primary_network_interface_id": "eni-0d35141d50c10c8c9",
+          "private_dns": "ip-172-31-1-12.ec2.internal",
+          "private_ip": "172.31.1.12",
+          "public_dns": "ec2-11-11-11-11.compute-1.amazonaws.com",
+          "public_ip": "11.11.11.11",
+          "root_block_device": [
+            {
+              "delete_on_termination": true,
+              "device_name": "/dev/xvda",
+              "encrypted": false,
+              "iops": 100,
+              "kms_key_id": "",
+              "tags": {},
+              "throughput": 0,
+              "volume_id": "vol-0537652153568b7fc",
+              "volume_size": 10,
+              "volume_type": "gp2"
+            }
+          ],
+          "secondary_private_ips": [],
+          "security_groups": [
+            "default"
+          ],
+          "source_dest_check": true,
+          "subnet_id": "subnet-286f234e",
+          "tags": {},
+          "tags_all": {},
+          "tenancy": "default",
+          "timeouts": null,
+          "user_data": null,
+          "user_data_base64": null,
+          "volume_tags": null,
+          "vpc_security_group_ids": [
+            "sg-5277e14a"
+          ]
+        },
+        "before_sensitive": {
+          "capacity_reservation_specification": [
+            {
+              "capacity_reservation_target": []
+            }
+          ],
+          "credit_specification": [
+            {}
+          ],
+          "ebs_block_device": [],
+          "enclave_options": [
+            {}
+          ],
+          "ephemeral_block_device": [],
+          "ipv6_addresses": [],
+          "launch_template": [],
+          "metadata_options": [
+            {}
+          ],
+          "network_interface": [],
+          "root_block_device": [
+            {}
+          ],
+          "secondary_private_ips": [],
+          "security_groups": [
+            false
+          ],
+          "tags_all": {},
+          "vpc_security_group_ids": [
+            false
+          ]
+        },
+        "after_sensitive": {
+          "capacity_reservation_specification": [
+            {
+              "capacity_reservation_target": []
+            }
+          ],
+          "credit_specification": [
+            {}
+          ],
+          "ebs_block_device": [],
+          "enclave_options": [
+            {}
+          ],
+          "ephemeral_block_device": [],
+          "ipv6_addresses": [],
+          "launch_template": [],
+          "metadata_options": [
+            {}
+          ],
+          "network_interface": [],
+          "root_block_device": [
+            {
+              "tags": {}
+            }
+          ],
+          "secondary_private_ips": [],
+          "security_groups": [
+            false
+          ],
+          "tags": {},
+          "tags_all": {},
+          "vpc_security_group_ids": [
+            false
+          ]
+        }
+      }
+    }
+  ],
+  "resource_changes": [
+    {
+      "address": "aws_instance.web_app_1",
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "web_app_1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "ami": "ami-0ff8a91507f77f867",
+          "arn": "arn:aws:ec2:us-east-1:111111111111:instance/i-01ba2abb329c4eec0",
+          "associate_public_ip_address": true,
+          "availability_zone": "us-east-1b",
+          "capacity_reservation_specification": [
+            {
+              "capacity_reservation_preference": "open",
+              "capacity_reservation_target": []
+            }
+          ],
+          "cpu_core_count": 1,
+          "cpu_threads_per_core": 2,
+          "credit_specification": [
+            {
+              "cpu_credits": "unlimited"
+            }
+          ],
+          "disable_api_termination": false,
+          "ebs_block_device": [],
+          "ebs_optimized": false,
+          "enclave_options": [
+            {
+              "enabled": false
+            }
+          ],
+          "ephemeral_block_device": [],
+          "get_password_data": false,
+          "hibernation": false,
+          "host_id": null,
+          "iam_instance_profile": "",
+          "id": "i-01ba2abb329c4eec0",
+          "instance_initiated_shutdown_behavior": "stop",
+          "instance_state": "running",
+          "instance_type": "t3.micro",
+          "ipv6_address_count": 0,
+          "ipv6_addresses": [],
+          "key_name": "",
+          "launch_template": [],
+          "metadata_options": [
+            {
+              "http_endpoint": "enabled",
+              "http_put_response_hop_limit": 1,
+              "http_tokens": "optional"
+            }
+          ],
+          "monitoring": false,
+          "network_interface": [],
+          "outpost_arn": "",
+          "password_data": "",
+          "placement_group": "",
+          "placement_partition_number": null,
+          "primary_network_interface_id": "eni-0d35141d50c10c8c9",
+          "private_dns": "ip-172-31-1-12.ec2.internal",
+          "private_ip": "172.31.1.12",
+          "public_dns": "ec2-11-11-11-11.compute-1.amazonaws.com",
+          "public_ip": "11.11.11.11",
+          "root_block_device": [
+            {
+              "delete_on_termination": true,
+              "device_name": "/dev/xvda",
+              "encrypted": false,
+              "iops": 100,
+              "kms_key_id": "",
+              "tags": {},
+              "throughput": 0,
+              "volume_id": "vol-0537652153568b7fc",
+              "volume_size": 10,
+              "volume_type": "gp2"
+            }
+          ],
+          "secondary_private_ips": [],
+          "security_groups": [
+            "default"
+          ],
+          "source_dest_check": true,
+          "subnet_id": "subnet-286f234e",
+          "tags": {},
+          "tags_all": {},
+          "tenancy": "default",
+          "timeouts": null,
+          "user_data": null,
+          "user_data_base64": null,
+          "volume_tags": null,
+          "vpc_security_group_ids": [
+            "sg-5277e14a"
+          ]
+        },
+        "after": {
+          "ami": "ami-0ff8a91507f77f867",
+          "arn": "arn:aws:ec2:us-east-1:111111111111:instance/i-01ba2abb329c4eec0",
+          "associate_public_ip_address": true,
+          "availability_zone": "us-east-1b",
+          "capacity_reservation_specification": [
+            {
+              "capacity_reservation_preference": "open",
+              "capacity_reservation_target": []
+            }
+          ],
+          "cpu_core_count": 1,
+          "cpu_threads_per_core": 2,
+          "credit_specification": [
+            {
+              "cpu_credits": "unlimited"
+            }
+          ],
+          "disable_api_termination": false,
+          "ebs_block_device": [],
+          "ebs_optimized": false,
+          "enclave_options": [
+            {
+              "enabled": false
+            }
+          ],
+          "ephemeral_block_device": [],
+          "get_password_data": false,
+          "hibernation": false,
+          "host_id": null,
+          "iam_instance_profile": "",
+          "id": "i-01ba2abb329c4eec0",
+          "instance_initiated_shutdown_behavior": "stop",
+          "instance_state": "running",
+          "instance_type": "t3.small",
+          "ipv6_address_count": 0,
+          "ipv6_addresses": [],
+          "key_name": "",
+          "launch_template": [],
+          "metadata_options": [
+            {
+              "http_endpoint": "enabled",
+              "http_put_response_hop_limit": 1,
+              "http_tokens": "optional"
+            }
+          ],
+          "monitoring": false,
+          "network_interface": [],
+          "outpost_arn": "",
+          "password_data": "",
+          "placement_group": "",
+          "placement_partition_number": null,
+          "primary_network_interface_id": "eni-0d35141d50c10c8c9",
+          "private_dns": "ip-172-31-1-12.ec2.internal",
+          "private_ip": "172.31.1.12",
+          "public_dns": "ec2-11-11-11-11.compute-1.amazonaws.com",
+          "public_ip": "11.11.11.11",
+          "root_block_device": [
+            {
+              "delete_on_termination": true,
+              "device_name": "/dev/xvda",
+              "encrypted": false,
+              "iops": 100,
+              "kms_key_id": "",
+              "tags": {},
+              "throughput": 0,
+              "volume_id": "vol-0537652153568b7fc",
+              "volume_size": 10,
+              "volume_type": "gp2"
+            }
+          ],
+          "secondary_private_ips": [],
+          "security_groups": [
+            "default"
+          ],
+          "source_dest_check": true,
+          "subnet_id": "subnet-286f234e",
+          "tags": {},
+          "tags_all": {},
+          "tenancy": "default",
+          "timeouts": null,
+          "user_data": null,
+          "user_data_base64": null,
+          "volume_tags": null,
+          "vpc_security_group_ids": [
+            "sg-5277e14a"
+          ]
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "capacity_reservation_specification": [
+            {
+              "capacity_reservation_target": []
+            }
+          ],
+          "credit_specification": [
+            {}
+          ],
+          "ebs_block_device": [],
+          "enclave_options": [
+            {}
+          ],
+          "ephemeral_block_device": [],
+          "ipv6_addresses": [],
+          "launch_template": [],
+          "metadata_options": [
+            {}
+          ],
+          "network_interface": [],
+          "root_block_device": [
+            {
+              "tags": {}
+            }
+          ],
+          "secondary_private_ips": [],
+          "security_groups": [
+            false
+          ],
+          "tags": {},
+          "tags_all": {},
+          "vpc_security_group_ids": [
+            false
+          ]
+        },
+        "after_sensitive": {
+          "capacity_reservation_specification": [
+            {
+              "capacity_reservation_target": []
+            }
+          ],
+          "credit_specification": [
+            {}
+          ],
+          "ebs_block_device": [],
+          "enclave_options": [
+            {}
+          ],
+          "ephemeral_block_device": [],
+          "ipv6_addresses": [],
+          "launch_template": [],
+          "metadata_options": [
+            {}
+          ],
+          "network_interface": [],
+          "root_block_device": [
+            {
+              "tags": {}
+            }
+          ],
+          "secondary_private_ips": [],
+          "security_groups": [
+            false
+          ],
+          "tags": {},
+          "tags_all": {},
+          "vpc_security_group_ids": [
+            false
+          ]
+        }
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "0.2",
+    "terraform_version": "1.0.11",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_instance.web_app_1",
+            "mode": "managed",
+            "type": "aws_instance",
+            "name": "web_app_1",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 1,
+            "values": {
+              "ami": "ami-0ff8a91507f77f867",
+              "arn": "arn:aws:ec2:us-east-1:111111111111:instance/i-01ba2abb329c4eec0",
+              "associate_public_ip_address": true,
+              "availability_zone": "us-east-1b",
+              "capacity_reservation_specification": [
+                {
+                  "capacity_reservation_preference": "open",
+                  "capacity_reservation_target": []
+                }
+              ],
+              "cpu_core_count": 1,
+              "cpu_threads_per_core": 2,
+              "credit_specification": [
+                {
+                  "cpu_credits": "unlimited"
+                }
+              ],
+              "disable_api_termination": false,
+              "ebs_block_device": [],
+              "ebs_optimized": false,
+              "enclave_options": [
+                {
+                  "enabled": false
+                }
+              ],
+              "ephemeral_block_device": [],
+              "get_password_data": false,
+              "hibernation": false,
+              "host_id": null,
+              "iam_instance_profile": "",
+              "id": "i-01ba2abb329c4eec0",
+              "instance_initiated_shutdown_behavior": "stop",
+              "instance_state": "running",
+              "instance_type": "t3.micro",
+              "ipv6_address_count": 0,
+              "ipv6_addresses": [],
+              "key_name": "",
+              "launch_template": [],
+              "metadata_options": [
+                {
+                  "http_endpoint": "enabled",
+                  "http_put_response_hop_limit": 1,
+                  "http_tokens": "optional"
+                }
+              ],
+              "monitoring": false,
+              "network_interface": [],
+              "outpost_arn": "",
+              "password_data": "",
+              "placement_group": "",
+              "placement_partition_number": null,
+              "primary_network_interface_id": "eni-0d35141d50c10c8c9",
+              "private_dns": "ip-172-31-1-12.ec2.internal",
+              "private_ip": "172.31.1.12",
+              "public_dns": "ec2-11-11-11-11.compute-1.amazonaws.com",
+              "public_ip": "11.11.11.11",
+              "root_block_device": [
+                {
+                  "delete_on_termination": true,
+                  "device_name": "/dev/xvda",
+                  "encrypted": false,
+                  "iops": 100,
+                  "kms_key_id": "",
+                  "tags": {},
+                  "throughput": 0,
+                  "volume_id": "vol-0537652153568b7fc",
+                  "volume_size": 10,
+                  "volume_type": "gp2"
+                }
+              ],
+              "secondary_private_ips": [],
+              "security_groups": [
+                "default"
+              ],
+              "source_dest_check": true,
+              "subnet_id": "subnet-286f234e",
+              "tags": {},
+              "tags_all": {},
+              "tenancy": "default",
+              "timeouts": null,
+              "user_data": null,
+              "user_data_base64": null,
+              "volume_tags": null,
+              "vpc_security_group_ids": [
+                "sg-5277e14a"
+              ]
+            },
+            "sensitive_values": {
+              "capacity_reservation_specification": [
+                {
+                  "capacity_reservation_target": []
+                }
+              ],
+              "credit_specification": [
+                {}
+              ],
+              "ebs_block_device": [],
+              "enclave_options": [
+                {}
+              ],
+              "ephemeral_block_device": [],
+              "ipv6_addresses": [],
+              "launch_template": [],
+              "metadata_options": [
+                {}
+              ],
+              "network_interface": [],
+              "root_block_device": [
+                {
+                  "tags": {}
+                }
+              ],
+              "secondary_private_ips": [],
+              "security_groups": [
+                false
+              ],
+              "tags": {},
+              "tags_all": {},
+              "vpc_security_group_ids": [
+                false
+              ]
+            }
+          },
+          {
+            "address": "aws_instance.web_app_2",
+            "mode": "managed",
+            "type": "aws_instance",
+            "name": "web_app_2",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 1,
+            "values": {
+              "ami": "ami-0ff8a91507f77f867",
+              "arn": "arn:aws:ec2:us-east-1:111111111111:instance/i-09c3101ad73485e4e",
+              "associate_public_ip_address": true,
+              "availability_zone": "us-east-1b",
+              "capacity_reservation_specification": [
+                {
+                  "capacity_reservation_preference": "open",
+                  "capacity_reservation_target": []
+                }
+              ],
+              "cpu_core_count": 1,
+              "cpu_threads_per_core": 2,
+              "credit_specification": [
+                {
+                  "cpu_credits": "unlimited"
+                }
+              ],
+              "disable_api_termination": false,
+              "ebs_block_device": [],
+              "ebs_optimized": false,
+              "enclave_options": [
+                {
+                  "enabled": false
+                }
+              ],
+              "ephemeral_block_device": [],
+              "get_password_data": false,
+              "hibernation": false,
+              "host_id": null,
+              "iam_instance_profile": "",
+              "id": "i-09c3101ad73485e4e",
+              "instance_initiated_shutdown_behavior": "stop",
+              "instance_state": "running",
+              "instance_type": "t3.micro",
+              "ipv6_address_count": 0,
+              "ipv6_addresses": [],
+              "key_name": "",
+              "launch_template": [],
+              "metadata_options": [
+                {
+                  "http_endpoint": "enabled",
+                  "http_put_response_hop_limit": 1,
+                  "http_tokens": "optional"
+                }
+              ],
+              "monitoring": false,
+              "network_interface": [],
+              "outpost_arn": "",
+              "password_data": "",
+              "placement_group": "",
+              "placement_partition_number": null,
+              "primary_network_interface_id": "eni-0a0823c85468fca6d",
+              "private_dns": "ip-172-31-0-231.ec2.internal",
+              "private_ip": "172.31.0.231",
+              "public_dns": "ec2-22-22-22-22.compute-1.amazonaws.com",
+              "public_ip": "22.22.22.22",
+              "root_block_device": [
+                {
+                  "delete_on_termination": true,
+                  "device_name": "/dev/xvda",
+                  "encrypted": false,
+                  "iops": 100,
+                  "kms_key_id": "",
+                  "tags": null,
+                  "throughput": 0,
+                  "volume_id": "vol-0c48247485d0960b3",
+                  "volume_size": 10,
+                  "volume_type": "gp2"
+                }
+              ],
+              "secondary_private_ips": [],
+              "security_groups": [
+                "default"
+              ],
+              "source_dest_check": true,
+              "subnet_id": "subnet-286f234e",
+              "tags": null,
+              "tags_all": {},
+              "tenancy": "default",
+              "timeouts": null,
+              "user_data": null,
+              "user_data_base64": null,
+              "volume_tags": null,
+              "vpc_security_group_ids": [
+                "sg-5277e14a"
+              ]
+            },
+            "sensitive_values": {
+              "capacity_reservation_specification": [
+                {
+                  "capacity_reservation_target": []
+                }
+              ],
+              "credit_specification": [
+                {}
+              ],
+              "ebs_block_device": [],
+              "enclave_options": [
+                {}
+              ],
+              "ephemeral_block_device": [],
+              "ipv6_addresses": [],
+              "launch_template": [],
+              "metadata_options": [
+                {}
+              ],
+              "network_interface": [],
+              "root_block_device": [
+                {}
+              ],
+              "secondary_private_ips": [],
+              "security_groups": [
+                false
+              ],
+              "tags_all": {},
+              "vpc_security_group_ids": [
+                false
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web_app_1",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web_app_1",
+          "provider_config_key": "aws",
+          "expressions": {
+            "ami": {
+              "constant_value": "ami-0ff8a91507f77f867"
+            },
+            "instance_type": {
+              "constant_value": "t3.small"
+            },
+            "root_block_device": [
+              {
+                "volume_size": {
+                  "constant_value": 10
+                }
+              }
+            ]
+          },
+          "schema_version": 1
+        },
+        {
+          "address": "aws_instance.web_app_2",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web_app_2",
+          "provider_config_key": "aws",
+          "expressions": {
+            "ami": {
+              "constant_value": "ami-0ff8a91507f77f867"
+            },
+            "instance_type": {
+              "constant_value": "t3.small"
+            },
+            "root_block_device": [
+              {
+                "volume_size": {
+                  "constant_value": 10
+                }
+              }
+            ]
+          },
+          "schema_version": 1
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This fixes https://github.com/infracost/infracost/issues/1152.

When `infracost diff` or `infracost breakdown` is run on a plan that has been generated with `-target`, we now only show the resources matching the target.

@alikhajeh1 the issue you had when reproducing this is related to: https://github.com/hashicorp/terraform/issues/23297. Basically, if the provider version has been updated since the last time the state was refreshed, this error can occur. The fix is to run `terraform refresh` first. We should consider adding a custom error wrapper for this case, but I've left it out of this PR for now.