### PR TITLE
feat(aws): add aws cloudtrail resource

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -51,6 +51,11 @@ resource_usage:
     monthly_handler_operations: 10000 # Monthly number of non-free handler operations (resources outside of the AWS::*, Alexa::*, and Custom::* namespaces).
     monthly_duration_secs: 0 # Monthly duration of non-free handler operations that go above 30 seconds, in seconds.  
 
+  aws_cloudtrail.my_cloudtrail:
+    monthly_additional_management_events: 1000 # Monthly additional copies of read and write management events. The first copy of management events per region is free, so this should only be non-zero if there are multiple trails recording management events in this region.
+    monthly_data_events: 2000 # Monthly data events delivered to S3, Lambda or DynamoDB
+    monthly_insight_events: 4000 # Monthly CloudTrail Insight events
+
   aws_cloudwatch_event_bus.my_events:
     monthly_custom_events: 1000000            # Monthly custom events published. Each 64 KB chunk of payload is billed as 1 event.
     monthly_third_party_events: 2000000       # Monthly third-party and cross-account events published. Each 64 KB chunk of payload is billed as 1 event.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -52,9 +52,9 @@ resource_usage:
     monthly_duration_secs: 0 # Monthly duration of non-free handler operations that go above 30 seconds, in seconds.  
 
   aws_cloudtrail.my_cloudtrail:
-    monthly_additional_management_events: 1000 # Monthly additional copies of read and write management events. The first copy of management events per region is free, so this should only be non-zero if there are multiple trails recording management events in this region.
-    monthly_data_events: 2000 # Monthly data events delivered to S3, Lambda or DynamoDB
-    monthly_insight_events: 4000 # Monthly CloudTrail Insight events
+    monthly_additional_management_events: 100000 # Monthly additional copies of read and write management events. The first copy of management events per region is free, so this should only be non-zero if there are multiple trails recording management events in this region.
+    monthly_data_events: 200000 # Monthly data events delivered to S3, Lambda or DynamoDB
+    monthly_insight_events: 400000 # Monthly CloudTrail Insight events
 
   aws_cloudwatch_event_bus.my_events:
     monthly_custom_events: 1000000            # Monthly custom events published. Each 64 KB chunk of payload is billed as 1 event.

--- a/internal/providers/terraform/aws/cloudtrail.go
+++ b/internal/providers/terraform/aws/cloudtrail.go
@@ -1,0 +1,26 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/resources/aws"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getCloudtrailRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_cloudtrail",
+		RFunc: newCloudtrail,
+	}
+}
+
+func newCloudtrail(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+	r := &aws.Cloudtrail{
+		Address:                 d.Address,
+		Region:                  region,
+		IncludeManagementEvents: d.Get("include_global_service_events").Bool(),
+		IncludeInsightEvents:    len(d.Get("insight_selector").Array()) > 0,
+	}
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/aws/cloudtrail_test.go
+++ b/internal/providers/terraform/aws/cloudtrail_test.go
@@ -1,0 +1,16 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestCloudtrailGoldenFile(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "cloudtrail_test")
+}

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -13,6 +13,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetCloudFormationStackRegistryItem(),
 	GetCloudFormationStackSetRegistryItem(),
 	GetCloudfrontDistributionRegistryItem(),
+	getCloudtrailRegistryItem(),
 	GetCloudwatchDashboardRegistryItem(),
 	GetCloudwatchEventBusItem(),
 	GetCloudwatchLogGroupItem(),

