### PR TITLE
feat: add azure log analytics workspace

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -779,9 +779,9 @@ resource_usage:
     monthly_inbound_data_transfer_gb: 1000 # Monthly inbound data transfer in GB
 
   azurerm_log_analytics_workspace.my_workspace:
-    monthly_log_data_ingestion_gb: 20 # Monthly log data ingested by the workspace in GB (only used for Pay-as-you-go workspaces).
-    monthly_additional_log_data_retention_gb: 30 # Monthly additional days of data retention that the workspace uses over the free allowance.
-    monthly_log_data_export_gb: 40 # Monthly data in GB exported from the workspace.
+    monthly_log_data_ingestion_gb: 20            # Monthly log data ingested by the workspace in GB (only used for Pay-as-you-go workspaces).
+    monthly_additional_log_data_retention_gb: 30 # Monthly additional GB of data retained past the free allowance.
+    monthly_log_data_export_gb: 40               # Monthly data in GB exported from the workspace.
 
   azurerm_frontdoor_firewall_policy.my_frontdoor_firewall_policy:
     monthly_custom_rule_requests: 11000     # Monthly number of custom rule requests

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -778,6 +778,11 @@ resource_usage:
       india: 387000                        # India
     monthly_inbound_data_transfer_gb: 1000 # Monthly inbound data transfer in GB
 
+  azurerm_log_analytics_workspace.my_workspace:
+    monthly_log_data_ingestion_gb: 20 # Monthly log data ingested by the workspace in GB (only used for Pay-as-you-go workspaces).
+    monthly_additional_log_data_retention_gb: 30 # Monthly additional days of data retention that the workspace uses over the free allowance.
+    monthly_log_data_export_gb: 40 # Monthly data in GB exported from the workspace.
+
   azurerm_frontdoor_firewall_policy.my_frontdoor_firewall_policy:
     monthly_custom_rule_requests: 11000     # Monthly number of custom rule requests
     monthly_managed_ruleset_requests: 10000 # Monthly number of managed ruleset requests

--- a/internal/providers/terraform/azure/log_analytics_workspace.go
+++ b/internal/providers/terraform/azure/log_analytics_workspace.go
@@ -1,0 +1,42 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getAzureRMLogAnalyticsWorkspaceRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_log_analytics_workspace",
+		RFunc: newLogAnalyticsWorkspace,
+		ReferenceAttributes: []string{
+			"resource_group_name",
+		},
+	}
+}
+
+func newLogAnalyticsWorkspace(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := lookupRegion(d, []string{"resource_group_name"})
+	sku := "PerGB2018"
+	if !d.IsEmpty("sku") {
+		sku = d.Get("sku").String()
+	}
+
+	// this attribute typo was fixed in https://github.com/hashicorp/terraform-provider-azurerm/pull/14910
+	// but we need to support the typo for backwards compatibility
+	capacity := d.Get("reservation_capcity_in_gb_per_day").Int()
+	if !d.IsEmpty("reservation_capacity_in_gb_per_day") {
+		capacity = d.Get("reservation_capacity_in_gb_per_day").Int()
+	}
+
+	r := &azure.LogAnalyticsWorkspace{
+		Address:                       d.Address,
+		Region:                        region,
+		SKU:                           sku,
+		ReservationCapacityInGBPerDay: capacity,
+		RetentionInDays:               d.Get("retention_in_days").Int(),
+	}
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/azure/log_analytics_workspace.go
+++ b/internal/providers/terraform/azure/log_analytics_workspace.go
@@ -22,11 +22,11 @@ func newLogAnalyticsWorkspace(d *schema.ResourceData, u *schema.UsageData) *sche
 		sku = d.Get("sku").String()
 	}
 
+	capacity := d.Get("reservation_capacity_in_gb_per_day").Int()
 	// this attribute typo was fixed in https://github.com/hashicorp/terraform-provider-azurerm/pull/14910
 	// but we need to support the typo for backwards compatibility
