### PR TITLE
fix: do not send run results to Dashboard when using self-hosted CPAPI

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -144,7 +144,7 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 		log.Errorf("Error reporting run: %s", err)
 	}
 
-	r.RunID, r.RunURL = result.RunID, result.RunURL
+	r.RunID, r.ShareURL = result.RunID, result.ShareURL
 
 	opts := output.Options{
 		DashboardEnabled: runCtx.Config.EnableDashboard,

--- a/internal/apiclient/dashboard.go
+++ b/internal/apiclient/dashboard.go
@@ -23,8 +23,8 @@ type CreateAPIKeyResponse struct {
 }
 
 type AddRunResponse struct {
-	RunID  string `json:"id"`
-	RunURL string `json:"shareUrl"`
+	RunID    string `json:"id"`
+	ShareURL string `json:"shareUrl"`
 }
 
 type runInput struct {
@@ -119,7 +119,7 @@ func (c *DashboardAPIClient) AddRun(ctx *config.RunContext, projectContexts []*c
 		}
 
 		response.RunID = results[0].Get("data.addRun.id").String()
-		response.RunURL = results[0].Get("data.addRun.shareUrl").String()
+		response.ShareURL = results[0].Get("data.addRun.shareUrl").String()
 	}
 	return response, nil
 }

--- a/internal/apiclient/dashboard.go
+++ b/internal/apiclient/dashboard.go
@@ -50,7 +50,7 @@ func NewDashboardAPIClient(ctx *config.RunContext) *DashboardAPIClient {
 			apiKey:   ctx.Config.APIKey,
 			uuid:     ctx.UUID(),
 		},
-		dashboardEnabled: ctx.Config.EnableDashboard,
+		dashboardEnabled: ctx.Config.EnableDashboard && !ctx.Config.IsSelfHosted(),
 	}
 }
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -17,7 +17,7 @@ var outputVersion = "0.2"
 type Root struct {
 	Version              string           `json:"version"`
 	RunID                string           `json:"runId,omitempty"`
-	RunURL               string           `json:"runURL,omitempty"`
+	ShareURL             string           `json:"shareUrl,omitempty"`
 	Currency             string           `json:"currency"`
 	Projects             []Project        `json:"projects"`
 	TotalHourlyCost      *decimal.Decimal `json:"totalHourlyCost"`
@@ -341,8 +341,8 @@ func (r *Root) summaryMessage(showSkipped bool) string {
 		}
 	}
 
-	if r.RunURL != "" {
-		msg += fmt.Sprintf("\n\nShare the results: %s", ui.LinkString(r.RunURL))
+	if r.ShareURL != "" {
+		msg += fmt.Sprintf("\n\nShare the results: %s", ui.LinkString(r.ShareURL))
 	}
 
 	return msg

--- a/schema/infracost.schema.json
+++ b/schema/infracost.schema.json
@@ -196,7 +196,7 @@
         "runId": {
           "type": "string"
         },
-        "runURL": {
+        "shareUrl": {
           "type": "string"
         },
         "currency": {


### PR DESCRIPTION
With self-hosted Cloud Pricing API the request to Infracost Dashboard
will not be authenticated.

Related to #1212.