### PR TITLE
feat: add sha checksum to binaries

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,12 +30,8 @@ jobs:
           RELEASE_NAME_PREFIX: "Release "
         with:
           args: |
-            ./build/infracost-linux-amd64.tar.gz
-            ./build/infracost-linux-arm64.tar.gz
-            ./build/infracost-windows-amd64.tar.gz
-            ./build/infracost-windows-arm64.tar.gz
-            ./build/infracost-darwin-amd64.tar.gz
-            ./build/infracost-darwin-arm64.tar.gz
+            ./build/*.tar.gz
+            ./build/*.sha256
             ./docs/generated/docs.tar.gz
 
       - name: Set up Docker Buildx

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,12 @@ install:
 	CGO_ENABLED=0 go install $(BUILD_FLAGS) $(PKG)
 
 release: build_all
-	cd build; tar -czf $(BINARY)-windows-amd64.tar.gz $(BINARY).exe
-	cd build; tar -czf $(BINARY)-windows-arm64.tar.gz $(BINARY)-arm64.exe
-	cd build; tar -czf $(BINARY)-linux-amd64.tar.gz $(BINARY)-linux-amd64
-	cd build; tar -czf $(BINARY)-linux-arm64.tar.gz $(BINARY)-linux-arm64
-	cd build; tar -czf $(BINARY)-darwin-amd64.tar.gz $(BINARY)-darwin-amd64
-	cd build; tar -czf $(BINARY)-darwin-arm64.tar.gz $(BINARY)-darwin-arm64
+	cd build; tar -czf $(BINARY)-windows-amd64.tar.gz $(BINARY).exe; shasum -a 256 $(BINARY)-windows-amd64.tar.gz > $(BINARY)-windows-amd64.tar.gz.sha256
+	cd build; tar -czf $(BINARY)-windows-arm64.tar.gz $(BINARY)-arm64.exe; shasum -a 256 $(BINARY)-windows-arm64.tar.gz > $(BINARY)-windows-arm64.tar.gz.sha256
+	cd build; tar -czf $(BINARY)-linux-amd64.tar.gz $(BINARY)-linux-amd64; shasum -a 256 $(BINARY)-linux-amd64.tar.gz > $(BINARY)-linux-amd64.tar.gz.sha256
+	cd build; tar -czf $(BINARY)-linux-arm64.tar.gz $(BINARY)-linux-arm64; shasum -a 256 $(BINARY)-linux-arm64.tar.gz > $(BINARY)-linux-arm64.tar.gz.sha256
+	cd build; tar -czf $(BINARY)-darwin-amd64.tar.gz $(BINARY)-darwin-amd64; shasum -a 256 $(BINARY)-darwin-amd64.tar.gz > $(BINARY)-darwin-amd64.tar.gz.sha256
+	cd build; tar -czf $(BINARY)-darwin-arm64.tar.gz $(BINARY)-darwin-arm64; shasum -a 256 $(BINARY)-darwin-arm64.tar.gz > $(BINARY)-darwin-arm64.tar.gz.sha256
 
 clean:
 	go clean

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,10 +4,39 @@ set -e
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 arch=$(uname -m | tr '[:upper:]' '[:lower:]' | sed -e s/x86_64/amd64/)
+if [ "$arch" = "aarch64" ]; then
+  arch="arm64"
+fi
+
+url="https://infracost.io/downloads/latest"
+tar="infracost-$os-$arch.tar.gz"
 echo "Downloading latest release of infracost-$os-$arch..."
-curl -sL https://github.com/infracost/infracost/releases/latest/download/infracost-$os-$arch.tar.gz | tar xz -C /tmp
+curl -sL $url/$tar -o /tmp/$tar
+echo
+
+code=$(curl -s -L -o /dev/null -w "%{http_code}" $url/$tar.sha256)
+if [ "$code" = "404" ]; then
+  echo "Checksum for infracost-$os-$arch release not found, skipping checksum validation"
+else
+  if [ -x "$(command -v shasum)" ]; then
+    echo "Validating checksum for infracost-$os-$arch..."
+    curl -sL $url/$tar.sha256 -o /tmp/$tar.sha256
+    (cd /tmp/;shasum -sqc $tar.sha256)
+    rm /tmp/$tar.sha256
+  else
+    echo "The shasum command could not be found, skipping checksum validation"
+  fi
+fi
+
+tar xzf /tmp/$tar -C /tmp
+rm /tmp/$tar
+
 echo
 echo "Moving /tmp/infracost-$os-$arch to /usr/local/bin/infracost (you might be asked for your password due to sudo)"
-sudo mv /tmp/infracost-$os-$arch /usr/local/bin/infracost
+if [ -x "$(command -v sudo)" ]; then
+  sudo mv /tmp/infracost-$os-$arch /usr/local/bin/infracost
+else
+  mv /tmp/infracost-$os-$arch /usr/local/bin/infracost
+fi
 echo
 echo "Completed installing $(infracost --version)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,23 +26,29 @@ curl -sL "$url/$tar" -o "/tmp/$tar"
 echo
 
 code=$(curl -s -L -o /dev/null -w "%{http_code}" "$url/$tar.sha256")
-if [ "$code" != "404" ]; then
+if [ "$code" = "404" ]; then
+    echo "Skipping checksum validation as the sha for the release could not be found, no action needed."
+else
   if [ -x "$(command -v shasum)" ]; then
     echo "Validating checksum for infracost-$os-$arch..."
     curl -sL "$url/$tar.sha256" -o "/tmp/$tar.sha256"
 
     if ! check_sha "$tar.sha256"; then
       echo
-      echo "Installation checksum failed! This could be a security issue so please email hello@infracost.io for help."
-      exit 1
+      read -r -p "Installation checksum failed. This could be a security issue. Would you like to continue? (y/n) " answer
+      if [ "$answer" != "y" ]; then
+        echo
+        echo "Exiting, please email hello@infracost.io for help."
+        exit 1
+      fi
     fi
 
     rm "/tmp/$tar.sha256"
   else
     echo "Skipping checksum validation as the shasum command could not be found, no action needed."
   fi
-  echo
 fi
+echo
 
 tar xzf "/tmp/$tar" -C /tmp
 rm "/tmp/$tar"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,17 @@
 # This script is used in the README and https://www.infracost.io/docs/#quick-start
 set -e
 
+# check_sha is separated into a defined function so that we can
+# capture the exit code effectively with `set -e` enabled
+check_sha() {
+  (
+    cd /tmp/
+    shasum -sc "$1"
+  )
+
+  return $?
+}
+
 os=$(uname | tr '[:upper:]' '[:lower:]')
 arch=$(uname -m | tr '[:upper:]' '[:lower:]' | sed -e s/x86_64/amd64/)
 if [ "$arch" = "aarch64" ]; then
@@ -11,32 +22,36 @@ fi
 url="https://infracost.io/downloads/latest"
 tar="infracost-$os-$arch.tar.gz"
 echo "Downloading latest release of infracost-$os-$arch..."
-curl -sL $url/$tar -o /tmp/$tar
+curl -sL "$url/$tar" -o "/tmp/$tar"
 echo
 
-code=$(curl -s -L -o /dev/null -w "%{http_code}" $url/$tar.sha256)
-if [ "$code" = "404" ]; then
-  echo "Checksum for infracost-$os-$arch release not found, skipping checksum validation"
-else
+code=$(curl -s -L -o /dev/null -w "%{http_code}" "$url/$tar.sha256")
+if [ "$code" != "404" ]; then
   if [ -x "$(command -v shasum)" ]; then
     echo "Validating checksum for infracost-$os-$arch..."
-    curl -sL $url/$tar.sha256 -o /tmp/$tar.sha256
-    (cd /tmp/;shasum -sqc $tar.sha256)
-    rm /tmp/$tar.sha256
+    curl -sL "$url/$tar.sha256" -o "/tmp/$tar.sha256"
+
+    if ! check_sha "$tar.sha256"; then
+      echo
+      echo "Installation checksum failed! This could be a security issue so please email hello@infracost.io for help."
+      exit 1
+    fi
+
+    rm "/tmp/$tar.sha256"
   else
-    echo "The shasum command could not be found, skipping checksum validation"
+    echo "Skipping checksum validation as the shasum command could not be found, no action needed."
   fi
+  echo
 fi
 
-tar xzf /tmp/$tar -C /tmp
-rm /tmp/$tar
+tar xzf "/tmp/$tar" -C /tmp
+rm "/tmp/$tar"
 
-echo
 echo "Moving /tmp/infracost-$os-$arch to /usr/local/bin/infracost (you might be asked for your password due to sudo)"
 if [ -x "$(command -v sudo)" ]; then
-  sudo mv /tmp/infracost-$os-$arch /usr/local/bin/infracost
+  sudo mv "/tmp/infracost-$os-$arch" "/usr/local/bin/infracost"
 else
-  mv /tmp/infracost-$os-$arch /usr/local/bin/infracost
+  mv "/tmp/infracost-$os-$arch" "/usr/local/bin/infracost"
 fi
 echo
 echo "Completed installing $(infracost --version)"


### PR DESCRIPTION
Adds checksums to release artefacts.

![Screenshot 2022-02-08 at 14 14 04](https://user-images.githubusercontent.com/6455139/153004613-929393da-a004-4a61-be98-8a05b4119848.png)

We then recommend users check these as part of install process, as outlined here: https://github.com/infracost/docs/pull/161