### PR TITLE
fix: Indent the "Calculating monthly cost estimate" spinner

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -329,6 +329,7 @@ func runProjectConfig(cmd *cobra.Command, runCtx *config.RunContext, ctx *config
 	spinnerOpts := ui.SpinnerOptions{
 		EnableLogging: runCtx.Config.IsLogging(),
 		NoColor:       runCtx.Config.NoColor,
+		Indent:        "  ",
 	}
 	spinner := ui.NewSpinner("Calculating monthly cost estimate", spinnerOpts)
 	defer spinner.Fail()


### PR DESCRIPTION
This makes the indenation on the "Calculating monthly cost estimate" spinner consistent with the other spinner lines.  It looks like they have been inconsistent for a while, but recent changes removed the blank line so it is now more apparent.

Old:
```
Detected Terraform directory at ./examples/terraform
  ✔ Checking for cached plan... found
✔ Calculating monthly cost estimate 
```

With this fix:
```
Detected Terraform directory at ./examples/terraform
  ✔ Checking for cached plan... found
  ✔ Calculating monthly cost estimate 
```
