### PR TITLE
Fix CI Dockerfile pushing to ci-latest instead of latest

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -68,9 +68,11 @@ jobs:
         with:
           images: |
             ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}
+          flavor: |
+            prefix=ci-,onlatest=true
           tags: |
-            type=semver,pattern=ci-{{version}}
-            type=semver,pattern=ci-{{major}}.{{minor}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push Docker images (CI)
         uses: docker/build-push-action@v2


### PR DESCRIPTION
I tested this logic on a temp tag I created with an action here: https://github.com/infracost/infracost/runs/4701823103?check_suite_focus=true