-	capacity := d.Get("reservation_capcity_in_gb_per_day").Int()
-	if !d.IsEmpty("reservation_capacity_in_gb_per_day") {
-		capacity = d.Get("reservation_capacity_in_gb_per_day").Int()
+	if !d.IsEmpty("reservation_capcity_in_gb_per_day") {
+		capacity = d.Get("reservation_capcity_in_gb_per_day").Int()
 	}
 
 	r := &azure.LogAnalyticsWorkspace{

--- a/internal/providers/terraform/azure/log_analytics_workspace_test.go
+++ b/internal/providers/terraform/azure/log_analytics_workspace_test.go
@@ -1,0 +1,17 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestLogAnalyticsWorkspaceGoldenFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "log_analytics_workspace_test", &tftest.GoldenFileOptions{
+		CaptureLogs: true,
+	})
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -67,6 +67,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMLoadBalancerOutboundRuleRegistryItem(),
 	GetAzureRMLinuxVirtualMachineRegistryItem(),
 	GetAzureRMLinuxVirtualMachineScaleSetRegistryItem(),
+	getAzureRMLogAnalyticsWorkspaceRegistryItem(),
 	GetAzureRMManagedDiskRegistryItem(),
 	GetAzureRMMariaDBServerRegistryItem(),
 	getAzureRMMSSQLDatabaseRegistryItem(),
@@ -244,6 +245,17 @@ var FreeResources = []string{
 	"azurerm_lb_nat_pool",
 	"azurerm_lb_nat_rule",
 	"azurerm_lb_probe",
+
+	// Azure Log Analytics
+	"azurerm_log_analytics_cluster_customer_managed_key",
+	"azurerm_log_analytics_data_export_rule",
+	"azurerm_log_analytics_datasource_windows_event",
+	"azurerm_log_analytics_datasource_windows_performance_counter",
+	"azurerm_log_analytics_linked_service",
+	"azurerm_log_analytics_linked_storage_account",
+	"azurerm_log_analytics_saved_search",
+	"azurerm_log_analytics_solution",
+	"azurerm_log_analytics_storage_insights",
 
 	// Azure Management
 	"azurerm_management_group",

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
@@ -1,0 +1,35 @@
+
+ Name                                                             Monthly Qty  Unit              Monthly Cost 
+                                                                                                              
+ azurerm_log_analytics_workspace.capacity_gb_data_ingestion                                                   
+ └─ Log data ingestion                                                     30  100 GB (per day)     $7,585.20 
+                                                                                                              
+ azurerm_log_analytics_workspace.capacity_typo_gb_data_ingestion                                              
+ └─ Log data ingestion                                                     30  100 GB (per day)     $7,585.20 
+                                                                                                              
+ azurerm_log_analytics_workspace.log_data_export                                                              
+ └─ Log data export                                                        40  GB                       $5.20 
+                                                                                                              
+ azurerm_log_analytics_workspace.log_data_retention_with_usage                                                
+ └─ Log data retention                                                     30  GB                       $3.90 
+                                                                                                              
+ azurerm_log_analytics_workspace.per_gb_data_ingestion                                                        
+ └─ Log data ingestion                                                     20  GB                      $59.80 
+                                                                                                              
+ OVERALL TOTAL                                                                                     $15,239.30 
+──────────────────────────────────
+13 cloud resources were detected:
+∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file
+∙ 4 weren't estimated, report them in https://github.com/infracost/infracost:
+  ∙ 4 x azurerm_log_analytics_workspace
+∙ 2 were free:
+  ∙ 1 x azurerm_log_analytics_workspace
+  ∙ 1 x azurerm_resource_group
+
+Add cost estimates to your pull requests: https://infracost.io/cicd
+Logs:
+
+level=warning msg="skipping azurerm_log_analytics_workspace.unsupported_legacy_workspace[\"PerNode\"] as it uses legacy pricing options"
+level=warning msg="skipping azurerm_log_analytics_workspace.unsupported_legacy_workspace[\"Premium\"] as it uses legacy pricing options"
+level=warning msg="skipping azurerm_log_analytics_workspace.unsupported_legacy_workspace[\"Standard\"] as it uses legacy pricing options"
+level=warning msg="skipping azurerm_log_analytics_workspace.unsupported_legacy_workspace[\"Unlimited\"] as it uses legacy pricing options"

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
@@ -1,22 +1,27 @@
 
- Name                                                             Monthly Qty  Unit              Monthly Cost 
-                                                                                                              
- azurerm_log_analytics_workspace.capacity_gb_data_ingestion                                                   
- └─ Log data ingestion                                                     30  100 GB (per day)     $7,585.20 
-                                                                                                              
- azurerm_log_analytics_workspace.capacity_typo_gb_data_ingestion                                              
- └─ Log data ingestion                                                     30  100 GB (per day)     $7,585.20 
-                                                                                                              
- azurerm_log_analytics_workspace.log_data_export                                                              
- └─ Log data export                                                        40  GB                       $5.20 
-                                                                                                              
- azurerm_log_analytics_workspace.log_data_retention_with_usage                                                
- └─ Log data retention                                                     30  GB                       $3.90 
-                                                                                                              
- azurerm_log_analytics_workspace.per_gb_data_ingestion                                                        
- └─ Log data ingestion                                                     20  GB                      $59.80 
-                                                                                                              
- OVERALL TOTAL                                                                                     $15,239.30 
+ Name                                                               Monthly Qty  Unit               Monthly Cost 
+                                                                                                                 
+ azurerm_log_analytics_workspace.capacity_gb_data_ingestion                                                      
+ └─ Log data ingestion                                                       30  100 GB (per day)      $7,585.20 
+                                                                                                                 
+ azurerm_log_analytics_workspace.capacity_typo_gb_data_ingestion                                                 
+ └─ Log data ingestion                                                       30  100 GB (per day)      $7,585.20 
+                                                                                                                 
+ azurerm_log_analytics_workspace.log_data_export                                                                 
+ ├─ Log data ingestion                                            Monthly cost depends on usage: $2.99 per GB    
+ └─ Log data export                                                          40  GB                        $5.20 
+                                                                                                                 
+ azurerm_log_analytics_workspace.log_data_retention_free                                                         
+ └─ Log data ingestion                                            Monthly cost depends on usage: $2.99 per GB    
+                                                                                                                 
+ azurerm_log_analytics_workspace.log_data_retention_with_usage                                                   
+ ├─ Log data ingestion                                            Monthly cost depends on usage: $2.99 per GB    
+ └─ Log data retention                                                       30  GB                        $3.90 
+                                                                                                                 
+ azurerm_log_analytics_workspace.per_gb_data_ingestion                                                           
+ └─ Log data ingestion                                                       20  GB                       $59.80 
+                                                                                                                 
+ OVERALL TOTAL                                                                                        $15,239.30 
 ──────────────────────────────────
 13 cloud resources were detected:
 ∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
@@ -1,27 +1,35 @@
 
- Name                                                               Monthly Qty  Unit               Monthly Cost 
-                                                                                                                 
- azurerm_log_analytics_workspace.capacity_gb_data_ingestion                                                      
- └─ Log data ingestion                                                       30  100 GB (per day)      $7,585.20 
-                                                                                                                 
- azurerm_log_analytics_workspace.capacity_typo_gb_data_ingestion                                                 
- └─ Log data ingestion                                                       30  100 GB (per day)      $7,585.20 
-                                                                                                                 
- azurerm_log_analytics_workspace.log_data_export                                                                 
- ├─ Log data ingestion                                            Monthly cost depends on usage: $2.99 per GB    
- └─ Log data export                                                          40  GB                        $5.20 
-                                                                                                                 
- azurerm_log_analytics_workspace.log_data_retention_free                                                         
- └─ Log data ingestion                                            Monthly cost depends on usage: $2.99 per GB    
-                                                                                                                 
- azurerm_log_analytics_workspace.log_data_retention_with_usage                                                   
- ├─ Log data ingestion                                            Monthly cost depends on usage: $2.99 per GB    
- └─ Log data retention                                                       30  GB                        $3.90 
-                                                                                                                 
- azurerm_log_analytics_workspace.per_gb_data_ingestion                                                           
- └─ Log data ingestion                                                       20  GB                       $59.80 
-                                                                                                                 
- OVERALL TOTAL                                                                                        $15,239.30 
+ Name                                                                                Monthly Qty  Unit               Monthly Cost 
+                                                                                                                                  
+ azurerm_log_analytics_workspace.capacity_gb_data_ingestion                                                                       
+ ├─ Log data ingestion                                                                        30  100 GB (per day)      $7,585.20 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
+                                                                                                                                  
+ azurerm_log_analytics_workspace.capacity_gb_data_ingestion_without_specification                                                 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
+                                                                                                                                  
+ azurerm_log_analytics_workspace.capacity_typo_gb_data_ingestion                                                                  
+ ├─ Log data ingestion                                                                        30  100 GB (per day)      $7,585.20 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
+                                                                                                                                  
+ azurerm_log_analytics_workspace.log_data_export                                                                                  
+ ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB    
+ └─ Log data export                                                                           40  GB                        $5.20 
+                                                                                                                                  
+ azurerm_log_analytics_workspace.log_data_retention_free                                                                          
+ ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB    
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
+                                                                                                                                  
+ azurerm_log_analytics_workspace.log_data_retention_with_usage                                                                    
+ ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB    
+ ├─ Log data retention                                                                        30  GB                        $3.90 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
+                                                                                                                                  
+ azurerm_log_analytics_workspace.per_gb_data_ingestion                                                                            
+ ├─ Log data ingestion                                                                        20  GB                       $59.80 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
+                                                                                                                                  
+ OVERALL TOTAL                                                                                                         $15,239.30 
 ──────────────────────────────────
 13 cloud resources were detected:
 ∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
@@ -25,14 +25,19 @@
  ├─ Log data retention                                                                        30  GB                        $3.90 
  └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
                                                                                                                                   
+ azurerm_log_analytics_workspace.log_data_retention_without_usage                                                                 
+ ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB    
+ ├─ Log data retention                                                             Monthly cost depends on usage: $0.13 per GB    
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
+                                                                                                                                  
  azurerm_log_analytics_workspace.per_gb_data_ingestion                                                                            
  ├─ Log data ingestion                                                                        20  GB                       $59.80 
  └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
                                                                                                                                   
  OVERALL TOTAL                                                                                                         $15,239.30 
 ──────────────────────────────────
-13 cloud resources were detected:
-∙ 7 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file
+14 cloud resources were detected:
+∙ 8 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 weren't estimated, report them in https://github.com/infracost/infracost:
   ∙ 4 x azurerm_log_analytics_workspace
 ∙ 2 were free:

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
@@ -1,43 +1,47 @@
 
- Name                                                                                Monthly Qty  Unit               Monthly Cost 
-                                                                                                                                  
- azurerm_log_analytics_workspace.capacity_gb_data_ingestion                                                                       
- ├─ Log data ingestion                                                                        30  100 GB (per day)      $7,585.20 
- └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
-                                                                                                                                  
- azurerm_log_analytics_workspace.capacity_gb_data_ingestion_without_specification                                                 
- └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
-                                                                                                                                  
- azurerm_log_analytics_workspace.capacity_typo_gb_data_ingestion                                                                  
- ├─ Log data ingestion                                                                        30  100 GB (per day)      $7,585.20 
- └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
-                                                                                                                                  
- azurerm_log_analytics_workspace.log_data_export                                                                                  
- ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB    
- └─ Log data export                                                                           40  GB                        $5.20 
-                                                                                                                                  
- azurerm_log_analytics_workspace.log_data_retention_free                                                                          
- ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB    
- └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
-                                                                                                                                  
- azurerm_log_analytics_workspace.log_data_retention_with_usage                                                                    
- ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB    
- ├─ Log data retention                                                                        30  GB                        $3.90 
- └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
-                                                                                                                                  
- azurerm_log_analytics_workspace.log_data_retention_without_usage                                                                 
- ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB    
- ├─ Log data retention                                                             Monthly cost depends on usage: $0.13 per GB    
- └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
-                                                                                                                                  
- azurerm_log_analytics_workspace.per_gb_data_ingestion                                                                            
- ├─ Log data ingestion                                                                        20  GB                       $59.80 
- └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB    
-                                                                                                                                  
- OVERALL TOTAL                                                                                                         $15,239.30 
+ Name                                                                                Monthly Qty  Unit                Monthly Cost 
+                                                                                                                                   
+ azurerm_log_analytics_workspace.capacity_gb_data_above_commitment_tiers                                                           
+ ├─ Log data ingestion                                                                        30  1000 GB (per day)     $65,790.00 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB     
+                                                                                                                                   
+ azurerm_log_analytics_workspace.capacity_gb_data_ingestion                                                                        
+ ├─ Log data ingestion                                                                        30  100 GB (per day)       $7,585.20 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB     
+                                                                                                                                   
+ azurerm_log_analytics_workspace.capacity_gb_data_ingestion_without_specification                                                  
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB     
+                                                                                                                                   
+ azurerm_log_analytics_workspace.capacity_typo_gb_data_ingestion                                                                   
+ ├─ Log data ingestion                                                                        30  100 GB (per day)       $7,585.20 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB     
+                                                                                                                                   
+ azurerm_log_analytics_workspace.log_data_export                                                                                   
+ ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB     
+ └─ Log data export                                                                           40  GB                         $5.20 
+                                                                                                                                   
+ azurerm_log_analytics_workspace.log_data_retention_free                                                                           
+ ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB     
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB     
+                                                                                                                                   
+ azurerm_log_analytics_workspace.log_data_retention_with_usage                                                                     
+ ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB     
+ ├─ Log data retention                                                                        30  GB                         $3.90 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB     
+                                                                                                                                   
+ azurerm_log_analytics_workspace.log_data_retention_without_usage                                                                  
+ ├─ Log data ingestion                                                             Monthly cost depends on usage: $2.99 per GB     
+ ├─ Log data retention                                                             Monthly cost depends on usage: $0.13 per GB     
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB     
+                                                                                                                                   
+ azurerm_log_analytics_workspace.per_gb_data_ingestion                                                                             
+ ├─ Log data ingestion                                                                        20  GB                        $59.80 
+ └─ Log data export                                                                Monthly cost depends on usage: $0.13 per GB     
+                                                                                                                                   
+ OVERALL TOTAL                                                                                                          $81,029.30 
 ──────────────────────────────────
-14 cloud resources were detected:
-∙ 8 were estimated, 8 include usage-based costs, see https://infracost.io/usage-file
+15 cloud resources were detected:
+∙ 9 were estimated, 9 include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 weren't estimated, report them in https://github.com/infracost/infracost:
   ∙ 4 x azurerm_log_analytics_workspace
 ∙ 2 were free:

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
@@ -39,6 +39,16 @@ resource "azurerm_log_analytics_workspace" "capacity_typo_gb_data_ingestion" {
   reservation_capcity_in_gb_per_day = 100
 }
 
+resource "azurerm_log_analytics_workspace" "capacity_gb_data_above_commitment_tiers" {
+  name                              = "acctest-09"
+  location                          = azurerm_resource_group.example.location
+  resource_group_name               = azurerm_resource_group.example.name
+  sku                               = "CapacityReservation"
+  # this reservation capacity doesn't actually exist in the azure pricing page. It should appear in the golden file as
+  # 1000 gb a day commitment tier.
+  reservation_capacity_in_gb_per_day = 1200
+}
+
 resource "azurerm_log_analytics_workspace" "capacity_gb_data_ingestion_without_specification" {
   name                = "acctest-03"
   location            = azurerm_resource_group.example.location

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
@@ -31,19 +31,19 @@ resource "azurerm_log_analytics_workspace" "capacity_gb_data_ingestion" {
 }
 
 resource "azurerm_log_analytics_workspace" "capacity_typo_gb_data_ingestion" {
-  name                              = "acctest-03"
-  location                          = azurerm_resource_group.example.location
-  resource_group_name               = azurerm_resource_group.example.name
-  sku                               = "CapacityReservation"
+  name                = "acctest-03"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "CapacityReservation"
   # this typo is deliberate see: https://github.com/hashicorp/terraform-provider-azurerm/pull/14910 for more info
   reservation_capcity_in_gb_per_day = 100
 }
 
 resource "azurerm_log_analytics_workspace" "capacity_gb_data_above_commitment_tiers" {
-  name                              = "acctest-09"
-  location                          = azurerm_resource_group.example.location
-  resource_group_name               = azurerm_resource_group.example.name
-  sku                               = "CapacityReservation"
+  name                = "acctest-09"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "CapacityReservation"
   # this reservation capacity doesn't actually exist in the azure pricing page. It should appear in the golden file as
   # 1000 gb a day commitment tier.
   reservation_capacity_in_gb_per_day = 1200
@@ -89,7 +89,7 @@ resource "azurerm_log_analytics_workspace" "log_data_export" {
 
 
 resource "azurerm_log_analytics_workspace" "unsupported_legacy_workspace" {
-  for_each            = toset( ["Unlimited", "Standard", "Premium", "PerNode"] )
+  for_each            = toset(["Unlimited", "Standard", "Premium", "PerNode"])
   name                = "acctest-unsupported-${each.key}"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
@@ -62,6 +62,13 @@ resource "azurerm_log_analytics_workspace" "log_data_retention_with_usage" {
   retention_in_days   = 33
 }
 
+resource "azurerm_log_analytics_workspace" "log_data_retention_without_usage" {
+  name                = "acctest-08"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 33
+}
 
 resource "azurerm_log_analytics_workspace" "log_data_export" {
   name                = "acctest-06"

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
@@ -1,0 +1,81 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_log_analytics_workspace" "free_workspace" {
+  name                = "acctest-free"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "Free"
+}
+
+resource "azurerm_log_analytics_workspace" "per_gb_data_ingestion" {
+  name                = "acctest-01"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_workspace" "capacity_gb_data_ingestion" {
+  name                               = "acctest-02"
+  location                           = azurerm_resource_group.example.location
+  resource_group_name                = azurerm_resource_group.example.name
+  sku                                = "CapacityReservation"
+  reservation_capacity_in_gb_per_day = 100
+}
+
+resource "azurerm_log_analytics_workspace" "capacity_typo_gb_data_ingestion" {
+  name                              = "acctest-03"
+  location                          = azurerm_resource_group.example.location
+  resource_group_name               = azurerm_resource_group.example.name
+  sku                               = "CapacityReservation"
+  # this typo is deliberate see: https://github.com/hashicorp/terraform-provider-azurerm/pull/14910 for more info
+  reservation_capcity_in_gb_per_day = 100
+}
+
+resource "azurerm_log_analytics_workspace" "capacity_gb_data_ingestion_without_specification" {
+  name                = "acctest-03"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "CapacityReservation"
+}
+
+resource "azurerm_log_analytics_workspace" "log_data_retention_free" {
+  name                = "acctest-04"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_log_analytics_workspace" "log_data_retention_with_usage" {
+  name                = "acctest-05"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 33
+}
+
+
+resource "azurerm_log_analytics_workspace" "log_data_export" {
+  name                = "acctest-06"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+}
+
+
+resource "azurerm_log_analytics_workspace" "unsupported_legacy_workspace" {
+  for_each            = toset( ["Unlimited", "Standard", "Premium", "PerNode"] )
+  name                = "acctest-unsupported-${each.key}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = each.value
+}
+

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.usage.yml
@@ -1,0 +1,8 @@
+version: 0.1
+resource_usage:
+  azurerm_log_analytics_workspace.per_gb_data_ingestion:
+    monthly_log_data_ingestion_gb: 20
+  azurerm_log_analytics_workspace.log_data_retention_with_usage:
+    monthly_additional_log_data_retention_gb: 30
+  azurerm_log_analytics_workspace.log_data_export:
+    monthly_log_data_export_gb: 40

--- a/internal/resources/azure/log_analytics_workspace.go
+++ b/internal/resources/azure/log_analytics_workspace.go
@@ -186,11 +186,16 @@ func (r *LogAnalyticsWorkspace) logDataIngestion() *schema.CostComponent {
 }
 
 func (r *LogAnalyticsWorkspace) logDataRetention() *schema.CostComponent {
+	var quantity *decimal.Decimal
+	if r.MonthlyAdditionalLogDataRetentionGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.MonthlyAdditionalLogDataRetentionGB))
+	}
+
 	return &schema.CostComponent{
 		Name:            "Log data retention",
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
-		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyAdditionalLogDataRetentionGB)),
+		MonthlyQuantity: quantity,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr(vendorName),
 			Region:        strPtr(r.Region),

--- a/internal/resources/azure/log_analytics_workspace.go
+++ b/internal/resources/azure/log_analytics_workspace.go
@@ -171,7 +171,7 @@ func (r *LogAnalyticsWorkspace) logDataIngestionFromCapacityReservation() *schem
 		for i, tier := range commitmentTiers {
 			// if the current tier is the final valid commitment tier then
 			// set selectedTier as it can't be any other tier.
-			if len(commitmentTiers)-1 == i+1 {
+			if len(commitmentTiers)-1 == i {
 				selectedTier = tier
 				break
 			}

--- a/internal/resources/azure/log_analytics_workspace.go
+++ b/internal/resources/azure/log_analytics_workspace.go
@@ -53,8 +53,8 @@ type LogAnalyticsWorkspace struct {
 	RetentionInDays               int64
 
 	MonthlyLogDataIngestionGB           *float64 `infracost_usage:"monthly_log_data_ingestion_gb"`
-	MonthlyAdditionalLogDataRetentionDB *float64 `infracost_usage:"monthly_additional_log_data_retention_gb"`
-	MonthlyLogDataExportDB              *float64 `infracost_usage:"monthly_log_data_export_gb"`
+	MonthlyAdditionalLogDataRetentionGB *float64 `infracost_usage:"monthly_additional_log_data_retention_gb"`
+	MonthlyLogDataExportGB              *float64 `infracost_usage:"monthly_log_data_export_gb"`
 }
 
 // LogAnalyticsWorkspaceUsageSchema defines a list which represents the usage schema of LogAnalyticsWorkspace.
@@ -88,8 +88,8 @@ func (r *LogAnalyticsWorkspace) PopulateUsage(u *schema.UsageData) {
 //		1. Log data ingestion, which can be either:
 //			a) Pay-as-you-go, which is only valid for a sku of PerGB2018 and uses a usage param
 //			b) Billed per commitment tiers, which is only valid for a sku of CapacityReservation
-//		2. Log retention, which is free up to 31 days and then is billed for each additional day after. Additional
-//		   days come from the usage param.
+//		2. Log retention, which is free up to 31 days and then is billed per GB of data retained after the free limit.
+//		   Additional GB used comes from the usage param.
 //		3. Data export, which is billed per monthly GB exported and is defined from a usage param.
 //
 // Outside the above rules - if the workspace has sku of Free we return as a free resource & if the workspace sku
@@ -128,7 +128,7 @@ func (r *LogAnalyticsWorkspace) BuildResource() *schema.Resource {
 		costComponents = append(costComponents, r.logDataRetention())
 	}
 
-	if r.MonthlyLogDataExportDB != nil {
+	if r.MonthlyLogDataExportGB != nil {
 		costComponents = append(costComponents, r.logDataExport())
 	}
 
@@ -187,7 +187,7 @@ func (r *LogAnalyticsWorkspace) logDataRetention() *schema.CostComponent {
 		Name:            "Log data retention",
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
-		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyAdditionalLogDataRetentionDB)),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyAdditionalLogDataRetentionGB)),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr(vendorName),
 			Region:        strPtr(r.Region),
@@ -207,7 +207,7 @@ func (r *LogAnalyticsWorkspace) logDataExport() *schema.CostComponent {
 		Name:            "Log data export",
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
-		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyLogDataExportDB)),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyLogDataExportGB)),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr(vendorName),
 			Region:        strPtr(r.Region),

--- a/internal/resources/azure/log_analytics_workspace.go
+++ b/internal/resources/azure/log_analytics_workspace.go
@@ -116,7 +116,7 @@ func (r *LogAnalyticsWorkspace) BuildResource() *schema.Resource {
 
 	var costComponents []*schema.CostComponent
 
-	if r.SKU == skuPerGB2018 && r.MonthlyLogDataIngestionGB != nil {
+	if r.SKU == skuPerGB2018 {
 		costComponents = append(costComponents, r.logDataIngestion())
 	}
 
@@ -160,11 +160,16 @@ func (r *LogAnalyticsWorkspace) logDataIngestionFromCapacityReservation() *schem
 }
 
 func (r *LogAnalyticsWorkspace) logDataIngestion() *schema.CostComponent {
+	var quantity *decimal.Decimal
+	if r.MonthlyLogDataIngestionGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.MonthlyLogDataIngestionGB))
+	}
+
 	return &schema.CostComponent{
 		Name:            "Log data ingestion",
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
-		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyLogDataIngestionGB)),
+		MonthlyQuantity: quantity,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr(vendorName),
 			Region:        strPtr(r.Region),

