### PR TITLE
Remove emoji from basic Markdown template.

### DIFF
--- a/cmd/infracost/testdata/comment_bitbucket_commit/comment_bitbucket_commit.golden
+++ b/cmd/infracost/testdata/comment_bitbucket_commit/comment_bitbucket_commit.golden
@@ -1,5 +1,5 @@
 
-## 💰 Infracost estimate: **monthly cost will increase by $40.56 (+100%) 📈**
+## Infracost estimate: **monthly cost will increase by $40.56 (+100%) 📈**
 
 | **Project** | **Previous** | **New** | **Diff** |
 | ----------- | -----------: | ------: | -------- |

--- a/cmd/infracost/testdata/comment_bitbucket_commit/comment_bitbucket_commit.golden
+++ b/cmd/infracost/testdata/comment_bitbucket_commit/comment_bitbucket_commit.golden
@@ -1,5 +1,5 @@
 
-## Infracost estimate: **monthly cost will increase by $40.56 (+100%) 📈**
+## Infracost estimate: **monthly cost will increase by $40.56 (+100%) ↑**
 
 | **Project** | **Previous** | **New** | **Diff** |
 | ----------- | -----------: | ------: | -------- |

--- a/cmd/infracost/testdata/comment_bitbucket_pull_request/comment_bitbucket_pull_request.golden
+++ b/cmd/infracost/testdata/comment_bitbucket_pull_request/comment_bitbucket_pull_request.golden
@@ -1,5 +1,5 @@
 
-## 💰 Infracost estimate: **monthly cost will increase by $40.56 (+100%) 📈**
+## Infracost estimate: **monthly cost will increase by $40.56 (+100%) 📈**
 
 | **Project** | **Previous** | **New** | **Diff** |
 | ----------- | -----------: | ------: | -------- |

--- a/cmd/infracost/testdata/comment_bitbucket_pull_request/comment_bitbucket_pull_request.golden
+++ b/cmd/infracost/testdata/comment_bitbucket_pull_request/comment_bitbucket_pull_request.golden
@@ -1,5 +1,5 @@
 
-## Infracost estimate: **monthly cost will increase by $40.56 (+100%) 📈**
+## Infracost estimate: **monthly cost will increase by $40.56 (+100%) ↑**
 
 | **Project** | **Previous** | **New** | **Diff** |
 | ----------- | -----------: | ------: | -------- |

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -45,15 +45,23 @@ func formatMarkdownCostChange(currency string, pastCost, cost *decimal.Decimal, 
 	return plusMinus + formatCost(currency, cost) + percentChange
 }
 
-func formatCostChangeSentence(currency string, pastCost, cost *decimal.Decimal) string {
+func formatCostChangeSentence(currency string, pastCost, cost *decimal.Decimal, useEmoji bool) string {
+	up := "📈"
+	down := "📉"
+
+	if !useEmoji {
+		up = "↑"
+		down = "↓"
+	}
+
 	if pastCost != nil {
 		if pastCost.Equals(*cost) {
 			return "monthly cost will not change"
 		} else if pastCost.GreaterThan(*cost) {
-			return "monthly cost will decrease by " + formatMarkdownCostChange(currency, pastCost, cost, true) + " 📉"
+			return "monthly cost will decrease by " + formatMarkdownCostChange(currency, pastCost, cost, true) + " " + down
 		}
 	}
-	return "monthly cost will increase by " + formatMarkdownCostChange(currency, pastCost, cost, true) + " 📈"
+	return "monthly cost will increase by " + formatMarkdownCostChange(currency, pastCost, cost, true) + " " + up
 }
 
 func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, error) {

--- a/internal/output/slack_message.go
+++ b/internal/output/slack_message.go
@@ -91,7 +91,7 @@ func ToSlackMessage(out Root, opts Options) ([]byte, error) {
 		slack.NewSectionBlock(
 			&slack.TextBlockObject{
 				Type: slack.MarkdownType,
-				Text: fmt.Sprintf("💰 Infracost estimate: *%s*", formatCostChangeSentence(out.Currency, out.PastTotalMonthlyCost, out.TotalMonthlyCost)),
+				Text: fmt.Sprintf("💰 Infracost estimate: *%s*", formatCostChangeSentence(out.Currency, out.PastTotalMonthlyCost, out.TotalMonthlyCost, true)),
 			},
 			[]*slack.TextBlockObject{}, nil,
 		),

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -362,7 +362,7 @@ var CommentMarkdownTemplate = `
 {{- define "totalRow"}}
 | **{{ truncateMiddle .Name 64 "..." }}** | **{{ formatCost .PastCost }}** | **{{ formatCost .Cost }}** | **{{ formatCostChange .PastCost .Cost }}** |
 {{- end }}
-## 💰 Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost }}**
+## Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost }}**
 
 | **Project** | **Previous** | **New** | **Diff** |
 | ----------- | -----------: | ------: | -------- |

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -297,7 +297,7 @@ var CommentMarkdownWithHTMLTemplate = `
       <td>{{ formatCostChange .PastCost .Cost }}</td>
     </tr>
 {{- end}}
-💰 Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost }}**
+💰 Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost true }}**
 <table>
   <thead>
     <td>Project</td>
@@ -362,7 +362,7 @@ var CommentMarkdownTemplate = `
 {{- define "totalRow"}}
 | **{{ truncateMiddle .Name 64 "..." }}** | **{{ formatCost .PastCost }}** | **{{ formatCost .Cost }}** | **{{ formatCostChange .PastCost .Cost }}** |
 {{- end }}
-## Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost }}**
+## Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost false }}**
 
 | **Project** | **Previous** | **New** | **Diff** |
 | ----------- | -----------: | ------: | -------- |


### PR DESCRIPTION
This template is designed to be the basic version of the output and
currently emojis can break with some database backends in Bitbucket
Server so removing the emoji from this template.

This would close #1396