### PR TITLE
fix: Fix pricing in golden file tests

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -308,10 +308,8 @@ resource_usage:
       monthly_expedited_select_data_scanned_gb: 500000 # Monthly data scanned by S3 Select in GB (for expedited level of S3 Glacier)
       monthly_expedited_select_data_returned_gb: 500000 # Monthly data returned by S3 Select in GB (for expedited level of S3 Glacier)
       monthly_standard_data_retrieval_requests: 500000 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_requests: 500000 # Monthly data Retrieval requests (for bulk level of S3 Glacier).
       monthly_expedited_data_retrieval_requests: 500000 # Monthly data Retrieval requests (for expedited level of S3 Glacier).
       monthly_standard_data_retrieval_gb: 5000 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_gb: 5000 # Monthly data retrievals in GB (for bulk level of S3 Glacier).
       monthly_expedited_data_retrieval_gb: 5000 # Monthly data retrievals in GB (for expedited level of S3 Glacier).
       early_delete_gb: 500000 # If an archive is deleted within 3 months of being uploaded, you will be charged an early deletion fee per GB.
     glacier_deep_archive: # Usages of S3 Glacier Deep Archive:

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -296,7 +296,7 @@ resource_usage:
       monthly_data_retrieval_gb: 40000 # Monthly data retrievals in GB
       monthly_select_data_scanned_gb: 40000 # Monthly data scanned by S3 Select in GB.
       monthly_select_data_returned_gb: 4000 # Monthly data returned by S3 Select in GB.
-    glacier: # Usages of S3 Glacier:
+    glacier_flexible_retrieval: # Usages of S3 Glacier Flexible Retrieval:
       storage_gb: 50000 # Total storage in GB.
       monthly_tier_1_requests: 5000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
       monthly_tier_2_requests: 500000 # Monthly GET, SELECT, and all other requests (Tier 2).

--- a/internal/providers/terraform/aws/s3_bucket.go
+++ b/internal/providers/terraform/aws/s3_bucket.go
@@ -22,7 +22,7 @@ func NewS3BucketResource(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 		"INTELLIGENT_TIERING": "intelligent_tiering",
 		"STANDARD_IA":         "standard_infrequent_access",
 		"ONEZONE_IA":          "one_zone_infrequent_access",
-		"GLACIER":             "glacier",
+		"GLACIER":             "glacier_flexible_retrieval",
 		"DEEP_ARCHIVE":        "glacier_deep_archive",
 	}
 

--- a/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.golden
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.golden
@@ -12,7 +12,7 @@
  ├─ Intelligent tiering                                                                             
  │  ├─ Storage (frequent access)            Monthly cost depends on usage: $0.023 per GB            
  │  ├─ Storage (infrequent access)          Monthly cost depends on usage: $0.0125 per GB           
- │  ├─ Storage (archive access)             Monthly cost depends on usage: $0.004 per GB            
+ │  ├─ Storage (archive access)             Monthly cost depends on usage: $0.0036 per GB           
  │  ├─ Storage (deep archive access)        Monthly cost depends on usage: $0.00099 per GB          
  │  ├─ Monitoring and automation            Monthly cost depends on usage: $0.0025 per 1k objects   
  │  ├─ PUT, COPY, POST, LIST requests       Monthly cost depends on usage: $0.005 per 1k requests   
@@ -38,7 +38,7 @@
  │  ├─ Select data scanned                  Monthly cost depends on usage: $0.002 per GB            
  │  └─ Select data returned                 Monthly cost depends on usage: $0.01 per GB             
  ├─ Glacier                                                                                         
- │  ├─ Storage                              Monthly cost depends on usage: $0.004 per GB            
+ │  ├─ Storage                              Monthly cost depends on usage: $0.0036 per GB           
  │  ├─ PUT, COPY, POST, LIST requests       Monthly cost depends on usage: $0.03 per 1k requests    
  │  ├─ GET, SELECT, and all other requests  Monthly cost depends on usage: $0.0004 per 1k requests  
  │  ├─ Lifecycle transition                 Monthly cost depends on usage: $0.03 per 1k requests    
@@ -50,11 +50,9 @@
  │  ├─ Retrievals (expedited)               Monthly cost depends on usage: $0.03 per GB             
  │  ├─ Select data scanned (expedited)      Monthly cost depends on usage: $0.02 per GB             
  │  ├─ Select data returned (expedited)     Monthly cost depends on usage: $0.03 per GB             
- │  ├─ Retrieval requests (bulk)            Monthly cost depends on usage: $0.025 per 1k requests   
- │  ├─ Retrievals (bulk)                    Monthly cost depends on usage: $0.0025 per GB           
  │  ├─ Select data scanned (bulk)           Monthly cost depends on usage: $0.001 per GB            
  │  ├─ Select data returned (bulk)          Monthly cost depends on usage: $0.0025 per GB           
- │  └─ Early delete (within 90 days)        Monthly cost depends on usage: $0.004 per GB            
+ │  └─ Early delete (within 90 days)        Monthly cost depends on usage: $0.0036 per GB           
  └─ Glacier deep archive                                                                            
     ├─ Storage                              Monthly cost depends on usage: $0.00099 per GB          
     ├─ PUT, COPY, POST, LIST requests       Monthly cost depends on usage: $0.05 per 1k requests    
