### PR TITLE
fix(aws): update usage type filter for AWS DynamoDB Table resource

### DIFF
--- a/internal/providers/terraform/aws/testdata/dynamodb_table_test/dynamodb_table_test.tf
+++ b/internal/providers/terraform/aws/testdata/dynamodb_table_test/dynamodb_table_test.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region                      = "us-east-1"
+  region                      = "us-east-2"
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true

--- a/internal/resources/aws/dynamodb_table.go
+++ b/internal/resources/aws/dynamodb_table.go
@@ -307,7 +307,7 @@ func (a *DynamoDBTable) dataStorageCostComponent(region string, storageGB *int64
 			Service:       strPtr("AmazonDynamoDB"),
 			ProductFamily: strPtr("Database Storage"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "usagetype", ValueRegex: regexPtr("^TimedStorage-ByteHrs$")},
+				{Key: "usagetype", ValueRegex: regexPtr("(?<!IA-)TimedStorage-ByteHrs$")},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{


### PR DESCRIPTION
The previous fix applied to us-east-1 region only, other regions include
region's abbreviation in `usagetype`, for example `USE2-TimedStorage-ByteHrs`.

The fix makes sure to match this, but not `USE2-IA-TimedStorage-ByteHrs`.

Fixes #1194.