--- a/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.golden
@@ -1,0 +1,24 @@
+
+ Name                                                      Monthly Qty  Unit                  Monthly Cost 
+                                                                                                           
+ aws_cloudtrail.cloudtrail_with_defaults                                                                   
+ ├─ Management events (additional copies)             Monthly cost depends on usage: $2.00 per 100k events 
+ └─ Data events                                       Monthly cost depends on usage: $0.10 per 100k events 
+                                                                                                           
+ aws_cloudtrail.cloudtrail_with_insight_selector                                                           
+ ├─ Management events (additional copies)             Monthly cost depends on usage: $2.00 per 100k events 
+ ├─ Data events                                       Monthly cost depends on usage: $0.10 per 100k events 
+ └─ Insight events                                    Monthly cost depends on usage: $0.35 per 100k events 
+                                                                                                           
+ aws_cloudtrail.cloudtrail_with_usage                                                                      
+ ├─ Management events (additional copies)                           10  100k events                 $20.00 
+ ├─ Data events                                                     20  100k events                  $2.00 
+ └─ Insight events                                                  30  100k events                 $10.50 
+                                                                                                           
+ aws_cloudtrail.cloudtrail_without_management_events                                                       
+ └─ Data events                                       Monthly cost depends on usage: $0.10 per 100k events 
+                                                                                                           
+ OVERALL TOTAL                                                                                      $32.50 
+──────────────────────────────────
+4 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.golden
@@ -11,14 +11,14 @@
  └─ Insight events                                    Monthly cost depends on usage: $0.35 per 100k events 
                                                                                                            
  aws_cloudtrail.cloudtrail_with_usage                                                                      
- ├─ Management events (additional copies)                           10  100k events                 $20.00 
- ├─ Data events                                                     20  100k events                  $2.00 
- └─ Insight events                                                  30  100k events                 $10.50 
+ ├─ Management events (additional copies)                            1  100k events                  $2.00 
+ ├─ Data events                                                      2  100k events                  $0.20 
+ └─ Insight events                                                   3  100k events                  $1.05 
                                                                                                            
  aws_cloudtrail.cloudtrail_without_management_events                                                       
  └─ Data events                                       Monthly cost depends on usage: $0.10 per 100k events 
                                                                                                            
- OVERALL TOTAL                                                                                      $32.50 
+ OVERALL TOTAL                                                                                       $3.25 
 ──────────────────────────────────
 4 cloud resources were detected:
 ∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.tf
+++ b/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_cloudtrail" "cloudtrail_with_defaults" {
+  name           = "cloudtrail-with-defaults"
+  s3_bucket_name = "bucket-1234"
+}
+
+resource "aws_cloudtrail" "cloudtrail_without_management_events" {
+  name                          = "cloudtrail-with-defaults"
+  s3_bucket_name                = "bucket-1234"
+  include_global_service_events = false
+}
+
+resource "aws_cloudtrail" "cloudtrail_with_insight_selector" {
+  name           = "cloudtrail-with-defaults"
+  s3_bucket_name = "bucket-1234"
+  insight_selector {
+    insight_type = "ApiCallRateInsight"
+  }
+}
+
+resource "aws_cloudtrail" "cloudtrail_with_usage" {
+  name           = "cloudtrail-with-defaults"
+  s3_bucket_name = "bucket-1234"
+  insight_selector {
+    insight_type = "ApiCallRateInsight"
+  }
+}

--- a/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.usage.yml
@@ -1,6 +1,6 @@
 version: 0.1
 resource_usage:
   aws_cloudtrail.cloudtrail_with_usage:
-    monthly_additional_management_events: 10
-    monthly_data_events: 20
-    monthly_insight_events: 30
+    monthly_additional_management_events: 100000
+    monthly_data_events: 200000
+    monthly_insight_events: 300000

--- a/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/cloudtrail_test/cloudtrail_test.usage.yml
@@ -1,0 +1,6 @@
+version: 0.1
+resource_usage:
+  aws_cloudtrail.cloudtrail_with_usage:
+    monthly_additional_management_events: 10
+    monthly_data_events: 20
+    monthly_insight_events: 30

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -182,7 +182,7 @@
  ├─ Capacity (first 50TB)                                     51,200  GB                           $1,064.96 
  ├─ Capacity (next 450TB)                                    512,000  GB                          $10,223.62 
  ├─ Capacity (over 500TB)                                    436,800  GB                           $8,358.60 
