### PR TITLE
fix: Update pricing for AWS/Azure resources

### DIFF
--- a/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
+++ b/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
@@ -39,7 +39,7 @@
                                                                                                                                
  azurerm_storage_account.example                                                                                               
  ├─ Capacity                                                        Monthly cost depends on usage: $0.0208 per GB              
- ├─ List and create container operations                            Monthly cost depends on usage: $0.05 per 10k operations    
+ ├─ Write operations                                                Monthly cost depends on usage: $0.05 per 10k operations    
  ├─ Read operations                                                 Monthly cost depends on usage: $0.004 per 10k operations   
  ├─ All other operations                                            Monthly cost depends on usage: $0.004 per 10k operations   
  └─ Blob index                                                      Monthly cost depends on usage: $0.03 per 10k tags          

--- a/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
@@ -14,7 +14,7 @@
                                                                                                            
  azurerm_storage_account.example                                                                           
  ├─ Capacity                                    Monthly cost depends on usage: $0.0196 per GB              
- ├─ List and create container operations        Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Write operations                            Monthly cost depends on usage: $0.054 per 10k operations   
  ├─ Read operations                             Monthly cost depends on usage: $0.0043 per 10k operations  
  ├─ All other operations                        Monthly cost depends on usage: $0.0043 per 10k operations  
  └─ Blob index                                  Monthly cost depends on usage: $0.039 per 10k tags         

--- a/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
@@ -8,7 +8,7 @@
                                                                                                      
  azurerm_storage_account.example                                                                     
  ├─ Capacity                              Monthly cost depends on usage: $0.0196 per GB              
- ├─ List and create container operations  Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Write operations                      Monthly cost depends on usage: $0.054 per 10k operations   
  ├─ Read operations                       Monthly cost depends on usage: $0.0043 per 10k operations  
  ├─ All other operations                  Monthly cost depends on usage: $0.0043 per 10k operations  
  └─ Blob index                            Monthly cost depends on usage: $0.039 per 10k tags         

--- a/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
@@ -8,7 +8,7 @@
                                                                                                                  
  azurerm_storage_account.example                                                                                 
  ├─ Capacity                                          Monthly cost depends on usage: $0.0196 per GB              
- ├─ List and create container operations              Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Write operations                                  Monthly cost depends on usage: $0.054 per 10k operations   
  ├─ Read operations                                   Monthly cost depends on usage: $0.0043 per 10k operations  
  ├─ All other operations                              Monthly cost depends on usage: $0.0043 per 10k operations  
  └─ Blob index                                        Monthly cost depends on usage: $0.039 per 10k tags         

--- a/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
@@ -24,7 +24,7 @@
                                                                                                           
  azurerm_storage_account.example                                                                          
  ├─ Capacity                                Monthly cost depends on usage: $0.0196 per GB                 
- ├─ List and create container operations    Monthly cost depends on usage: $0.054 per 10k operations      
+ ├─ Write operations                        Monthly cost depends on usage: $0.054 per 10k operations      
  ├─ Read operations                         Monthly cost depends on usage: $0.0043 per 10k operations     
  ├─ All other operations                    Monthly cost depends on usage: $0.0043 per 10k operations     
  └─ Blob index                              Monthly cost depends on usage: $0.039 per 10k tags            

--- a/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
@@ -8,7 +8,7 @@
                                                                                                      
  azurerm_storage_account.example                                                                     
  ├─ Capacity                              Monthly cost depends on usage: $0.0196 per GB              
- ├─ List and create container operations  Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Write operations                      Monthly cost depends on usage: $0.054 per 10k operations   
  ├─ Read operations                       Monthly cost depends on usage: $0.0043 per 10k operations  
  ├─ All other operations                  Monthly cost depends on usage: $0.0043 per 10k operations  
  └─ Blob index                            Monthly cost depends on usage: $0.039 per 10k tags         

--- a/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
@@ -2,7 +2,7 @@
  Name                                                Monthly Qty  Unit              Monthly Cost 
                                                                                                  
  azurerm_postgresql_flexible_server.burstable                                                    
- ├─ Compute (B_Standard_B1ms)                                730  hours                   $32.12 
+ ├─ Compute (B_Standard_B1ms)                                730  hours                   $16.06 
  ├─ Storage                                                  128  GB                      $17.66 
  └─ Additional backup storage                              5,000  GB                     $475.00 
                                                                                                  
