### PR TITLE
fix: solve range panic with terragrunt due to mismatch in project ctx

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/testutil"
 )
 
@@ -120,6 +121,12 @@ func TestBreakdownTerraformUsageFileInvalidKey(t *testing.T) {
 
 func TestBreakdownTerragrunt(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../../examples/terragrunt"}, nil)
+}
+
+func TestBreakdownTerragruntWithDashboardEnabled(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../../examples/terragrunt"}, nil, func(c *config.Config) {
+		c.EnableDashboard = true
+	})
 }
 
 func TestBreakdownTerragruntNested(t *testing.T) {

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_dashboard_enabled/breakdown_terragrunt_with_dashboard_enabled.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_dashboard_enabled/breakdown_terragrunt_with_dashboard_enabled.golden
@@ -1,0 +1,46 @@
+Project: infracost/infracost/examples/terragrunt/dev REPLACED_PROJECT_PATH
+
+ Name                                                         Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                    
+ aws_instance.web_app                                                                                               
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)                  730  hours                              $8.47 
+ ├─ root_block_device                                                                                               
+ │  └─ Storage (general purpose SSD, gp2)                              50  GB                                 $5.00 
+ └─ ebs_block_device[0]                                                                                             
+    ├─ Storage (provisioned IOPS SSD, io1)                            100  GB                                $12.50 
+    └─ Provisioned IOPS                                               400  IOPS                              $26.00 
+                                                                                                                    
+ aws_lambda_function.hello_world                                                                                    
+ ├─ Requests                                          Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration                                          Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                    
+ Project total                                                                                               $51.97 
+
+──────────────────────────────────
+Project: infracost/infracost/examples/terragrunt/prod REPLACED_PROJECT_PATH
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+ ├─ root_block_device                                                                                                 
+ │  └─ Storage (general purpose SSD, gp2)                               100  GB                                $10.00 
+ └─ ebs_block_device[0]                                                                                               
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration                                            Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ Project total                                                                                                $747.64 
+
+ OVERALL TOTAL                                                                                                $799.61 
+──────────────────────────────────
+4 cloud resources were detected, rerun with --show-skipped to see details:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
+
+Share the results: https://dashboard.infracost.io/share/REPLACED_SHARE_CODE
+
+Err:
+


### PR DESCRIPTION
fixes #1281

* Solves issue where enable dashboard with a terragrunt run caused fatal panic. This was due to the project ctx not mapping 1-1 with the output projects. This PR solves this by creating same length `projectContexts` as output `projects`.
* Adds goldenfile coverage for dashboard enabled