### PR TITLE
fix: use --terraform-plan-flags during init and info

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,8 @@ type Project struct {
 	// TerraformCloudToken sets the Team API Token or User API Token so infracost can use it to access the plan.
 	// Only applicable for terraform cloud/enterprise users.
 	TerraformCloudToken string `yaml:"terraform_cloud_token,omitempty" envconfig:"INFRACOST_TERRAFORM_CLOUD_TOKEN"`
+	// TerragruntFlags set additional flags that should be passed to terragrunt.
+	TerragruntFlags string `envconfig:"INFRACOST_TERRAGRUNT_FLAGS"`
 	// UsageFile is the full path to usage file that specifies values for usage-based resources
 	UsageFile string `yaml:"usage_file,omitempty" ignored:"true"`
 	// TerraformUseState sets if the users wants to use the terraform state for infracost ops.

--- a/internal/providers/terraform/cmd.go
+++ b/internal/providers/terraform/cmd.go
@@ -21,6 +21,7 @@ type CmdOptions struct {
 	TerraformWorkspace  string
 	TerraformConfigFile string
 	Env                 map[string]string
+	Flags               []string
 }
 
 type CmdError struct {
@@ -38,7 +39,7 @@ func Cmd(opts *CmdOptions, args ...string) ([]byte, error) {
 		exe = defaultTerraformBinary
 	}
 
-	cmd := exec.Command(exe, args...)
+	cmd := exec.Command(exe, append(args, opts.Flags...)...)
 	log.Infof("Running command: %s", cmd.String())
 	cmd.Dir = opts.Dir
 	cmd.Env = os.Environ()


### PR DESCRIPTION
@aliscott This includes the `--terraform-plan-flags` when running terragrunt info-all AND when running terraform init.  I'm not sure about using them during init, maybe we should only do that when it is a terragrunt init?