--- a/internal/resources/azure/log_analytics_workspace.go
+++ b/internal/resources/azure/log_analytics_workspace.go
@@ -1,0 +1,223 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+const (
+	logAnalyticsServiceName = "Log Analytics"
+	azureMonitorServiceName = "Azure Monitor"
+	governanceProductFamily = "Management and Governance"
+
+	skuCapacityReservation = "CapacityReservation"
+	skuPerGB2018           = "PerGB2018"
+	skuFree                = "Free"
+	skuFilterPAYG          = "Pay-as-you-go"
+
+	logRetentionFreeTierLimit = 30
+)
+
+var (
+	// unsupportedLegacySkus represents skus that Infracost doesn't support because these skus are
+	// legacy pricing tiers: https://docs.microsoft.com/en-us/azure/azure-monitor//logs/manage-cost-storage#legacy-pricing-tiers
+	unsupportedLegacySkus = map[string]struct{}{
+		"unlimited": {},
+		"standard":  {},
+		"premium":   {},
+		"pernode":   {},
+	}
+)
+
+// LogAnalyticsWorkspace struct represents an Azure Monitor log workspace. A workspace consolidates data
+// from multiple sources into a single data lake. A workspace defines:
+//
+//		1. The geographic location of the data.
+//		2. Access rights that define which users can access data.
+//		3. Configuration settings such as the pricing tier and data retention.
+//
+// Resource information: https://azure.microsoft.com/en-gb/services/monitor/
+// Pricing information: https://azure.microsoft.com/en-gb/pricing/details/monitor/
+type LogAnalyticsWorkspace struct {
+	Address string
+	Region  string
+	SKU     string
+
+	ReservationCapacityInGBPerDay int64
+	RetentionInDays               int64
+
+	MonthlyLogDataIngestionGB           *float64 `infracost_usage:"monthly_log_data_ingestion_gb"`
+	MonthlyAdditionalLogDataRetentionDB *float64 `infracost_usage:"monthly_additional_log_data_retention_gb"`
+	MonthlyLogDataExportDB              *float64 `infracost_usage:"monthly_log_data_export_gb"`
+}
+
+// LogAnalyticsWorkspaceUsageSchema defines a list which represents the usage schema of LogAnalyticsWorkspace.
+var LogAnalyticsWorkspaceUsageSchema = []*schema.UsageItem{
+	{
+		Key:          "monthly_log_data_ingestion_gb",
+		DefaultValue: 0,
+		ValueType:    schema.Float64,
+	},
+	{
+		Key:          "monthly_additional_log_data_retention_gb",
+		DefaultValue: 0,
+		ValueType:    schema.Float64,
+	},
+	{
+		Key:          "monthly_log_data_export_gb",
+		DefaultValue: 0,
+		ValueType:    schema.Float64,
+	},
+}
+
+// PopulateUsage parses the u schema.UsageData into the LogAnalyticsWorkspace.
+// It uses the `infracost_usage` struct tags to populate data into the LogAnalyticsWorkspace.
+func (r *LogAnalyticsWorkspace) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid LogAnalyticsWorkspace struct.
+// The returned schema.Resource can have 3 potential schema.CostComponent associated with it:
+//
+//		1. Log data ingestion, which can be either:
+//			a) Pay-as-you-go, which is only valid for a sku of PerGB2018 and uses a usage param
+//			b) Billed per commitment tiers, which is only valid for a sku of CapacityReservation
+//		2. Log retention, which is free up to 31 days and then is billed for each additional day after. Additional
+//		   days come from the usage param.
+//		3. Data export, which is billed per monthly GB exported and is defined from a usage param.
+//
+// Outside the above rules - if the workspace has sku of Free we return as a free resource & if the workspace sku
+// is in a list of unsupported skus then we mark as skipped with a warning.
+func (r *LogAnalyticsWorkspace) BuildResource() *schema.Resource {
+	if r.SKU == skuFree {
+		return &schema.Resource{
+			Name:        r.Address,
+			IsSkipped:   true,
+			NoPrice:     true,
+			UsageSchema: LogAnalyticsWorkspaceUsageSchema,
+		}
+	}
+
+	if _, ok := unsupportedLegacySkus[strings.ToLower(r.SKU)]; ok {
+		log.Warnf("skipping %s as it uses legacy pricing options", r.Address)
+
+		return &schema.Resource{
+			Name:        r.Address,
+			IsSkipped:   true,
+			UsageSchema: LogAnalyticsWorkspaceUsageSchema,
+		}
+	}
+
+	var costComponents []*schema.CostComponent
+
+	if r.SKU == skuPerGB2018 && r.MonthlyLogDataIngestionGB != nil {
+		costComponents = append(costComponents, r.logDataIngestion())
+	}
+
+	if r.SKU == skuCapacityReservation && r.ReservationCapacityInGBPerDay > 0 {
+		costComponents = append(costComponents, r.logDataIngestionFromCapacityReservation())
+	}
+
+	if r.RetentionInDays > logRetentionFreeTierLimit {
+		costComponents = append(costComponents, r.logDataRetention())
+	}
+
+	if r.MonthlyLogDataExportDB != nil {
+		costComponents = append(costComponents, r.logDataExport())
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    LogAnalyticsWorkspaceUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+func (r *LogAnalyticsWorkspace) logDataIngestionFromCapacityReservation() *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Log data ingestion",
+		Unit:            fmt.Sprintf("%d GB (per day)", r.ReservationCapacityInGBPerDay),
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(30)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr(azureMonitorServiceName),
+			ProductFamily: strPtr(governanceProductFamily),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "skuName", Value: strPtr(fmt.Sprintf("%d GB Commitment Tier", r.ReservationCapacityInGBPerDay))},
+				{Key: "meterName", Value: strPtr(fmt.Sprintf("%d GB Commitment Tier", r.ReservationCapacityInGBPerDay))},
+			},
+		},
+		PriceFilter: priceFilterConsumption,
+	}
+}
+
+func (r *LogAnalyticsWorkspace) logDataIngestion() *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Log data ingestion",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyLogDataIngestionGB)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr(logAnalyticsServiceName),
+			ProductFamily: strPtr(governanceProductFamily),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "skuName", Value: strPtr(skuFilterPAYG)},
+				{Key: "meterName", Value: strPtr("Data Ingestion")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("5"),
+		},
+	}
+}
+
+func (r *LogAnalyticsWorkspace) logDataRetention() *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Log data retention",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyAdditionalLogDataRetentionDB)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr(logAnalyticsServiceName),
+			ProductFamily: strPtr(governanceProductFamily),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "skuName", Value: strPtr(skuFilterPAYG)},
+				{Key: "meterName", Value: strPtr("Data Retention")},
+			},
+		},
+		PriceFilter: priceFilterConsumption,
+	}
+}
+
+func (r *LogAnalyticsWorkspace) logDataExport() *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Log data export",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyLogDataExportDB)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr(azureMonitorServiceName),
+			ProductFamily: strPtr(governanceProductFamily),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "skuName", Value: strPtr("Log Analytics data export")},
+				{Key: "meterName", Value: strPtr("Data Exported")},
+			},
+		},
+		PriceFilter: priceFilterConsumption,
+	}
+}

