### PR TITLE
fix: provider region specification and provide sane defaults

### DIFF
--- a/internal/providers/terraform/aws/cloudtrail.go
+++ b/internal/providers/terraform/aws/cloudtrail.go
@@ -17,7 +17,7 @@ func newCloudtrail(d *schema.ResourceData, u *schema.UsageData) *schema.Resource
 	r := &aws.Cloudtrail{
 		Address:                 d.Address,
 		Region:                  region,
-		IncludeManagementEvents: d.Get("include_global_service_events").Bool(),
+		IncludeManagementEvents: d.GetBoolOrDefault("include_global_service_events", true),
 		IncludeInsightEvents:    len(d.Get("insight_selector").Array()) > 0,
 	}
 	r.PopulateUsage(u)

--- a/internal/providers/terraform/aws/kinesis_firehose_delivery_stream.go
+++ b/internal/providers/terraform/aws/kinesis_firehose_delivery_stream.go
@@ -1,9 +1,10 @@
 package aws
 
 import (
+	"github.com/tidwall/gjson"
+
 	"github.com/infracost/infracost/internal/resources/aws"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/tidwall/gjson"
 )
 
 func getKinesisFirehoseDeliveryStreamRegistryItem() *schema.RegistryItem {
@@ -14,10 +15,11 @@ func getKinesisFirehoseDeliveryStreamRegistryItem() *schema.RegistryItem {
 }
 
 func NewKinesisFirehoseDeliveryStream(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	formatConversionEnabled := d.GetBoolOrDefault("extended_s3_configuration.0.data_format_conversion_configuration.0.enabled", true)
 	r := &aws.KinesisFirehoseDeliveryStream{
 		Address:                     d.Address,
 		Region:                      d.Get("region").String(),
-		DataFormatConversionEnabled: d.Get("extended_s3_configuration.0.data_format_conversion_configuration").Exists() && d.Get("extended_s3_configuration.0.data_format_conversion_configuration.0.enabled").Bool(),
+		DataFormatConversionEnabled: d.Get("extended_s3_configuration.0.data_format_conversion_configuration").Exists() && formatConversionEnabled,
 		VPCDeliveryEnabled:          d.Get("elasticsearch_configuration.0.vpc_config").Type != gjson.Null,
 		VPCDeliveryAZs:              int64(len(d.Get("elasticsearch_configuration.0.vpc_config.0.subnet_ids").Array())),
 	}

--- a/internal/providers/terraform/aws/neptune_cluster_snapshot.go
+++ b/internal/providers/terraform/aws/neptune_cluster_snapshot.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/infracost/infracost/internal/resources/aws"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/tidwall/gjson"
 )
 
 func getNeptuneClusterSnapshotRegistryItem() *schema.RegistryItem {
@@ -22,9 +21,7 @@ func NewNeptuneClusterSnapshot(d *schema.ResourceData, u *schema.UsageData) *sch
 	dbClusterIdentifiers := d.References("db_cluster_identifier")
 	if len(dbClusterIdentifiers) > 0 {
 		cluster := dbClusterIdentifiers[0]
-		if cluster.Get("backup_retention_period").Type != gjson.Null {
-			backupRetentionPeriod = intPtr(cluster.Get("backup_retention_period").Int())
-		}
+		backupRetentionPeriod = intPtr(cluster.GetInt64OrDefault("backup_retention_period", 1))
 	}
 
 	r := &aws.NeptuneClusterSnapshot{

--- a/internal/providers/terraform/aws/rds_cluster.go
+++ b/internal/providers/terraform/aws/rds_cluster.go
@@ -16,9 +16,9 @@ func NewRDSCluster(d *schema.ResourceData, u *schema.UsageData) *schema.Resource
 	r := &aws.RDSCluster{
 		Address:               d.Address,
 		Region:                d.Get("region").String(),
-		Engine:                d.Get("engine").String(),
-		BackupRetentionPeriod: d.Get("backup_retention_period").Int(),
-		EngineMode:            d.Get("engine_mode").String(),
+		Engine:                d.GetStringOrDefault("engine", "aurora"),
+		BackupRetentionPeriod: d.GetInt64OrDefault("backup_retention_period", 1),
+		EngineMode:            d.GetStringOrDefault("engine_mode", "provisioned"),
 	}
 
 	r.PopulateUsage(u)

--- a/internal/providers/terraform/aws/transfer_server.go
+++ b/internal/providers/terraform/aws/transfer_server.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"sort"
+
 	"github.com/infracost/infracost/internal/resources/aws"
 	"github.com/infracost/infracost/internal/schema"
 )
@@ -20,6 +22,8 @@ func newTransferServer(d *schema.ResourceData, u *schema.UsageData) *schema.Reso
 		for _, data := range d.Get("protocols").Array() {
 			protocols = append(protocols, data.String())
 		}
+	
+		sort.Strings(protocols)
 	} else {
 		defaultProtocol := "SFTP"
 		protocols = append(protocols, defaultProtocol)

--- a/internal/providers/terraform/azure/firewall.go
+++ b/internal/providers/terraform/azure/firewall.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
 	"github.com/tidwall/gjson"
+
+	"github.com/infracost/infracost/internal/schema"
 )
 
 func GetAzureRMFirewallRegistryItem() *schema.RegistryItem {
@@ -26,10 +27,7 @@ func NewAzureRMFirewall(d *schema.ResourceData, u *schema.UsageData) *schema.Res
 		skuTier = d.Get("sku_tier").String()
 	}
 
-	// Compare d.Get() with empty array because by default an empty array of virtual hub block: "virtual_hub":[] exists,
-	// and it means that d.Get("virtual_hub").Type will never return gjson.Null
-
-	if v := d.Get("virtual_hub").String(); v != "[]" {
+	if len(d.Get("virtual_hub").Array()) > 0 {
 		if strings.ToLower(skuTier) == "standard" {
 			skuTier = "Secured Virtual Hub"
 		} else {

--- a/internal/providers/terraform/azure/vpn_gateway.go
+++ b/internal/providers/terraform/azure/vpn_gateway.go
@@ -16,7 +16,7 @@ func newVPNGateway(d *schema.ResourceData, u *schema.UsageData) *schema.Resource
 	v := &azure.VPNGateway{
 		Address:    d.Address,
 		Region:     d.Get("region").String(),
-		ScaleUnits: d.Get("scale_unit").Int(),
+		ScaleUnits: d.GetInt64OrDefault("scale_unit", 1),
 		Type:       "S2S",
 	}
 	v.PopulateUsage(u)

--- a/internal/providers/terraform/google/container_node_pool.go
+++ b/internal/providers/terraform/google/container_node_pool.go
@@ -1,10 +1,11 @@
 package google
 
 import (
-	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+
+	"github.com/infracost/infracost/internal/schema"
 )
 
 func GetContainerNodePoolRegistryItem() *schema.RegistryItem {

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -148,7 +148,10 @@ func (p HCLProvider) modulesToPlanJSON(modules []*hcl.Module) PlanSchema {
 				providerConfigKey := providerKey
 				providerAttr := block.GetAttribute("provider")
 				if providerAttr != nil {
-					providerConfigKey = providerAttr.Value().AsString()
+					value := providerAttr.Value()
+					if value.Type() == cty.String {
+						providerConfigKey = value.AsString()
+					}
 				}
 
 				sch.Configuration.RootModule.Resources = append(sch.Configuration.RootModule.Resources, ResourceData{

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -228,7 +228,14 @@ func marshalAttributeValues(value cty.Value) map[string]interface{} {
 	for it.Next() {
 		k, v := it.Element()
 		vJSON, _ := ctyJson.Marshal(v, v.Type())
-		ret[k.AsString()] = json.RawMessage(vJSON)
+		key := k.AsString()
+
+		// ignore count values
+		if key == "count" {
+			continue
+		}
+
+		ret[key] = json.RawMessage(vJSON)
 	}
 	return ret
 }

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -96,11 +96,17 @@ func (p HCLProvider) modulesToPlanJSON(modules []*hcl.Module) PlanSchema {
 					providerKey = name
 				}
 
+				region := ""
+				value := block.GetAttribute("region").Value()
+				if value != cty.NilVal {
+					region = value.AsString()
+				}
+
 				sch.Configuration.ProviderConfig[name] = ProviderConfig{
 					Name: name,
 					Expressions: map[string]interface{}{
 						"region": map[string]interface{}{
-							"constant_value": block.GetAttribute("region").Value().AsString(),
+							"constant_value": region,
 						},
 					},
 				}

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -72,6 +72,7 @@ func (p HCLProvider) modulesToPlanJSON(modules []*hcl.Module) PlanSchema {
 		},
 		ResourceChanges: []ResourceChangesJSON{},
 		Configuration: Configuration{
+			ProviderConfig: make(map[string]ProviderConfig),
 			RootModule: struct {
 				Resources []ResourceData `json:"resources"`
 			}{
@@ -81,6 +82,31 @@ func (p HCLProvider) modulesToPlanJSON(modules []*hcl.Module) PlanSchema {
 	}
 
 	for _, module := range modules {
+		var providerKey string
+
+		for _, block := range module.Blocks {
+			if block.Type() == "provider" {
+				name := block.TypeLabel()
+				if a := block.GetAttribute("alias"); a != nil {
+					name = a.Value().AsString()
+				}
+
+				// set the default provider key
+				if providerKey == "" {
+					providerKey = name
+				}
+
+				sch.Configuration.ProviderConfig[name] = ProviderConfig{
+					Name: name,
+					Expressions: map[string]interface{}{
+						"region": map[string]interface{}{
+							"constant_value": block.GetAttribute("region").Value().AsString(),
+						},
+					},
+				}
+			}
+		}
+
 		for _, block := range module.Blocks {
 			if block.Type() == "resource" {
 				r := ResourceJSON{
@@ -113,12 +139,19 @@ func (p HCLProvider) modulesToPlanJSON(modules []*hcl.Module) PlanSchema {
 				c.Change.After = jsonValues
 				r.Values = jsonValues
 
+				providerConfigKey := providerKey
+				providerAttr := block.GetAttribute("provider")
+				if providerAttr != nil {
+					providerConfigKey = providerAttr.Value().AsString()
+				}
+
 				sch.Configuration.RootModule.Resources = append(sch.Configuration.RootModule.Resources, ResourceData{
-					Address:     block.FullName(),
-					Mode:        "managed",
-					Type:        block.TypeLabel(),
-					Name:        block.LocalName(),
-					Expressions: blockToReferences(block),
+					Address:           block.FullName(),
+					Mode:              "managed",
+					Type:              block.TypeLabel(),
+					Name:              block.LocalName(),
+					ProviderConfigKey: providerConfigKey,
+					Expressions:       blockToReferences(block),
 				})
 
 				sch.ResourceChanges = append(sch.ResourceChanges, c)
@@ -241,17 +274,24 @@ type PlanRootModule struct {
 }
 
 type Configuration struct {
-	RootModule struct {
+	ProviderConfig map[string]ProviderConfig `json:"provider_config"`
+	RootModule     struct {
 		Resources []ResourceData `json:"resources"`
 	} `json:"root_module"`
 }
 
-type ResourceData struct {
-	Address     string                 `json:"address"`
-	Mode        string                 `json:"mode"`
-	Type        string                 `json:"type"`
+type ProviderConfig struct {
 	Name        string                 `json:"name"`
 	Expressions map[string]interface{} `json:"expressions"`
+}
+
+type ResourceData struct {
+	Address           string                 `json:"address"`
+	Mode              string                 `json:"mode"`
+	Type              string                 `json:"type"`
+	Name              string                 `json:"name"`
+	ProviderConfigKey string                 `json:"provider_config_key"`
+	Expressions       map[string]interface{} `json:"expressions"`
 }
 
 type ChildModule struct {

--- a/internal/schema/resource_data.go
+++ b/internal/schema/resource_data.go
@@ -46,6 +46,23 @@ func (d *ResourceData) Get(key string) gjson.Result {
 	return d.RawValues.Get(key)
 }
 
+func (d *ResourceData) GetStringOrDefault(key, def string) string {
+	v := d.RawValues.Get(key).String()
+	if v != "" {
+		return v
+	}
+
+	return def
+}
+
+func (d *ResourceData) GetInt64OrDefault(key string, def int64) int64 {
+	if d.RawValues.Get(key).Exists() {
+		return d.RawValues.Get(key).Int()
+	}
+
+	return def
+}
+
 // Return true if the key doesn't exist, is null, or is an empty string.
 // Needed because gjson.Exists returns true as long as a key exists, even if it's empty or null.
 func (d *ResourceData) IsEmpty(key string) bool {

--- a/internal/schema/resource_data.go
+++ b/internal/schema/resource_data.go
@@ -63,6 +63,14 @@ func (d *ResourceData) GetInt64OrDefault(key string, def int64) int64 {
 	return def
 }
 
+func (d *ResourceData) GetBoolOrDefault(key string, def bool) bool {
+	if d.RawValues.Get(key).Exists() {
+		return d.RawValues.Get(key).Bool()
+	}
+
+	return def
+}
+
 // Return true if the key doesn't exist, is null, or is an empty string.
 // Needed because gjson.Exists returns true as long as a key exists, even if it's empty or null.
 func (d *ResourceData) IsEmpty(key string) bool {


### PR DESCRIPTION
* add top provider region information to HCL output so that prices reflect both top level provider and aliased providers
* remove "count" attribute from output which was causing duplication of prices
* add defaults to a number of resources so that the HCL output is in line with what the Terraform schema displays in docs.
* changes the method for azure `location` retrieval to format the strings as they are returned from the azure provider
---

With these changes only one test is failing across all the provider golden files (`aws_autoscaling_group`) 🍾 