### PR TITLE
feat(google): add artifact registry repository

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -422,10 +422,16 @@ resource_usage:
     rule_group_rules: 5          # Total number of Rule Group rules used by the Web ACL.
     managed_rule_group_rules: 10 # Total number of Managed Rule Group rules used by the Web ACL.  
     monthly_requests: 1000000 # Monthly number of web requests received.
-    
+
   #
   # Terraform GCP resources
   #
+  google_artifact_registry_repository.my_artifact_registry:
+    storage_gb: 150 # Total data stored in the repository in GB
+    monthly_egress_data_transfer_gb: # Monthly data delivered from the artifact registry repository in GB. You can specify any number of Google Cloud regions below, replacing - for _ e.g.:
+      europe_north1: 100 # 100 GB of data delivered from the artifact registry to europe-north1.
+      australia_southeast1: 200 # 200 GB of data delivered from the artifact registry to australia-southeast1.
+
   google_bigquery_dataset.my_dataset:
     monthly_queries_tb: 100 # Monthly number of bytes processed (also referred to as bytes read) in TB.
 

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -429,8 +429,8 @@ resource_usage:
   google_artifact_registry_repository.my_artifact_registry:
     storage_gb: 150 # Total data stored in the repository in GB
     monthly_egress_data_transfer_gb: # Monthly data delivered from the artifact registry repository in GB. You can specify any number of Google Cloud regions below, replacing - for _ e.g.:
-      europe_north1: 100 # 100 GB of data delivered from the artifact registry to europe-north1.
-      australia_southeast1: 200 # 200 GB of data delivered from the artifact registry to australia-southeast1.
+      europe_north1: 100 # GB of data delivered from the artifact registry to europe-north1.
+      australia_southeast1: 200 # GB of data delivered from the artifact registry to australia-southeast1.
 
   google_bigquery_dataset.my_dataset:
     monthly_queries_tb: 100 # Monthly number of bytes processed (also referred to as bytes read) in TB.

--- a/internal/providers/terraform/google/artifact_registry_repository.go
+++ b/internal/providers/terraform/google/artifact_registry_repository.go
@@ -1,0 +1,34 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/resources/google"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getArtifactRegistryRepositoryRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "google_artifact_registry_repository",
+		RFunc: newArtifactRegistryRepository,
+	}
+}
+
+func newArtifactRegistryRepository(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+	zone := d.Get("zone").String()
+	if zone != "" {
+		region = zoneToRegion(zone)
+	}
+
+	location := d.Get("location").String()
+	if location != "" {
+		region = location
+	}
+
+	r := &google.ArtifactRegistryRepository{
+		Address: d.Address,
+		Region:  region,
+	}
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/google/artifact_registry_repository_test.go
+++ b/internal/providers/terraform/google/artifact_registry_repository_test.go
@@ -1,0 +1,16 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestArtifactRegistryRepositoryGoldenFile(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "artifact_registry_repository_test")
+}

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -3,6 +3,7 @@ package google
 import "github.com/infracost/infracost/internal/schema"
 
 var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
+	getArtifactRegistryRepositoryRegistryItem(),
 	GetBigqueryDatasetRegistryItem(),
 	GetBigqueryTableRegistryItem(),
 	GetCloudFunctionsRegistryItem(),

--- a/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.golden
+++ b/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.golden
@@ -1,0 +1,32 @@
+
+ Name                                                              Monthly Qty  Unit            Monthly Cost 
+                                                                                                             
+ google_artifact_registry_repository.asia_east1_usage                                                        
+ ├─ Storage usage                                                          150  GB                    $15.00 
+ └─ Data egress AsiaPacific to AsiaPacific                                 100  GB                     $5.00 
+                                                                                                             
+ google_artifact_registry_repository.australia_southeast1_usage                                              
+ ├─ Storage usage                                                          150  GB                    $15.00 
+ └─ Data egress from/to Oceania                                            100  GB                     $8.00 
+                                                                                                             
+ google_artifact_registry_repository.europe_north1_usage                                                     
+ ├─ Storage usage                                                          150  GB                    $15.00 
+ ├─ Data egress from/to Oceania                                            100  GB                    $15.00 
+ ├─ Data egress Europe to Europe                                           200  GB                     $4.00 
+ └─ Data egress Europe to South America                                    100  GB                     $8.00 
+                                                                                                             
+ google_artifact_registry_repository.multiregion_europe_usage                                                
+ └─ Storage usage                                                          150  GB                    $15.00 
+                                                                                                             
+ google_artifact_registry_repository.us_east1                                                                
+ └─ Storage usage                                                Monthly cost depends on usage: $0.10 per GB 
+                                                                                                             
+ google_artifact_registry_repository.us_east1_usage                                                          
+ ├─ Storage usage                                                          150  GB                    $15.00 
+ ├─ Data egress from/to Oceania                                            100  GB                    $15.00 
+ └─ Data egress North America to North America                             100  GB                     $1.00 
+                                                                                                             
+ OVERALL TOTAL                                                                                       $131.00 
+──────────────────────────────────
+6 cloud resources were detected:
+∙ 6 were estimated

