### PR TITLE
feat: add run uuid to cli

### DIFF
--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -6,15 +6,16 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/infracost/infracost/internal/apiclient"
-	"github.com/infracost/infracost/internal/config"
-	"github.com/infracost/infracost/internal/output"
-	"github.com/infracost/infracost/internal/ui"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/mod/semver"
+
+	"github.com/infracost/infracost/internal/apiclient"
+	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/output"
+	"github.com/infracost/infracost/internal/ui"
 )
 
 var minOutputVersion = "0.2"
@@ -161,7 +162,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 				return err
 			}
 
-			pricingClient := apiclient.NewPricingAPIClient(ctx.Config)
+			pricingClient := apiclient.NewPricingAPIClient(ctx)
 			err = pricingClient.AddEvent("infracost-output", ctx.EventEnv())
 			if err != nil {
 				log.Errorf("Error reporting event: %s", err)

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Rhymond/go-money"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/pkg/errors"
+
 	"github.com/infracost/infracost/internal/apiclient"
 	"github.com/infracost/infracost/internal/clierror"
 	"github.com/infracost/infracost/internal/config"
@@ -23,7 +25,6 @@ import (
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/infracost/infracost/internal/ui"
 	"github.com/infracost/infracost/internal/usage"
-	"github.com/pkg/errors"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -169,7 +170,7 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 	}
 
 	env := buildRunEnv(runCtx, projectContexts, r)
-	pricingClient := apiclient.NewPricingAPIClient(runCtx.Config)
+	pricingClient := apiclient.NewPricingAPIClient(runCtx)
 	err = pricingClient.AddEvent("infracost-run", env)
 	if err != nil {
 		log.Errorf("Error reporting event: %s", err)
@@ -305,7 +306,7 @@ func runProjectConfig(cmd *cobra.Command, runCtx *config.RunContext, ctx *config
 	defer spinner.Fail()
 
 	for _, project := range projects {
-		if err := prices.PopulatePrices(runCtx.Config, project); err != nil {
+		if err := prices.PopulatePrices(runCtx, project); err != nil {
 			spinner.Fail()
 			fmt.Fprintln(os.Stderr, "")
 

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -19,7 +20,7 @@ type APIClient struct {
 	endpoint  string
 	apiKey    string
 	tlsConfig *tls.Config
-	runID     string
+	uuid      uuid.UUID
 }
 
 type GraphQLQuery struct {
@@ -103,7 +104,9 @@ func (c *APIClient) AddDefaultHeaders(req *http.Request) {
 func (c *APIClient) AddAuthHeaders(req *http.Request) {
 	c.AddDefaultHeaders(req)
 	req.Header.Set("X-Api-Key", c.apiKey)
-	req.Header.Set("X-Trace-Id", c.runID)
+	if c.uuid != uuid.Nil {
+		req.Header.Set("X-Infracost-Trace-Id", fmt.Sprintf("cli=%s", c.uuid.String()))
+	}
 }
 
 func userAgent() string {

--- a/internal/apiclient/dashboard.go
+++ b/internal/apiclient/dashboard.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/output"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 type DashboardAPIClient struct {
@@ -42,6 +43,7 @@ func NewDashboardAPIClient(ctx *config.RunContext) *DashboardAPIClient {
 		APIClient: APIClient{
 			endpoint: ctx.Config.DashboardAPIEndpoint,
 			apiKey:   ctx.Config.APIKey,
+			uuid:     ctx.UUID(),
 		},
 		dashboardEnabled: ctx.Config.EnableDashboard,
 	}

--- a/internal/apiclient/errors.go
+++ b/internal/apiclient/errors.go
@@ -1,10 +1,11 @@
 package apiclient
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/infracost/infracost/internal/clierror"
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/ui"
-	"github.com/pkg/errors"
 )
 
 func ReportCLIError(ctx *config.RunContext, cliErr error) error {
@@ -17,6 +18,6 @@ func ReportCLIError(ctx *config.RunContext, cliErr error) error {
 	d := ctx.EventEnv()
 	d["error"] = errMsg
 
-	c := NewPricingAPIClient(ctx.Config)
+	c := NewPricingAPIClient(ctx)
 	return c.AddEvent("infracost-error", d)
 }

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -30,7 +30,7 @@ type PriceQueryResult struct {
 }
 
 func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
-	currency := cfg.Config.Currency
+	currency := ctx.Config.Currency
 	if currency == "" {
 		currency = "USD"
 	}
@@ -40,35 +40,35 @@ func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 		rootCAs = x509.NewCertPool()
 	}
 
-	if cfg.Config.TLSCACertFile != "" {
-		caCerts, err := ioutil.ReadFile(cfg.Config.TLSCACertFile)
+	if ctx.Config.TLSCACertFile != "" {
+		caCerts, err := ioutil.ReadFile(ctx.Config.TLSCACertFile)
 		if err != nil {
-			log.Errorf("Error reading CA cert file %s: %v", cfg.Config.TLSCACertFile, err)
+			log.Errorf("Error reading CA cert file %s: %v", ctx.Config.TLSCACertFile, err)
 		} else {
 			ok := rootCAs.AppendCertsFromPEM(caCerts)
 
 			if !ok {
 				log.Warningf("No CA certs appended, only using system certs")
 			} else {
-				log.Debugf("Loaded CA certs from %s", cfg.Config.TLSCACertFile)
+				log.Debugf("Loaded CA certs from %s", ctx.Config.TLSCACertFile)
 			}
 		}
 	}
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: cfg.Config.TLSInsecureSkipVerify, // nolint: gosec
+		InsecureSkipVerify: ctx.Config.TLSInsecureSkipVerify, // nolint: gosec
 		RootCAs:            rootCAs,
 	}
 
 	return &PricingAPIClient{
 		APIClient: APIClient{
-			endpoint:  cfg.Config.PricingAPIEndpoint,
-			apiKey:    cfg.Config.APIKey,
+			endpoint:  ctx.Config.PricingAPIEndpoint,
+			apiKey:    ctx.Config.APIKey,
 			tlsConfig: tlsConfig,
-			uuid:      cfg.UUID(),
+			uuid:      ctx.UUID(),
 		},
 		Currency:       currency,
-		EventsDisabled: cfg.Config.EventsDisabled,
+		EventsDisabled: ctx.Config.EventsDisabled,
 	}
 }
 

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -29,8 +29,8 @@ type PriceQueryResult struct {
 	Result gjson.Result
 }
 
-func NewPricingAPIClient(cfg *config.Config) *PricingAPIClient {
-	currency := cfg.Currency
+func NewPricingAPIClient(cfg *config.RunContext) *PricingAPIClient {
+	currency := cfg.Config.Currency
 	if currency == "" {
 		currency = "USD"
 	}
@@ -40,34 +40,35 @@ func NewPricingAPIClient(cfg *config.Config) *PricingAPIClient {
 		rootCAs = x509.NewCertPool()
 	}
 
-	if cfg.TLSCACertFile != "" {
-		caCerts, err := ioutil.ReadFile(cfg.TLSCACertFile)
+	if cfg.Config.TLSCACertFile != "" {
+		caCerts, err := ioutil.ReadFile(cfg.Config.TLSCACertFile)
 		if err != nil {
-			log.Errorf("Error reading CA cert file %s: %v", cfg.TLSCACertFile, err)
+			log.Errorf("Error reading CA cert file %s: %v", cfg.Config.TLSCACertFile, err)
 		} else {
 			ok := rootCAs.AppendCertsFromPEM(caCerts)
 
 			if !ok {
 				log.Warningf("No CA certs appended, only using system certs")
 			} else {
-				log.Debugf("Loaded CA certs from %s", cfg.TLSCACertFile)
+				log.Debugf("Loaded CA certs from %s", cfg.Config.TLSCACertFile)
 			}
 		}
 	}
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: cfg.TLSInsecureSkipVerify, // nolint: gosec
+		InsecureSkipVerify: cfg.Config.TLSInsecureSkipVerify, // nolint: gosec
 		RootCAs:            rootCAs,
 	}
 
 	return &PricingAPIClient{
 		APIClient: APIClient{
-			endpoint:  cfg.PricingAPIEndpoint,
-			apiKey:    cfg.APIKey,
+			endpoint:  cfg.Config.PricingAPIEndpoint,
+			apiKey:    cfg.Config.APIKey,
 			tlsConfig: tlsConfig,
+			uuid:      cfg.UUID(),
 		},
 		Currency:       currency,
-		EventsDisabled: cfg.EventsDisabled,
+		EventsDisabled: cfg.Config.EventsDisabled,
 	}
 }
 

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -29,7 +29,7 @@ type PriceQueryResult struct {
 	Result gjson.Result
 }
 
-func NewPricingAPIClient(cfg *config.RunContext) *PricingAPIClient {
+func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 	currency := cfg.Config.Currency
 	if currency == "" {
 		currency = "USD"

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func PopulatePrices(cfg *config.Config, project *schema.Project) error {
+func PopulatePrices(cfg *config.RunContext, project *schema.Project) error {
 	resources := project.AllResources()
 
 	c := apiclient.NewPricingAPIClient(cfg)

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -15,7 +15,7 @@ import (
 func PopulatePrices(ctx *config.RunContext, project *schema.Project) error {
 	resources := project.AllResources()
 
-	c := apiclient.NewPricingAPIClient(cfg)
+	c := apiclient.NewPricingAPIClient(ctx)
 
 	err := GetPricesConcurrent(c, resources)
 	if err != nil {

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func PopulatePrices(cfg *config.RunContext, project *schema.Project) error {
+func PopulatePrices(ctx *config.RunContext, project *schema.Project) error {
 	resources := project.AllResources()
 
 	c := apiclient.NewPricingAPIClient(cfg)

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -267,7 +267,7 @@ func RunCostCalculations(t *testing.T, runCtx *config.RunContext, tfProject Terr
 	}
 
 	for _, project := range projects {
-		err = prices.PopulatePrices(runCtx.Config, project)
+		err = prices.PopulatePrices(runCtx, project)
 		if err != nil {
 			return projects, err
 		}


### PR DESCRIPTION
![](https://media.giphy.com/media/nITKVYrWIatviLkfWN/giphy.gif)

* Adds uuid to run context which is populated to ApiClient
* Remove `X-Trace-Id` header which was unused and replace with `X-Infracost-Trace-Id` populated with run context uuid

See https://github.com/infracost/cloud-pricing-api/pull/137 for pricing api implementation
See https://github.com/infracost/dashboard/pull/26 for dashboard implementation