### PR TITLE
chore(azure): disable Hot LRS example for Azure StorageV2 account resource

### DIFF
--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -178,15 +178,6 @@
  ├─ Read operations                                               10  10k operations                   $0.04 
  └─ All other operations                                         100  10k operations                   $0.44 
                                                                                                              
- azurerm_storage_account.v2_hot_lrs                                                                          
- ├─ Capacity (first 50TB)                                     51,200  GB                           $1,064.96 
- ├─ Capacity (next 450TB)                                    512,000  GB                          $10,223.62 
- ├─ Capacity (over 500TB)                                    436,800  GB                           $8,358.60 
- ├─ List and create container operations                         100  10k operations                   $5.50 
- ├─ Read operations                                               10  10k operations                   $0.04 
- ├─ All other operations                                         100  10k operations                   $0.44 
- └─ Blob index                                                    10  10k tags                         $0.39 
-                                                                                                             
  azurerm_storage_account.v2_hot_lrs_nfsv3                                                                    
  ├─ Capacity (first 50TB)                                     51,200  GB                           $1,075.20 
  ├─ Capacity (next 450TB)                                    512,000  GB                          $10,240.00 
@@ -223,10 +214,10 @@
  ├─ Read operations                               Monthly cost depends on usage: $0.006 per 10k operations   
  └─ All other operations                          Monthly cost depends on usage: $0.006 per 10k operations   
                                                                                                              
- OVERALL TOTAL                                                                                 $2,241,800.82 
+ OVERALL TOTAL                                                                                 $2,222,147.27 
 ──────────────────────────────────
-34 cloud resources were detected:
-∙ 27 were estimated, 27 include usage-based costs, see https://infracost.io/usage-file
+33 cloud resources were detected:
+∙ 26 were estimated, 26 include usage-based costs, see https://infracost.io/usage-file
 ∙ 6 weren't estimated, report them in https://github.com/infracost/infracost:
   ∙ 6 x azurerm_storage_account
 ∙ 1 was free:

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.tf
@@ -239,15 +239,17 @@ resource "azurerm_storage_account" "v2_cool_lrs_nfsv3" {
   nfsv3_enabled            = true
 }
 
-resource "azurerm_storage_account" "v2_hot_lrs" {
-  name                     = "storageaccountname"
-  resource_group_name      = azurerm_resource_group.example.name
-  location                 = azurerm_resource_group.example.location
-  account_kind             = "StorageV2"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  access_tier              = "Hot"
-}
+# Temporarily disabled due to duplication issue in Azure StorageV2 pricing
+# records (same productHash for different cost components).
+# resource "azurerm_storage_account" "v2_hot_lrs" {
+#   name                     = "storageaccountname"
+#   resource_group_name      = azurerm_resource_group.example.name
+#   location                 = azurerm_resource_group.example.location
+#   account_kind             = "StorageV2"
+#   account_tier             = "Standard"
+#   account_replication_type = "LRS"
+#   access_tier              = "Hot"
+# }
 
 resource "azurerm_storage_account" "v2_hot_lrs_nfsv3" {
   name                     = "storageaccountname"


### PR DESCRIPTION
Azure pricing records for Hot LRS operations are identical apart from
meterName. CPAPI calculates productHashes not including the meterName
attribute thus different operations may be overriden by each other
during update jobs. Disabling the Hot LRS example unblocks CLI's CI
while we can come up with a solution.