--- a/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.golden
+++ b/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.golden
@@ -2,31 +2,32 @@
  Name                                                              Monthly Qty  Unit            Monthly Cost 
                                                                                                              
  google_artifact_registry_repository.asia_east1_usage                                                        
- ├─ Storage usage                                                          150  GB                    $15.00 
+ ├─ Storage                                                                150  GB                    $15.00 
  └─ Data egress AsiaPacific to AsiaPacific                                 100  GB                     $5.00 
                                                                                                              
  google_artifact_registry_repository.australia_southeast1_usage                                              
- ├─ Storage usage                                                          150  GB                    $15.00 
+ ├─ Storage                                                                150  GB                    $15.00 
  └─ Data egress from/to Oceania                                            100  GB                     $8.00 
                                                                                                              
  google_artifact_registry_repository.europe_north1_usage                                                     
- ├─ Storage usage                                                          150  GB                    $15.00 
+ ├─ Storage                                                                150  GB                    $15.00 
  ├─ Data egress from/to Oceania                                            100  GB                    $15.00 
  ├─ Data egress Europe to Europe                                           200  GB                     $4.00 
- └─ Data egress Europe to South America                                    100  GB                     $8.00 
+ └─ Intercontinental (Excl Oceania)                                        100  GB                     $8.00 
                                                                                                              
  google_artifact_registry_repository.multiregion_europe_usage                                                
- └─ Storage usage                                                          150  GB                    $15.00 
+ └─ Storage                                                                150  GB                    $15.00 
                                                                                                              
  google_artifact_registry_repository.us_east1                                                                
- └─ Storage usage                                                Monthly cost depends on usage: $0.10 per GB 
+ └─ Storage                                                      Monthly cost depends on usage: $0.10 per GB 
                                                                                                              
  google_artifact_registry_repository.us_east1_usage                                                          
- ├─ Storage usage                                                          150  GB                    $15.00 
+ ├─ Storage                                                                150  GB                    $15.00 
  ├─ Data egress from/to Oceania                                            100  GB                    $15.00 
+ ├─ Intercontinental (Excl Oceania)                                        200  GB                    $16.00 
  └─ Data egress North America to North America                             100  GB                     $1.00 
                                                                                                              
- OVERALL TOTAL                                                                                       $131.00 
+ OVERALL TOTAL                                                                                       $147.00 
 ──────────────────────────────────
 6 cloud resources were detected:
 ∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.golden
+++ b/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.golden
@@ -29,4 +29,4 @@
  OVERALL TOTAL                                                                                       $131.00 
 ──────────────────────────────────
 6 cloud resources were detected:
-∙ 6 were estimated
+∙ 6 were estimated, 6 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.tf
+++ b/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.tf
@@ -1,0 +1,52 @@
+provider "google" {
+  credentials = "{\"type\":\"service_account\"}"
+  region      = "us-central1"
+}
+
+resource "google_artifact_registry_repository" "us_east1" {
+  provider = google-beta
+
+  location      = "us-east1"
+  repository_id = "my-repository"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository" "us_east1_usage" {
+  provider = google-beta
+
+  location      = "us-east1"
+  repository_id = "my-repository"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository" "europe_north1_usage" {
+  provider = google-beta
+
+  location      = "europe-north1"
+  repository_id = "my-repository"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository" "asia_east1_usage" {
+  provider = google-beta
+
+  location      = "asia-east1"
+  repository_id = "my-repository"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository" "australia_southeast1_usage" {
+  provider = google-beta
+
+  location      = "australia-southeast1"
+  repository_id = "my-repository"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository" "multiregion_europe_usage" {
+  provider = google-beta
+
+  location      = "europe"
+  repository_id = "my-repository"
+  format        = "DOCKER"
+}

--- a/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.tf
+++ b/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.tf
@@ -3,6 +3,11 @@ provider "google" {
   region      = "us-central1"
 }
 
