### PR TITLE
feat: add parallel running of hcl provider in breakdown

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -136,7 +136,9 @@ func TestBreakdownInvalidPath(t *testing.T) {
 }
 
 func TestBreakdownPlanError(t *testing.T) {
-	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../..//examples/terraform", "--terraform-plan-flags", "-var-file=invalid"}, nil)
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../..//examples/terraform", "--terraform-plan-flags", "-var-file=invalid"}, nil, func(ctx *config.RunContext) {
+		ctx.Config.DisableHCL = true
+	})
 }
 
 func TestBreakdownTerragrunt(t *testing.T) {

--- a/cmd/infracost/configure.go
+++ b/cmd/infracost/configure.go
@@ -5,10 +5,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/infracost/infracost/internal/config"
-	"github.com/infracost/infracost/internal/ui"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/ui"
 )
 
 var supportedConfigureKeys = map[string]struct{}{
@@ -16,6 +17,7 @@ var supportedConfigureKeys = map[string]struct{}{
 	"currency":                 {},
 	"pricing_api_endpoint":     {},
 	"enable_dashboard":         {},
+	"disable_hcl":              {},
 	"tls_insecure_skip_verify": {},
 	"tls_ca_cert_file":         {},
 }
@@ -103,6 +105,14 @@ func configureSetCmd(ctx *config.RunContext) *cobra.Command {
 				saveConfiguration = true
 			case "currency":
 				ctx.Config.Configuration.Currency = value
+				saveConfiguration = true
+			case "disable_hcl":
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					return errors.New("Invalid value, must be true or false")
+				}
+
+				ctx.Config.Configuration.DisableHCL = &b
 				saveConfiguration = true
 			case "enable_dashboard":
 				b, err := strconv.ParseBool(value)

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -261,7 +261,14 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 }
 
 func formatHCLProjects(wg *sync.WaitGroup, hclProjects []*schema.Project, hclR *output.Root) {
-	defer wg.Done()
+	defer func() {
+		err := recover()
+		if err != nil {
+			log.Debugf("runtime error from formating hcl projects %s", err)
+		}
+
+		wg.Done()
+	}()
 
 	rr, err := output.ToOutputFormat(hclProjects)
 	if err != nil {

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -267,7 +267,7 @@ func formatHCLProjects(wg *sync.WaitGroup, ctx *config.RunContext, hclProjects [
 		wg.Done()
 
 		if err != nil {
-			err = apiclient.ReportCLIError(ctx, fmt.Errorf("hcl-runtime-error: formating hcl projects %s\n%s", err, debug.Stack()))
+			err = apiclient.ReportCLIError(ctx, fmt.Errorf("hcl-runtime-error: formatting hcl projects %s\n%s", err, debug.Stack()))
 			if err != nil {
 				log.Debugf("error reporting unexpected hcl runtime error: %s", err)
 			}

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -440,7 +440,6 @@ func runProjectConfig(cmd *cobra.Command, runCtx *config.RunContext, ctx *config
 }
 
 func runHCLProvider(wg *sync.WaitGroup, ctx *config.ProjectContext, usageFile *usage.UsageFile, runCtx *config.RunContext, out *projectOutput) {
-	t1 := time.Now()
 	defer func() {
 		err := recover()
 		if err != nil {
@@ -449,6 +448,11 @@ func runHCLProvider(wg *sync.WaitGroup, ctx *config.ProjectContext, usageFile *u
 
 		wg.Done()
 	}()
+	if runCtx.Config.DisableHCL {
+		return
+	}
+
+	t1 := time.Now()
 
 	hclProvider, err := terraform.NewHCLProvider(ctx, terraform.NewPlanJSONProvider(ctx))
 	if err != nil {

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -770,14 +770,23 @@ func AddHCLEnvVars(r output.Root, hclR output.Root, env map[string]interface{}) 
 		hclTotal = *hclR.TotalMonthlyCost
 	}
 
-	percentChange := "0.00"
-	if !initialTotal.IsZero() {
-		percentChange = hclTotal.Sub(initialTotal).Abs().Div(initialTotal).Mul(decimal.NewFromInt(100)).StringFixed(2)
+	env["hclPercentChange"] = "0.00"
+	env["absHclPercentChange"] = "0.00"
+	change := percentChange(hclTotal, initialTotal)
+	abs := change.Abs()
+
+	if abs.GreaterThan(decimal.NewFromInt(0)) {
+		env["hclPercentChange"] = change.StringFixed(2)
+		env["absHclPercentChange"] = abs.StringFixed(2)
+	}
+}
+
+func percentChange(newTotal decimal.Decimal, initialTotal decimal.Decimal) decimal.Decimal {
+	if initialTotal.IsZero() {
+		return decimal.NewFromInt(0)
 	}
 
-	env["hclTotalMonthly"] = hclTotal.StringFixed(2)
-	env["tfTotalMonthly"] = initialTotal.StringFixed(2)
-	env["hclPercentChange"] = percentChange
+	return newTotal.Sub(initialTotal).Div(initialTotal).Mul(decimal.NewFromInt(100))
 }
 
 func unwrapped(err error) error {

--- a/cmd/infracost/run_test.go
+++ b/cmd/infracost/run_test.go
@@ -75,9 +75,8 @@ func TestAddHCLEnvVars(t *testing.T) {
 				env:  map[string]interface{}{},
 			},
 			want: map[string]interface{}{
-				"hclTotalMonthly":  "0.00",
-				"tfTotalMonthly":   "1.99",
-				"hclPercentChange": "100.00",
+				"hclPercentChange":    "-100.00",
+				"absHclPercentChange": "100.00",
 			},
 		},
 		{
@@ -88,9 +87,8 @@ func TestAddHCLEnvVars(t *testing.T) {
 				env:  map[string]interface{}{},
 			},
 			want: map[string]interface{}{
-				"hclTotalMonthly":  "0.00",
-				"tfTotalMonthly":   "0.00",
-				"hclPercentChange": "0.00",
+				"hclPercentChange":    "0.00",
+				"absHclPercentChange": "0.00",
 			},
 		},
 		{
@@ -105,9 +103,8 @@ func TestAddHCLEnvVars(t *testing.T) {
 				env: map[string]interface{}{},
 			},
 			want: map[string]interface{}{
-				"hclTotalMonthly":  "8.00",
-				"tfTotalMonthly":   "10.00",
-				"hclPercentChange": "20.00",
+				"hclPercentChange":    "-20.00",
+				"absHclPercentChange": "20.00",
 			},
 		},
 		{
@@ -122,9 +119,8 @@ func TestAddHCLEnvVars(t *testing.T) {
 				env: map[string]interface{}{},
 			},
 			want: map[string]interface{}{
-				"hclTotalMonthly":  "7.00",
-				"tfTotalMonthly":   "11.00",
-				"hclPercentChange": "36.36",
+				"hclPercentChange":    "-36.36",
+				"absHclPercentChange": "36.36",
 			},
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	DefaultPricingAPIEndpoint string `yaml:"default_pricing_api_endpoint,omitempty" envconfig:"INFRACOST_DEFAULT_PRICING_API_ENDPOINT"`
 	DashboardAPIEndpoint      string `yaml:"dashboard_api_endpoint,omitempty" envconfig:"INFRACOST_DASHBOARD_API_ENDPOINT"`
 	EnableDashboard           bool   `yaml:"enable_dashboard,omitempty" envconfig:"INFRACOST_ENABLE_DASHBOARD"`
+	DisableHCL                bool   `yaml:"disable_hcl,omitempty" envconfig:"INFRACOST_DISABLE_HCL"`
 
 	TLSInsecureSkipVerify *bool  `envconfig:"INFRACOST_TLS_INSECURE_SKIP_VERIFY"`
 	TLSCACertFile         string `envconfig:"INFRACOST_TLS_CA_CERT_FILE"`

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -16,6 +16,7 @@ type Configuration struct {
 	Version               string `yaml:"version"`
 	Currency              string `yaml:"currency,omitempty"`
 	EnableDashboard       *bool  `yaml:"enable_dashboard,omitempty"`
+	DisableHCL            *bool  `yaml:"disable_hcl,omitempty"`
 	TLSInsecureSkipVerify *bool  `yaml:"tls_insecure_skip_verify,omitempty"`
 	TLSCACertFile         string `yaml:"tls_ca_cert_file,omitempty"`
 }
@@ -43,6 +44,10 @@ func loadConfiguration(cfg *Config) error {
 
 	if cfg.Configuration.EnableDashboard != nil {
 		cfg.EnableDashboard = *cfg.Configuration.EnableDashboard
+	}
+
+	if cfg.Configuration.DisableHCL != nil {
+		cfg.DisableHCL = *cfg.Configuration.DisableHCL
 	}
 
 	if cfg.Configuration.TLSInsecureSkipVerify != nil {

--- a/internal/config/project_context.go
+++ b/internal/config/project_context.go
@@ -6,9 +6,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/infracost/infracost/internal/schema"
-	log "github.com/sirupsen/logrus"
 )
 
 type ProjectContexter interface {
@@ -19,6 +21,7 @@ type ProjectContext struct {
 	RunContext    *RunContext
 	ProjectConfig *Project
 	contextVals   map[string]interface{}
+	mu            *sync.Mutex
 
 	UsingCache bool
 	CacheErr   string
@@ -29,6 +32,7 @@ func NewProjectContext(runCtx *RunContext, projectCfg *Project) *ProjectContext 
 		RunContext:    runCtx,
 		ProjectConfig: projectCfg,
 		contextVals:   map[string]interface{}{},
+		mu:            &sync.Mutex{},
 	}
 }
 
@@ -41,6 +45,8 @@ func EmptyProjectContext() *ProjectContext {
 }
 
 func (c *ProjectContext) SetContextValue(key string, value interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.contextVals[key] = value
 }
 


### PR DESCRIPTION
Adds HCL support for parallel running if the provider is `DirProvider`. 

* add various reporting metrics to allow for comparison of approaches. (timings of load resources, percentage difference)
* add configuration property to disable parallel running if needed