### PR TITLE
Fix ASG module when creating launch configuration/template

### DIFF
--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
@@ -32,6 +32,28 @@
     └─ root_block_device                                                                           
        └─ Storage (general purpose SSD, gp2)                          16  GB                 $1.60 
                                                                                                    
+ aws_autoscaling_group.asg_lc_min_size                                                             
+ └─ aws_launch_configuration.lc_basic                                                              
+    ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)           1,460  hours             $67.74 
+    ├─ EC2 detailed monitoring                                        14  metrics            $4.20 
+    ├─ root_block_device                                                                           
+    │  └─ Storage (general purpose SSD, gp2)                          20  GB                 $2.00 
+    ├─ ebs_block_device[0]                                                                         
+    │  └─ Storage (general purpose SSD, gp2)                          20  GB                 $2.00 
+    └─ ebs_block_device[1]                                                                         
+       └─ Storage (general purpose SSD, gp3)                          20  GB                 $1.60 
+                                                                                                   
+ aws_autoscaling_group.asg_lc_min_size_zero                                                        
+ └─ aws_launch_configuration.lc_basic                                                              
+    ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)             730  hours             $33.87 
+    ├─ EC2 detailed monitoring                                         7  metrics            $2.10 
+    ├─ root_block_device                                                                           
+    │  └─ Storage (general purpose SSD, gp2)                          10  GB                 $1.00 
+    ├─ ebs_block_device[0]                                                                         
+    │  └─ Storage (general purpose SSD, gp2)                          10  GB                 $1.00 
+    └─ ebs_block_device[1]                                                                         
+       └─ Storage (general purpose SSD, gp3)                          10  GB                 $0.80 
+                                                                                                   
  aws_autoscaling_group.asg_lc_reserved                                                             
  └─ aws_launch_configuration.lc_reserved                                                           
     ├─ Instance usage (Linux/UNIX, reserved, t3.medium)              730  hours             $19.05 
@@ -89,6 +111,24 @@
     ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)           1,460  hours             $67.74 
     └─ Inference accelerator (eia2.medium)                         1,460  hours            $175.20 
                                                                                                    
+ aws_autoscaling_group.asg_lt_min_size                                                             
+ └─ aws_launch_template.lt_basic                                                                   
+    ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)           1,460  hours             $67.74 
+    ├─ block_device_mapping[0]                                                                     
+    │  └─ Storage (general purpose SSD, gp2)                          20  GB                 $2.00 
+    └─ block_device_mapping[1]                                                                     
+       ├─ Storage (provisioned IOPS SSD, io1)                         40  GB                 $5.00 
+       └─ Provisioned IOPS                                           400  IOPS              $26.00 
+                                                                                                   
+ aws_autoscaling_group.asg_lt_min_size_zero                                                        
+ └─ aws_launch_template.lt_basic                                                                   
+    ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)             730  hours             $33.87 
+    ├─ block_device_mapping[0]                                                                     
+    │  └─ Storage (general purpose SSD, gp2)                          10  GB                 $1.00 
+    └─ block_device_mapping[1]                                                                     
+       ├─ Storage (provisioned IOPS SSD, io1)                         20  GB                 $2.50 
+       └─ Provisioned IOPS                                           200  IOPS              $13.00 
+                                                                                                   
  aws_autoscaling_group.asg_lt_monitoring                                                           
  └─ aws_launch_template.lt_monitoring                                                              
     ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)           1,460  hours             $67.74 
@@ -112,15 +152,28 @@
  └─ aws_launch_template.lt_mixed_instance_dynamic                                                  
     └─ Instance usage (Linux/UNIX, on-demand, t2.large)            2,190  hours            $203.23 
                                                                                                    
- OVERALL TOTAL                                                                           $3,133.01 
+ module.asg-lc.aws_autoscaling_group.this[0]                                                       
+ └─ module.asg-lc.aws_launch_configuration.this[0]                                                 
+    ├─ Instance usage (Linux/UNIX, on-demand, t3.micro)              730  hours              $7.59 
+    ├─ EC2 detailed monitoring                                         7  metrics            $2.10 
+    └─ root_block_device                                                                           
+       └─ Storage (general purpose SSD, gp2)                           8  GB                 $0.80 
+                                                                                                   
+ module.asg-lt.aws_autoscaling_group.this[0]                                                       
+ └─ module.asg-lt.aws_launch_template.this[0]                                                      
+    ├─ Instance usage (Linux/UNIX, on-demand, t3.micro)              730  hours              $7.59 
+    └─ block_device_mapping[0]                                                                     
+       └─ Storage (general purpose SSD, gp2)                          10  GB                 $1.00 
+                                                                                                   
+ OVERALL TOTAL                                                                           $3,419.53 
 ──────────────────────────────────
-40 cloud resources were detected:
-∙ 18 were estimated, 18 include usage-based costs, see https://infracost.io/usage-file
+50 cloud resources were detected:
+∙ 26 were estimated, 26 include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 weren't estimated, report them in https://github.com/infracost/infracost:
   ∙ 2 x aws_autoscaling_group
-∙ 20 were free:
-  ∙ 11 x aws_launch_template
-  ∙ 9 x aws_launch_configuration
+∙ 22 were free:
+  ∙ 12 x aws_launch_template
+  ∙ 10 x aws_launch_configuration
 Logs:
 
 level=warning msg="Skipping resource aws_launch_configuration.lc_tenancy_host. Infracost currently does not support host tenancy for AWS Launch Configurations"

--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.tf
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.tf
@@ -36,6 +36,25 @@ resource "aws_autoscaling_group" "asg_lc_basic" {
   min_size             = 1
 }
 