+provider "google-beta" {
+  credentials = "{\"type\":\"service_account\"}"
+  region      = "us-central1"
+}
+
 resource "google_artifact_registry_repository" "us_east1" {
   provider = google-beta
 

--- a/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.usage.yml
+++ b/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.usage.yml
@@ -1,0 +1,28 @@
+version: 0.1
+resource_usage:
+  google_artifact_registry_repository.us_east1_usage:
+    storage_gb: 150
+    monthly_egress_data_transfer_gb:
+      us_east1: 100
+      us_west1: 100
+      australia_southeast1: 100
+  google_artifact_registry_repository.europe_north1_usage:
+    storage_gb: 150
+    monthly_egress_data_transfer_gb:
+      europe_north1: 100
+      europe_west1: 100
+      europe_west4: 100
+      southamerica_east1: 100
+      australia_southeast1: 100
+  google_artifact_registry_repository.asia_east1_usage:
+    storage_gb: 150
+    monthly_egress_data_transfer_gb:
+      asia_northeast1: 100
+  google_artifact_registry_repository.australia_southeast1_usage:
+    storage_gb: 150
+    monthly_egress_data_transfer_gb:
+      europe_west1: 100
+  google_artifact_registry_repository.multiregion_europe_usage:
+    storage_gb: 150
+    monthly_egress_data_transfer_gb:
+      europe_west1: 100

--- a/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.usage.yml
+++ b/internal/providers/terraform/google/testdata/artifact_registry_repository_test/artifact_registry_repository_test.usage.yml
@@ -6,6 +6,8 @@ resource_usage:
       us_east1: 100
       us_west1: 100
       australia_southeast1: 100
+      europe_north1: 100
+      southamerica_east1: 100
   google_artifact_registry_repository.europe_north1_usage:
     storage_gb: 150
     monthly_egress_data_transfer_gb:

--- a/internal/resources/google/artifact_registry_repository.go
+++ b/internal/resources/google/artifact_registry_repository.go
@@ -205,7 +205,7 @@ func (r *ArtifactRegistryRepository) internalEgressComponents() []*schema.CostCo
 
 func (r *ArtifactRegistryRepository) storageCostComponent() *schema.CostComponent {
 	return &schema.CostComponent{
-		Name:            "Storage usage",
+		Name:            "Storage",
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: floatPtrToDecimalPtr(r.StorageGB),
@@ -327,6 +327,10 @@ func (r *ArtifactRegistryRepository) egressComponentName(continent string) strin
 		return "Data egress from/to Oceania"
 	}
 
+	if r.Continent == continentSouthAmerica || continent == continentSouthAmerica {
+		return "Intercontinental (Excl Oceania)"
+	}
+
 	// replace the gcp continent naming with the correctly spelled continent
 	// for the cli output.
 	from := r.Continent
@@ -339,7 +343,11 @@ func (r *ArtifactRegistryRepository) egressComponentName(continent string) strin
 		to = "AsiaPacific"
 	}
 
-	return fmt.Sprintf("Data egress %s to %s", from, to)
+	if continent == r.Continent {
+		return fmt.Sprintf("Data egress %s to %s", from, to)
+	}
+
+	return "Intercontinental (Excl Oceania)"
 }
 
 func (r *ArtifactRegistryRepository) egressRegionFilter(continent string) *string {
@@ -348,6 +356,10 @@ func (r *ArtifactRegistryRepository) egressRegionFilter(continent string) *strin
 	}
 
 	if _, ok := artifactGlobalEgressContinents[continent]; ok {
+		return strPtr("global")
+	}
+
+	if r.Continent != continent {
 		return strPtr("global")
 	}
 

