### PR TITLE
Add GitLab comment output format

### DIFF
--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -39,7 +39,11 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 
   Create markdown report to post in a GitHub comment:
 
-      infracost output --format github-comment --path "out*.json" # glob needs quotes`,
+      infracost output --format github-comment --path "out*.json" # glob needs quotes
+
+  Create markdown report to post in a GitLab comment:
+
+      infracost output --format gitlab-comment --path "out*.json" # glob needs quotes`,
 		ValidArgs: []string{"--", "-"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inputFiles := []string{}
@@ -145,7 +149,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 				b, err = output.ToHTML(combined, opts)
 			case "diff":
 				b, err = output.ToDiff(combined, opts)
-			case "github-comment":
+			case "github-comment", "gitlab-comment":
 				opts.IncludeHTML = true
 				b, err = output.ToMarkdown(combined, opts)
 			case "slack-message":
@@ -179,7 +183,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	cmd.Flags().StringP("out-file", "o", "", "Save output to a file, helpful with format flag")
 
-	cmd.Flags().String("format", "table", "Output format: json, diff, table, html, github-comment, slack-message")
+	cmd.Flags().String("format", "table", "Output format: json, diff, table, html, github-comment, gitlab-comment, slack-message")
 	cmd.Flags().Bool("show-skipped", false, "Show unsupported resources")
 	cmd.Flags().StringSlice("fields", []string{"monthlyQuantity", "unit", "monthlyCost"}, "Comma separated list of output fields: all,price,monthlyQuantity,unit,hourlyCost,monthlyCost.\nSupported by table and html output formats")
 

--- a/cmd/infracost/output_test.go
+++ b/cmd/infracost/output_test.go
@@ -23,16 +23,28 @@ func TestOutputFormatJSON(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "json", "--path", "./testdata/example_out.json", "--path", "./testdata/azure_firewall_out.json"}, opts)
 }
 
