### PR TITLE
fix: add in hcl only identifiers so that resources can reference 

### DIFF
--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -121,14 +121,16 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *Context, moduleBlock *Block) *Block {
 			children = append(children, NewHCLBlock(b.AsHCLBlock(), ctx, moduleBlock))
 		}
 
-		// add commonly used identifiers to the block so that if it's referenced by other
-		// blocks in context evaluation.
-		if _, ok := body.Attributes["id"]; !ok {
-			body.Attributes["id"] = newUniqueAttribute("id")
-		}
+		if hclBlock.Type == "resource" || hclBlock.Type == "data" {
+			// add commonly used identifiers to the block so that if it's referenced by other
+			// blocks in context evaluation.
+			if _, ok := body.Attributes["id"]; !ok {
+				body.Attributes["id"] = newUniqueAttribute("id")
+			}
 
-		if _, ok := body.Attributes["arn"]; !ok {
-			body.Attributes["arn"] = newUniqueAttribute("arn")
+			if _, ok := body.Attributes["arn"]; !ok {
+				body.Attributes["arn"] = newUniqueAttribute("arn")
+			}
 		}
 
 		return &Block{

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -123,8 +123,13 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *Context, moduleBlock *Block) *Block {
 
 		// add commonly used identifiers to the block so that if it's referenced by other
 		// blocks in context evaluation.
-		body.Attributes["id"] = newUniqueAttribute("id")
-		body.Attributes["arn"] = newUniqueAttribute("arn")
+		if _, ok := body.Attributes["id"]; !ok {
+			body.Attributes["id"] = newUniqueAttribute("id")
+		}
+
+		if _, ok := body.Attributes["arn"]; !ok {
+			body.Attributes["arn"] = newUniqueAttribute("arn")
+		}
 
 		return &Block{
 			context:     ctx,

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	log "github.com/sirupsen/logrus"
@@ -120,6 +121,11 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *Context, moduleBlock *Block) *Block {
 			children = append(children, NewHCLBlock(b.AsHCLBlock(), ctx, moduleBlock))
 		}
 
+		// add commonly used identifiers to the block so that if it's referenced by other
+		// blocks in context evaluation.
+		body.Attributes["id"] = newUniqueAttribute("id")
+		body.Attributes["arn"] = newUniqueAttribute("arn")
+
 		return &Block{
 			context:     ctx,
 			hclBlock:    hclBlock,
@@ -151,6 +157,15 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *Context, moduleBlock *Block) *Block {
 		hclBlock:    hclBlock,
 		moduleBlock: moduleBlock,
 		childBlocks: children,
+	}
+}
+
+func newUniqueAttribute(name string) *hclsyntax.Attribute {
+	return &hclsyntax.Attribute{
+		Name: name,
+		Expr: &hclsyntax.LiteralValueExpr{
+			Val: cty.StringVal(uuid.NewString()),
+		},
 	}
 }
 

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -396,7 +396,7 @@ func (e *Evaluator) getValuesByBlockType(blockType string) cty.Value {
 				continue
 			}
 
-			blockMap, ok := values[b.Label()]
+			blockMap, ok := values[b.Labels()[0]]
 			if !ok {
 				values[b.Labels()[0]] = cty.ObjectVal(make(map[string]cty.Value))
 				blockMap = values[b.Labels()[0]]

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -491,7 +491,7 @@ func (e *Evaluator) loadModules() []*ModuleCall {
 
 		moduleCall, err := e.loadModule(moduleBlock)
 		if err != nil {
-			log.Warnf("Failed to load module %s: err: %s", moduleCall.Name, err)
+			log.Warnf("Failed to load module err: %s", err)
 			continue
 		}
 


### PR DESCRIPTION
fixes golden file tests for a number of resources that use `resource.my_resource.id` and then Infracost looks up a reference based on this `id`