### PR TITLE
Fix/windows tls certs

### DIFF
--- a/cmd/infracost/configure.go
+++ b/cmd/infracost/configure.go
@@ -86,13 +86,17 @@ func configureSetCmd(ctx *config.RunContext) *cobra.Command {
 				ctx.Config.Credentials.APIKey = value
 				saveCredentials = true
 			case "tls_insecure_skip_verify":
-				b, err := strconv.ParseBool(value)
+				if value == "" {
+					ctx.Config.Configuration.TLSInsecureSkipVerify = nil
+				} else {
+					b, err := strconv.ParseBool(value)
 
-				if err != nil {
-					return errors.New("Invalid value, must be true or false")
+					if err != nil {
+						return errors.New("Invalid value, must be true or false")
+					}
+
+					ctx.Config.Configuration.TLSInsecureSkipVerify = &b
 				}
-
-				ctx.Config.Configuration.TLSInsecureSkipVerify = &b
 				saveConfiguration = true
 			case "tls_ca_cert_file":
 				ctx.Config.Configuration.TLSCACertFile = value

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -55,8 +55,17 @@ func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 		}
 	}
 
+	skipVerify := false
+	if ctx.Config.TLSInsecureSkipVerify != nil {
+		skipVerify = *ctx.Config.TLSInsecureSkipVerify
+	} else if len(rootCAs.Subjects()) == 0 && ctx.Config.TLSCACertFile == "" {
+		// Skip verify hasn't been explicitly set, there's no cert file, and there are no root CAs (i.e. this is
+		// windows).  Default to skipping the verify.
+		skipVerify = true
+	}
+
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: ctx.Config.TLSInsecureSkipVerify, // nolint: gosec
+		InsecureSkipVerify: skipVerify, // nolint: gosec
 		RootCAs:            rootCAs,
 	}
 

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -35,7 +35,7 @@ func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 		currency = "USD"
 	}
 
-	tlsConfig := tls.Config{}
+	tlsConfig := tls.Config{} // nolint: gosec
 
 	if ctx.Config.TLSCACertFile != "" {
 		rootCAs, _ := x509.SystemCertPool()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,7 +57,7 @@ type Config struct {
 	DashboardAPIEndpoint      string `yaml:"dashboard_api_endpoint,omitempty" envconfig:"INFRACOST_DASHBOARD_API_ENDPOINT"`
 	EnableDashboard           bool   `yaml:"enable_dashboard,omitempty" envconfig:"INFRACOST_ENABLE_DASHBOARD"`
 
-	TLSInsecureSkipVerify bool   `envconfig:"INFRACOST_TLS_INSECURE_SKIP_VERIFY"`
+	TLSInsecureSkipVerify *bool  `envconfig:"INFRACOST_TLS_INSECURE_SKIP_VERIFY"`
 	TLSCACertFile         string `envconfig:"INFRACOST_TLS_CA_CERT_FILE"`
 
 	Currency string `envconfig:"INFRACOST_CURRENCY"`

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -16,7 +16,7 @@ type Configuration struct {
 	Version               string `yaml:"version"`
 	Currency              string `yaml:"currency,omitempty"`
 	EnableDashboard       *bool  `yaml:"enable_dashboard,omitempty"`
-	TLSInsecureSkipVerify *bool  `yaml:"tls_insecure_skip_verify"`
+	TLSInsecureSkipVerify *bool  `yaml:"tls_insecure_skip_verify,omitempty"`
 	TLSCACertFile         string `yaml:"tls_ca_cert_file,omitempty"`
 }
 

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -46,7 +46,7 @@ func loadConfiguration(cfg *Config) error {
 	}
 
 	if cfg.Configuration.TLSInsecureSkipVerify != nil {
-		cfg.TLSInsecureSkipVerify = *cfg.Configuration.TLSInsecureSkipVerify
+		cfg.TLSInsecureSkipVerify = cfg.Configuration.TLSInsecureSkipVerify
 	}
 
 	if cfg.TLSCACertFile == "" {


### PR DESCRIPTION
This is a fix for #1238.  Go doesn't know how to find the root CAs on windows, so this PR causes us to skip the cert verify step if no root CAs are found and verification has not been explicitly enabled.