### PR TITLE
Fix semver comparison of Terragrunt version

### DIFF
--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -448,7 +448,7 @@ func checkTerraformVersion(v string, fullV string) error {
 		return errors.Errorf("Terraform %s is not supported. Please use Terraform version >= %s.", v, minTerraformVer)
 	}
 
-	if strings.HasPrefix(fullV, "terragrunt") && semver.Compare(v, minTerragruntVer) < 0 {
+	if strings.HasPrefix(fullV, "terragrunt") && semver.Compare("v"+v, minTerragruntVer) < 0 {
 		return errors.Errorf("Terragrunt %s is not supported. Please use Terragrunt version >= %s.", v, minTerragruntVer)
 	}
 


### PR DESCRIPTION
When trying to use the terragrunt integration I was getting the following error:

```bash
$ infracost breakdown --path prod
Detected Terragrunt directory at .
  ✔ Running terragrunt run-all terragrunt-info
Error: Terragrunt 0.35.12 is not supported. Please use Terragrunt version >= v0.28.1.
```

The problem seems to be the `semver` comparision [here](https://github.com/infracost/infracost/blob/1042c84a6294c81ffcba8e6b0bdfd9d729ab0eb2/internal/providers/terraform/dir_provider.go#L451).

Since the output of `terragrunt -version` doesn't include the `v` prefix, this will always evaluate as [less than](https://pkg.go.dev/golang.org/x/mod/semver#Compare).

```bash
$ terraform -version
Terraform v1.0.11
on linux_amd64
$ terragrunt -version
terragrunt version 0.35.12
```
