### PR TITLE
chore: change register prompts

### DIFF
--- a/cmd/infracost/register.go
+++ b/cmd/infracost/register.go
@@ -43,8 +43,10 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 
 					if ciInterest {
 						fmt.Println("Add cost estimates to your pull requests: " + ui.LinkString("https://infracost.io/cicd"))
+						return nil
 					}
 
+					fmt.Printf("You can now run %s and point to your Terraform directory or JSON plan file.\n", ui.PrimaryString("infracost breakdown --path=..."))
 					return nil
 				}
 

--- a/cmd/infracost/register.go
+++ b/cmd/infracost/register.go
@@ -110,7 +110,7 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 						"Setting the INFRACOST_API_KEY environment variable overrides the key from credentials.yml.",
 						"You can now run",
 						ui.PrimaryString("infracost breakdown --path=..."),
-						"and point to your Terraform directory or JSON plan file.\n",
+						"and point to your Terraform directory or plan JSON file.\n",
 					)
 
 					return nil
@@ -127,7 +127,7 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 
 			fmt.Printf("This was saved to %s\n\n", config.CredentialsFilePath())
 			if ciInterest {
-				fmt.Printf("You can now add cost estimates to your pull requests: %s\n", ui.LinkStringf("https://infracost.io/cicd"))
+				fmt.Printf("You can now add cost estimates to your pull requests: %s\n", ui.LinkString("https://infracost.io/cicd"))
 				return nil
 			}
 

--- a/cmd/infracost/register.go
+++ b/cmd/infracost/register.go
@@ -22,6 +22,7 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 		Long:  "Register for a free Infracost API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var isRegenerate bool
+			var ciInterest bool
 
 			if ctx.Config.Credentials.APIKey != "" {
 
@@ -47,6 +48,12 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 					return nil
 				}
 
+				ciInterest, err = promptForCIDocs(isRegenerate)
+				if err != nil {
+					// user cancelled
+					return nil
+				}
+
 				fmt.Println()
 			}
 
@@ -65,10 +72,13 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 				return nil
 			}
 
-			ciInterest, err := promptForCIDocs(isRegenerate)
-			if err != nil {
-				// user cancelled
-				return nil
+			// prompt for the ci docs after user email,name only if not regenerating
+			if !isRegenerate {
+				ciInterest, err = promptForCIDocs(isRegenerate)
+				if err != nil {
+					// user cancelled
+					return nil
+				}
 			}
 
 			d := apiclient.NewDashboardAPIClient(ctx)
@@ -84,7 +94,7 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 				return nil
 			}
 
-			fmt.Printf("\nThank you %s! Your API key is: %s\n", name, r.APIKey)
+			fmt.Printf("\nThanks %s! Your API key is: %s\n", name, r.APIKey)
 
 			if isRegenerate {
 				fmt.Println()

--- a/cmd/infracost/register.go
+++ b/cmd/infracost/register.go
@@ -21,8 +21,6 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 		Short: "Register for a free Infracost API key",
 		Long:  "Register for a free Infracost API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			var msg string
 			var isRegenerate bool
 
 			if ctx.Config.Credentials.APIKey != "" {
@@ -86,7 +84,7 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 				return nil
 			}
 
-			fmt.Printf("\nThank you %s!\nYour API key is: %s\n", name, r.APIKey)
+			fmt.Printf("\nThank you %s! Your API key is: %s\n", name, r.APIKey)
 
 			if isRegenerate {
 				fmt.Println()
@@ -96,15 +94,13 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 				}
 
 				if !confirm {
-					msg = fmt.Sprintf("%s\n%s %s %s",
+					fmt.Printf("%s\n%s %s %s",
 						"Setting the INFRACOST_API_KEY environment variable overrides the key from credentials.yml.",
 						"You can now run",
 						ui.PrimaryString("infracost breakdown --path=..."),
-						"and point to your Terraform directory or JSON/plan file.",
+						"and point to your Terraform directory or JSON plan file.\n",
 					)
 
-					fmt.Println("")
-					ui.PrintSuccess(cmd.ErrOrStderr(), msg)
 					return nil
 				}
 			}
@@ -117,16 +113,18 @@ func registerCmd(ctx *config.RunContext) *cobra.Command {
 				return err
 			}
 
-			msg = fmt.Sprintf("Your API key has been saved to %s\n\n", config.CredentialsFilePath())
+			fmt.Printf("This was saved to %s\n\n", config.CredentialsFilePath())
 			if ciInterest {
-				msg += fmt.Sprintf("You can now add cost estimates to your pull requests: %s", ui.LinkStringf("https://infracost.io/cicd"))
-			} else {
-				msg += fmt.Sprintf("You can now run %s and point to your Terraform directory or JSON/plan file.", ui.PrimaryString("infracost breakdown --path=..."))
+				fmt.Printf("You can now add cost estimates to your pull requests: %s\n", ui.LinkStringf("https://infracost.io/cicd"))
+				return nil
 			}
 
-			fmt.Println("")
-			ui.PrintSuccess(cmd.ErrOrStderr(), msg)
+			if isRegenerate {
+				fmt.Printf("You can now run %s and point to your Terraform directory or JSON plan file.\n", ui.PrimaryString("infracost breakdown --path=..."))
+				return nil
+			}
 
+			fmt.Printf("You can now run %s to see how to use the CLI\n", ui.PrimaryString("infracost breakdown --help"))
 			return nil
 		},
 	}

--- a/internal/apiclient/dashboard.go
+++ b/internal/apiclient/dashboard.go
@@ -55,8 +55,8 @@ func NewDashboardAPIClient(ctx *config.RunContext) *DashboardAPIClient {
 	}
 }
 
-func (c *DashboardAPIClient) CreateAPIKey(name string, email string) (CreateAPIKeyResponse, error) {
-	d := map[string]string{"name": name, "email": email}
+func (c *DashboardAPIClient) CreateAPIKey(name string, email string, ciInterest bool) (CreateAPIKeyResponse, error) {
+	d := map[string]interface{}{"name": name, "email": email, "ci": ciInterest}
 	respBody, err := c.doRequest("POST", "/apiKeys?source=cli-register", d)
 	if err != nil {
 		return CreateAPIKeyResponse{}, err


### PR DESCRIPTION
Adds extra step in register for both regenerating and new users:

**First time registering - answers Y**
![Screenshot 2022-02-07 at 15 19 16](https://user-images.githubusercontent.com/6455139/152817078-90ad92cc-1567-4c1f-937d-e78f32f6f079.png)



**First time registering  - answers N**
![Screenshot 2022-02-07 at 15 19 40](https://user-images.githubusercontent.com/6455139/152817094-7448a88f-56d1-4b8c-a14f-9748ad2a7478.png)


**Reregistering, says Y to API key then answers Y to docs**
![Screenshot 2022-02-07 at 15 18 51](https://user-images.githubusercontent.com/6455139/152817053-7aa26c39-a031-4d7f-a0e5-51c86cbcb556.png)

**Reregistering, says N to API key then answers Y to docs**
![Screenshot 2022-02-04 at 16 11 43](https://user-images.githubusercontent.com/6455139/152565684-d805eb51-2793-4ba5-93de-051e9ee7917f.png)