+resource "aws_autoscaling_group" "asg_lc_min_size" {
+  launch_configuration = aws_launch_configuration.lc_basic.id
+  max_size             = 3
+  min_size             = 2
+}
+
+resource "aws_autoscaling_group" "asg_lc_min_size_zero" {
+  launch_configuration = aws_launch_configuration.lc_basic.id
+  max_size             = 3
+  min_size             = 0
+}
+
+resource "aws_autoscaling_group" "asg_lc_desired_capacity_zero" {
+  launch_configuration = aws_launch_configuration.lc_basic.id
+  desired_capacity     = 0
+  max_size             = 3
+  min_size             = 0
+}
+
 resource "aws_launch_configuration" "lc_ebs_optimized" {
   image_id          = "fake_ami"
   instance_type     = "r3.xlarge"
@@ -177,6 +196,31 @@ resource "aws_autoscaling_group" "asg_lt_basic" {
   desired_capacity = 2
   max_size         = 3
   min_size         = 1
+}
+
+resource "aws_autoscaling_group" "asg_lt_min_size" {
+  launch_template {
+    id = aws_launch_template.lt_basic.id
+  }
+  max_size = 3
+  min_size = 2
+}
+
+resource "aws_autoscaling_group" "asg_lt_min_size_zero" {
+  launch_template {
+    id = aws_launch_template.lt_basic.id
+  }
+  max_size = 3
+  min_size = 0
+}
+
+resource "aws_autoscaling_group" "asg_lt_desired_capacity_zero" {
+  launch_template {
+    id = aws_launch_template.lt_basic.id
+  }
+  desired_capacity = 0
+  max_size         = 3
+  min_size         = 0
 }
 
 resource "aws_launch_template" "lt_tenancy_dedicated" {
@@ -375,4 +419,40 @@ resource "aws_autoscaling_group" "asg_mixed_instance_dynamic" {
       on_demand_percentage_above_base_capacity = 100
     }
   }
+}
+
+module "asg-lc" {
+  source           = "terraform-aws-modules/autoscaling/aws"
+  version          = "~> 4"
+  name             = "asg"
+  use_lc           = true
+  create_lc        = true
+  lc_name          = "lc"
+  image_id         = "ami-0ff8a91507f77f867"
+  instance_type    = "t3.micro"
+  min_size         = 0
+  max_size         = 2
+  desired_capacity = 1
+}
+
+module "asg-lt" {
+  source           = "terraform-aws-modules/autoscaling/aws"
+  version          = "~> 4"
+  name             = "asg"
+  use_lt           = true
+  create_lt        = true
+  lt_name          = "lt"
+  image_id         = "ami-0ff8a91507f77f867"
+  instance_type    = "t3.micro"
+  min_size         = 0
+  max_size         = 2
+  desired_capacity = 1
+  block_device_mappings = [
+    {
+      device_name = "/dev/xvdf"
+      ebs = {
+        volume_size = 10
+      }
+    }
+  ]
 }

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -686,6 +686,18 @@ func parseKnownModuleRefs(resData map[string]*schema.ResourceData, conf gjson.Re
 			Attribute:        "launch_template",
 			ModuleSource:     "terraform-aws-modules/eks/aws",
 		},
+		{
+			SourceAddrSuffix: "aws_autoscaling_group.this",
+			DestAddrSuffix:   "aws_launch_template.this",
+			Attribute:        "launch_template",
+			ModuleSource:     "terraform-aws-modules/autoscaling/aws",
+		},
+		{
+			SourceAddrSuffix: "aws_autoscaling_group.this",
+			DestAddrSuffix:   "aws_launch_configuration.this",
+			Attribute:        "launch_configuration",
+			ModuleSource:     "terraform-aws-modules/autoscaling/aws",
+		},
 	}
 
 	for _, d := range resData {

--- a/internal/resources/aws/launch_configuration.go
+++ b/internal/resources/aws/launch_configuration.go
@@ -82,7 +82,7 @@ func (a *LaunchConfiguration) BuildResource() *schema.Resource {
 		EstimateUsage:  instanceResource.EstimateUsage,
 	}
 
-	qty := int64(0)
+	qty := int64(1)
 	if a.InstanceCount != nil {
 		qty = *a.InstanceCount
 	}

--- a/internal/resources/aws/launch_template.go
+++ b/internal/resources/aws/launch_template.go
@@ -91,7 +91,7 @@ func (a *LaunchTemplate) BuildResource() *schema.Resource {
 		EstimateUsage:  instanceResource.EstimateUsage,
 	}
 
-	instanceCount := int64(0)
+	instanceCount := int64(1)
 	if a.InstanceCount != nil {
 		instanceCount = *a.InstanceCount
 	}
@@ -118,7 +118,7 @@ func (a *LaunchTemplate) BuildResource() *schema.Resource {
 }
 
 func (a *LaunchTemplate) calculateOnDemandAndSpotInstanceCounts() (int64, int64) {
-	instanceCount := int64(0)
+	instanceCount := int64(1)
 	if a.InstanceCount != nil {
 		instanceCount = *a.InstanceCount
 	}


### PR DESCRIPTION
This fixes the https://registry.terraform.io/modules/HDE/autoscaling/aws/latest module not showing any results when it creates a launch configuration or launch template. It does this by adding special mappings for those cases.

This also fixes the case if the `desired_capacity` attribute is missing by using a default instance count of 1, so we still show a result for this case. The alternative is setting nil quantity values in this case so we show the `Monthly cost depends on usage` message, but this seemed clearer to me.

Fixes https://github.com/infracost/infracost/issues/1180.