--- a/internal/resources/google/artifact_registry_repository.go
+++ b/internal/resources/google/artifact_registry_repository.go
@@ -76,17 +76,17 @@ type locationDataTransfer struct {
 	EuropeWest3            *float64 `infracost_usage:"europe_west3"`
 	EuropeWest4            *float64 `infracost_usage:"europe_west4"`
 	EuropeWest6            *float64 `infracost_usage:"europe_west6"`
-	NorthamericaNortheast1 *float64 `infracost_usage:"northamerica_northeast1"`
-	NorthamericaNortheast2 *float64 `infracost_usage:"northamerica_northeast2"`
-	SouthamericaEast1      *float64 `infracost_usage:"southamerica_east1"`
-	SouthamericaWest1      *float64 `infracost_usage:"southamerica_west1"`
-	UsCentral1             *float64 `infracost_usage:"us_central1"`
-	UsEast1                *float64 `infracost_usage:"us_east1"`
-	UsEast4                *float64 `infracost_usage:"us_east4"`
-	UsWest1                *float64 `infracost_usage:"us_west1"`
-	UsWest2                *float64 `infracost_usage:"us_west2"`
-	UsWest3                *float64 `infracost_usage:"us_west3"`
-	UsWest4                *float64 `infracost_usage:"us_west4"`
+	NorthAmericaNortheast1 *float64 `infracost_usage:"northamerica_northeast1"`
+	NorthAmericaNortheast2 *float64 `infracost_usage:"northamerica_northeast2"`
+	SouthAmericaEast1      *float64 `infracost_usage:"southamerica_east1"`
+	SouthAmericaWest1      *float64 `infracost_usage:"southamerica_west1"`
+	USCentral1             *float64 `infracost_usage:"us_central1"`
+	USEast1                *float64 `infracost_usage:"us_east1"`
+	USEast4                *float64 `infracost_usage:"us_east4"`
+	USWest1                *float64 `infracost_usage:"us_west1"`
+	USWest2                *float64 `infracost_usage:"us_west2"`
+	USWest3                *float64 `infracost_usage:"us_west3"`
+	USWest4                *float64 `infracost_usage:"us_west4"`
 }
 
 var locationDataTransferUsage = []*schema.UsageItem{

--- a/internal/resources/google/artifact_registry_repository.go
+++ b/internal/resources/google/artifact_registry_repository.go
@@ -2,13 +2,13 @@ package google
 
 import (
 	"fmt"
+	"regexp"
+
+	"github.com/shopspring/decimal"
+
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/infracost/infracost/internal/usage"
-	"github.com/shopspring/decimal"
-	"reflect"
-	"regexp"
-	"strings"
 )
 
 var (
@@ -52,73 +52,7 @@ type ArtifactRegistryRepository struct {
 	StorageGB *float64 `infracost_usage:"storage_gb"`
 	// MonthlyEgressDataTransferGB represents a complex usage cost that defines data transfer to different regions in the
 	// google cloud infra. This does not include outbound internet egress (e.g. downloading artifact data to a local machine).
-	MonthlyEgressDataTransferGB *artifactRegistryRegionDataTransfer `infracost_usage:"monthly_egress_data_transfer_gb"`
-}
-
-// artifactRegistryRegionDataTransfer represents a usage map that allows the users to specify which regions the artifact registry
-// has data egress to/from.
-type artifactRegistryRegionDataTransfer struct {
-	AsiaEast1              *float64 `infracost_usage:"asia_east1"`
-	AsiaEast2              *float64 `infracost_usage:"asia_east2"`
-	AsiaNortheast1         *float64 `infracost_usage:"asia_northeast1"`
-	AsiaNortheast2         *float64 `infracost_usage:"asia_northeast2"`
-	AsiaNortheast3         *float64 `infracost_usage:"asia_northeast3"`
-	AsiaSouth1             *float64 `infracost_usage:"asia_south1"`
-	AsiaSouth2             *float64 `infracost_usage:"asia_south2"`
-	AsiaSoutheast1         *float64 `infracost_usage:"asia_southeast1"`
-	AsiaSoutheast2         *float64 `infracost_usage:"asia_southeast2"`
-	AustraliaSoutheast1    *float64 `infracost_usage:"australia_southeast1"`
-	AustraliaSoutheast2    *float64 `infracost_usage:"australia_southeast2"`
-	EuropeCentral2         *float64 `infracost_usage:"europe_central2"`
-	EuropeNorth1           *float64 `infracost_usage:"europe_north1"`
-	EuropeWest1            *float64 `infracost_usage:"europe_west1"`
-	EuropeWest2            *float64 `infracost_usage:"europe_west2"`
-	EuropeWest3            *float64 `infracost_usage:"europe_west3"`
-	EuropeWest4            *float64 `infracost_usage:"europe_west4"`
-	EuropeWest6            *float64 `infracost_usage:"europe_west6"`
-	NorthAmericaNortheast1 *float64 `infracost_usage:"northamerica_northeast1"`
-	NorthAmericaNortheast2 *float64 `infracost_usage:"northamerica_northeast2"`
-	SouthAmericaEast1      *float64 `infracost_usage:"southamerica_east1"`
-	SouthAmericaWest1      *float64 `infracost_usage:"southamerica_west1"`
-	USCentral1             *float64 `infracost_usage:"us_central1"`
-	USEast1                *float64 `infracost_usage:"us_east1"`
-	USEast4                *float64 `infracost_usage:"us_east4"`
-	USWest1                *float64 `infracost_usage:"us_west1"`
-	USWest2                *float64 `infracost_usage:"us_west2"`
-	USWest3                *float64 `infracost_usage:"us_west3"`
-	USWest4                *float64 `infracost_usage:"us_west4"`
-}
-
-var artifactRegistryRegionDataTransferUsage = []*schema.UsageItem{
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_east1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_east2"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_northeast1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_northeast2"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_northeast3"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_south1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_south2"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_southeast1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_southeast2"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"australia_southeast1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"australia_southeast2"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_central2"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_north1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west2"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west3"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west4"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west6"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"northamerica_northeast1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"northamerica_northeast2"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"southamerica_east1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"southamerica_west1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_central1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_east1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_east4"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west1"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west2"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west3"`},
-	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west4"`},
+	MonthlyEgressDataTransferGB *RegionsUsage `infracost_usage:"monthly_egress_data_transfer_gb"`
 }
 
 // artifactRegistryRepositoryUsageSchema defines a list which represents the usage schema of ArtifactRegistryRepository.
@@ -128,7 +62,7 @@ var artifactRegistryRepositoryUsageSchema = []*schema.UsageItem{
 		Key: "monthly_egress_data_transfer_gb",
 		DefaultValue: &usage.ResourceUsage{
 			Name:  "monthly_egress_data_transfer_gb",
-			Items: artifactRegistryRegionDataTransferUsage,
+			Items: RegionUsageSchema,
 		},
 		ValueType: schema.SubResourceUsage,
 	},
@@ -247,24 +181,22 @@ func (r *ArtifactRegistryRepository) toEgressFilters() []artifactRegistryEgressF
 		return nil
 	}
 
-	var data []artifactRegistryEgressFilters
-	v := reflect.ValueOf(*r.MonthlyEgressDataTransferGB)
-	t := reflect.TypeOf(*r.MonthlyEgressDataTransferGB)
+	values := r.MonthlyEgressDataTransferGB.Values()
 