--- a/internal/resources/azure/log_analytics_workspace.go
+++ b/internal/resources/azure/log_analytics_workspace.go
@@ -128,9 +128,7 @@ func (r *LogAnalyticsWorkspace) BuildResource() *schema.Resource {
 		costComponents = append(costComponents, r.logDataRetention())
 	}
 
-	if r.MonthlyLogDataExportGB != nil {
-		costComponents = append(costComponents, r.logDataExport())
-	}
+	costComponents = append(costComponents, r.logDataExport())
 
 	return &schema.Resource{
 		Name:           r.Address,
@@ -208,11 +206,16 @@ func (r *LogAnalyticsWorkspace) logDataRetention() *schema.CostComponent {
 }
 
 func (r *LogAnalyticsWorkspace) logDataExport() *schema.CostComponent {
+	var quantity *decimal.Decimal
+	if r.MonthlyLogDataExportGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.MonthlyLogDataExportGB))
+	}
+
 	return &schema.CostComponent{
 		Name:            "Log data export",
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
-		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(*r.MonthlyLogDataExportGB)),
+		MonthlyQuantity: quantity,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr(vendorName),
 			Region:        strPtr(r.Region),

--- a/internal/resources/azure/log_analytics_workspace.go
+++ b/internal/resources/azure/log_analytics_workspace.go
@@ -113,8 +113,8 @@ func (r *LogAnalyticsWorkspace) PopulateUsage(u *schema.UsageData) {
 //		1. Log data ingestion, which can be either:
 //			a) Pay-as-you-go, which is only valid for a sku of PerGB2018 and uses a usage param
 //			b) Billed per commitment tiers, which is only valid for a sku of CapacityReservation
-//		2. Log retention, which is free up to 31 days and then is billed per GB of data retained after the free limit.
-//		   Additional GB used comes from the usage param.
+//		2. Log retention, which is free up to 31 days. Data retained beyond these no-charge periods
+//		   will be charged for each GB of data retained for a month (pro-rated daily).
 //		3. Data export, which is billed per monthly GB exported and is defined from a usage param.
 //
 // Outside the above rules - if the workspace has sku of Free we return as a free resource & if the workspace sku
@@ -170,7 +170,7 @@ func (r *LogAnalyticsWorkspace) logDataIngestionFromCapacityReservation() *schem
 	if _, ok := validCommitmentTiers[r.ReservationCapacityInGBPerDay]; !ok {
 		for i, tier := range commitmentTiers {
 			// if the current tier is the final valid commitment tier then
-			// set selected tier as this element as it can't be any other tier.
+			// set selectedTier as it can't be any other tier.
 			if len(commitmentTiers)-1 == i+1 {
 				selectedTier = tier
 				break


### PR DESCRIPTION
## Objective:

Add support for azurerm_log_analytics_workspace . Fixes #1258

## Pricing details:

1. Log data ingestion, which can be either:
	a) Pay-as-you-go, which is only valid for a sku of `PerGB2018` and uses a usage param
	b) Billed per commitment tiers, which is only valid for a sku of `CapacityReservation`
2. Log retention, which is free up to 31 days and then is billed for each additional GB retained after the free tier.
3. Data export, which is billed per monthly GB exported and is defined from a usage param.

Outside the above rules - if the workspace has sku of Free we return as a free resource & if the workspace sku
is in a list of unsupported skus then we mark as skipped with a warning.

## Status:

- [x] Generated the resource files
- [x] Updated the internal/resources file
- [x] Updated the internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/165)

## Issues:

I have left out `azurerm_log_analytics_cluster` inline with the reasoning outlined here: https://github.com/infracost/infracost/issues/1258