- ├─ Write operations                                             100  10k operations                   $5.50 
+ ├─ List and create container operations                         100  10k operations                   $5.50 
  ├─ Read operations                                               10  10k operations                   $0.04 
  ├─ All other operations                                         100  10k operations                   $0.44 
  └─ Blob index                                                    10  10k tags                         $0.39 

--- a/internal/resources/aws/cloudtrail.go
+++ b/internal/resources/aws/cloudtrail.go
@@ -1,0 +1,139 @@
+package aws
+
+import (
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+var (
+	cloudTrailServiceName = strPtr("AWSCloudTrail")
+
+	cloudTrailManagementEvent = "Management events (additional copies)"
+	cloudTrailDataEvent       = "Data events"
+	cloudTrailInsightEvent    = "Insight events"
+
+	cloudTrailBillingMultiplier = decimal.NewFromInt(100000)
+)
+
+// Cloudtrail struct represents a cloudtrail instance to monitor activity across a set of resources.
+// AWS Cloudtrail monitors and records account activity across infrastructure, keeping an audit log of activity.
+// This is mostly used for security purposes.
+//
+// Resource information: https://aws.amazon.com/cloudtrail/
+// Pricing information: https://aws.amazon.com/cloudtrail/pricing/
+type Cloudtrail struct {
+	Address                 string
+	Region                  string
+	IncludeManagementEvents bool
+	IncludeInsightEvents    bool
+
+	MonthlyAdditionalManagementEvents *float64 `infracost_usage:"monthly_additional_management_events"`
+	MonthlyDataEvents                 *float64 `infracost_usage:"monthly_data_events"`
+	MonthlyInsightEvents              *float64 `infracost_usage:"monthly_insight_events"`
+}
+
+var cloudTrailUsageSchema = []*schema.UsageItem{
+	{Key: "monthly_additional_management_events", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "monthly_data_events", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "monthly_insight_events", DefaultValue: 0, ValueType: schema.Float64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the Cloudtrail.
+// It uses the `infracost_usage` struct tags to populate data into the Cloudtrail.
+func (r *Cloudtrail) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid Cloudtrail struct.
+// It returns Cloudtrail as a schema.Resource with 3 main cost components. All cost components are defined as "events".
+// All cost components are charged per 100k events delivered/analyzed.
+//
+// 1. Additional Management events delivered to S3, charged at $2.00 per 100k management events delivered.
+// 	  Management events are normally priced as free, however if a user specifies an additional replication of events
+// 	  this is charged. We only show this cost therefore if Cloudtrail.IncludeManagementEvents is set. This is set at
+//	  a per IAC basis.
+// 2. Data events delivered to S3, charged at $0.10 per 100k events delivered.
+// 3. CloudTrail Insights, charged at $0.35 per 100k events analyzed. This again is configured optionally on a Cloudtrail
+//    instance. Hence, we only include the cost component if Cloudtrail.IncludeInsightEvents. This is set at
+//    a per IAC basis.
+//
+// This method is called after the resource is initialised by an IaC provider. See providers folder for more information.
+func (r *Cloudtrail) BuildResource() *schema.Resource {
+	var costComponents []*schema.CostComponent
+
+	if r.IncludeManagementEvents || r.MonthlyAdditionalManagementEvents != nil {
+		costComponents = append(costComponents, r.managementEventCostComponent())
+	}
+
+	costComponents = append(costComponents, r.dataEventsCostComponent())
+
+	if r.IncludeInsightEvents || r.MonthlyInsightEvents != nil {
+		costComponents = append(costComponents, r.insightEventsCostComponent())
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    cloudTrailUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+func (r *Cloudtrail) managementEventCostComponent() *schema.CostComponent {
+	var quantity *decimal.Decimal
+	if r.MonthlyAdditionalManagementEvents != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.MonthlyAdditionalManagementEvents))
+	}
+
+	return r.eventCostComponent(cloudTrailManagementEvent, quantity)
+}
+
+func (r *Cloudtrail) dataEventsCostComponent() *schema.CostComponent {
+	var quantity *decimal.Decimal
+	if r.MonthlyDataEvents != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.MonthlyDataEvents))
+	}
+
+	return r.eventCostComponent(cloudTrailDataEvent, quantity)
+}
+
+func (r *Cloudtrail) insightEventsCostComponent() *schema.CostComponent {
+	var quantity *decimal.Decimal
+	if r.MonthlyInsightEvents != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.MonthlyInsightEvents))
+	}
+
+	return r.eventCostComponent(cloudTrailInsightEvent, quantity)
+}
+
+func (r *Cloudtrail) eventCostComponent(name string, quantity *decimal.Decimal) *schema.CostComponent {
+	productFamily := "Management Tools - AWS CloudTrail Paid Events Recorded"
+	if name == cloudTrailDataEvent {
+		productFamily = "Management Tools - AWS CloudTrail Data Events Recorded"
+	}
+
+	if name == cloudTrailInsightEvent {
+		productFamily = "Management Tools - AWS CloudTrail Insights Events"
+	}
+
+	var monthlyQuantity *decimal.Decimal
+	if quantity != nil {
+		monthlyQuantity = decimalPtr(quantity.Mul(cloudTrailBillingMultiplier))
+	}
+	return &schema.CostComponent{
+		Name:            name,
+		Unit:            "100k events",
+		UnitMultiplier:  cloudTrailBillingMultiplier,
+		MonthlyQuantity: monthlyQuantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    vendorName,
+			Region:        strPtr(r.Region),
+			Service:       cloudTrailServiceName,
+			ProductFamily: strPtr(productFamily),
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("on_demand"),
+		},
+	}
+}

