### PR TITLE
Fix Azure VM instance type prefixes

### DIFF
--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -52,6 +52,8 @@ func linuxVirtualMachineCostComponent(region string, instanceType string) *schem
 	productNameRe := "/Virtual Machines .* Series$/"
 	if strings.HasPrefix(instanceType, "Basic_") {
 		productNameRe = "/Virtual Machines .* Series Basic$/"
+	} else if !strings.HasPrefix(instanceType, "Standard_") {
+		instanceType = fmt.Sprintf("Standard_%s", instanceType)
 	}
 
 	return &schema.CostComponent{

--- a/internal/providers/terraform/azure/windows_virtual_machine.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine.go
@@ -51,6 +51,8 @@ func windowsVirtualMachineCostComponent(region string, instanceType string, lice
 	productNameRe := "/Virtual Machines .* Series Windows$/"
 	if strings.HasPrefix(instanceType, "Basic_") {
 		productNameRe = "/Virtual Machines .* Series Basic Windows$/"
+	} else if !strings.HasPrefix(instanceType, "Standard_") {
+		instanceType = fmt.Sprintf("Standard_%s", instanceType)
 	}
 
 	// Handle Azure Hybrid Benefit

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -330,7 +330,9 @@ func providerRegion(addr string, providerConf gjson.Result, vars gjson.Result, r
 		if region == "" {
 			region = defaultProviderRegions[providerPrefix]
 
-			if region != "" {
+			// Don't show this log for azurerm users since they have a different method of looking up the region.
+			// A lot of Azure resources get their region from their referenced azurerm_resource_group resource
+			if region != "" && providerPrefix != "azurerm" {
 				log.Debugf("Falling back to default region (%s) for %s", region, addr)
 			}
 		}


### PR DESCRIPTION
Fixes the case here: https://github.com/infracost/infracost/issues/1298

In the Azure API instance types 'Standard_DS1_v2' and 'DS1_v2' are equivalent. But in the pricing database they are stored in the 'Standard_DS1_v2' format. This makes sure we are able to get prices for both formats.

Also removes the log `Falling back to default region (eastus)` for Azure resources, since they mostly use a different method for finding their region and do so at a resource level.