### PR TITLE
fix: Remove double quotes escaping from feedback urls in comment templates

### DIFF
--- a/cmd/infracost/testdata/comment_azure_repos_pull_request/comment_azure_repos_pull_request.golden
+++ b/cmd/infracost/testdata/comment_azure_repos_pull_request/comment_azure_repos_pull_request.golden
@@ -129,7 +129,7 @@ Key: ~ changed, + added, - removed
 This comment will be updated when the cost estimate changes.
 
 <sub>
-  Is this comment useful? <a href=\"https://www.infracost.io/feedback/submit/?value=yes\" rel=\"noopener noreferrer\" target=\"_blank\">Yes</a>, <a href=\"https://www.infracost.io/feedback/submit/?value=no\" rel=\"noopener noreferrer\" target=\"_blank\">No</a>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
 </sub>
 
 Comment not posted to Azure Repos (--dry-run was specified)

--- a/cmd/infracost/testdata/comment_git_hub_commit/comment_git_hub_commit.golden
+++ b/cmd/infracost/testdata/comment_git_hub_commit/comment_git_hub_commit.golden
@@ -127,7 +127,7 @@ Key: ~ changed, + added, - removed
 </details>
 
 <sub>
-  Is this comment useful? <a href=\"https://www.infracost.io/feedback/submit/?value=yes\" rel=\"noopener noreferrer\" target=\"_blank\">Yes</a>, <a href=\"https://www.infracost.io/feedback/submit/?value=no\" rel=\"noopener noreferrer\" target=\"_blank\">No</a>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
 </sub>
 
 Comment not posted to GitHub (--dry-run was specified)

--- a/cmd/infracost/testdata/comment_git_hub_pull_request/comment_git_hub_pull_request.golden
+++ b/cmd/infracost/testdata/comment_git_hub_pull_request/comment_git_hub_pull_request.golden
@@ -129,7 +129,7 @@ Key: ~ changed, + added, - removed
 This comment will be updated when the cost estimate changes.
 
 <sub>
-  Is this comment useful? <a href=\"https://www.infracost.io/feedback/submit/?value=yes\" rel=\"noopener noreferrer\" target=\"_blank\">Yes</a>, <a href=\"https://www.infracost.io/feedback/submit/?value=no\" rel=\"noopener noreferrer\" target=\"_blank\">No</a>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
 </sub>
 
 Comment not posted to GitHub (--dry-run was specified)

--- a/cmd/infracost/testdata/comment_git_lab_commit/comment_git_lab_commit.golden
+++ b/cmd/infracost/testdata/comment_git_lab_commit/comment_git_lab_commit.golden
@@ -127,7 +127,7 @@ Key: ~ changed, + added, - removed
 </details>
 
 <sub>
-  Is this comment useful? <a href=\"https://www.infracost.io/feedback/submit/?value=yes\" rel=\"noopener noreferrer\" target=\"_blank\">Yes</a>, <a href=\"https://www.infracost.io/feedback/submit/?value=no\" rel=\"noopener noreferrer\" target=\"_blank\">No</a>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
 </sub>
 
 Comment not posted to GitLab (--dry-run was specified)

--- a/cmd/infracost/testdata/comment_git_lab_merge_request/comment_git_lab_merge_request.golden
+++ b/cmd/infracost/testdata/comment_git_lab_merge_request/comment_git_lab_merge_request.golden
@@ -129,7 +129,7 @@ Key: ~ changed, + added, - removed
 This comment will be updated when the cost estimate changes.
 
 <sub>
-  Is this comment useful? <a href=\"https://www.infracost.io/feedback/submit/?value=yes\" rel=\"noopener noreferrer\" target=\"_blank\">Yes</a>, <a href=\"https://www.infracost.io/feedback/submit/?value=no\" rel=\"noopener noreferrer\" target=\"_blank\">No</a>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
 </sub>
 
 Comment not posted to GitLab (--dry-run was specified)

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -361,7 +361,7 @@ This comment will be replaced when the cost estimate changes
 {{- if .MarkdownOptions.IncludeFeedbackLink }}
 
 <sub>
-  Is this comment useful? <a href=\"https://www.infracost.io/feedback/submit/?value=yes\" rel=\"noopener noreferrer\" target=\"_blank\">Yes</a>, <a href=\"https://www.infracost.io/feedback/submit/?value=no\" rel=\"noopener noreferrer\" target=\"_blank\">No</a>
+  Is this comment useful? <a href="https://www.infracost.io/feedback/submit/?value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://www.infracost.io/feedback/submit/?value=no" rel="noopener noreferrer" target="_blank">No</a>
 </sub>
 {{- end}}
 `


### PR DESCRIPTION
GitLab doesn't unescape the double quotes thus not showing the Yes/No
URLs correctly. Removing the escaping fixed it. GitHub/Azure Repos
worked well too.

GitLab: https://gitlab.com/infracost/gitlab-ci-demo/-/merge_requests/23#note_827909510
GitHub: https://github.com/vdmgolub/infracost-test/pull/6#issuecomment-1026800345
Azure Repos: last comment https://dev.azure.com/infracost/base/_git/azure-devops-repo-demo/pullrequest/65