--- a/internal/resources/aws/cloudtrail.go
+++ b/internal/resources/aws/cloudtrail.go
@@ -117,15 +117,11 @@ func (r *Cloudtrail) eventCostComponent(name string, quantity *decimal.Decimal) 
 		productFamily = "Management Tools - AWS CloudTrail Insights Events"
 	}
 
-	var monthlyQuantity *decimal.Decimal
-	if quantity != nil {
-		monthlyQuantity = decimalPtr(quantity.Mul(cloudTrailBillingMultiplier))
-	}
 	return &schema.CostComponent{
 		Name:            name,
 		Unit:            "100k events",
 		UnitMultiplier:  cloudTrailBillingMultiplier,
-		MonthlyQuantity: monthlyQuantity,
+		MonthlyQuantity: quantity,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    vendorName,
 			Region:        strPtr(r.Region),

--- a/internal/resources/aws/util.go
+++ b/internal/resources/aws/util.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	underscore = regexp.MustCompile(`_`)
+	vendorName = strPtr("aws")
 )
 
 func strPtr(s string) *string {


### PR DESCRIPTION
## Objective:

![](https://media.giphy.com/media/nPOxhmHbuQInu/giphy.gif)

Add support for aws cloudtrail, Fixes #1038

## Pricing details:

1. Additional Management events delivered to S3, charged at $2.00 per 100k management events delivered. Management events are normally priced as free, however if a user specifies an additional replication of events this is charged. We only show this cost therefore if Cloudtrail.IncludeManagementEvents is set.
2. Data events delivered to S3, charged at $0.10 per 100k events delivered.
3. CloudTrail Insights, charged at $0.35 per 100k events analyzed. This again is configured optionally on a Cloudtrail instance. Hence, we only include the cost component if Cloudtrail.IncludeInsightEvents.

## Status:

- [x] Generated the resource files
- [x] Updated the internal/resources file
- [x] Updated the internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/136/commits/e8a472ecf1b409f57af24ba9436aa09172597fbd)

## Issues:

All gravy