### PR TITLE
fix: Validate PR/MR number in comment commands

### DIFF
--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"strconv"
+
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/output"
 	"github.com/infracost/infracost/internal/ui"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -70,4 +73,29 @@ func buildCommentBody(cmd *cobra.Command, ctx *config.RunContext, paths []string
 	}
 
 	return b, nil
+}
+
+type PRNumber int
+
+func (p *PRNumber) Set(value string) error {
+	if value == "" {
+		return nil
+	}
+
+	v, err := strconv.ParseInt(value, 0, 64)
+	*p = PRNumber(v)
+
+	if err != nil {
+		return errors.New("must be integer")
+	}
+
+	return nil
+}
+
+func (p *PRNumber) String() string {
+	return strconv.Itoa(int(*p))
+}
+
+func (p *PRNumber) Type() string {
+	return "int"
 }

--- a/cmd/infracost/comment_azure_repos.go
+++ b/cmd/infracost/comment_azure_repos.go
@@ -106,7 +106,8 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagFilename("path", "json")
-	cmd.Flags().Int("pull-request", 0, "Pull request number to post comment on")
+	var prNumber PRNumber
+	cmd.Flags().Var(&prNumber, "pull-request", "Pull request number to post comment on")
 	_ = cmd.MarkFlagRequired("pull-request")
 	cmd.Flags().String("repo-url", "", "Repository URL, e.g. https://dev.azure.com/my-org/my-project/_git/my-repo")
 	_ = cmd.MarkFlagRequired("repo-url")

--- a/cmd/infracost/comment_bitbucket.go
+++ b/cmd/infracost/comment_bitbucket.go
@@ -123,7 +123,8 @@ func commentBitbucketCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagFilename("path", "json")
-	cmd.Flags().Int("pull-request", 0, "Pull request number to post comment on")
+	var prNumber PRNumber
+	cmd.Flags().Var(&prNumber, "pull-request", "Pull request number to post comment on")
 	cmd.Flags().String("repo", "", "Repository in format workspace/repo")
 	_ = cmd.MarkFlagRequired("repo")
 	cmd.Flags().String("tag", "", "Customize special text used to detect comments posted by Infracost (placed at the bottom of a comment)")

--- a/cmd/infracost/comment_github.go
+++ b/cmd/infracost/comment_github.go
@@ -123,7 +123,8 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagFilename("path", "json")
-	cmd.Flags().Int("pull-request", 0, "Pull request number to post comment on, mutually exclusive with commit")
+	var prNumber PRNumber
+	cmd.Flags().Var(&prNumber, "pull-request", "Pull request number to post comment on, mutually exclusive with commit")
 	cmd.Flags().String("repo", "", "Repository in format owner/repo")
 	_ = cmd.MarkFlagRequired("repo")
 	cmd.Flags().String("tag", "", "Customize hidden markdown tag used to detect comments posted by Infracost")

--- a/cmd/infracost/comment_gitlab.go
+++ b/cmd/infracost/comment_gitlab.go
@@ -122,7 +122,8 @@ func commentGitLabCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().StringArrayP("path", "p", []string{}, "Path to Infracost JSON files, glob patterns need quotes")
 	_ = cmd.MarkFlagRequired("path")
 	_ = cmd.MarkFlagFilename("path", "json")
-	cmd.Flags().Int("merge-request", 0, "Merge request number to post comment on, mutually exclusive with commit")
+	var mrNumber PRNumber
+	cmd.Flags().Var(&mrNumber, "merge-request", "Merge request number to post comment on, mutually exclusive with commit")
 	cmd.Flags().String("repo", "", "Repository in format owner/repo")
 	_ = cmd.MarkFlagRequired("repo")
 	cmd.Flags().String("tag", "", "Customize hidden markdown tag used to detect comments posted by Infracost")


### PR DESCRIPTION
Current behavior when the flag is followed by other flags:
```bash
Error: invalid argument "--bitbucket-token" for "--pull-request" flag: strconv.ParseInt: parsing "--bitbucket-token": invalid syntax
exit status 1
make: *** [run] Error 1
```

The updated error:
```bash
Error: invalid argument "--bitbucket-token" for "--pull-request" flag: must be integer
exit status 1
make: *** [run] Error 1
```

When the flag goes last (current behavior with or without the fix):
```bash
Error: flag needs an argument: --pull-request
exit status 1
make: *** [run] Error 1
```