-func TestOutputFormatGithubComment(t *testing.T) {
+func TestOutputFormatGitHubComment(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "github-comment", "--path", "./testdata/example_out.json", "--path", "./testdata/terraform_v0.14_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
 }
 
-func TestOutputFormatGithubCommentMultipleSkipped(t *testing.T) {
+func TestOutputFormatGitHubCommentMultipleSkipped(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "github-comment", "--path", "./testdata/example_out.json", "--path", "./testdata/terraform_v0.14_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
 }
 
-func TestOutputFormatGithubCommentNoChange(t *testing.T) {
+func TestOutputFormatGitHubCommentNoChange(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "github-comment", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
+}
+
+func TestOutputFormatGitLabComment(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "gitlab-comment", "--path", "./testdata/example_out.json", "--path", "./testdata/terraform_v0.14_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
+}
+
+func TestOutputFormatGitLabCommentMultipleSkipped(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "gitlab-comment", "--path", "./testdata/example_out.json", "--path", "./testdata/terraform_v0.14_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
+}
+
+func TestOutputFormatGitLabCommentNoChange(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "gitlab-comment", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
 }
 
 func TestOutputFormatSlackMessage(t *testing.T) {

--- a/cmd/infracost/testdata/output_format_git_hub_comment/output_format_git_hub_comment.golden
+++ b/cmd/infracost/testdata/output_format_git_hub_comment/output_format_git_hub_comment.golden
@@ -1,0 +1,229 @@
+
+💰 Infracost estimate: **monthly cost will increase by $1,402 (+1,728%) 📈**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/cmd/infracost/testdata</td>
+      <td align="right">$0</td>
+      <td align="right">$1,361</td>
+      <td>+$1,361</td>
+    </tr>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$81.12</td>
+      <td>+$40.56 (+100%)</td>
+    </tr>
+    <tr>
+      <td>All projects</td>
+      <td align="right">$81.12</td>
+      <td align="right">$1,483</td>
+      <td>+$1,402 (+1,728%)</td>
+    </tr>
+  </tbody>
+</table>
+
+1 project has no cost estimate changes.
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+Project: infracost/infracost/cmd/infracost/testdata
+
++ aws_instance.web_app
+  +$743
+
+    + Instance usage (Linux/UNIX, on-demand, m5.4xlarge)
+      +$561
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_instance.zero_cost_instance
+  +$182
+
+    + Instance usage (Linux/UNIX, reserved, m5.4xlarge)
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_lambda_function.hello_world
+  +$437
+
+    + Requests
+      +$20.00
+
+    + Duration
+      +$417
+
++ aws_lambda_function.zero_cost_lambda
+  $0.00
+
+    + Requests
+      $0.00
+
+    + Duration
+      $0.00
+
++ aws_s3_bucket.usage
+  $0.00
+
+    + Standard
+    
+        + Storage
+          $0.00
+    
+        + PUT, COPY, POST, LIST requests
+          $0.00
+    
+        + GET, SELECT, and all other requests
+          $0.00
+    
+        + Select data scanned
+          $0.00
+    
+        + Select data returned
+          $0.00
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata
+Amount:  +$1,361 ($0.00 → $1,361)
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+
++ aws_instance.instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
+  +$12.99
+
+    + Database instance (on-demand, Single-AZ, db.t3.micro)
+      +$12.41
+
+    + Storage (general purpose SSD, gp2)
+      +$0.58
+
++ module.instances.aws_instance.module_instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+Amount:  +$40.56 ($40.56 → $81.12)
+Percent: +100%
+
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
+Run infracost breakdown to see their full breakdown.
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+```
+</details>
+

--- a/cmd/infracost/testdata/output_format_git_hub_comment_multiple_skipped/output_format_git_hub_comment_multiple_skipped.golden
+++ b/cmd/infracost/testdata/output_format_git_hub_comment_multiple_skipped/output_format_git_hub_comment_multiple_skipped.golden
@@ -1,0 +1,229 @@
+
+💰 Infracost estimate: **monthly cost will increase by $1,402 (+1,152%) 📈**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/cmd/infracost/testdata</td>
+      <td align="right">$0</td>
+      <td align="right">$1,361</td>
+      <td>+$1,361</td>
+    </tr>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$81.12</td>
+      <td>+$40.56 (+100%)</td>
+    </tr>
+    <tr>
+      <td>All projects</td>
+      <td align="right">$122</td>
+      <td align="right">$1,524</td>
+      <td>+$1,402 (+1,152%)</td>
+    </tr>
+  </tbody>
+</table>
+
+2 projects have no cost estimate changes.
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+Project: infracost/infracost/cmd/infracost/testdata
+
++ aws_instance.web_app
+  +$743
+
+    + Instance usage (Linux/UNIX, on-demand, m5.4xlarge)
+      +$561
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_instance.zero_cost_instance
+  +$182
+
+    + Instance usage (Linux/UNIX, reserved, m5.4xlarge)
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_lambda_function.hello_world
+  +$437
+
+    + Requests
+      +$20.00
+
+    + Duration
+      +$417
+
++ aws_lambda_function.zero_cost_lambda
+  $0.00
+
+    + Requests
+      $0.00
+
+    + Duration
+      $0.00
+
++ aws_s3_bucket.usage
+  $0.00
+
+    + Standard
+    
+        + Storage
+          $0.00
+    
+        + PUT, COPY, POST, LIST requests
+          $0.00
+    
+        + GET, SELECT, and all other requests
+          $0.00
+    
+        + Select data scanned
+          $0.00
+    
+        + Select data returned
+          $0.00
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata
+Amount:  +$1,361 ($0.00 → $1,361)
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+
++ aws_instance.instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
+  +$12.99
+
+    + Database instance (on-demand, Single-AZ, db.t3.micro)
+      +$12.41
+
+    + Storage (general purpose SSD, gp2)
+      +$0.58
+
++ module.instances.aws_instance.module_instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+Amount:  +$40.56 ($40.56 → $81.12)
+Percent: +100%
+
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json, infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
+Run infracost breakdown to see their full breakdown.
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+```
+</details>
+

--- a/cmd/infracost/testdata/output_format_git_hub_comment_no_change/output_format_git_hub_comment_no_change.golden
+++ b/cmd/infracost/testdata/output_format_git_hub_comment_no_change/output_format_git_hub_comment_no_change.golden
@@ -1,0 +1,33 @@
+
+💰 Infracost estimate: **monthly cost will not change**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...aform_v0.14_nochange_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$40.56</td>
+      <td>$0</td>
+    </tr>
+  </tbody>
+</table>
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
+Run infracost breakdown to see their full breakdown.
+
+──────────────────────────────────
+
+```
+</details>
+

--- a/cmd/infracost/testdata/output_format_git_lab_comment/output_format_git_lab_comment.golden
+++ b/cmd/infracost/testdata/output_format_git_lab_comment/output_format_git_lab_comment.golden
@@ -1,0 +1,229 @@
+
+💰 Infracost estimate: **monthly cost will increase by $1,402 (+1,728%) 📈**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/cmd/infracost/testdata</td>
+      <td align="right">$0</td>
+      <td align="right">$1,361</td>
+      <td>+$1,361</td>
+    </tr>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$81.12</td>
+      <td>+$40.56 (+100%)</td>
+    </tr>
+    <tr>
+      <td>All projects</td>
+      <td align="right">$81.12</td>
+      <td align="right">$1,483</td>
+      <td>+$1,402 (+1,728%)</td>
+    </tr>
+  </tbody>
+</table>
+
+1 project has no cost estimate changes.
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+Project: infracost/infracost/cmd/infracost/testdata
+
++ aws_instance.web_app
+  +$743
+
+    + Instance usage (Linux/UNIX, on-demand, m5.4xlarge)
+      +$561
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_instance.zero_cost_instance
+  +$182
+
+    + Instance usage (Linux/UNIX, reserved, m5.4xlarge)
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_lambda_function.hello_world
+  +$437
+
+    + Requests
+      +$20.00
+
+    + Duration
+      +$417
+
++ aws_lambda_function.zero_cost_lambda
+  $0.00
+
+    + Requests
+      $0.00
+
+    + Duration
+      $0.00
+
++ aws_s3_bucket.usage
+  $0.00
+
+    + Standard
+    
+        + Storage
+          $0.00
+    
+        + PUT, COPY, POST, LIST requests
+          $0.00
+    
+        + GET, SELECT, and all other requests
+          $0.00
+    
+        + Select data scanned
+          $0.00
+    
+        + Select data returned
+          $0.00
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata
+Amount:  +$1,361 ($0.00 → $1,361)
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+
++ aws_instance.instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
+  +$12.99
+
+    + Database instance (on-demand, Single-AZ, db.t3.micro)
+      +$12.41
+
+    + Storage (general purpose SSD, gp2)
+      +$0.58
+
++ module.instances.aws_instance.module_instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+Amount:  +$40.56 ($40.56 → $81.12)
+Percent: +100%
+
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
+Run infracost breakdown to see their full breakdown.
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+```
+</details>
+

--- a/cmd/infracost/testdata/output_format_git_lab_comment_multiple_skipped/output_format_git_lab_comment_multiple_skipped.golden
+++ b/cmd/infracost/testdata/output_format_git_lab_comment_multiple_skipped/output_format_git_lab_comment_multiple_skipped.golden
@@ -1,0 +1,229 @@
+
+💰 Infracost estimate: **monthly cost will increase by $1,402 (+1,152%) 📈**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/cmd/infracost/testdata</td>
+      <td align="right">$0</td>
+      <td align="right">$1,361</td>
+      <td>+$1,361</td>
+    </tr>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$81.12</td>
+      <td>+$40.56 (+100%)</td>
+    </tr>
+    <tr>
+      <td>All projects</td>
+      <td align="right">$122</td>
+      <td align="right">$1,524</td>
+      <td>+$1,402 (+1,152%)</td>
+    </tr>
+  </tbody>
+</table>
+
+2 projects have no cost estimate changes.
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+Project: infracost/infracost/cmd/infracost/testdata
+
++ aws_instance.web_app
+  +$743
+
+    + Instance usage (Linux/UNIX, on-demand, m5.4xlarge)
+      +$561
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_instance.zero_cost_instance
+  +$182
+
+    + Instance usage (Linux/UNIX, reserved, m5.4xlarge)
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_lambda_function.hello_world
+  +$437
+
+    + Requests
+      +$20.00
+
+    + Duration
+      +$417
+
++ aws_lambda_function.zero_cost_lambda
+  $0.00
+
+    + Requests
+      $0.00
+
+    + Duration
+      $0.00
+
++ aws_s3_bucket.usage
+  $0.00
+
+    + Standard
+    
+        + Storage
+          $0.00
+    
+        + PUT, COPY, POST, LIST requests
+          $0.00
+    
+        + GET, SELECT, and all other requests
+          $0.00
+    
+        + Select data scanned
+          $0.00
+    
+        + Select data returned
+          $0.00
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata
+Amount:  +$1,361 ($0.00 → $1,361)
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+
++ aws_instance.instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
+  +$12.99
+
+    + Database instance (on-demand, Single-AZ, db.t3.micro)
+      +$12.41
+
+    + Storage (general purpose SSD, gp2)
+      +$0.58
+
++ module.instances.aws_instance.module_instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+Amount:  +$40.56 ($40.56 → $81.12)
+Percent: +100%
+
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json, infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
+Run infracost breakdown to see their full breakdown.
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+```
+</details>
+

--- a/cmd/infracost/testdata/output_format_git_lab_comment_no_change/output_format_git_lab_comment_no_change.golden
+++ b/cmd/infracost/testdata/output_format_git_lab_comment_no_change/output_format_git_lab_comment_no_change.golden
@@ -1,0 +1,33 @@
+
+💰 Infracost estimate: **monthly cost will not change**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...aform_v0.14_nochange_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$40.56</td>
+      <td>$0</td>
+    </tr>
+  </tbody>
+</table>
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
+Run infracost breakdown to see their full breakdown.
+
+──────────────────────────────────
+
+```
+</details>
+

--- a/cmd/infracost/testdata/output_help/output_help.golden
+++ b/cmd/infracost/testdata/output_help/output_help.golden
@@ -20,10 +20,14 @@ EXAMPLES
 
       infracost output --format github-comment --path "out*.json" # glob needs quotes
 
+  Create markdown report to post in a GitLab comment:
+
+      infracost output --format gitlab-comment --path "out*.json" # glob needs quotes
+
 FLAGS
       --fields strings     Comma separated list of output fields: all,price,monthlyQuantity,unit,hourlyCost,monthlyCost.
                            Supported by table and html output formats (default [monthlyQuantity,unit,monthlyCost])
-      --format string      Output format: json, diff, table, html, github-comment, slack-message (default "table")
+      --format string      Output format: json, diff, table, html, github-comment, gitlab-comment, slack-message (default "table")
   -h, --help               help for output
   -o, --out-file string    Save output to a file, helpful with format flag
   -p, --path stringArray   Path to Infracost JSON files, glob patterns need quotes

--- a/internal/providers/terraform/azure/testdata/express_route_connection_test/express_route_connection_test.tf
+++ b/internal/providers/terraform/azure/testdata/express_route_connection_test/express_route_connection_test.tf
@@ -5,67 +5,67 @@ provider "azurerm" {
 
 
 resource "azurerm_resource_group" "resource_group" {
-  name = "example-resources"
+  name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_virtual_wan" "virtual_wan" {
-  name = "example-virtualwan"
+  name                = "example-virtualwan"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
+  location            = azurerm_resource_group.resource_group.location
 }
 
 resource "azurerm_virtual_hub" "virtual_hub" {
-  name = "example-virtualhub"
+  name                = "example-virtualhub"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
-  address_prefix = "10.0.1.0/24"
+  location            = azurerm_resource_group.resource_group.location
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
+  address_prefix      = "10.0.1.0/24"
 }
 
 resource "azurerm_express_route_gateway" "express_route" {
-  name = "express-route"
+  name                = "express-route"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_hub_id = azurerm_virtual_hub.virtual_hub.id
-  scale_units = 1
+  location            = azurerm_resource_group.resource_group.location
+  virtual_hub_id      = azurerm_virtual_hub.virtual_hub.id
+  scale_units         = 1
 }
 
 resource "azurerm_express_route_port" "route_port" {
-  name = "example-erp"
+  name                = "example-erp"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  peering_location = "Equinix-Seattle-SE2"
-  bandwidth_in_gbps = 10
-  encapsulation = "Dot1Q"
+  location            = azurerm_resource_group.resource_group.location
+  peering_location    = "Equinix-Seattle-SE2"
+  bandwidth_in_gbps   = 10
+  encapsulation       = "Dot1Q"
 }
 
 resource "azurerm_express_route_circuit" "route_circuit" {
-  name = "example-erc"
-  resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
+  name                  = "example-erc"
+  resource_group_name   = azurerm_resource_group.resource_group.name
+  location              = azurerm_resource_group.resource_group.location
   express_route_port_id = azurerm_express_route_port.route_port.id
-  bandwidth_in_gbps = 5
+  bandwidth_in_gbps     = 5
 
   sku {
-    tier = "Standard"
+    tier   = "Standard"
     family = "MeteredData"
   }
 }
 
 resource "azurerm_express_route_circuit_peering" "circuit_peering" {
-  peering_type = "AzurePrivatePeering"
-  express_route_circuit_name = azurerm_express_route_circuit.route_circuit.name
-  resource_group_name = azurerm_resource_group.resource_group.name
-  shared_key = "ItsASecret"
-  peer_asn = 100
-  primary_peer_address_prefix = "192.168.1.0/30"
+  peering_type                  = "AzurePrivatePeering"
+  express_route_circuit_name    = azurerm_express_route_circuit.route_circuit.name
+  resource_group_name           = azurerm_resource_group.resource_group.name
+  shared_key                    = "ItsASecret"
+  peer_asn                      = 100
+  primary_peer_address_prefix   = "192.168.1.0/30"
   secondary_peer_address_prefix = "192.168.2.0/30"
-  vlan_id = 100
+  vlan_id                       = 100
 }
 
 resource "azurerm_express_route_connection" "express_route_conn" {
-  name = "express-route-conn"
+  name                             = "express-route-conn"
   express_route_circuit_peering_id = azurerm_express_route_circuit_peering.circuit_peering.id
-  express_route_gateway_id = azurerm_express_route_gateway.express_route.id
+  express_route_gateway_id         = azurerm_express_route_gateway.express_route.id
 }

--- a/internal/providers/terraform/azure/testdata/express_route_gateway_test/express_route_gateway_test.tf
+++ b/internal/providers/terraform/azure/testdata/express_route_gateway_test/express_route_gateway_test.tf
@@ -4,28 +4,28 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "resource_group" {
-  name = "example-resources"
+  name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_virtual_wan" "virtual_wan" {
-  name = "example-virtualwan"
+  name                = "example-virtualwan"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
+  location            = azurerm_resource_group.resource_group.location
 }
 
 resource "azurerm_virtual_hub" "virtual_hub" {
-  name = "example-virtualhub"
+  name                = "example-virtualhub"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
-  address_prefix = "10.0.1.0/24"
+  location            = azurerm_resource_group.resource_group.location
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
+  address_prefix      = "10.0.1.0/24"
 }
 
 resource "azurerm_express_route_gateway" "express_route" {
-  name = "express-route"
+  name                = "express-route"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_hub_id = azurerm_virtual_hub.virtual_hub.id
-  scale_units = 4
+  location            = azurerm_resource_group.resource_group.location
+  virtual_hub_id      = azurerm_virtual_hub.virtual_hub.id
+  scale_units         = 4
 }

--- a/internal/providers/terraform/azure/testdata/point_to_site_vpn_gateway_test/point_to_site_vpn_gateway_test.tf
+++ b/internal/providers/terraform/azure/testdata/point_to_site_vpn_gateway_test/point_to_site_vpn_gateway_test.tf
@@ -5,37 +5,37 @@ provider "azurerm" {
 
 
 resource "azurerm_resource_group" "resource_group" {
-  name = "example-resources"
+  name     = "example-resources"
   location = "West Europe"
 }
 resource "azurerm_virtual_wan" "virtual_wan" {
-  name = "example-virtualwan"
+  name                = "example-virtualwan"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
+  location            = azurerm_resource_group.resource_group.location
 }
 
 resource "azurerm_virtual_hub" "virtual_hub" {
-  name = "example-virtualhub"
+  name                = "example-virtualhub"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
+  location            = azurerm_resource_group.resource_group.location
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
 }
 
 resource "azurerm_vpn_server_configuration" "server_config" {
-  name = "example-config"
+  name                = "example-config"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
+  location            = azurerm_resource_group.resource_group.location
   vpn_authentication_types = [
-    "Certificate"]
+  "Certificate"]
 }
 
 
 resource "azurerm_point_to_site_vpn_gateway" "point_to_site_vpn" {
-  name = "example-vpn"
-  location = azurerm_resource_group.resource_group.location
-  resource_group_name = azurerm_resource_group.resource_group.name
-  virtual_hub_id = azurerm_virtual_hub.virtual_hub.id
-  scale_unit = 5
+  name                        = "example-vpn"
+  location                    = azurerm_resource_group.resource_group.location
+  resource_group_name         = azurerm_resource_group.resource_group.name
+  virtual_hub_id              = azurerm_virtual_hub.virtual_hub.id
+  scale_unit                  = 5
   vpn_server_configuration_id = azurerm_vpn_server_configuration.server_config.id
   connection_configuration {
     name = "example-gateway-config"
@@ -49,11 +49,11 @@ resource "azurerm_point_to_site_vpn_gateway" "point_to_site_vpn" {
 }
 
 resource "azurerm_point_to_site_vpn_gateway" "point_to_site_vpn_with_usage" {
-  name = "example-vpn"
-  location = azurerm_resource_group.resource_group.location
-  resource_group_name = azurerm_resource_group.resource_group.name
-  virtual_hub_id = azurerm_virtual_hub.virtual_hub.id
-  scale_unit = 5
+  name                        = "example-vpn"
+  location                    = azurerm_resource_group.resource_group.location
+  resource_group_name         = azurerm_resource_group.resource_group.name
+  virtual_hub_id              = azurerm_virtual_hub.virtual_hub.id
+  scale_unit                  = 5
   vpn_server_configuration_id = azurerm_vpn_server_configuration.server_config.id
   connection_configuration {
     name = "example-gateway-config"

--- a/internal/providers/terraform/azure/testdata/virtual_hub_test/virtual_hub_test.tf
+++ b/internal/providers/terraform/azure/testdata/virtual_hub_test/virtual_hub_test.tf
@@ -5,43 +5,43 @@ provider "azurerm" {
 
 
 resource "azurerm_resource_group" "resource_group" {
-  name = "example-resources"
+  name     = "example-resources"
   location = "West Europe"
 }
 
 resource "azurerm_virtual_wan" "virtual_wan" {
-  name = "example-virtualwan"
+  name                = "example-virtualwan"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
+  location            = azurerm_resource_group.resource_group.location
 }
 
 resource "azurerm_virtual_hub" "virtual_hub" {
-  name = "example-virtualhub"
+  name                = "example-virtualhub"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
-  sku = "Standard"
+  location            = azurerm_resource_group.resource_group.location
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
+  sku                 = "Standard"
 }
 
 resource "azurerm_virtual_hub" "free_virtual_hub_by_default" {
-  name = "example-virtualhub"
+  name                = "example-virtualhub"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
+  location            = azurerm_resource_group.resource_group.location
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
 }
 
 resource "azurerm_virtual_hub" "free_virtual_hub_by_specification" {
-  name = "example-virtualhub"
+  name                = "example-virtualhub"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
-  sku = "Basic"
+  location            = azurerm_resource_group.resource_group.location
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
+  sku                 = "Basic"
 }
 
 resource "azurerm_virtual_hub" "virtual_hub_with_usage" {
-  name = "example-virtualhub"
+  name                = "example-virtualhub"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
-  sku = "Standard"
+  location            = azurerm_resource_group.resource_group.location
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
+  sku                 = "Standard"
 }

--- a/internal/providers/terraform/azure/testdata/vpn_gateway_connection_test/vpn_gateway_connection_test.tf
+++ b/internal/providers/terraform/azure/testdata/vpn_gateway_connection_test/vpn_gateway_connection_test.tf
@@ -4,51 +4,51 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "resource_group" {
-  name = "example-resources"
+  name     = "example-resources"
   location = "West Europe"
 }
 resource "azurerm_virtual_wan" "virtual_wan" {
-  name = "example-virtualwan"
+  name                = "example-virtualwan"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
+  location            = azurerm_resource_group.resource_group.location
 }
 
 resource "azurerm_virtual_hub" "virtual_hub" {
-  name = "example-virtualhub"
+  name                = "example-virtualhub"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
+  location            = azurerm_resource_group.resource_group.location
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
 }
 
 resource "azurerm_vpn_gateway" "vpn_gateway" {
-  name = "example-vpn"
-  location = azurerm_resource_group.resource_group.location
+  name                = "example-vpn"
+  location            = azurerm_resource_group.resource_group.location
   resource_group_name = azurerm_resource_group.resource_group.name
-  virtual_hub_id = azurerm_virtual_hub.virtual_hub.id
+  virtual_hub_id      = azurerm_virtual_hub.virtual_hub.id
 }
 
 resource "azurerm_vpn_site" "vpn_site" {
-  name = "example-vpn-site"
-  location = azurerm_resource_group.resource_group.location
+  name                = "example-vpn-site"
+  location            = azurerm_resource_group.resource_group.location
   resource_group_name = azurerm_resource_group.resource_group.name
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
   link {
-    name = "link1"
+    name       = "link1"
     ip_address = "10.1.0.0"
   }
   link {
-    name = "link2"
+    name       = "link2"
     ip_address = "10.2.0.0"
   }
 }
 
 resource "azurerm_vpn_gateway_connection" "vpn_gateway_connection" {
-  name = "example-vpn-gateway-conn"
-  vpn_gateway_id = azurerm_vpn_gateway.vpn_gateway.id
+  name               = "example-vpn-gateway-conn"
+  vpn_gateway_id     = azurerm_vpn_gateway.vpn_gateway.id
   remote_vpn_site_id = azurerm_vpn_site.vpn_site.id
 
   vpn_link {
-    name = "link1"
+    name             = "link1"
     vpn_site_link_id = azurerm_vpn_site.vpn_site.link[0].id
   }
 }

--- a/internal/providers/terraform/azure/testdata/vpn_gateway_test/vpn_gateway_test.tf
+++ b/internal/providers/terraform/azure/testdata/vpn_gateway_test/vpn_gateway_test.tf
@@ -5,33 +5,33 @@ provider "azurerm" {
 
 
 resource "azurerm_resource_group" "resource_group" {
-  name = "example-resources"
+  name     = "example-resources"
   location = "West Europe"
 }
 resource "azurerm_virtual_wan" "virtual_wan" {
-  name = "example-virtualwan"
+  name                = "example-virtualwan"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
+  location            = azurerm_resource_group.resource_group.location
 }
 
 resource "azurerm_virtual_hub" "virtual_hub" {
-  name = "example-virtualhub"
+  name                = "example-virtualhub"
   resource_group_name = azurerm_resource_group.resource_group.name
-  location = azurerm_resource_group.resource_group.location
-  virtual_wan_id = azurerm_virtual_wan.virtual_wan.id
+  location            = azurerm_resource_group.resource_group.location
+  virtual_wan_id      = azurerm_virtual_wan.virtual_wan.id
 }
 
 resource "azurerm_vpn_gateway" "default_vpn" {
-  name = "example-vpn"
-  location = azurerm_resource_group.resource_group.location
+  name                = "example-vpn"
+  location            = azurerm_resource_group.resource_group.location
   resource_group_name = azurerm_resource_group.resource_group.name
-  virtual_hub_id = azurerm_virtual_hub.virtual_hub.id
+  virtual_hub_id      = azurerm_virtual_hub.virtual_hub.id
 }
 
 resource "azurerm_vpn_gateway" "vpn_with_scale_units" {
-  name = "example-vpn-scale"
-  location = azurerm_resource_group.resource_group.location
+  name                = "example-vpn-scale"
+  location            = azurerm_resource_group.resource_group.location
   resource_group_name = azurerm_resource_group.resource_group.name
-  virtual_hub_id = azurerm_virtual_hub.virtual_hub.id
-  scale_unit = 3
+  virtual_hub_id      = azurerm_virtual_hub.virtual_hub.id
+  scale_unit          = 3
 }

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -303,6 +303,7 @@ func (p *DirProvider) runPlan(opts *CmdOptions, spinner *ui.Spinner, initOnFail 
 			strings.Contains(extractedErr, "Error: Initialization required") ||
 			strings.Contains(extractedErr, "Error: Backend initialization required") ||
 			strings.Contains(extractedErr, "Error: Provider requirements cannot be satisfied by locked dependencies") ||
+			strings.Contains(extractedErr, "Error: Inconsistent dependency lock file") ||
 			strings.Contains(extractedErr, "Error: Module not installed")) {
 			spinner.Stop()
 			err = p.runInit(opts, ui.NewSpinner("Running terraform init", p.spinnerOpts))


### PR DESCRIPTION
Initially this is the same as the GitHub one, but we can update it in the future to use some more GitLab specific markdown features.