### PR TITLE
feat: add hcl variable inputs from terraform plan flags

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -43,6 +43,14 @@ func TestBreakdownTerraformDirectory(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../../examples/terraform"}, &GoldenFileOptions{RunHCL: true})
 }
 
+func TestBreakdownTerraformDirectoryWithVars(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../../examples/terraformwithvars", "--terraform-plan-flags", "-var-file=input.tfvars -var=block2_ebs_volume_size=2000 -var block2_volume_type=io1"}, &GoldenFileOptions{RunHCL: true})
+}
+
+func TestBreakdownTerraformDirectoryWithHCLVarFlags(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../../examples/terraformwithvars", "--var-file", "input.tfvars", "--var", "block2_ebs_volume_size=2000", "--var", "block2_volume_type=io1"}, &GoldenFileOptions{OnlyRunHCL: true})
+}
+
 func TestBreakdownTerraformDirectoryWithModules(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../../examples/terraformwithmodules"}, &GoldenFileOptions{RunHCL: true})
 }

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -28,7 +28,10 @@ type GoldenFileOptions = struct {
 	Currency    string
 	CaptureLogs bool
 	IsJSON      bool
-	RunHCL      bool
+	// RunHCL sets the cmd test to also run the cmd with --hcl-only set
+	RunHCL bool
+	// OnlyRunHCL sets the cmd test to only run cmd with --hcl-only set and ignore the Terraform binary.
+	OnlyRunHCL bool
 }
 
 func DefaultOptions() *GoldenFileOptions {
@@ -40,7 +43,7 @@ func DefaultOptions() *GoldenFileOptions {
 }
 
 func GoldenFileCommandTest(t *testing.T, testName string, args []string, testOptions *GoldenFileOptions, ctxOptions ...func(ctx *config.RunContext)) {
-	if testOptions != nil && testOptions.RunHCL {
+	if testOptions != nil && (testOptions.RunHCL || testOptions.OnlyRunHCL) {
 		t.Run("HCL", func(t *testing.T) {
 			hclArgs := make([]string, len(args)+2)
 			copy(hclArgs, args)
@@ -51,9 +54,11 @@ func GoldenFileCommandTest(t *testing.T, testName string, args []string, testOpt
 		})
 	}
 
-	t.Run("Terraform CLI", func(t *testing.T) {
-		goldenFileCommandTest(t, testName, args, testOptions, ctxOptions)
-	})
+	if testOptions != nil && !testOptions.OnlyRunHCL {
+		t.Run("Terraform CLI", func(t *testing.T) {
+			goldenFileCommandTest(t, testName, args, testOptions, ctxOptions)
+		})
+	}
 }
 
 func goldenFileCommandTest(t *testing.T, testName string, args []string, testOptions *GoldenFileOptions, ctxOptions []func(ctx *config.RunContext)) {

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -60,8 +60,9 @@ func addRunFlags(cmd *cobra.Command) {
 
 	cmd.Flags().Bool("sync-usage-file", false, "Sync usage-file with missing resources, needs usage-file too (experimental)")
 
-	cmd.Flags().Bool("hcl-only", false, "Run infracost without terraform, parsing hcl files at the given path. This option does not need credentials and is much quicker to run.")
-	cmd.Flags().StringSlice("tfvar-files", nil, "Path to .tfvars file, can be used multiple times and evaluated in order of specification")
+	cmd.Flags().Bool("hcl-only", false, "Run infracost without terraform, parsing hcl files at the given path. This option does not need credentials and is much quicker to run. (experimental)")
+	cmd.Flags().StringSlice("var-file", nil, "Can only be used with --hcl-only. Load variable values from the given file, in addition\nto the default files terraform.tfvars and *.auto.tfvars. Use this option more than once to\ninclude more than one variables file. (experimental)")
+	cmd.Flags().StringSlice("var", nil, "Can only be used with --hcl-only. Set a value for one of the input variables in the root module\nof the terraform configuration. Use this option more than once to set more than one variable. (experimental)")
 
 	_ = cmd.MarkFlagFilename("path", "json", "tf")
 	_ = cmd.MarkFlagFilename("config-file", "yml")
@@ -525,7 +526,8 @@ func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {
 	if hasProjectFlags {
 		projectCfg.Path, _ = cmd.Flags().GetString("path")
 		projectCfg.HCLOnly, _ = cmd.Flags().GetBool("hcl-only")
-		projectCfg.TFVarFiles, _ = cmd.Flags().GetStringSlice("tfvar-files")
+		projectCfg.TFVarFiles, _ = cmd.Flags().GetStringSlice("var-file")
+		projectCfg.TFVars, _ = cmd.Flags().GetStringSlice("var")
 		projectCfg.UsageFile, _ = cmd.Flags().GetString("usage-file")
 		projectCfg.TerraformPlanFlags, _ = cmd.Flags().GetString("terraform-plan-flags")
 		projectCfg.TerraformUseState, _ = cmd.Flags().GetBool("terraform-use-state")

--- a/cmd/infracost/testdata/breakdown_terraform_directory_with_hclvar_flags/breakdown_terraform_directory_with_hclvar_flags.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_directory_with_hclvar_flags/breakdown_terraform_directory_with_hclvar_flags.golden
@@ -1,0 +1,24 @@
+Project: infracost/infracost/examples/terraformwithvars
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.2xlarge)          730  hours       $280.32 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ ├─ ebs_block_device[0]                                                                  
+ │  ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+ │  └─ Provisioned IOPS                                       1,000  IOPS         $65.00 
+ └─ ebs_block_device[1]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    2,000  GB          $250.00 
+    └─ Provisioned IOPS                                         500  IOPS         $32.50 
+                                                                                         
+ OVERALL TOTAL                                                                   $757.82 
+──────────────────────────────────
+1 cloud resource was detected, rerun with --show-skipped to see details:
+∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
+
+Add cost estimates to your pull requests: https://infracost.io/cicd
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terraform_directory_with_vars/breakdown_terraform_directory_with_vars.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_directory_with_vars/breakdown_terraform_directory_with_vars.golden
@@ -1,0 +1,24 @@
+Project: infracost/infracost/examples/terraformwithvars
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.2xlarge)          730  hours       $280.32 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ ├─ ebs_block_device[0]                                                                  
+ │  ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+ │  └─ Provisioned IOPS                                       1,000  IOPS         $65.00 
+ └─ ebs_block_device[1]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    2,000  GB          $250.00 
+    └─ Provisioned IOPS                                         500  IOPS         $32.50 
+                                                                                         
+ OVERALL TOTAL                                                                   $757.82 
+──────────────────────────────────
+1 cloud resource was detected, rerun with --show-skipped to see details:
+∙ 1 was estimated, 1 includes usage-based costs, see https://infracost.io/usage-file
+
+Add cost estimates to your pull requests: https://infracost.io/cicd
+
+Err:
+

--- a/examples/terraformwithvars/blocks.auto.tfvars
+++ b/examples/terraformwithvars/blocks.auto.tfvars
@@ -1,0 +1,1 @@
+root_block_size = 50

--- a/examples/terraformwithvars/infracost-usage.yml
+++ b/examples/terraformwithvars/infracost-usage.yml
@@ -1,0 +1,6 @@
+# You can use this file to define resource usage estimates for Infracost to use when calculating
+# the cost of usage-based resource, such as AWS Lambda.
+# `infracost breakdown --usage-file infracost-usage.yml [other flags]`
+# See https://infracost.io/usage-file/ for docs
+version: 0.1
+resource_usage:

--- a/examples/terraformwithvars/input.tfvars
+++ b/examples/terraformwithvars/input.tfvars
@@ -1,0 +1,3 @@
+instance_type          = "m5.2xlarge"
+block1_ebs_iops        = 1000
+block2_ebs_iops        = 500

--- a/examples/terraformwithvars/main.tf
+++ b/examples/terraformwithvars/main.tf
@@ -1,0 +1,62 @@
+provider "aws" {
+  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = var.root_block_size
+  }
+
+  ebs_block_device {
+    device_name = "block1"
+    volume_type = var.block1_volume_type
+    volume_size = var.block1_ebs_volume_size
+    iops        = var.block1_ebs_iops
+  }
+
+  ebs_block_device {
+    device_name = "block2"
+    volume_type = var.block2_volume_type
+    volume_size = var.block2_ebs_volume_size
+    iops        = var.block2_ebs_iops
+  }
+}
+
+variable "instance_type" {
+  default = "m5.4xlarge"
+}
+
+variable "root_block_size" {
+  type = number
+}
+
+variable "block1_volume_type" {
+  type = string
+}
+
+variable "block1_ebs_volume_size" {
+  type = number
+}
+
+variable "block1_ebs_iops" {
+  type = number
+}
+
+variable "block2_volume_type" {
+  type = string
+}
+
+variable "block2_ebs_volume_size" {
+  type = number
+}
+
+variable "block2_ebs_iops" {
+  type = number
+}

--- a/examples/terraformwithvars/terraform.tfvars
+++ b/examples/terraformwithvars/terraform.tfvars
@@ -1,0 +1,2 @@
+block1_ebs_iops        = 800
+block1_ebs_volume_size = 1000

--- a/examples/terraformwithvars/volume-type.auto.tfvars
+++ b/examples/terraformwithvars/volume-type.auto.tfvars
@@ -1,0 +1,1 @@
+block1_volume_type = "io1"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,8 @@ type Project struct {
 	HCLOnly bool `yaml:"hcl_only,omitempty"`
 	// TFVarFiles is the number of var files that are needed to run an HCLOnly run
 	TFVarFiles []string `yaml:"tf_var_files"`
+	// TFVars is a slice of input vars that is used to run an HCLOnly run
+	TFVars []string `json:"tf_vars"`
 	// TerraformPlanFlags are flags to pass to terraform plan with Terraform directory paths
 	TerraformPlanFlags string `yaml:"terraform_plan_flags,omitempty" ignored:"true"`
 	// TerraformBinary is an optional field used to change the path to the terraform or terragrunt binary


### PR DESCRIPTION
Adds variable file and flag support for hcl, through:

* parsing `terraform-plan-flags`
* `var` and `var-file` flags
* parsing default `terraform.tfvars` file and `.auto.tfvars` files