@@ -77,7 +75,7 @@
  ├─ Intelligent tiering                                                                             
  │  ├─ Storage (frequent access)                       20,000  GB                           $460.00 
  │  ├─ Storage (infrequent access)                     20,000  GB                           $250.00 
- │  ├─ Storage (archive access)                        20,000  GB                            $80.00 
+ │  ├─ Storage (archive access)                        20,000  GB                            $72.00 
  │  ├─ Storage (deep archive access)                   20,000  GB                            $19.80 
  │  ├─ Monitoring and automation                           20  1k objects                     $0.05 
  │  ├─ PUT, COPY, POST, LIST requests                      20  1k requests                    $0.10 
@@ -103,7 +101,7 @@
  │  ├─ Select data scanned                             40,000  GB                            $80.00 
  │  └─ Select data returned                            40,000  GB                           $400.00 
  ├─ Glacier                                                                                         
- │  ├─ Storage                                         50,000  GB                           $200.00 
+ │  ├─ Storage                                         50,000  GB                           $180.00 
  │  ├─ PUT, COPY, POST, LIST requests                      50  1k requests                    $1.50 
  │  ├─ GET, SELECT, and all other requests                 50  1k requests                    $0.02 
  │  ├─ Lifecycle transition                                50  1k requests                    $1.50 
@@ -115,11 +113,9 @@
  │  ├─ Retrievals (expedited)                          50,000  GB                         $1,500.00 
  │  ├─ Select data scanned (expedited)                 50,000  GB                         $1,000.00 
  │  ├─ Select data returned (expedited)                50,000  GB                         $1,500.00 
- │  ├─ Retrieval requests (bulk)                           50  1k requests                    $1.25 
- │  ├─ Retrievals (bulk)                               50,000  GB                           $125.00 
  │  ├─ Select data scanned (bulk)                      50,000  GB                            $50.00 
  │  ├─ Select data returned (bulk)                     50,000  GB                           $125.00 
- │  └─ Early delete (within 90 days)                   50,000  GB                           $200.00 
+ │  └─ Early delete (within 90 days)                   50,000  GB                           $180.00 
  └─ Glacier deep archive                                                                            
     ├─ Storage                                         60,000  GB                            $59.40 
     ├─ PUT, COPY, POST, LIST requests                      60  1k requests                    $3.00 
@@ -131,7 +127,7 @@
     ├─ Retrievals (bulk)                               60,000  GB                           $150.00 
     └─ Early delete (within 180 days)                  60,000  GB                            $59.40 
                                                                                                     
- OVERALL TOTAL                                                                           $11,985.78 
+ OVERALL TOTAL                                                                           $11,811.53 
 ──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.golden
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.golden
@@ -37,7 +37,7 @@
  │  ├─ Retrievals                           Monthly cost depends on usage: $0.01 per GB             
  │  ├─ Select data scanned                  Monthly cost depends on usage: $0.002 per GB            
  │  └─ Select data returned                 Monthly cost depends on usage: $0.01 per GB             
- ├─ Glacier                                                                                         
+ ├─ Glacier flexible retrieval                                                                      
  │  ├─ Storage                              Monthly cost depends on usage: $0.0036 per GB           
  │  ├─ PUT, COPY, POST, LIST requests       Monthly cost depends on usage: $0.03 per 1k requests    
  │  ├─ GET, SELECT, and all other requests  Monthly cost depends on usage: $0.0004 per 1k requests  
@@ -100,7 +100,7 @@
  │  ├─ Retrievals                                      40,000  GB                           $400.00 
  │  ├─ Select data scanned                             40,000  GB                            $80.00 
  │  └─ Select data returned                            40,000  GB                           $400.00 
- ├─ Glacier                                                                                         
+ ├─ Glacier flexible retrieval                                                                      
  │  ├─ Storage                                         50,000  GB                           $180.00 
  │  ├─ PUT, COPY, POST, LIST requests                      50  1k requests                    $1.50 
  │  ├─ GET, SELECT, and all other requests                 50  1k requests                    $0.02 

--- a/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.usage.yml
@@ -40,7 +40,7 @@ resource_usage:
       monthly_select_data_scanned_gb:        40000
       monthly_select_data_returned_gb:       40000
 
-    glacier:
+    glacier_flexible_retrieval:
       storage_gb:                                50000
       monthly_tier_1_requests:                   50000
       monthly_tier_2_requests:                   50000

--- a/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_test/s3_bucket_test.usage.yml
@@ -52,10 +52,8 @@ resource_usage:
       monthly_expedited_select_data_scanned_gb:  50000
       monthly_expedited_select_data_returned_gb: 50000
       monthly_standard_data_retrieval_requests:  50000
-      monthly_bulk_data_retrieval_requests:      50000
       monthly_expedited_data_retrieval_requests: 50000
       monthly_standard_data_retrieval_gb:        50000
-      monthly_bulk_data_retrieval_gb:            50000
       monthly_expedited_data_retrieval_gb:       50000
       early_delete_gb:                           50000
 

--- a/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
+++ b/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.golden
@@ -38,11 +38,14 @@
  └─ Executions                                                                     0.1  1M requests                      $0.02 
                                                                                                                                
  azurerm_storage_account.example                                                                                               
