### PR TITLE
fix(aws): Fix aws_transfer_server default protocol

### DIFF
--- a/internal/providers/terraform/aws/testdata/transfer_server_test/transfer_server_test.golden
+++ b/internal/providers/terraform/aws/testdata/transfer_server_test/transfer_server_test.golden
@@ -2,7 +2,7 @@
  Name                                                 Monthly Qty  Unit            Monthly Cost 
                                                                                                 
  aws_transfer_server.default_no_protocols                                                       
- ├─ FTPS protocol enabled                                     730  hours                $219.00 
+ ├─ SFTP protocol enabled                                     730  hours                $219.00 
  ├─ Data downloaded                                 Monthly cost depends on usage: $0.04 per GB 
  └─ Data uploaded                                   Monthly cost depends on usage: $0.04 per GB 
                                                                                                 

--- a/internal/providers/terraform/aws/transfer_server.go
+++ b/internal/providers/terraform/aws/transfer_server.go
@@ -21,7 +21,7 @@ func newTransferServer(d *schema.ResourceData, u *schema.UsageData) *schema.Reso
 			protocols = append(protocols, data.String())
 		}
 	} else {
-		defaultProtocol := "FTPS"
+		defaultProtocol := "SFTP"
 		protocols = append(protocols, defaultProtocol)
 	}
 

--- a/internal/providers/terraform/azure/postgresql_flexible_server.go
+++ b/internal/providers/terraform/azure/postgresql_flexible_server.go
@@ -130,7 +130,7 @@ func NewAzureRMPostrgreSQLFlexibleServer(d *schema.ResourceData, u *schema.Usage
 			ProductFamily: strPtr("Databases"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "productName", Value: strPtr("Azure Database for PostgreSQL Flexible Server Backup Storage")},
-				{Key: "meterName", Value: strPtr("Backup Storage LRS Data Stored")},
+				{Key: "meterName", Value: strPtr("Backup Storage Data Stored")},
 			},
 		},
 	})


### PR DESCRIPTION
Found a bug in my code while writing a new contributing code. According to TF registry the default protocol should be `SFTP`: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/transfer_server#protocols.

I've also refactored the cost components to be the same as in the guide. We're pushing to have the same style across resources, so I decided it will be a good reference.