### PR TITLE
feat(azure): add azure-repos-comment output

### DIFF
--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -44,7 +44,11 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 
   Create markdown report to post in a GitLab comment:
 
-      infracost output --format gitlab-comment --path "out*.json" # glob needs quotes`,
+      infracost output --format gitlab-comment --path "out*.json" # glob needs quotes
+
+  Create markdown report to post in a Azure DevOps Repos comment:
+
+      infracost output --format azure-repos-comment --path "out*.json" # glob needs quotes`,
 		ValidArgs: []string{"--", "-"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inputFiles := []string{}
@@ -159,7 +163,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 				b, err = output.ToHTML(combined, opts)
 			case "diff":
 				b, err = output.ToDiff(combined, opts)
-			case "github-comment", "gitlab-comment":
+			case "github-comment", "gitlab-comment", "azure-repos-comment":
 				opts.IncludeHTML = true
 				b, err = output.ToMarkdown(combined, opts)
 			case "slack-message":
@@ -193,7 +197,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	cmd.Flags().StringP("out-file", "o", "", "Save output to a file, helpful with format flag")
 
-	cmd.Flags().String("format", "table", "Output format: json, diff, table, html, github-comment, gitlab-comment, slack-message")
+	cmd.Flags().String("format", "table", "Output format: json, diff, table, html, github-comment, gitlab-comment, azure-repos-comment, slack-message")
 	cmd.Flags().Bool("show-skipped", false, "Show unsupported resources")
 	cmd.Flags().StringSlice("fields", []string{"monthlyQuantity", "unit", "monthlyCost"}, "Comma separated list of output fields: all,price,monthlyQuantity,unit,hourlyCost,monthlyCost.\nSupported by table and html output formats")
 

--- a/cmd/infracost/output_test.go
+++ b/cmd/infracost/output_test.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/infracost/infracost/internal/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/infracost/infracost/internal/testutil"
 )
 
 func TestOutputHelp(t *testing.T) {
@@ -45,6 +46,18 @@ func TestOutputFormatGitLabCommentMultipleSkipped(t *testing.T) {
 
 func TestOutputFormatGitLabCommentNoChange(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "gitlab-comment", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
+}
+
+func TestOutputFormatAzureReposComment(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "azure-repos-comment", "--path", "./testdata/example_out.json", "--path", "./testdata/terraform_v0.14_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
+}
+
+func TestOutputFormatAzureReposCommentMultipleSkipped(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "azure-repos-comment", "--path", "./testdata/example_out.json", "--path", "./testdata/terraform_v0.14_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
+}
+
+func TestOutputFormatAzureReposCommentNoChange(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "azure-repos-comment", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
 }
 
 func TestOutputFormatSlackMessage(t *testing.T) {

--- a/cmd/infracost/testdata/output_format_azure_repos_comment/output_format_azure_repos_comment.golden
+++ b/cmd/infracost/testdata/output_format_azure_repos_comment/output_format_azure_repos_comment.golden
@@ -1,0 +1,229 @@
+
+💰 Infracost estimate: **monthly cost will increase by $1,402 (+1,728%) 📈**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/cmd/infracost/testdata</td>
+      <td align="right">$0</td>
+      <td align="right">$1,361</td>
+      <td>+$1,361</td>
+    </tr>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$81.12</td>
+      <td>+$40.56 (+100%)</td>
+    </tr>
+    <tr>
+      <td>All projects</td>
+      <td align="right">$81.12</td>
+      <td align="right">$1,483</td>
+      <td>+$1,402 (+1,728%)</td>
+    </tr>
+  </tbody>
+</table>
+
+1 project has no cost estimate changes.
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+Project: infracost/infracost/cmd/infracost/testdata
+
++ aws_instance.web_app
+  +$743
+
+    + Instance usage (Linux/UNIX, on-demand, m5.4xlarge)
+      +$561
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_instance.zero_cost_instance
+  +$182
+
+    + Instance usage (Linux/UNIX, reserved, m5.4xlarge)
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_lambda_function.hello_world
+  +$437
+
+    + Requests
+      +$20.00
+
+    + Duration
+      +$417
+
++ aws_lambda_function.zero_cost_lambda
+  $0.00
+
+    + Requests
+      $0.00
+
+    + Duration
+      $0.00
+
++ aws_s3_bucket.usage
+  $0.00
+
+    + Standard
+    
+        + Storage
+          $0.00
+    
+        + PUT, COPY, POST, LIST requests
+          $0.00
+    
+        + GET, SELECT, and all other requests
+          $0.00
+    
+        + Select data scanned
+          $0.00
+    
+        + Select data returned
+          $0.00
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata
+Amount:  +$1,361 ($0.00 → $1,361)
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+
++ aws_instance.instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
+  +$12.99
+
+    + Database instance (on-demand, Single-AZ, db.t3.micro)
+      +$12.41
+
+    + Storage (general purpose SSD, gp2)
+      +$0.58
+
++ module.instances.aws_instance.module_instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+Amount:  +$40.56 ($40.56 → $81.12)
+Percent: +100%
+
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
+Run infracost breakdown to see their full breakdown.
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+```
+</details>
+

--- a/cmd/infracost/testdata/output_format_azure_repos_comment_multiple_skipped/output_format_azure_repos_comment_multiple_skipped.golden
+++ b/cmd/infracost/testdata/output_format_azure_repos_comment_multiple_skipped/output_format_azure_repos_comment_multiple_skipped.golden
@@ -1,0 +1,229 @@
+
+💰 Infracost estimate: **monthly cost will increase by $1,402 (+1,152%) 📈**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/cmd/infracost/testdata</td>
+      <td align="right">$0</td>
+      <td align="right">$1,361</td>
+      <td>+$1,361</td>
+    </tr>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$81.12</td>
+      <td>+$40.56 (+100%)</td>
+    </tr>
+    <tr>
+      <td>All projects</td>
+      <td align="right">$122</td>
+      <td align="right">$1,524</td>
+      <td>+$1,402 (+1,152%)</td>
+    </tr>
+  </tbody>
+</table>
+
+2 projects have no cost estimate changes.
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+Project: infracost/infracost/cmd/infracost/testdata
+
++ aws_instance.web_app
+  +$743
+
+    + Instance usage (Linux/UNIX, on-demand, m5.4xlarge)
+      +$561
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_instance.zero_cost_instance
+  +$182
+
+    + Instance usage (Linux/UNIX, reserved, m5.4xlarge)
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$5.00
+
+    + ebs_block_device[0]
+    
+        + Storage (provisioned IOPS SSD, io1)
+          +$125
+    
+        + Provisioned IOPS
+          +$52.00
+
++ aws_lambda_function.hello_world
+  +$437
+
+    + Requests
+      +$20.00
+
+    + Duration
+      +$417
+
++ aws_lambda_function.zero_cost_lambda
+  $0.00
+
+    + Requests
+      $0.00
+
+    + Duration
+      $0.00
+
++ aws_s3_bucket.usage
+  $0.00
+
+    + Standard
+    
+        + Storage
+          $0.00
+    
+        + PUT, COPY, POST, LIST requests
+          $0.00
+    
+        + GET, SELECT, and all other requests
+          $0.00
+    
+        + Select data scanned
+          $0.00
+    
+        + Select data returned
+          $0.00
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata
+Amount:  +$1,361 ($0.00 → $1,361)
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+
++ aws_instance.instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ aws_instance.instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
+  +$12.99
+
+    + Database instance (on-demand, Single-AZ, db.t3.micro)
+      +$12.41
+
+    + Storage (general purpose SSD, gp2)
+      +$0.58
+
++ module.instances.aws_instance.module_instance_2
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_counted[1]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
++ module.instances.aws_instance.module_instance_named["test.2"]
+  +$4.60
+
+    + Instance usage (Linux/UNIX, on-demand, t3.nano)
+      +$3.80
+
+    + CPU credits
+      $0.00
+
+    + root_block_device
+    
+        + Storage (general purpose SSD, gp2)
+          +$0.80
+
+Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
+Amount:  +$40.56 ($40.56 → $81.12)
+Percent: +100%
+
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json, infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
+Run infracost breakdown to see their full breakdown.
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+```
+</details>
+

--- a/cmd/infracost/testdata/output_format_azure_repos_comment_no_change/output_format_azure_repos_comment_no_change.golden
+++ b/cmd/infracost/testdata/output_format_azure_repos_comment_no_change/output_format_azure_repos_comment_no_change.golden
@@ -1,0 +1,33 @@
+
+💰 Infracost estimate: **monthly cost will not change**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...aform_v0.14_nochange_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$40.56</td>
+      <td>$0</td>
+    </tr>
+  </tbody>
+</table>
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
+Run infracost breakdown to see their full breakdown.
+
+──────────────────────────────────
+
+```
+</details>
+

--- a/cmd/infracost/testdata/output_help/output_help.golden
+++ b/cmd/infracost/testdata/output_help/output_help.golden
@@ -24,10 +24,14 @@ EXAMPLES
 
       infracost output --format gitlab-comment --path "out*.json" # glob needs quotes
 
+  Create markdown report to post in a Azure DevOps Repos comment:
+
+      infracost output --format azure-repos-comment --path "out*.json" # glob needs quotes
+
 FLAGS
       --fields strings     Comma separated list of output fields: all,price,monthlyQuantity,unit,hourlyCost,monthlyCost.
                            Supported by table and html output formats (default [monthlyQuantity,unit,monthlyCost])
-      --format string      Output format: json, diff, table, html, github-comment, gitlab-comment, slack-message (default "table")
+      --format string      Output format: json, diff, table, html, github-comment, gitlab-comment, azure-repos-comment, slack-message (default "table")
   -h, --help               help for output
   -o, --out-file string    Save output to a file, helpful with format flag
   -p, --path stringArray   Path to Infracost JSON files, glob patterns need quotes

--- a/scripts/ci/comment.sh
+++ b/scripts/ci/comment.sh
@@ -8,7 +8,7 @@ set -e
 # The script uses the following environment variables:
 #   - COMMENT_FORMAT: The format of the comment as supported by `infracost output`.
 #       Default: github-comment
-#       Options: github-comment, gitlab-comment
+#       Options: github-comment, gitlab-comment, azure-repos-comment
 #   - COMMENT_BEHAVIOR: The behavior of the comment as supported by `compost`.
 #       Default: update
 #       Options:


### PR DESCRIPTION
Adds `azure-repos-comment` output, which closes #1208

![](https://media.giphy.com/media/vinApXdZo4P72/giphy.gif)

I've tested the markdown output on azure repos and it works 👌 , see below:

![Screenshot 2022-01-03 at 11 12 53](https://user-images.githubusercontent.com/6455139/147924410-5e8f8de6-bf61-4fe4-abcb-aa19a385cef9.png)

