### PR TITLE
fix: recursive block evaluation in output

### DIFF
--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	log "github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -92,4 +93,126 @@ func (attr *Attribute) Equals(val interface{}) bool {
 	}
 
 	return false
+}
+
+func createDotReferenceFromTraversal(traversals ...hcl.Traversal) (*Reference, error) {
+	var refParts []string
+
+	for _, x := range traversals {
+		for _, p := range x {
+			switch part := p.(type) {
+			case hcl.TraverseRoot:
+				refParts = append(refParts, part.Name)
+			case hcl.TraverseAttr:
+				refParts = append(refParts, part.Name)
+			case hcl.TraverseIndex:
+				refParts[len(refParts)-1] = fmt.Sprintf("%s[%s]", refParts[len(refParts)-1], getIndexValue(part))
+			}
+		}
+	}
+	return newReference(refParts)
+}
+
+func getIndexValue(part hcl.TraverseIndex) string {
+	switch part.Key.Type() {
+	case cty.String:
+		return fmt.Sprintf("%q", part.Key.AsString())
+	case cty.Number:
+		var intVal int
+		if err := gocty.FromCtyValue(part.Key, &intVal); err != nil {
+			log.Warn("could not unpack the int, returning 0")
+			return "0"
+		}
+		return fmt.Sprintf("%d", intVal)
+	default:
+		return "0"
+	}
+}
+
+func (attr *Attribute) Reference() (*Reference, error) {
+	if attr == nil {
+		return nil, fmt.Errorf("attribute is nil")
+	}
+	switch t := attr.HCLAttr.Expr.(type) {
+	case *hclsyntax.RelativeTraversalExpr:
+		switch s := t.Source.(type) {
+		case *hclsyntax.IndexExpr:
+			collectionRef, err := createDotReferenceFromTraversal(s.Collection.Variables()...)
+			if err != nil {
+				return nil, err
+			}
+			key, _ := s.Key.Value(attr.Ctx.Inner())
+			collectionRef.SetKey(key)
+			return collectionRef, nil
+		default:
+			return createDotReferenceFromTraversal(t.Source.Variables()...)
+		}
+	case *hclsyntax.ScopeTraversalExpr:
+		return createDotReferenceFromTraversal(t.Traversal)
+	case *hclsyntax.TemplateExpr:
+		refs := attr.referencesInTemplate()
+		if len(refs) == 0 {
+			return nil, fmt.Errorf("no references in template")
+		}
+		return refs[0], nil
+	default:
+		return nil, fmt.Errorf("not a reference: no scope traversal")
+	}
+}
+
+func (attr *Attribute) AllReferences() []*Reference {
+	if attr == nil {
+		return nil
+	}
+	var refs []*Reference
+	refs = append(refs, attr.referencesInTemplate()...)
+	refs = append(refs, attr.referencesInConditional()...)
+	ref, err := attr.Reference()
+	if err == nil {
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func (attr *Attribute) referencesInTemplate() []*Reference {
+	if attr == nil {
+		return nil
+	}
+	var refs []*Reference
+	switch t := attr.HCLAttr.Expr.(type) {
+	case *hclsyntax.TemplateExpr:
+		for _, part := range t.Parts {
+			ref, err := createDotReferenceFromTraversal(part.Variables()...)
+			if err != nil {
+				continue
+			}
+			refs = append(refs, ref)
+		}
+	case *hclsyntax.TupleConsExpr:
+		ref, err := createDotReferenceFromTraversal(t.Variables()...)
+		if err == nil {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
+}
+
+func (attr *Attribute) referencesInConditional() []*Reference {
+	if attr == nil {
+		return nil
+	}
+	var refs []*Reference
+	switch t := attr.HCLAttr.Expr.(type) {
+	case *hclsyntax.ConditionalExpr:
+		if ref, err := createDotReferenceFromTraversal(t.TrueResult.Variables()...); err == nil {
+			refs = append(refs, ref)
+		}
+		if ref, err := createDotReferenceFromTraversal(t.FalseResult.Variables()...); err == nil {
+			refs = append(refs, ref)
+		}
+		if ref, err := createDotReferenceFromTraversal(t.Condition.Variables()...); err == nil {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
 }

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -135,18 +135,18 @@ func (attr *Attribute) Reference() (*Reference, error) {
 	}
 	switch t := attr.HCLAttr.Expr.(type) {
 	case *hclsyntax.RelativeTraversalExpr:
-		switch s := t.Source.(type) {
-		case *hclsyntax.IndexExpr:
+		if s, ok := t.Source.(*hclsyntax.IndexExpr); ok {
 			collectionRef, err := createDotReferenceFromTraversal(s.Collection.Variables()...)
 			if err != nil {
 				return nil, err
 			}
 			key, _ := s.Key.Value(attr.Ctx.Inner())
 			collectionRef.SetKey(key)
+
 			return collectionRef, nil
-		default:
-			return createDotReferenceFromTraversal(t.Source.Variables()...)
 		}
+
+		return createDotReferenceFromTraversal(t.Source.Variables()...)
 	case *hclsyntax.ScopeTraversalExpr:
 		return createDotReferenceFromTraversal(t.Traversal)
 	case *hclsyntax.TemplateExpr:
@@ -202,8 +202,8 @@ func (attr *Attribute) referencesInConditional() []*Reference {
 		return nil
 	}
 	var refs []*Reference
-	switch t := attr.HCLAttr.Expr.(type) {
-	case *hclsyntax.ConditionalExpr:
+
+	if t, ok := attr.HCLAttr.Expr.(*hclsyntax.ConditionalExpr); ok {
 		if ref, err := createDotReferenceFromTraversal(t.TrueResult.Variables()...); err == nil {
 			refs = append(refs, ref)
 		}
@@ -214,5 +214,6 @@ func (attr *Attribute) referencesInConditional() []*Reference {
 			refs = append(refs, ref)
 		}
 	}
+
 	return refs
 }

--- a/internal/hcl/reference.go
+++ b/internal/hcl/reference.go
@@ -3,6 +3,8 @@ package hcl
 import (
 	"fmt"
 	"strings"
+
+	"github.com/zclconf/go-cty/cty"
 )
 
 type Reference struct {
@@ -53,6 +55,17 @@ func newReference(parts []string) (*Reference, error) {
 	}
 
 	return &ref, nil
+}
+
+func (r *Reference) SetKey(key cty.Value) {
+	switch key.Type() {
+	case cty.Number:
+		f := key.AsBigFloat()
+		f64, _ := f.Float64()
+		r.key = fmt.Sprintf("[%d]", int(f64))
+	case cty.String:
+		r.key = fmt.Sprintf("[%q]", key.AsString())
+	}
 }
 
 func (r *Reference) String() string {


### PR DESCRIPTION
1. Fixes test/parsing so that HCL blocks are marshalled recursively. This solves Infracost lookup on resources that have many nested blocks. e.g. `aws_cloudfront_distribution`, where Infracost needs to fetch `origin_shield.enabled`/`origin_shield_region`

```
resource "aws_cloudfront_distribution" "s3_distribution_0_with_shield" {
  origin {
    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
    origin_id   = local.s3_origin_id
   ...
    origin_shield {
      enabled              = true
      origin_shield_region = "sa-east-1"
    }
  }

  enabled             = true
  ...  
}
```

2. Fixes issue where attributes referenced which were non `id` based, e.g. name, were not being evaluated correctly. We now add the `expressions` into the HCL plan JSON output so Infracost can lookup attributes based on this. e.g.:

```
  launch_template {
    name    = aws_launch_template.foo3.name # now supported in HCL
    version = "default_version"
  }
```