### PR TITLE
chore: Generate share links for comment command

### DIFF
--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/output"
+	"github.com/infracost/infracost/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +36,7 @@ func commentCmd(ctx *config.RunContext) *cobra.Command {
 	return cmd
 }
 
-func buildCommentBody(ctx *config.RunContext, paths []string, mdOpts output.MarkdownOptions) ([]byte, error) {
+func buildCommentBody(cmd *cobra.Command, ctx *config.RunContext, paths []string, mdOpts output.MarkdownOptions) ([]byte, error) {
 	inputs, err := output.LoadPaths(paths)
 	if err != nil {
 		return nil, err
@@ -46,6 +47,15 @@ func buildCommentBody(ctx *config.RunContext, paths []string, mdOpts output.Mark
 		return nil, err
 	}
 	combined.IsCIRun = ctx.IsCIRun()
+
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	if ctx.Config.EnableDashboard && !dryRun {
+		if ctx.Config.IsSelfHosted() {
+			ui.PrintWarning(cmd.ErrOrStderr(), "The dashboard is part of Infracost's hosted services. Contact hello@infracost.io for help.")
+		}
+
+		combined.RunID, combined.ShareURL = shareCombinedRun(ctx, combined, inputs)
+	}
 
 	opts := output.Options{
 		DashboardEnabled: ctx.Config.EnableDashboard,

--- a/cmd/infracost/comment_azure_repos.go
+++ b/cmd/infracost/comment_azure_repos.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/infracost/infracost/internal/apiclient"
 	"github.com/infracost/infracost/internal/comment"
 	"github.com/infracost/infracost/internal/config"
@@ -9,8 +12,6 @@ import (
 	"github.com/infracost/infracost/internal/ui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"strconv"
-	"strings"
 )
 
 var validCommentAzureReposBehaviors = []string{"update", "new", "delete-and-new"}
@@ -61,7 +62,7 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 
 			paths, _ := cmd.Flags().GetStringArray("path")
 
-			body, err := buildCommentBody(ctx, paths, output.MarkdownOptions{
+			body, err := buildCommentBody(cmd, ctx, paths, output.MarkdownOptions{
 				WillUpdate:          prNumber != 0 && behavior == "update",
 				WillReplace:         prNumber != 0 && behavior == "delete-and-new",
 				IncludeFeedbackLink: true,

--- a/cmd/infracost/comment_github.go
+++ b/cmd/infracost/comment_github.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/infracost/infracost/internal/apiclient"
 	"github.com/infracost/infracost/internal/comment"
 	"github.com/infracost/infracost/internal/config"
@@ -9,8 +12,6 @@ import (
 	"github.com/infracost/infracost/internal/ui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"strconv"
-	"strings"
 )
 
 var validCommentGitHubBehaviors = []string{"update", "new", "hide-and-new", "delete-and-new"}
@@ -75,7 +76,7 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 
 			paths, _ := cmd.Flags().GetStringArray("path")
 
-			body, err := buildCommentBody(ctx, paths, output.MarkdownOptions{
+			body, err := buildCommentBody(cmd, ctx, paths, output.MarkdownOptions{
 				WillUpdate:          prNumber != 0 && behavior == "update",
 				WillReplace:         prNumber != 0 && behavior == "delete-and-new",
 				IncludeFeedbackLink: true,

--- a/cmd/infracost/comment_gitlab.go
+++ b/cmd/infracost/comment_gitlab.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/infracost/infracost/internal/apiclient"
 	"github.com/infracost/infracost/internal/comment"
 	"github.com/infracost/infracost/internal/config"
@@ -9,8 +12,6 @@ import (
 	"github.com/infracost/infracost/internal/ui"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"strconv"
-	"strings"
 )
 
 var validCommentGitLabBehaviors = []string{"update", "new", "delete-and-new"}
@@ -75,7 +76,7 @@ func commentGitLabCmd(ctx *config.RunContext) *cobra.Command {
 
 			paths, _ := cmd.Flags().GetStringArray("path")
 
-			body, err := buildCommentBody(ctx, paths, output.MarkdownOptions{
+			body, err := buildCommentBody(cmd, ctx, paths, output.MarkdownOptions{
 				WillUpdate:          mrNumber != 0 && behavior == "update",
 				WillReplace:         mrNumber != 0 && behavior == "delete-and-new",
 				IncludeFeedbackLink: true,

--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -109,7 +109,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 					ui.PrintWarning(cmd.ErrOrStderr(), "The dashboard is part of Infracost's hosted services. Contact hello@infracost.io for help.")
 				}
 
-				combined.RunID, combined.ShareURL = shareRun(ctx, combined, inputs)
+				combined.RunID, combined.ShareURL = shareCombinedRun(ctx, combined, inputs)
 			}
 
 			var b []byte
@@ -169,7 +169,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 	return cmd
 }
 
-func shareRun(ctx *config.RunContext, combined output.Root, inputs []output.ReportInput) (string, string) {
+func shareCombinedRun(ctx *config.RunContext, combined output.Root, inputs []output.ReportInput) (string, string) {
 	if len(inputs) == 1 && inputs[0].Root.RunID != "" {
 		result := inputs[0].Root
 		return result.RunID, result.ShareURL


### PR DESCRIPTION
If Dashboard support is enabled the `comment` command will combine the
provided reports and send them to Infracost Dashboard similar to
`output` command's behavior.