### PR TITLE
feat: on release trigger chocolatey-packages workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -103,3 +103,15 @@ jobs:
       AMPLIFY_APP_ID: ${{ secrets.AMPLIFY_APP_ID }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  update-choco-version:
+    name: Update chocolatey version
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://api.github.com/repos/infracost/chocolatey-packages/dispatches \
+            -d '{"event_type":"infracost_choco"}'


### PR DESCRIPTION
Adds  `update-choco-version` job that triggers the workflow defined in `chocolatey-packages`. Relevant PR here: https://github.com/infracost/chocolatey-packages/pull/1