### PR TITLE
fix: Use simple prompts for register commands on Windows

### DIFF
--- a/internal/ui/promts.go
+++ b/internal/ui/promts.go
@@ -1,0 +1,63 @@
+package ui
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ValidateFn represents a validation function type for prompts. Function of
+// this type should accept a string input and return an error if validation fails;
+// otherwise return nil.
+type ValidateFn func(input string) error
+
+// StringPrompt provides a single line for user input. It accepts an optional
+// validation function.
+func StringPrompt(label string, validate ValidateFn) string {
+	input := ""
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Fprint(os.Stdout, label+": ")
+		input, _ = reader.ReadString('\n')
+		input = strings.TrimSpace(input)
+
+		if validate == nil {
+			return input
+		}
+
+		err := validate(input)
+		if err == nil {
+			break
+		}
+
+		fmt.Fprintln(os.Stderr, err)
+	}
+
+	return input
+}
+
+// YesNoPrompt provides a yes/no user input. "No" is a default answer if left
+// empty.
+func YesNoPrompt(label string) bool {
+	choices := "y/N"
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Fprintf(os.Stdout, "%s [%s] ", label, choices)
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSpace(input)
+
+		if input == "" {
+			return false
+		}
+
+		switch strings.ToLower(input) {
+		case "y", "yes":
+			return true
+		case "n", "no":
+			return false
+		}
+	}
+}


### PR DESCRIPTION
The prompt libraries like promptui or survey produce double output on Windows.
Using simple prompts solves the issue, but doesn't alter experience for
Linux/macOS users.

Fixes #924 and #1265.