@@ -21,7 +21,7 @@
  ├─ Storage                                       Monthly cost depends on usage: $0.14 per GB    
  └─ Additional backup storage                     Monthly cost depends on usage: $0.095 per GB   
                                                                                                  
- OVERALL TOTAL                                                                         $3,294.05 
+ OVERALL TOTAL                                                                         $3,277.99 
 ──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -182,7 +182,7 @@
  ├─ Capacity (first 50TB)                                     51,200  GB                           $1,064.96 
  ├─ Capacity (next 450TB)                                    512,000  GB                          $10,223.62 
  ├─ Capacity (over 500TB)                                    436,800  GB                           $8,358.60 
- ├─ Write operations                                             100  10k operations                   $5.50 
+ ├─ List and create container operations                         100  10k operations                   $5.50 
  ├─ Read operations                                               10  10k operations                   $0.04 
  ├─ All other operations                                         100  10k operations                   $0.44 
  └─ Blob index                                                    10  10k tags                         $0.39 

--- a/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
@@ -3,7 +3,7 @@
                                                                                                                         
  azurerm_storage_account.example                                                                                        
  ├─ Capacity                                                 Monthly cost depends on usage: $0.0196 per GB              
- ├─ List and create container operations                     Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Write operations                                         Monthly cost depends on usage: $0.054 per 10k operations   
  ├─ Read operations                                          Monthly cost depends on usage: $0.0043 per 10k operations  
  ├─ All other operations                                     Monthly cost depends on usage: $0.0043 per 10k operations  
  └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         

--- a/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
@@ -3,7 +3,7 @@
                                                                                                                         
  azurerm_storage_account.example                                                                                        
  ├─ Capacity                                                 Monthly cost depends on usage: $0.0196 per GB              
- ├─ List and create container operations                     Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Write operations                                         Monthly cost depends on usage: $0.054 per 10k operations   
  ├─ Read operations                                          Monthly cost depends on usage: $0.0043 per 10k operations  
  ├─ All other operations                                     Monthly cost depends on usage: $0.0043 per 10k operations  
  └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         

--- a/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
@@ -3,7 +3,7 @@
                                                                                                                         
  azurerm_storage_account.example                                                                                        
  ├─ Capacity                                                 Monthly cost depends on usage: $0.0196 per GB              
- ├─ List and create container operations                     Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Write operations                                         Monthly cost depends on usage: $0.054 per 10k operations   
  ├─ Read operations                                          Monthly cost depends on usage: $0.0043 per 10k operations  
  ├─ All other operations                                     Monthly cost depends on usage: $0.0043 per 10k operations  
  └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         

--- a/internal/resources/aws/s3_storage_class_helpers.go
+++ b/internal/resources/aws/s3_storage_class_helpers.go
@@ -122,8 +122,8 @@ func s3LifecycleTransitionsCostComponent(region string, usageType string, operat
 			Region:     strPtr(region),
 			Service:    strPtr("AmazonS3"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s/i", usageType))},
-				{Key: "operation", ValueRegex: strPtr(fmt.Sprintf("/%s/i", operation))},
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", usageType))},
+				{Key: "operation", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", operation))},
 			},
 		},
 	}


### PR DESCRIPTION
## AWS S3
There are currently 2 products with `Requests-Tier4` usagetype: one for
Glacier and one for Standard. Glacier related product records have values
in `operation` attribute, but it is an empty string for Standard
storage. The `operation` regex with empty string returned both products.

SQL query for pricing:
```sql
select 
attributes->>'usagetype' as usagetype
, attributes->>'operation' as operation
, region
, prices
, *
from products 
where "vendorName" = 'aws' 
and service = 'AmazonS3' 
and region = 'us-east-1' 
and attributes->>'usagetype' = 'Requests-Tier4'
order by 
attributes->>'usagetype'
```

## Azure PostgreSQL Flexible Server

From Azure announcement: https://techcommunity.microsoft.com/t5/azure-database-for-postgresql/azure-database-for-postgresql-flexible-server-is-now-ga/ba-p/2987030

> As of December 1st, 2021, the price of the B1MS Burstable compute tier is being reduced by 50%.

## Azure Storage Account

Pricing has changed for Hot LRS Storage Accounts. The resource doesn't
show the cost components if their price can't be found anymore.
