### PR TITLE
fix: Update filter for google_container_node_pool resource

### DIFF
--- a/internal/providers/terraform/google/compute_instance.go
+++ b/internal/providers/terraform/google/compute_instance.go
@@ -86,7 +86,7 @@ func computeCostComponent(region, machineType string, purchaseOption string, ins
 			Service:       strPtr("Compute Engine"),
 			ProductFamily: strPtr("Compute Instance"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "machineType", ValueRegex: strPtr(fmt.Sprintf("/%s/i", machineType))},
+				{Key: "machineType", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", machineType))},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{


### PR DESCRIPTION
For `n2d-highcpu-2` machine type it returned two prices for
`n2d-highcpu-2` and `n2d-highcpu-224`. Setting line begin/end in the
regex solves incorrect match.

Fixes #1392.