+	var data []artifactRegistryEgressFilters
 	transferMap := make(map[string]int)
 
-	for i := 0; i < v.NumField(); i++ {
-		if v.Field(i).IsNil() {
+	for _, region := range values {
+		if region.Value == 0 {
 			continue
 		}
 
-		region := strings.ReplaceAll(t.Field(i).Tag.Get("infracost_usage"), "_", "-")
-		if r.isEgressFree(region) {
+		if r.isEgressFree(region.Key) {
 			continue
 		}
 
-		continent := continentName(region)
-		value := decimal.NewFromFloat(*v.Field(i).Interface().(*float64))
+		continent := continentName(region.Key)
+		value := decimal.NewFromFloat(region.Value)
 
 		// check if the user has specified multiple regions that are based in the same continent.
 		// We want to bunch these cost components into a single value output.

--- a/internal/resources/google/artifact_registry_repository.go
+++ b/internal/resources/google/artifact_registry_repository.go
@@ -1,0 +1,368 @@
+package google
+
+import (
+	"fmt"
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
+	"github.com/shopspring/decimal"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+var (
+	artifactRegSvcName = strPtr("Artifact Registry")
+
+	continentDefault      = "Intercontinental (Excl Oceania)"
+	continentNorthAmerica = "North America"
+	continentSouthAmerica = "South America"
+	continentEurope       = "Europe"
+	// GCP misspells AsiaPacific without the i. The below is not a typo!
+	continentApac    = "AsiaPacfic"
+	continentOceania = "Oceania"
+
+	artifactGlobalEgressContinents = map[string]struct{}{
+		continentOceania:      {},
+		continentSouthAmerica: {},
+	}
+	artifactRegMultiRegionNames = map[string]struct{}{
+		"us":     {},
+		"europe": {},
+		"asia":   {},
+	}
+
+	regionSep = regexp.MustCompile(`[_\-]`)
+)
+
+// ArtifactRegistryRepository struct represents a GCP artifact Registry. Artifact registry is essentially
+// a next generation version of google's container registry. It allows users to store container images and language
+// packages in the GCP.
+//
+// Pricing for Artifact Registry is based on storage amounts and data transfer.
+//
+// Resource information: https://cloud.google.com/artifact-registry
+// Pricing information: https://cloud.google.com/artifact-registry/pricing
+type ArtifactRegistryRepository struct {
+	Address   string
+	Region    string
+	Continent string
+
+	// StorageGB represents a usage cost that defines the amount of gb the artifact registry uses on a per monthly basis.
+	StorageGB *float64 `infracost_usage:"storage_gb"`
+	// MonthlyEgressDataTransferGB represents a complex usage cost that defines data transfer to different regions in the
+	// google cloud infra. This does not include outbound internet egress (e.g. downloading artifact data to a local machine).
+	MonthlyEgressDataTransferGB *locationDataTransfer `infracost_usage:"monthly_egress_data_transfer_gb"`
+}
+
+// locationDataTransfer represents a usage map that allows the users to specify which regions the artifact registry
+// has data egress to/from.
+type locationDataTransfer struct {
+	AsiaEast1              *float64 `infracost_usage:"asia_east1"`
+	AsiaEast2              *float64 `infracost_usage:"asia_east2"`
+	AsiaNortheast1         *float64 `infracost_usage:"asia_northeast1"`
+	AsiaNortheast2         *float64 `infracost_usage:"asia_northeast2"`
+	AsiaNortheast3         *float64 `infracost_usage:"asia_northeast3"`
+	AsiaSouth1             *float64 `infracost_usage:"asia_south1"`
+	AsiaSouth2             *float64 `infracost_usage:"asia_south2"`
+	AsiaSoutheast1         *float64 `infracost_usage:"asia_southeast1"`
+	AsiaSoutheast2         *float64 `infracost_usage:"asia_southeast2"`
+	AustraliaSoutheast1    *float64 `infracost_usage:"australia_southeast1"`
+	AustraliaSoutheast2    *float64 `infracost_usage:"australia_southeast2"`
+	EuropeCentral2         *float64 `infracost_usage:"europe_central2"`
+	EuropeNorth1           *float64 `infracost_usage:"europe_north1"`
+	EuropeWest1            *float64 `infracost_usage:"europe_west1"`
+	EuropeWest2            *float64 `infracost_usage:"europe_west2"`
+	EuropeWest3            *float64 `infracost_usage:"europe_west3"`
+	EuropeWest4            *float64 `infracost_usage:"europe_west4"`
+	EuropeWest6            *float64 `infracost_usage:"europe_west6"`
+	NorthamericaNortheast1 *float64 `infracost_usage:"northamerica_northeast1"`
+	NorthamericaNortheast2 *float64 `infracost_usage:"northamerica_northeast2"`
+	SouthamericaEast1      *float64 `infracost_usage:"southamerica_east1"`
+	SouthamericaWest1      *float64 `infracost_usage:"southamerica_west1"`
+	UsCentral1             *float64 `infracost_usage:"us_central1"`
+	UsEast1                *float64 `infracost_usage:"us_east1"`
+	UsEast4                *float64 `infracost_usage:"us_east4"`
+	UsWest1                *float64 `infracost_usage:"us_west1"`
+	UsWest2                *float64 `infracost_usage:"us_west2"`
+	UsWest3                *float64 `infracost_usage:"us_west3"`
+	UsWest4                *float64 `infracost_usage:"us_west4"`
+}
+
+var locationDataTransferUsage = []*schema.UsageItem{
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_east1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_east2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_northeast1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_northeast2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_northeast3"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_south1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_south2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_southeast1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_southeast2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"australia_southeast1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"australia_southeast2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_central2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_north1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west3"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west4"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west6"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"northamerica_northeast1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"northamerica_northeast2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"southamerica_east1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"southamerica_west1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_central1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_east1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_east4"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west3"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west4"`},
+}
+
+// artifactRegistryRepositoryUsageSchema defines a list which represents the usage schema of ArtifactRegistryRepository.
+var artifactRegistryRepositoryUsageSchema = []*schema.UsageItem{
+	{Key: "storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{
+		Key: "monthly_egress_data_transfer_gb",
+		DefaultValue: &usage.ResourceUsage{
+			Name:  "monthly_egress_data_transfer_gb",
+			Items: locationDataTransferUsage,
+		},
+		ValueType: schema.SubResourceUsage,
+	},
+}
+
+// PopulateUsage parses the u schema.UsageData into the ArtifactRegistryRepository.
+// It uses the `infracost_usage` struct tags to populate data into the ArtifactRegistryRepository.
+func (r *ArtifactRegistryRepository) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid ArtifactRegistryRepository struct. It returns ArtifactRegistryRepository
+// as a schema.Resource with two main cost components: storage costs & egress costs.
+//
+// Storage costs:
+// 		priced at $0.10 a month after artifact registry usage is > 0.5 GB. We ignore the free tier as there
+// 		is no way to currently tell if other artifact registry resources have gone beyond this free usage tier.
+//
+// Network costs:
+//		1. free within the same region
+// 		2. free from multi-region to a region within the same continent, e.g. europe -> europe-west1
+//		3. $0.01 when between different regions in North America continent
+// 		4. $0.02 when between different regions in Europe continent
+//		5. $0.05 when between different regions in AsiaPacific continent
+// 		6. $0.15 when between any region and Oceania continent
+// 		7. $0.08 for all other intercontinental data transfer
+//
+// This method is called after the resource is initialised by an IaC provider. See providers folder for more information.
+func (r *ArtifactRegistryRepository) BuildResource() *schema.Resource {
+	r.Continent = continentName(r.Region)
+
+	costComponents := []*schema.CostComponent{
+		r.storageCostComponent(),
+	}
+
+	if r.MonthlyEgressDataTransferGB != nil {
+		costComponents = append(costComponents, r.internalEgressComponents()...)
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    artifactRegistryRepositoryUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+func (r *ArtifactRegistryRepository) internalEgressComponents() []*schema.CostComponent {
+	filters := r.toEgressFilters()
+	components := make([]*schema.CostComponent, 0, len(filters))
+	for _, v := range filters {
+		components = append(components, &schema.CostComponent{
+			Name:            v.name,
+			Unit:            "GB",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: v.value,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    vendorName,
+				Region:        v.region,
+				Service:       artifactRegSvcName,
+				ProductFamily: strPtr("Network"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "description", Value: v.desc},
+					{Key: "resourceGroup", Value: strPtr("InterregionEgress")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("OnDemand"),
+			},
+		})
+	}
+
+	return components
+}
+
+func (r *ArtifactRegistryRepository) storageCostComponent() *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Storage usage",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: floatPtrToDecimalPtr(r.StorageGB),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    vendorName,
+			Service:       artifactRegSvcName,
+			ProductFamily: strPtr("ApplicationServices"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "description", Value: strPtr("Artifact Registry Storage")},
+				{Key: "resourceGroup", Value: strPtr("Storage")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("OnDemand"),
+			// we ignore the free tier pricing and start at the paid pricing which is at 0.5.
+			StartUsageAmount: strPtr("0.5"),
+		},
+	}
+}
+
+type artifactRegistryEgressFilters struct {
+	name   string
+	desc   *string
+	region *string
+	value  *decimal.Decimal
+}
+
+func (r *ArtifactRegistryRepository) toEgressFilters() []artifactRegistryEgressFilters {
+	if r.MonthlyEgressDataTransferGB == nil {
+		return nil
+	}
+
+	var data []artifactRegistryEgressFilters
+	v := reflect.ValueOf(*r.MonthlyEgressDataTransferGB)
+	t := reflect.TypeOf(*r.MonthlyEgressDataTransferGB)
+
+	transferMap := make(map[string]int)
+
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).IsNil() {
+			continue
+		}
+
+		region := strings.ReplaceAll(t.Field(i).Tag.Get("infracost_usage"), "_", "-")
+		if r.isEgressFree(region) {
+			continue
+		}
+
+		continent := continentName(region)
+		value := decimal.NewFromFloat(*v.Field(i).Interface().(*float64))
+
+		// check if the user has specified multiple regions that are based in the same continent.
+		// We want to bunch these cost components into a single value output.
+		name := r.egressComponentName(continent)
+		if x, ok := transferMap[name]; ok {
+			value = data[x].value.Add(value)
+			data[x].value = &value
+			continue
+		}
+
+		data = append(data, artifactRegistryEgressFilters{
+			name:   name,
+			desc:   r.egressDescriptionFilter(continent),
+			region: r.egressRegionFilter(continent),
+			value:  &value,
+		})
+		transferMap[name] = len(data) - 1
+	}
+
+	return data
+}
+
+func (r *ArtifactRegistryRepository) isEgressFree(region string) bool {
+	// data moving within the same region is free
+	if r.Region == region {
+		return true
+	}
+
+	// data moving from multi-region artifact repository to a region located in the same continent as the multi-region
+	// artifact repository is free.
+	if _, ok := artifactRegMultiRegionNames[r.Region]; ok {
+		p := regionSep.Split(region, -1)
+
+		if p[0] == r.Region {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *ArtifactRegistryRepository) egressDescriptionFilter(continent string) *string {
+	if continent == continentOceania {
+		return strPtr("Artifact Registry Network Inter Region Egress Intercontinental to/from Oceania")
+	}
+
+	if r.Continent == continentSouthAmerica || continent == continentSouthAmerica {
+		return strPtr("Artifact Registry Network Inter Region Egress Intercontinental (Excl Oceania)")
+	}
+
+	if r.Continent == continent {
+		return strPtr(fmt.Sprintf("Artifact Registry Network Inter Region Egress %s to %s", r.Continent, continent))
+	}
+
+	return strPtr("Artifact Registry Network Inter Region Egress Intercontinental (Excl Oceania)")
+}
+
+func (r *ArtifactRegistryRepository) egressComponentName(continent string) string {
+	if continent == continentOceania || r.Continent == continentOceania {
+		return "Data egress from/to Oceania"
+	}
+
+	// replace the gcp continent naming with the correctly spelled continent
+	// for the cli output.
+	from := r.Continent
+	if from == continentApac {
+		from = "AsiaPacific"
+	}
+
+	to := continent
+	if to == continentApac {
+		to = "AsiaPacific"
+	}
+
+	return fmt.Sprintf("Data egress %s to %s", from, to)
+}
+
+func (r *ArtifactRegistryRepository) egressRegionFilter(continent string) *string {
+	if _, ok := artifactGlobalEgressContinents[r.Continent]; ok {
+		return strPtr("global")
+	}
+
+	if _, ok := artifactGlobalEgressContinents[continent]; ok {
+		return strPtr("global")
+	}
+
+	return strPtr(r.Region)
+}
+
+func continentName(region string) string {
+	p := regionSep.Split(region, -1)
+	if len(p) == 0 {
+		return continentNorthAmerica
+	}
+
+	switch p[0] {
+	case "us", "northamerica":
+		return continentNorthAmerica
+	case "europe":
+		return continentEurope
+	case "asia":
+		return continentApac
+	case "southamerica":
+		return continentSouthAmerica
+	case "australia":
+		return continentOceania
+	}
+
+	return continentDefault
+}

--- a/internal/resources/google/util.go
+++ b/internal/resources/google/util.go
@@ -2,12 +2,17 @@ package google
 
 import (
 	"fmt"
+	"reflect"
+	"regexp"
 
 	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/schema"
 )
 
 var (
 	vendorName = strPtr("gcp")
+	underscore = regexp.MustCompile(`_`)
 )
 
 func strPtr(s string) *string {
@@ -36,4 +41,115 @@ func floatPtrToDecimalPtr(f *float64) *decimal.Decimal {
 		return nil
 	}
 	return decimalPtr(decimal.NewFromFloat(*f))
+}
+
+// RegionsUsage is a reusable type that represents a usage cost map.
+// This can be used in resources that define a usage parameter that's changed on a per-region basis, e.g:
+//
+// monthly_data_processed_gb:
+//   asia_northeast1: 188
+//   asia_east2: 78
+//
+// can be handled by adding a usage cost property to your resource like so:
+//
+// type MyResource struct {
+//    ...
+//    MonthlyDataProcessedGB *RegionsUsage `infracost_usage:"monthly_processed_gb"`
+// }
+type RegionsUsage struct {
+	AsiaEast1              *float64 `infracost_usage:"asia_east1"`
+	AsiaEast2              *float64 `infracost_usage:"asia_east2"`
+	AsiaNortheast1         *float64 `infracost_usage:"asia_northeast1"`
+	AsiaNortheast2         *float64 `infracost_usage:"asia_northeast2"`
+	AsiaNortheast3         *float64 `infracost_usage:"asia_northeast3"`
+	AsiaSouth1             *float64 `infracost_usage:"asia_south1"`
+	AsiaSouth2             *float64 `infracost_usage:"asia_south2"`
+	AsiaSoutheast1         *float64 `infracost_usage:"asia_southeast1"`
+	AsiaSoutheast2         *float64 `infracost_usage:"asia_southeast2"`
+	AustraliaSoutheast1    *float64 `infracost_usage:"australia_southeast1"`
+	AustraliaSoutheast2    *float64 `infracost_usage:"australia_southeast2"`
+	EuropeCentral2         *float64 `infracost_usage:"europe_central2"`
+	EuropeNorth1           *float64 `infracost_usage:"europe_north1"`
+	EuropeWest1            *float64 `infracost_usage:"europe_west1"`
+	EuropeWest2            *float64 `infracost_usage:"europe_west2"`
+	EuropeWest3            *float64 `infracost_usage:"europe_west3"`
+	EuropeWest4            *float64 `infracost_usage:"europe_west4"`
+	EuropeWest6            *float64 `infracost_usage:"europe_west6"`
+	NorthAmericaNortheast1 *float64 `infracost_usage:"northamerica_northeast1"`
+	NorthAmericaNortheast2 *float64 `infracost_usage:"northamerica_northeast2"`
+	SouthAmericaEast1      *float64 `infracost_usage:"southamerica_east1"`
+	SouthAmericaWest1      *float64 `infracost_usage:"southamerica_west1"`
+	USCentral1             *float64 `infracost_usage:"us_central1"`
+	USEast1                *float64 `infracost_usage:"us_east1"`
+	USEast4                *float64 `infracost_usage:"us_east4"`
+	USWest1                *float64 `infracost_usage:"us_west1"`
+	USWest2                *float64 `infracost_usage:"us_west2"`
+	USWest3                *float64 `infracost_usage:"us_west3"`
+	USWest4                *float64 `infracost_usage:"us_west4"`
+}
+
+// RegionUsageSchema is the schema representation of the RegionsUsage type.
+// This can be used as a schema.SubResourceUsage to define a structure that's
+// commonly used with resources that vary on a per region basis.
+var RegionUsageSchema = []*schema.UsageItem{
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_east1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_east2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_northeast1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_northeast2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_northeast3"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_south1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_south2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_southeast1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"asia_southeast2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"australia_southeast1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"australia_southeast2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_central2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_north1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west3"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west4"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"europe_west6"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"northamerica_northeast1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"northamerica_northeast2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"southamerica_east1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"southamerica_west1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_central1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_east1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_east4"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west1"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west2"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west3"`},
+	{ValueType: schema.Float64, DefaultValue: 0, Key: `infracost_usage:"us_west4"`},
+}
+
+// RegionUsage defines a hard definition in the regions map.
+type RegionUsage struct {
+	Key   string
+	Value float64
+}
+
+// Values returns RegionUsage as a slice which can be iterated over
+// to create cost components. The keys of the regions returned have
+// their underscores replaced with hypens so they can be used in
+// product filters and cost lookups.
+func (r RegionsUsage) Values() []RegionUsage {
+	s := reflect.ValueOf(r)
+	t := reflect.TypeOf(r)
+
+	var regions []RegionUsage
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+
+		if f.IsNil() {
+			continue
+		}
+
+		regions = append(regions, RegionUsage{
+			Key:   underscore.ReplaceAllString(t.Field(i).Tag.Get("infracost_usage"), "-"),
+			Value: *f.Interface().(*float64),
+		})
+	}
+
+	return regions
 }

--- a/internal/resources/google/util.go
+++ b/internal/resources/google/util.go
@@ -6,6 +6,10 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+var (
+	vendorName = strPtr("gcp")
+)
+
 func strPtr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
## Objective:

Add support for Google Artifact Registry Repository 

## Pricing details:

Pricing details can be found here: https://cloud.google.com/artifact-registry/pricing and is broken down into:

**Storage costs:**
		priced at $0.10 a month after artifact registry usage is > 0.5 GB. We ignore the free tier as there is no way to currently tell if other artifact registry resources have gone beyond this free usage tier.

**Network costs:**
		1. free within the same region
		2. free from multi-region to a region within the same continent, e.g. europe -> europe-west1
		3. $0.01 when between different regions in North America continent
		4. $0.02 when between different regions in Europe continent
		5. $0.05 when between different regions in AsiaPacific continent
		6. $0.15 when between any region and Oceania continent
		7. $0.08 for all other intercontinental data transfer

## Status:

- [x] Generated the resource files
- [x] Updated the internal/resources file
- [x] Updated the internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/136)

## Issues:

* Artifact registry also incurs costs for internet egress, e.g. data downloaded by from the repository to the infra outside of google. I have not included this pricing as this is bunched into the generic tiered network costs that is currently in discussion.
* I have not included [vulnerability scanning prices](https://cloud.google.com/artifact-registry/pricing#scanning) as this seems to fall outside of this resource to `google_container_analysis_occurence` see [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_analysis_occurrence)