### PR TITLE
docs: add region usage appendix

### DIFF
--- a/contributing/add_new_resource_guide.md
+++ b/contributing/add_new_resource_guide.md
@@ -1191,8 +1191,7 @@ type MyResource struct {
 }
 ```
 
-And then after `PopulateUsage` is called it can be accessed to retrieve set values. `RegionsUsage` helper struct also comes with 
-a `Values` method that returns the set values as a `slice` with key/value pairs that is helpful to iterate over to create cost components, e.g with a usage like so:
+And then after `PopulateUsage` is called it can be accessed to retrieve set values. `RegionsUsage` helper struct also comes with a `Values` method that returns the set values as a `slice` with key/value pairs that is helpful to iterate over to create cost components, e.g with a usage like so:
 
 ```yaml
   my_resource.resource:

--- a/contributing/add_new_resource_guide.md
+++ b/contributing/add_new_resource_guide.md
@@ -1166,9 +1166,7 @@ Unless the resource has global or zone-based pricing, the first line of the reso
 
 ### Region usage
 
-A number of resources have usage costs which vary on a per-region basis. This means that developers often have to define
-a usage file with a complex map key with all the cloud provider regions. E.g. `google_artifact_registry_repository` can have 
-any number of google regions under the `monthly_egress_data_transfer_gb` usage param:
+A number of resources have usage costs which vary on a per-region basis. This means that you often have to define a usage file with a complex map key with all the cloud provider regions. For example, `google_artifact_registry_repository` can have any number of Google regions under the `monthly_egress_data_transfer_gb` usage parameter:
 
 ```yaml
   google_artifact_registry_repository.artifact_registry:

--- a/contributing/add_new_resource_guide.md
+++ b/contributing/add_new_resource_guide.md
@@ -1179,8 +1179,7 @@ A number of resources have usage costs which vary on a per-region basis. This me
       southamerica_east1: 100
 ```
 
-If you have a resource like this, rather than defining your own usage field, it is advisable you use one of the shared `RegionsUsage`
-structs that handle this structure for you. These structs can be found in both [the google](../internal/resources/google/util.go) & [aws](../internal/resources/aws/util.go) resource util files.
+If you have a resource like this, rather than defining your own usage field, you should use one of the shared `RegionsUsage` structs that handle this structure for you. These structs can be found in both [the `google`](../internal/resources/google/util.go) & [`aws`](../internal/resources/aws/util.go) resource util files.
 
 These can simply be embedded into a struct field like so:
 


### PR DESCRIPTION
Adds helper appendix to adding new resource docs to make sure developers know to use the shared `RegionsUsage` struct. This means we only have one place to maintain region keys and it's easier for contributors to get up and running.