### PR TITLE
Log out-file message if log-level is set

### DIFF
--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	timestampRegex   = regexp.MustCompile(`(\d{4})-(\d{2})-(\d{2})(T| )(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)(([\+-](\d{2}):(\d{2})|Z| [A-Z]+)?)`)
-	outputPathRegex  = regexp.MustCompile(`Output saved to .*`)
 	urlRegex         = regexp.MustCompile(`https://dashboard.infracost.io/share/.*`)
 	projectPathRegex = regexp.MustCompile(`(Project: .*) \(.*/infracost/examples/.*\)`)
 	versionRegex     = regexp.MustCompile(`Infracost v.*`)
@@ -106,7 +105,6 @@ func GoldenFileCommandTest(t *testing.T, testName string, args []string, testOpt
 // including timestamps and temp file paths
 func stripDynamicValues(actual []byte) []byte {
 	actual = timestampRegex.ReplaceAll(actual, []byte("REPLACED_TIME"))
-	actual = outputPathRegex.ReplaceAll(actual, []byte("Output saved to REPLACED_OUTPUT_PATH"))
 	actual = urlRegex.ReplaceAll(actual, []byte("https://dashboard.infracost.io/share/REPLACED_SHARE_CODE"))
 	actual = projectPathRegex.ReplaceAll(actual, []byte("$1 REPLACED_PROJECT_PATH"))
 	actual = versionRegex.ReplaceAll(actual, []byte("Infracost vREPLACED_VERSION"))

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -243,18 +243,22 @@ func loadGlobalFlags(ctx *config.RunContext, cmd *cobra.Command) error {
 }
 
 // saveOutFile saves the output of the command to the file path past in the `--out-file` flag
-func saveOutFile(cmd *cobra.Command, outFile string, b []byte) error {
-	return saveOutFileWithMsg(cmd, outFile, fmt.Sprintf("Output saved to %s\n", outFile), b)
+func saveOutFile(ctx *config.RunContext, cmd *cobra.Command, outFile string, b []byte) error {
+	return saveOutFileWithMsg(ctx, cmd, outFile, fmt.Sprintf("Output saved to %s", outFile), b)
 }
 
 // saveOutFile saves the output of the command to the file path past in the `--out-file` flag
-func saveOutFileWithMsg(cmd *cobra.Command, outFile, successMsg string, b []byte) error {
+func saveOutFileWithMsg(ctx *config.RunContext, cmd *cobra.Command, outFile, successMsg string, b []byte) error {
 	err := ioutil.WriteFile(outFile, b, 0644) // nolint:gosec
 	if err != nil {
 		return errors.Wrap(err, "Unable to save output")
 	}
 
-	cmd.PrintErr(successMsg)
+	if ctx.Config.IsLogging() {
+		log.Info(successMsg)
+	} else {
+		cmd.PrintErrf("%s\n", successMsg)
+	}
 
 	return nil
 }

--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -155,7 +155,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 			}
 
 			if outFile, _ := cmd.Flags().GetString("out-file"); outFile != "" {
-				err = saveOutFile(cmd, outFile, b)
+				err = saveOutFile(ctx, cmd, outFile, b)
 				if err != nil {
 					return err
 				}

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -225,17 +225,16 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 		log.Errorf("Error reporting event: %s", err)
 	}
 
-	// Print a new line to separate the logs from the output
-	if runCtx.Config.IsLogging() {
-		cmd.PrintErrln()
-	}
-
 	if outFile, _ := cmd.Flags().GetString("out-file"); outFile != "" {
-		err = saveOutFile(cmd, outFile, b)
+		err = saveOutFile(runCtx, cmd, outFile, b)
 		if err != nil {
 			return err
 		}
 	} else {
+		// Print a new line to separate the logs from the output
+		if runCtx.Config.IsLogging() {
+			cmd.PrintErrln()
+		}
 		cmd.Println(string(b))
 	}
 

--- a/cmd/infracost/testdata/breakdown_terraform_out_file_html/breakdown_terraform_out_file_html.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_out_file_html/breakdown_terraform_out_file_html.golden
@@ -1,4 +1,0 @@
-
-Err:
-
-Output saved to REPLACED_OUTPUT_PATH

--- a/cmd/infracost/testdata/breakdown_terraform_out_file_json/breakdown_terraform_out_file_json.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_out_file_json/breakdown_terraform_out_file_json.golden
@@ -1,4 +1,0 @@
-
-Err:
-
-Output saved to REPLACED_OUTPUT_PATH

--- a/cmd/infracost/testdata/breakdown_terraform_out_file_table/breakdown_terraform_out_file_table.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_out_file_table/breakdown_terraform_out_file_table.golden
@@ -1,4 +1,0 @@
-
-Err:
-
-Output saved to REPLACED_OUTPUT_PATH

--- a/cmd/infracost/testdata/diff_terraform_out_file/diff_terraform_out_file.golden
+++ b/cmd/infracost/testdata/diff_terraform_out_file/diff_terraform_out_file.golden
@@ -1,4 +1,0 @@
-
-Err:
-
-Output saved to REPLACED_OUTPUT_PATH

--- a/cmd/infracost/testdata/output_terraform_out_file_html/output_terraform_out_file_html.golden
+++ b/cmd/infracost/testdata/output_terraform_out_file_html/output_terraform_out_file_html.golden
@@ -1,3 +1,0 @@
-
-Err:
-Output saved to REPLACED_OUTPUT_PATH

--- a/cmd/infracost/testdata/output_terraform_out_file_json/output_terraform_out_file_json.golden
+++ b/cmd/infracost/testdata/output_terraform_out_file_json/output_terraform_out_file_json.golden
@@ -1,3 +1,0 @@
-
-Err:
-Output saved to REPLACED_OUTPUT_PATH

--- a/cmd/infracost/testdata/output_terraform_out_file_table/output_terraform_out_file_table.golden
+++ b/cmd/infracost/testdata/output_terraform_out_file_table/output_terraform_out_file_table.golden
@@ -1,3 +1,0 @@
-
-Err:
-Output saved to REPLACED_OUTPUT_PATH


### PR DESCRIPTION
We shouldn't output this to the stderr if the user has specified a log level. Instead we should log it as an info level log.