### PR TITLE
docs: simplify help texts

### DIFF
--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -11,17 +11,17 @@ func commentCmd(ctx *config.RunContext) *cobra.Command {
 		Use:   "comment",
 		Short: "Post an Infracost comment to GitHub, GitLab or Azure Repos",
 		Long:  "Post an Infracost comment to GitHub, GitLab or Azure Repos",
-		Example: `  Update a comment on a GitHub pull request:
+		Example: `  Update the Infracost comment on a GitHub pull request:
 
-      infracost comment github --repo my-org/my-github-repo --pull-request 3 --path infracost.json --github-token $GITHUB_TOKEN
+      infracost comment github --repo my-org/my-repo --pull-request 3 --path infracost.json --behavior update --github-token $GITHUB_TOKEN
 
-  Post a new comment to a GitLab commit:
+  Delete old Infracost comments and post a new comment to a GitLab commit:
 
-      infracost comment gitlab --repo my-org/my-gitlab-repo --commit 2ca7182 --path infracost.json --behavior new --gitlab-token $GITLAB_TOKEN
+      infracost comment gitlab --repo my-org/my-repo --commit 2ca7182 --path infracost.json --behavior delete-and-new --gitlab-token $GITLAB_TOKEN
 
   Post a new comment to an Azure Repos pull request:
 
-      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-azure-repo --pull-request 3 --path infracost.json --azure-access-token $AZURE_ACCESS_TOKEN`,
+      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-repo --pull-request 3 --path infracost.json --behavior new --azure-access-token $AZURE_ACCESS_TOKEN`,
 		ValidArgs: []string{"--", "-"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()

--- a/cmd/infracost/comment_azure_repos.go
+++ b/cmd/infracost/comment_azure_repos.go
@@ -20,9 +20,9 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 		Use:   "azure-repos",
 		Short: "Post an Infracost comment to Azure Repos",
 		Long:  "Post an Infracost comment to Azure Repos",
-		Example: `  Update a comment on a pull request:
+		Example: `  Update comment on a pull request:
 
-      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-azure-repo --pull-request 3 --path infracost.json --azure-access-token $AZURE_ACCESS_TOKEN`,
+      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-repo --pull-request 3 --path infracost.json --azure-access-token $AZURE_ACCESS_TOKEN`,
 		ValidArgs: []string{"--", "-"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx.SetContextValue("platform", "azure-repos")
@@ -93,8 +93,8 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("behavior", "update", `Behavior when posting the comment, one of:
-  update (default)  Update the latest comment
+	cmd.Flags().String("behavior", "update", `Behavior when posting comment, one of:
+  update (default)  Update latest comment
   new               Create a new comment
   delete-and-new    Delete previous matching comments and create a new comment`)
 	_ = cmd.RegisterFlagCompletionFunc("behavior", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -105,12 +105,12 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagFilename("path", "json")
-	cmd.Flags().Int("pull-request", 0, "pull request number to post the comment on")
+	cmd.Flags().Int("pull-request", 0, "pull request number to post comment on")
 	_ = cmd.MarkFlagRequired("pull-request")
-	cmd.Flags().String("repo-url", "", "Repository URL, e.g. https://dev.azure.com/my-org/my-project/_git/my-azure-repo")
+	cmd.Flags().String("repo-url", "", "Repository URL, e.g. https://dev.azure.com/my-org/my-project/_git/my-repo")
 	_ = cmd.MarkFlagRequired("repo-url")
-	cmd.Flags().String("tag", "", "Customize the embedded tag that is used for detecting comments posted by Infracost")
-	cmd.Flags().Bool("dry-run", false, "Generate the comment without actually posting to Azure Repos.")
+	cmd.Flags().String("tag", "", "Customize hidden markdown tag used to detect comments posted by Infracost")
+	cmd.Flags().Bool("dry-run", false, "Generate comment without actually posting to Azure Repos")
 
 	return cmd
 }

--- a/cmd/infracost/comment_azure_repos.go
+++ b/cmd/infracost/comment_azure_repos.go
@@ -105,7 +105,7 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagFilename("path", "json")
-	cmd.Flags().Int("pull-request", 0, "pull request number to post comment on")
+	cmd.Flags().Int("pull-request", 0, "Pull request number to post comment on")
 	_ = cmd.MarkFlagRequired("pull-request")
 	cmd.Flags().String("repo-url", "", "Repository URL, e.g. https://dev.azure.com/my-org/my-project/_git/my-repo")
 	_ = cmd.MarkFlagRequired("repo-url")

--- a/cmd/infracost/comment_github.go
+++ b/cmd/infracost/comment_github.go
@@ -20,13 +20,13 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 		Use:   "github",
 		Short: "Post an Infracost comment to GitHub",
 		Long:  "Post an Infracost comment to GitHub",
-		Example: `  Update a comment on a pull request:
+		Example: `  Update comment on a pull request:
 
-      infracost comment github --repo my-org/my-github-repo --pull-request 3 --path infracost.json --github-token $GITHUB_TOKEN
+      infracost comment github --repo my-org/my-repo --pull-request 3 --path infracost.json --github-token $GITHUB_TOKEN
 
   Post a new comment to a commit:
 
-      infracost comment github --repo my-org/my-github-repo --commit 2ca7182 --path infracost.json --behavior hide-and-new --github-token $GITHUB_TOKEN`,
+      infracost comment github --repo my-org/my-repo --commit 2ca7182 --path infracost.json --behavior hide-and-new --github-token $GITHUB_TOKEN`,
 		ValidArgs: []string{"--", "-"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx.SetContextValue("platform", "github")
@@ -107,26 +107,26 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("behavior", "update", `Behavior when posting the comment, one of:
-  update (default)  Update the latest comment
+	cmd.Flags().String("behavior", "update", `Behavior when posting comment, one of:
+  update (default)  Update latest comment
   new               Create a new comment
   hide-and-new      Hide previous matching comments and create a new comment
   delete-and-new    Delete previous matching comments and create a new comment`)
 	_ = cmd.RegisterFlagCompletionFunc("behavior", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return validCommentGitHubBehaviors, cobra.ShellCompDirectiveDefault
 	})
-	cmd.Flags().String("commit", "", "Commit SHA to post/get the comment, mutually exclusive with pull-request")
-	cmd.Flags().String("github-api-url", "https://api.github.com", "GitHub API URL, defaults to https://api.github.com")
+	cmd.Flags().String("commit", "", "Commit SHA to post comment on, mutually exclusive with pull-request")
+	cmd.Flags().String("github-api-url", "https://api.github.com", "GitHub API URL")
 	cmd.Flags().String("github-token", "", "GitHub token")
 	_ = cmd.MarkFlagRequired("github-token")
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagFilename("path", "json")
-	cmd.Flags().Int("pull-request", 0, "Pull request number to post the comment on, mutually exclusive with commit")
-	cmd.Flags().String("repo", "", "Repository in the format owner/repo")
+	cmd.Flags().Int("pull-request", 0, "Pull request number to post comment on, mutually exclusive with commit")
+	cmd.Flags().String("repo", "", "Repository in format owner/repo")
 	_ = cmd.MarkFlagRequired("repo")
-	cmd.Flags().String("tag", "", "Customize the embedded tag that is used for detecting comments posted by Infracost")
-	cmd.Flags().Bool("dry-run", false, "Generate the comment without actually posting to GitHub.")
+	cmd.Flags().String("tag", "", "Customize hidden markdown tag used to detect comments posted by Infracost")
+	cmd.Flags().Bool("dry-run", false, "Generate comment without actually posting to GitHub")
 
 	return cmd
 }

--- a/cmd/infracost/comment_gitlab.go
+++ b/cmd/infracost/comment_gitlab.go
@@ -20,13 +20,13 @@ func commentGitLabCmd(ctx *config.RunContext) *cobra.Command {
 		Use:   "gitlab",
 		Short: "Post an Infracost comment to GitLab",
 		Long:  "Post an Infracost comment to GitLab",
-		Example: `  Update a comment on a merge request:
+		Example: `  Update comment on a merge request:
 
-      infracost comment gitlab --repo my-org/my-gitlab-repo --merge-request 3 --path infracost.json --gitlab-token $GITLAB_TOKEN
+      infracost comment gitlab --repo my-org/my-repo --merge-request 3 --path infracost.json --gitlab-token $GITLAB_TOKEN
 
   Post a new comment to a commit:
 
-      infracost comment gitlab --repo my-org/my-gitlab-repo --commit 2ca7182 --path infracost.json --behavior delete-and-new --gitlab-token $GITLAB_TOKEN`,
+      infracost comment gitlab --repo my-org/my-repo --commit 2ca7182 --path infracost.json --behavior delete-and-new --gitlab-token $GITLAB_TOKEN`,
 		ValidArgs: []string{"--", "-"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx.SetContextValue("platform", "gitlab")
@@ -107,25 +107,25 @@ func commentGitLabCmd(ctx *config.RunContext) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("behavior", "update", `Behavior when posting the comment, one of:
-  update (default)  Update the latest comment
+	cmd.Flags().String("behavior", "update", `Behavior when posting comment, one of:
+  update (default)  Update latest comment
   new               Create a new comment
   delete-and-new    Delete previous matching comments and create a new comment`)
 	_ = cmd.RegisterFlagCompletionFunc("behavior", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return validCommentGitLabBehaviors, cobra.ShellCompDirectiveDefault
 	})
-	cmd.Flags().String("commit", "", "Commit SHA to post/get the comment, mutually exclusive with merge-request")
-	cmd.Flags().String("gitlab-server-url", "https://gitlab.com", "GitLab Server URL, defaults to https://gitlab.com")
+	cmd.Flags().String("commit", "", "Commit SHA to post comment on, mutually exclusive with merge-request")
+	cmd.Flags().String("gitlab-server-url", "https://gitlab.com", "GitLab Server URL")
 	cmd.Flags().String("gitlab-token", "", "GitLab token")
 	_ = cmd.MarkFlagRequired("gitlab-token")
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagFilename("path", "json")
-	cmd.Flags().Int("merge-request", 0, "Merge request number to post the comment on, mutually exclusive with commit")
-	cmd.Flags().String("repo", "", "Repository in the format owner/repo")
+	cmd.Flags().Int("merge-request", 0, "Merge request number to post comment on, mutually exclusive with commit")
+	cmd.Flags().String("repo", "", "Repository in format owner/repo")
 	_ = cmd.MarkFlagRequired("repo")
-	cmd.Flags().String("tag", "", "Customize the embedded tag that is used for detecting comments posted by Infracost")
-	cmd.Flags().Bool("dry-run", false, "Generate the comment without actually posting to GitLab.")
+	cmd.Flags().String("tag", "", "Customize hidden markdown tag used to detect comments posted by Infracost")
+	cmd.Flags().Bool("dry-run", false, "Generate comment without actually posting to GitLab")
 
 	return cmd
 }

--- a/cmd/infracost/testdata/comment/comment.golden
+++ b/cmd/infracost/testdata/comment/comment.golden
@@ -5,17 +5,17 @@ USAGE
   infracost comment [command]
 
 EXAMPLES
-  Update a comment on a GitHub pull request:
+  Update the Infracost comment on a GitHub pull request:
 
-      infracost comment github --repo my-org/my-github-repo --pull-request 3 --path infracost.json --github-token $GITHUB_TOKEN
+      infracost comment github --repo my-org/my-repo --pull-request 3 --path infracost.json --behavior update --github-token $GITHUB_TOKEN
 
-  Post a new comment to a GitLab commit:
+  Delete old Infracost comments and post a new comment to a GitLab commit:
 
-      infracost comment gitlab --repo my-org/my-gitlab-repo --commit 2ca7182 --path infracost.json --behavior new --gitlab-token $GITLAB_TOKEN
+      infracost comment gitlab --repo my-org/my-repo --commit 2ca7182 --path infracost.json --behavior delete-and-new --gitlab-token $GITLAB_TOKEN
 
   Post a new comment to an Azure Repos pull request:
 
-      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-azure-repo --pull-request 3 --path infracost.json --azure-access-token $AZURE_ACCESS_TOKEN
+      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-repo --pull-request 3 --path infracost.json --behavior new --azure-access-token $AZURE_ACCESS_TOKEN
 
 AVAILABLE COMMANDS
   azure-repos Post an Infracost comment to Azure Repos

--- a/cmd/infracost/testdata/comment_azure_repos_help/comment_azure_repos_help.golden
+++ b/cmd/infracost/testdata/comment_azure_repos_help/comment_azure_repos_help.golden
@@ -4,22 +4,22 @@ USAGE
   infracost comment azure-repos [flags]
 
 EXAMPLES
-  Update a comment on a pull request:
+  Update comment on a pull request:
 
-      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-azure-repo --pull-request 3 --path infracost.json --azure-access-token $AZURE_ACCESS_TOKEN
+      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-repo --pull-request 3 --path infracost.json --azure-access-token $AZURE_ACCESS_TOKEN
 
 FLAGS
       --azure-access-token string   Azure DevOps access token
-      --behavior string             Behavior when posting the comment, one of:
-                                      update (default)  Update the latest comment
+      --behavior string             Behavior when posting comment, one of:
+                                      update (default)  Update latest comment
                                       new               Create a new comment
                                       delete-and-new    Delete previous matching comments and create a new comment (default "update")
-      --dry-run                     Generate the comment without actually posting to Azure Repos.
+      --dry-run                     Generate comment without actually posting to Azure Repos
   -h, --help                        help for azure-repos
   -p, --path stringArray            Path to Infracost JSON files, glob patterns need quotes
-      --pull-request int            pull request number to post the comment on
-      --repo-url string             Repository URL, e.g. https://dev.azure.com/my-org/my-project/_git/my-azure-repo
-      --tag string                  Customize the embedded tag that is used for detecting comments posted by Infracost
+      --pull-request int            Pull request number to post comment on
+      --repo-url string             Repository URL, e.g. https://dev.azure.com/my-org/my-project/_git/my-repo
+      --tag string                  Customize hidden markdown tag used to detect comments posted by Infracost
 
 GLOBAL FLAGS
       --log-level string   Log level (trace, debug, info, warn, error, fatal)

--- a/cmd/infracost/testdata/comment_git_hub_help/comment_git_hub_help.golden
+++ b/cmd/infracost/testdata/comment_git_hub_help/comment_git_hub_help.golden
@@ -4,29 +4,29 @@ USAGE
   infracost comment github [flags]
 
 EXAMPLES
-  Update a comment on a pull request:
+  Update comment on a pull request:
 
-      infracost comment github --repo my-org/my-github-repo --pull-request 3 --path infracost.json --github-token $GITHUB_TOKEN
+      infracost comment github --repo my-org/my-repo --pull-request 3 --path infracost.json --github-token $GITHUB_TOKEN
 
   Post a new comment to a commit:
 
-      infracost comment github --repo my-org/my-github-repo --commit 2ca7182 --path infracost.json --behavior hide-and-new --github-token $GITHUB_TOKEN
+      infracost comment github --repo my-org/my-repo --commit 2ca7182 --path infracost.json --behavior hide-and-new --github-token $GITHUB_TOKEN
 
 FLAGS
-      --behavior string         Behavior when posting the comment, one of:
-                                  update (default)  Update the latest comment
+      --behavior string         Behavior when posting comment, one of:
+                                  update (default)  Update latest comment
                                   new               Create a new comment
                                   hide-and-new      Hide previous matching comments and create a new comment
                                   delete-and-new    Delete previous matching comments and create a new comment (default "update")
-      --commit string           Commit SHA to post/get the comment, mutually exclusive with pull-request
-      --dry-run                 Generate the comment without actually posting to GitHub.
-      --github-api-url string   GitHub API URL, defaults to https://api.github.com (default "https://api.github.com")
+      --commit string           Commit SHA to post comment on, mutually exclusive with pull-request
+      --dry-run                 Generate comment without actually posting to GitHub
+      --github-api-url string   GitHub API URL (default "https://api.github.com")
       --github-token string     GitHub token
   -h, --help                    help for github
   -p, --path stringArray        Path to Infracost JSON files, glob patterns need quotes
-      --pull-request int        Pull request number to post the comment on, mutually exclusive with commit
-      --repo string             Repository in the format owner/repo
-      --tag string              Customize the embedded tag that is used for detecting comments posted by Infracost
+      --pull-request int        Pull request number to post comment on, mutually exclusive with commit
+      --repo string             Repository in format owner/repo
+      --tag string              Customize hidden markdown tag used to detect comments posted by Infracost
 
 GLOBAL FLAGS
       --log-level string   Log level (trace, debug, info, warn, error, fatal)

--- a/cmd/infracost/testdata/comment_git_lab_help/comment_git_lab_help.golden
+++ b/cmd/infracost/testdata/comment_git_lab_help/comment_git_lab_help.golden
@@ -4,28 +4,28 @@ USAGE
   infracost comment gitlab [flags]
 
 EXAMPLES
-  Update a comment on a merge request:
+  Update comment on a merge request:
 
-      infracost comment gitlab --repo my-org/my-gitlab-repo --merge-request 3 --path infracost.json --gitlab-token $GITLAB_TOKEN
+      infracost comment gitlab --repo my-org/my-repo --merge-request 3 --path infracost.json --gitlab-token $GITLAB_TOKEN
 
   Post a new comment to a commit:
 
-      infracost comment gitlab --repo my-org/my-gitlab-repo --commit 2ca7182 --path infracost.json --behavior delete-and-new --gitlab-token $GITLAB_TOKEN
+      infracost comment gitlab --repo my-org/my-repo --commit 2ca7182 --path infracost.json --behavior delete-and-new --gitlab-token $GITLAB_TOKEN
 
 FLAGS
-      --behavior string            Behavior when posting the comment, one of:
-                                     update (default)  Update the latest comment
+      --behavior string            Behavior when posting comment, one of:
+                                     update (default)  Update latest comment
                                      new               Create a new comment
                                      delete-and-new    Delete previous matching comments and create a new comment (default "update")
-      --commit string              Commit SHA to post/get the comment, mutually exclusive with merge-request
-      --dry-run                    Generate the comment without actually posting to GitLab.
-      --gitlab-server-url string   GitLab Server URL, defaults to https://gitlab.com (default "https://gitlab.com")
+      --commit string              Commit SHA to post comment on, mutually exclusive with merge-request
+      --dry-run                    Generate comment without actually posting to GitLab
+      --gitlab-server-url string   GitLab Server URL (default "https://gitlab.com")
       --gitlab-token string        GitLab token
   -h, --help                       help for gitlab
-      --merge-request int          Merge request number to post the comment on, mutually exclusive with commit
+      --merge-request int          Merge request number to post comment on, mutually exclusive with commit
   -p, --path stringArray           Path to Infracost JSON files, glob patterns need quotes
-      --repo string                Repository in the format owner/repo
-      --tag string                 Customize the embedded tag that is used for detecting comments posted by Infracost
+      --repo string                Repository in format owner/repo
+      --tag string                 Customize hidden markdown tag used to detect comments posted by Infracost
 
 GLOBAL FLAGS
       --log-level string   Log level (trace, debug, info, warn, error, fatal)

--- a/cmd/infracost/testdata/comment_help/comment_help.golden
+++ b/cmd/infracost/testdata/comment_help/comment_help.golden
@@ -5,17 +5,17 @@ USAGE
   infracost comment [command]
 
 EXAMPLES
-  Update a comment on a GitHub pull request:
+  Update the Infracost comment on a GitHub pull request:
 
-      infracost comment github --repo my-org/my-github-repo --pull-request 3 --path infracost.json --github-token $GITHUB_TOKEN
+      infracost comment github --repo my-org/my-repo --pull-request 3 --path infracost.json --behavior update --github-token $GITHUB_TOKEN
 
-  Post a new comment to a GitLab commit:
+  Delete old Infracost comments and post a new comment to a GitLab commit:
 
-      infracost comment gitlab --repo my-org/my-gitlab-repo --commit 2ca7182 --path infracost.json --behavior new --gitlab-token $GITLAB_TOKEN
+      infracost comment gitlab --repo my-org/my-repo --commit 2ca7182 --path infracost.json --behavior delete-and-new --gitlab-token $GITLAB_TOKEN
 
   Post a new comment to an Azure Repos pull request:
 
-      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-azure-repo --pull-request 3 --path infracost.json --azure-access-token $AZURE_ACCESS_TOKEN
+      infracost comment azure-repos --repo-url https://dev.azure.com/my-org/my-project/_git/my-repo --pull-request 3 --path infracost.json --behavior new --azure-access-token $AZURE_ACCESS_TOKEN
 
 AVAILABLE COMMANDS
   azure-repos Post an Infracost comment to Azure Repos


### PR DESCRIPTION
@vdmgolub can you please review this? This keeps the style of our help texts the same as previous commands. 
I included update behavior in the top-level comment help so it's clear there is an option for it, but I left it out in the sub-command as that help text shows that it's the default.

If you're ok with these, can you please update the golden files and merge? 