- ├─ Capacity                                                        Monthly cost depends on usage: $0.0208 per GB              
- ├─ Write operations                                                Monthly cost depends on usage: $0.05 per 10k operations    
- ├─ Read operations                                                 Monthly cost depends on usage: $0.004 per 10k operations   
+ ├─ Capacity                                                        Monthly cost depends on usage: $0.0152 per GB              
+ ├─ Write operations                                                Monthly cost depends on usage: $0.10 per 10k operations    
+ ├─ List and create container operations                            Monthly cost depends on usage: $0.05 per 10k operations    
+ ├─ Read operations                                                 Monthly cost depends on usage: $0.01 per 10k operations    
  ├─ All other operations                                            Monthly cost depends on usage: $0.004 per 10k operations   
- └─ Blob index                                                      Monthly cost depends on usage: $0.03 per 10k tags          
+ ├─ Data retrieval                                                  Monthly cost depends on usage: $0.01 per GB                
+ ├─ Blob index                                                      Monthly cost depends on usage: $0.03 per 10k tags          
+ └─ Early deletion                                                  Monthly cost depends on usage: $0.0152 per GB              
                                                                                                                                
  OVERALL TOTAL                                                                                                       $1,134.69 
 ──────────────────────────────────

--- a/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.tf
+++ b/internal/providers/terraform/azure/testdata/function_app_test/function_app_test.tf
@@ -55,6 +55,7 @@ resource "azurerm_storage_account" "example" {
   location                 = azurerm_resource_group.example1.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  access_tier              = "Cool"
 }
 
 resource "azurerm_function_app" "elasticFunction" {

--- a/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.golden
@@ -13,11 +13,14 @@
  └─ Zookeeper node (Standard_A5)                             2,190  hours                          $554.07 
                                                                                                            
  azurerm_storage_account.example                                                                           
- ├─ Capacity                                    Monthly cost depends on usage: $0.0196 per GB              
- ├─ Write operations                            Monthly cost depends on usage: $0.054 per 10k operations   
- ├─ Read operations                             Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ Capacity                                    Monthly cost depends on usage: $0.01 per GB                
+ ├─ Write operations                            Monthly cost depends on usage: $0.10 per 10k operations    
+ ├─ List and create container operations        Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                             Monthly cost depends on usage: $0.01 per 10k operations    
  ├─ All other operations                        Monthly cost depends on usage: $0.0043 per 10k operations  
- └─ Blob index                                  Monthly cost depends on usage: $0.039 per 10k tags         
+ ├─ Data retrieval                              Monthly cost depends on usage: $0.01 per GB                
+ ├─ Blob index                                  Monthly cost depends on usage: $0.039 per 10k tags         
+ └─ Early deletion                              Monthly cost depends on usage: $0.01 per GB                
                                                                                                            
  OVERALL TOTAL                                                                                   $3,967.55 
 ──────────────────────────────────

--- a/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.tf
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hadoop_cluster_test/hdinsight_hadoop_cluster_test.tf
@@ -14,6 +14,7 @@ resource "azurerm_storage_account" "example" {
   location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  access_tier              = "Cool"
 }
 
 resource "azurerm_storage_container" "example" {

--- a/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.golden
@@ -7,11 +7,14 @@
  └─ Zookeeper node (Standard_D4a V4)                   2,190  hours                          $525.60 
                                                                                                      
  azurerm_storage_account.example                                                                     
- ├─ Capacity                              Monthly cost depends on usage: $0.0196 per GB              
- ├─ Write operations                      Monthly cost depends on usage: $0.054 per 10k operations   
- ├─ Read operations                       Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ Capacity                              Monthly cost depends on usage: $0.01 per GB                
+ ├─ Write operations                      Monthly cost depends on usage: $0.10 per 10k operations    
+ ├─ List and create container operations  Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                       Monthly cost depends on usage: $0.01 per 10k operations    
  ├─ All other operations                  Monthly cost depends on usage: $0.0043 per 10k operations  
- └─ Blob index                            Monthly cost depends on usage: $0.039 per 10k tags         
+ ├─ Data retrieval                        Monthly cost depends on usage: $0.01 per GB                
+ ├─ Blob index                            Monthly cost depends on usage: $0.039 per 10k tags         
+ └─ Early deletion                        Monthly cost depends on usage: $0.01 per GB                
                                                                                                      
  OVERALL TOTAL                                                                             $3,907.40 
 ──────────────────────────────────

--- a/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.tf
+++ b/internal/providers/terraform/azure/testdata/hdinsight_hbase_cluster_test/hdinsight_hbase_cluster_test.tf
@@ -14,6 +14,7 @@ resource "azurerm_storage_account" "example" {
   location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  access_tier              = "Cool"
 }
 
 resource "azurerm_storage_container" "example" {

--- a/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.golden
@@ -7,11 +7,14 @@
  └─ Zookeeper node (Standard_E64i_V3)                              2,190  hours                       $12,246.48 
                                                                                                                  
  azurerm_storage_account.example                                                                                 
- ├─ Capacity                                          Monthly cost depends on usage: $0.0196 per GB              
- ├─ Write operations                                  Monthly cost depends on usage: $0.054 per 10k operations   
- ├─ Read operations                                   Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ Capacity                                          Monthly cost depends on usage: $0.01 per GB                
+ ├─ Write operations                                  Monthly cost depends on usage: $0.10 per 10k operations    
+ ├─ List and create container operations              Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                                   Monthly cost depends on usage: $0.01 per 10k operations    
  ├─ All other operations                              Monthly cost depends on usage: $0.0043 per 10k operations  
- └─ Blob index                                        Monthly cost depends on usage: $0.039 per 10k tags         
+ ├─ Data retrieval                                    Monthly cost depends on usage: $0.01 per GB                
+ ├─ Blob index                                        Monthly cost depends on usage: $0.039 per 10k tags         
+ └─ Early deletion                                    Monthly cost depends on usage: $0.01 per GB                
                                                                                                                  
  OVERALL TOTAL                                                                                        $15,852.68 
 ──────────────────────────────────

--- a/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.tf
+++ b/internal/providers/terraform/azure/testdata/hdinsight_interactive_query_cluster_test/hdinsight_interactive_query_cluster_test.tf
@@ -14,6 +14,7 @@ resource "azurerm_storage_account" "example" {
   location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  access_tier              = "Cool"
 }
 
 resource "azurerm_storage_container" "example" {

--- a/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.golden
@@ -23,11 +23,14 @@
  └─ Disk operations                                          40  100K operations                    $0.01 
                                                                                                           
  azurerm_storage_account.example                                                                          
- ├─ Capacity                                Monthly cost depends on usage: $0.0196 per GB                 
- ├─ Write operations                        Monthly cost depends on usage: $0.054 per 10k operations      
- ├─ Read operations                         Monthly cost depends on usage: $0.0043 per 10k operations     
+ ├─ Capacity                                Monthly cost depends on usage: $0.01 per GB                   
+ ├─ Write operations                        Monthly cost depends on usage: $0.10 per 10k operations       
+ ├─ List and create container operations    Monthly cost depends on usage: $0.054 per 10k operations      
+ ├─ Read operations                         Monthly cost depends on usage: $0.01 per 10k operations       
  ├─ All other operations                    Monthly cost depends on usage: $0.0043 per 10k operations     
- └─ Blob index                              Monthly cost depends on usage: $0.039 per 10k tags            
+ ├─ Data retrieval                          Monthly cost depends on usage: $0.01 per GB                   
+ ├─ Blob index                              Monthly cost depends on usage: $0.039 per 10k tags            
+ └─ Early deletion                          Monthly cost depends on usage: $0.01 per GB                   
                                                                                                           
  OVERALL TOTAL                                                                                 $27,535.31 
 ──────────────────────────────────

--- a/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.tf
+++ b/internal/providers/terraform/azure/testdata/hdinsight_kafka_cluster_test/hdinsight_kafka_cluster_test.tf
@@ -14,6 +14,7 @@ resource "azurerm_storage_account" "example" {
   location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  access_tier              = "Cool"
 }
 
 resource "azurerm_storage_container" "example" {

--- a/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.golden
@@ -7,11 +7,14 @@
  └─ Zookeeper node (Standard_G2)                       2,190  hours                        $3,232.44 
                                                                                                      
  azurerm_storage_account.example                                                                     
- ├─ Capacity                              Monthly cost depends on usage: $0.0196 per GB              
- ├─ Write operations                      Monthly cost depends on usage: $0.054 per 10k operations   
- ├─ Read operations                       Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ Capacity                              Monthly cost depends on usage: $0.01 per GB                
+ ├─ Write operations                      Monthly cost depends on usage: $0.10 per 10k operations    
+ ├─ List and create container operations  Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                       Monthly cost depends on usage: $0.01 per 10k operations    
  ├─ All other operations                  Monthly cost depends on usage: $0.0043 per 10k operations  
- └─ Blob index                            Monthly cost depends on usage: $0.039 per 10k tags         
+ ├─ Data retrieval                        Monthly cost depends on usage: $0.01 per GB                
+ ├─ Blob index                            Monthly cost depends on usage: $0.039 per 10k tags         
+ └─ Early deletion                        Monthly cost depends on usage: $0.01 per GB                
                                                                                                      
  OVERALL TOTAL                                                                             $8,619.84 
 ──────────────────────────────────

--- a/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.tf
+++ b/internal/providers/terraform/azure/testdata/hdinsight_spark_cluster_test/hdinsight_spark_cluster_test.tf
@@ -14,6 +14,7 @@ resource "azurerm_storage_account" "example" {
   location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  access_tier              = "Cool"
 }
 
 resource "azurerm_storage_container" "example" {

--- a/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.golden
@@ -2,11 +2,14 @@
  Name                                                               Monthly Qty  Unit                      Monthly Cost 
                                                                                                                         
  azurerm_storage_account.example                                                                                        
- ├─ Capacity                                                 Monthly cost depends on usage: $0.0196 per GB              
- ├─ Write operations                                         Monthly cost depends on usage: $0.054 per 10k operations   
- ├─ Read operations                                          Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.01 per GB                
+ ├─ Write operations                                         Monthly cost depends on usage: $0.10 per 10k operations    
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                                          Monthly cost depends on usage: $0.01 per 10k operations    
  ├─ All other operations                                     Monthly cost depends on usage: $0.0043 per 10k operations  
- └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+ ├─ Data retrieval                                           Monthly cost depends on usage: $0.01 per GB                
+ ├─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+ └─ Early deletion                                           Monthly cost depends on usage: $0.01 per GB                
                                                                                                                         
  azurerm_synapse_spark_pool.autoscale                                                                                   
  └─ small (4 nodes)                                                         144  vCore-hours                     $22.26 

--- a/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.tf
+++ b/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.tf
@@ -15,6 +15,7 @@ resource "azurerm_storage_account" "example" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
+  access_tier              = "Cool"
   is_hns_enabled           = "true"
 }
 

--- a/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.golden
@@ -2,11 +2,14 @@
  Name                                                               Monthly Qty  Unit                      Monthly Cost 
                                                                                                                         
  azurerm_storage_account.example                                                                                        
- ├─ Capacity                                                 Monthly cost depends on usage: $0.0196 per GB              
- ├─ Write operations                                         Monthly cost depends on usage: $0.054 per 10k operations   
- ├─ Read operations                                          Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.01 per GB                
+ ├─ Write operations                                         Monthly cost depends on usage: $0.10 per 10k operations    
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                                          Monthly cost depends on usage: $0.01 per 10k operations    
  ├─ All other operations                                     Monthly cost depends on usage: $0.0043 per 10k operations  
- └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+ ├─ Data retrieval                                           Monthly cost depends on usage: $0.01 per GB                
+ ├─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+ └─ Early deletion                                           Monthly cost depends on usage: $0.01 per GB                
                                                                                                                         
  azurerm_synapse_sql_pool.default                                                                                       
  ├─ DWU blocks (DW200c)                                                     730  hours                        $2,204.60 

--- a/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.tf
+++ b/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.tf
@@ -15,6 +15,7 @@ resource "azurerm_storage_account" "example" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
+  access_tier              = "Cool"
   is_hns_enabled           = "true"
 }
 

--- a/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.golden
@@ -2,11 +2,14 @@
  Name                                                               Monthly Qty  Unit                      Monthly Cost 
                                                                                                                         
  azurerm_storage_account.example                                                                                        
- ├─ Capacity                                                 Monthly cost depends on usage: $0.0196 per GB              
- ├─ Write operations                                         Monthly cost depends on usage: $0.054 per 10k operations   
- ├─ Read operations                                          Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.01 per GB                
+ ├─ Write operations                                         Monthly cost depends on usage: $0.10 per 10k operations    
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.054 per 10k operations   
+ ├─ Read operations                                          Monthly cost depends on usage: $0.01 per 10k operations    
  ├─ All other operations                                     Monthly cost depends on usage: $0.0043 per 10k operations  
- └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+ ├─ Data retrieval                                           Monthly cost depends on usage: $0.01 per GB                
+ ├─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+ └─ Early deletion                                           Monthly cost depends on usage: $0.01 per GB                
                                                                                                                         
  azurerm_synapse_workspace.dataflows                                                                                    
  ├─ Serverless SQL pool size                                 Monthly cost depends on usage: $5.00 per TB                

--- a/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.tf
+++ b/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.tf
@@ -15,6 +15,7 @@ resource "azurerm_storage_account" "example" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
+  access_tier              = "Cool"
   is_hns_enabled           = "true"
 }
 

--- a/internal/resources/aws/dynamodb_table.go
+++ b/internal/resources/aws/dynamodb_table.go
@@ -307,7 +307,7 @@ func (a *DynamoDBTable) dataStorageCostComponent(region string, storageGB *int64
 			Service:       strPtr("AmazonDynamoDB"),
 			ProductFamily: strPtr("Database Storage"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "usagetype", ValueRegex: strPtr("/TimedStorage-ByteHrs/")},
+				{Key: "usagetype", ValueRegex: regexPtr("^TimedStorage-ByteHrs$")},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{

--- a/internal/resources/aws/s3_bucket.go
+++ b/internal/resources/aws/s3_bucket.go
@@ -41,7 +41,7 @@ var S3BucketUsageSchema = []*schema.UsageItem{
 	{Key: "intelligent_tiering", DefaultValue: &usage.ResourceUsage{Name: "intelligent_tiering", Items: S3IntelligentTieringStorageClassUsageSchema}, ValueType: schema.SubResourceUsage},
 	{Key: "standard_infrequent_access", DefaultValue: &usage.ResourceUsage{Name: "standard_infrequent_access", Items: S3StandardInfrequentAccessStorageClassUsageSchema}, ValueType: schema.SubResourceUsage},
 	{Key: "one_zone_infrequent_access", DefaultValue: &usage.ResourceUsage{Name: "one_zone_infrequent_access", Items: S3OneZoneInfrequentAccessStorageClassUsageSchema}, ValueType: schema.SubResourceUsage},
-	{Key: "glacier", DefaultValue: &usage.ResourceUsage{Name: "glacier", Items: S3GlacierStorageClassUsageSchema}, ValueType: schema.SubResourceUsage},
+	{Key: "glacier_flexible_retrieval", DefaultValue: &usage.ResourceUsage{Name: "glacier_flexible_retrieval", Items: S3GlacierFlexibleRetrievalStorageClassUsageSchema}, ValueType: schema.SubResourceUsage},
 	{Key: "glacier_deep_archive", DefaultValue: &usage.ResourceUsage{Name: "glacier_deep_archive", Items: S3GlacierDeepArchiveStorageClassUsageSchema}, ValueType: schema.SubResourceUsage},
 }
 
@@ -52,7 +52,7 @@ func (a *S3Bucket) AllStorageClasses() []S3StorageClass {
 			&S3IntelligentTieringStorageClass{Region: a.Region},
 			&S3StandardInfrequentAccessStorageClass{Region: a.Region},
 			&S3OneZoneInfrequentAccessStorageClass{Region: a.Region},
-			&S3GlacierStorageClass{Region: a.Region},
+			&S3GlacierFlexibleRetrievalStorageClass{Region: a.Region},
 			&S3GlacierDeepArchiveStorageClass{Region: a.Region},
 		}
 	}
@@ -109,7 +109,7 @@ func (a *S3Bucket) BuildResource() *schema.Resource {
 			"one_zone_infrequent_access": {
 				"storage_gb": "OneZoneIAStorage",
 			},
-			"glacier": {
+			"glacier_flexible_retrieval": {
 				"storage_gb": "GlacierStorage",
 			},
 			"glacier_deep_archive": {

--- a/internal/resources/aws/s3_bucket_estimate_test.go
+++ b/internal/resources/aws/s3_bucket_estimate_test.go
@@ -155,7 +155,7 @@ func TestS3Bucket(t *testing.T) {
 		"one_zone_infrequent_access": map[string]interface{}{
 			"storage_gb": 2.7,
 		},
-		"glacier": map[string]interface{}{
+		"glacier_flexible_retrieval": map[string]interface{}{
 			"storage_gb": 2.8,
 		},
 	}, estimates.usage)

--- a/internal/resources/aws/s3_glacier_flexible_retrieval_storage_class.go
+++ b/internal/resources/aws/s3_glacier_flexible_retrieval_storage_class.go
@@ -5,7 +5,7 @@ import (
 	"github.com/infracost/infracost/internal/schema"
 )
 
-type S3GlacierStorageClass struct {
+type S3GlacierFlexibleRetrievalStorageClass struct {
 	// "required" args that can't really be missing.
 	Region string
 
@@ -27,7 +27,7 @@ type S3GlacierStorageClass struct {
 	EarlyDeleteGB                         *float64 `infracost_usage:"early_delete_gb"`
 }
 
-var S3GlacierStorageClassUsageSchema = []*schema.UsageItem{
+var S3GlacierFlexibleRetrievalStorageClassUsageSchema = []*schema.UsageItem{
 	{Key: "storage_gb", DefaultValue: 0, ValueType: schema.Int64},
 	{Key: "monthly_tier_1_requests", DefaultValue: 0, ValueType: schema.Int64},
 	{Key: "monthly_tier_2_requests", DefaultValue: 0, ValueType: schema.Int64},
@@ -45,18 +45,18 @@ var S3GlacierStorageClassUsageSchema = []*schema.UsageItem{
 	{Key: "early_delete_gb", DefaultValue: 0.0, ValueType: schema.Float64},
 }
 
-func (a *S3GlacierStorageClass) UsageKey() string {
-	return "glacier"
+func (a *S3GlacierFlexibleRetrievalStorageClass) UsageKey() string {
+	return "glacier_flexible_retrieval"
 }
 
-func (a *S3GlacierStorageClass) PopulateUsage(u *schema.UsageData) {
+func (a *S3GlacierFlexibleRetrievalStorageClass) PopulateUsage(u *schema.UsageData) {
 	resources.PopulateArgsWithUsage(a, u)
 }
 
-func (a *S3GlacierStorageClass) BuildResource() *schema.Resource {
+func (a *S3GlacierFlexibleRetrievalStorageClass) BuildResource() *schema.Resource {
 	return &schema.Resource{
-		Name:        "Glacier",
-		UsageSchema: S3GlacierStorageClassUsageSchema,
+		Name:        "Glacier flexible retrieval",
+		UsageSchema: S3GlacierFlexibleRetrievalStorageClassUsageSchema,
 		CostComponents: []*schema.CostComponent{
 			s3StorageCostComponent("Storage", "AmazonGlacier", a.Region, "TimedStorage-ByteHrs", a.StorageGB),
 			s3ApiOperationCostComponent("PUT, COPY, POST, LIST requests", "AmazonS3", a.Region, "Requests-GLACIER-Tier1", "PostObject", a.MonthlyTier1Requests),

--- a/internal/resources/aws/s3_glacier_storage_class.go
+++ b/internal/resources/aws/s3_glacier_storage_class.go
@@ -22,8 +22,6 @@ type S3GlacierStorageClass struct {
 	MonthlyExpeditedDataRetrievalGB       *float64 `infracost_usage:"monthly_expedited_data_retrieval_gb"`
 	MonthlyExpeditedSelectDataScannedGB   *float64 `infracost_usage:"monthly_expedited_select_data_scanned_gb"`
 	MonthlyExpeditedSelectDataReturnedGB  *float64 `infracost_usage:"monthly_expedited_select_data_returned_gb"`
-	MonthlyBulkDataRetrievalRequests      *int64   `infracost_usage:"monthly_bulk_data_retrieval_requests"`
-	MonthlyBulkDataRetrievalGB            *float64 `infracost_usage:"monthly_bulk_data_retrieval_gb"`
 	MonthlyBulkSelectDataScannedGB        *float64 `infracost_usage:"monthly_bulk_select_data_scanned_gb"`
 	MonthlyBulkSelectDataReturnedGB       *float64 `infracost_usage:"monthly_bulk_select_data_returned_gb"`
 	EarlyDeleteGB                         *float64 `infracost_usage:"early_delete_gb"`
@@ -42,8 +40,6 @@ var S3GlacierStorageClassUsageSchema = []*schema.UsageItem{
 	{Key: "monthly_expedited_data_retrieval_gb", DefaultValue: 0.0, ValueType: schema.Float64},
 	{Key: "monthly_expedited_select_data_scanned_gb", DefaultValue: 0.0, ValueType: schema.Float64},
 	{Key: "monthly_expedited_select_data_returned_gb", DefaultValue: 0.0, ValueType: schema.Float64},
-	{Key: "monthly_bulk_data_retrieval_requests", DefaultValue: 0, ValueType: schema.Int64},
-	{Key: "monthly_bulk_data_retrieval_gb", DefaultValue: 0.0, ValueType: schema.Float64},
 	{Key: "monthly_bulk_select_data_scanned_gb", DefaultValue: 0.0, ValueType: schema.Float64},
 	{Key: "monthly_bulk_select_data_returned_gb", DefaultValue: 0.0, ValueType: schema.Float64},
 	{Key: "early_delete_gb", DefaultValue: 0.0, ValueType: schema.Float64},
@@ -74,8 +70,6 @@ func (a *S3GlacierStorageClass) BuildResource() *schema.Resource {
 			s3DataCostComponent("Retrievals (expedited)", "AmazonGlacier", a.Region, "Expedited-Retrieval-Bytes", a.MonthlyExpeditedDataRetrievalGB),
 			s3DataCostComponent("Select data scanned (expedited)", "AmazonGlacier", a.Region, "Exp-Select-Scanned-Bytes", a.MonthlyExpeditedSelectDataScannedGB),
 			s3DataCostComponent("Select data returned (expedited)", "AmazonGlacier", a.Region, "Exp-Select-Returned-Bytes", a.MonthlyExpeditedSelectDataReturnedGB),
-			s3ApiCostComponent("Retrieval requests (bulk)", "AmazonGlacier", a.Region, "Requests-Tier2", a.MonthlyBulkDataRetrievalRequests),
-			s3DataCostComponent("Retrievals (bulk)", "AmazonGlacier", a.Region, "Bulk-Retrieval-Bytes", a.MonthlyBulkDataRetrievalGB),
 			s3DataCostComponent("Select data scanned (bulk)", "AmazonGlacier", a.Region, "Bulk-Select-Scanned-Bytes", a.MonthlyBulkSelectDataScannedGB),
 			s3DataCostComponent("Select data returned (bulk)", "AmazonGlacier", a.Region, "Bulk-Select-Returned-Bytes", a.MonthlyBulkSelectDataReturnedGB),
 			s3DataCostComponent("Early delete (within 90 days)", "AmazonGlacier", a.Region, "EarlyDelete-ByteHrs", a.EarlyDeleteGB),

--- a/internal/resources/aws/util.go
+++ b/internal/resources/aws/util.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"math"
 	"reflect"
 	"regexp"
@@ -80,6 +81,10 @@ func stringInSlice(slice []string, s string) bool {
 		}
 	}
 	return false
+}
+
+func regexPtr(regex string) *string {
+	return strPtr(fmt.Sprintf("/%s/i", regex))
 }
 
 // RegionMapping is a helpful conversion map that changes

--- a/internal/usage/testdata/usage_file/usage_file.golden
+++ b/internal/usage/testdata/usage_file/usage_file.golden
@@ -83,10 +83,8 @@ resource_usage:
       # monthly_expedited_select_data_scanned_gb: 0.0 # Monthly data scanned by S3 Select in GB (for expedited level of S3 Glacier)
       # monthly_expedited_select_data_returned_gb: 0.0 # Monthly data returned by S3 Select in GB (for expedited level of S3 Glacier)
       # monthly_standard_data_retrieval_requests: 0 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      # monthly_bulk_data_retrieval_requests: 0 # Monthly data Retrieval requests (for bulk level of S3 Glacier).
       # monthly_expedited_data_retrieval_requests: 0 # Monthly data Retrieval requests (for expedited level of S3 Glacier).
       # monthly_standard_data_retrieval_gb: 0.0 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      # monthly_bulk_data_retrieval_gb: 0.0 # Monthly data retrievals in GB (for bulk level of S3 Glacier).
       # monthly_expedited_data_retrieval_gb: 0.0 # Monthly data retrievals in GB (for expedited level of S3 Glacier).
       # early_delete_gb: 0.0 # If an archive is deleted within 3 months of being uploaded, you will be charged an early deletion fee per GB.
     # glacier_deep_archive:
@@ -254,10 +252,8 @@ resource_usage:
       # monthly_expedited_select_data_scanned_gb: 0.0 # Monthly data scanned by S3 Select in GB (for expedited level of S3 Glacier)
       # monthly_expedited_select_data_returned_gb: 0.0 # Monthly data returned by S3 Select in GB (for expedited level of S3 Glacier)
       # monthly_standard_data_retrieval_requests: 0 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      # monthly_bulk_data_retrieval_requests: 0 # Monthly data Retrieval requests (for bulk level of S3 Glacier).
       # monthly_expedited_data_retrieval_requests: 0 # Monthly data Retrieval requests (for expedited level of S3 Glacier).
       # monthly_standard_data_retrieval_gb: 0.0 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      # monthly_bulk_data_retrieval_gb: 0.0 # Monthly data retrievals in GB (for bulk level of S3 Glacier).
       # monthly_expedited_data_retrieval_gb: 0.0 # Monthly data retrievals in GB (for expedited level of S3 Glacier).
       # early_delete_gb: 0.0 # If an archive is deleted within 3 months of being uploaded, you will be charged an early deletion fee per GB.
     # glacier_deep_archive:

--- a/internal/usage/testdata/usage_file/usage_file.golden
+++ b/internal/usage/testdata/usage_file/usage_file.golden
@@ -71,7 +71,7 @@ resource_usage:
       # monthly_data_retrieval_gb: 0.0 # Monthly data retrievals in GB
       # monthly_select_data_scanned_gb: 0.0 # Monthly data scanned by S3 Select in GB.
       # monthly_select_data_returned_gb: 0.0 # Monthly data returned by S3 Select in GB.
-    glacier:
+    glacier_flexible_retrieval:
       storage_gb: 50000 # Total storage in GB.
       # monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
       # monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
@@ -240,7 +240,7 @@ resource_usage:
       # monthly_data_retrieval_gb: 0.0 # Monthly data retrievals in GB
       # monthly_select_data_scanned_gb: 0.0 # Monthly data scanned by S3 Select in GB.
       # monthly_select_data_returned_gb: 0.0 # Monthly data returned by S3 Select in GB.
-    # glacier:
+    # glacier_flexible_retrieval:
       # storage_gb: 0 # Total storage in GB.
       # monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
       # monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).

--- a/internal/usage/testdata/usage_file/usage_file_existing_usage.yml
+++ b/internal/usage/testdata/usage_file/usage_file_existing_usage.yml
@@ -14,7 +14,7 @@ resource_usage:
     reserved_instance_payment_option: all_upfront
   aws_s3_bucket.with_usage:
     object_tags: 10000000 # This comment shouldn't be overwritten
-    glacier:
+    glacier_flexible_retrieval:
       storage_gb: 50000
   aws_cloudfront_distribution.with_usage:
     custom_ssl_certificates: 3

--- a/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
+++ b/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
@@ -112,10 +112,8 @@ version: 0.1
       # monthly_expedited_select_data_scanned_gb: 0.0 # Monthly data scanned by S3 Select in GB (for expedited level of S3 Glacier)
       # monthly_expedited_select_data_returned_gb: 0.0 # Monthly data returned by S3 Select in GB (for expedited level of S3 Glacier)
       # monthly_standard_data_retrieval_requests: 0 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      # monthly_bulk_data_retrieval_requests: 0 # Monthly data Retrieval requests (for bulk level of S3 Glacier).
       # monthly_expedited_data_retrieval_requests: 0 # Monthly data Retrieval requests (for expedited level of S3 Glacier).
       # monthly_standard_data_retrieval_gb: 0.0 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      # monthly_bulk_data_retrieval_gb: 0.0 # Monthly data retrievals in GB (for bulk level of S3 Glacier).
       # monthly_expedited_data_retrieval_gb: 0.0 # Monthly data retrievals in GB (for expedited level of S3 Glacier).
       # early_delete_gb: 0.0 # If an archive is deleted within 3 months of being uploaded, you will be charged an early deletion fee per GB.
     # glacier_deep_archive:

--- a/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
+++ b/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
@@ -100,7 +100,7 @@ version: 0.1
       # monthly_data_retrieval_gb: 0.0 # Monthly data retrievals in GB
       # monthly_select_data_scanned_gb: 0.0 # Monthly data scanned by S3 Select in GB.
       # monthly_select_data_returned_gb: 0.0 # Monthly data returned by S3 Select in GB.
-    # glacier:
+    # glacier_flexible_retrieval:
       # storage_gb: 0 # Total storage in GB.
       # monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
       # monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).


### PR DESCRIPTION
## AWS

Per [announcement](https://aws.amazon.com/blogs/storage/s3-storage-class-price-reductions/?nc1=b_rp):

- Several storage prices are reduced.
- S3 Glacier bulk retrievals are free now. Thus their cost components
  are removed.
- S3 Glacier is renamed to S3 Glacier Flexible Retrieval.
- Update DynamoDB Table product filter. Latest update brought in a new price for IA storage and the filter was matching two records.

## Azure

Azure Pricing is inconsistent for "Hot LRS" tier: the previous pricing update removed List operations and added Write operations. But the latest one flip-flopped them again. Switching to "Cool LRS" tier seems to be stable.