### PR TITLE
chore: Change styling of output URLs

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -497,7 +497,7 @@ func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {
 	if cmd.Name() != "infracost" && !hasPathFlag && !hasConfigFile {
 		m := fmt.Sprintf("No path specified\n\nUse the %s flag to specify the path to one of the following:\n", ui.PrimaryString("--path"))
 		m += " - Terraform plan JSON file\n - Terraform/Terragrunt directory\n - Terraform plan file\n - Terraform state JSON file"
-		m += "\n\nAlternatively, use --config-file to process multiple projects, see https://infracost.io/config-file"
+		m += "\n\nAlternatively, use --config-file to process multiple projects, see " + ui.SecondaryLinkString("https://infracost.io/config-file")
 
 		ui.PrintUsage(cmd)
 		return errors.New(m)

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -313,19 +313,21 @@ func (r *Root) summaryMessage(showSkipped bool) string {
 		}
 
 		if r.Summary.TotalUsageBasedResources != nil && *r.Summary.TotalUsageBasedResources > 0 {
+			usageLink := ui.SecondaryLinkString("https://infracost.io/usage-file")
 			if *r.Summary.TotalUsageBasedResources == 1 {
-				msg += fmt.Sprintf(", 1 includes usage-based costs, see %s", "https://infracost.io/usage-file")
+				msg += fmt.Sprintf(", 1 includes usage-based costs, see %s", usageLink)
 			} else {
-				msg += fmt.Sprintf(", %d include usage-based costs, see %s", *r.Summary.TotalUsageBasedResources, "https://infracost.io/usage-file")
+				msg += fmt.Sprintf(", %d include usage-based costs, see %s", *r.Summary.TotalUsageBasedResources, usageLink)
 			}
 		}
 	}
 
 	if r.Summary.TotalUnsupportedResources != nil && *r.Summary.TotalUnsupportedResources > 0 {
+		reportLink := ui.SecondaryLinkString("https://github.com/infracost/infracost")
 		if *r.Summary.TotalUnsupportedResources == 1 {
-			msg += fmt.Sprintf("\n∙ 1 wasn't estimated, report it in %s", "https://github.com/infracost/infracost")
+			msg += fmt.Sprintf("\n∙ 1 wasn't estimated, report it in %s", reportLink)
 		} else {
-			msg += fmt.Sprintf("\n∙ %d weren't estimated, report them in %s", *r.Summary.TotalUnsupportedResources, "https://github.com/infracost/infracost")
+			msg += fmt.Sprintf("\n∙ %d weren't estimated, report them in %s", *r.Summary.TotalUnsupportedResources, reportLink)
 		}
 
 		if showSkipped {

--- a/internal/ui/strings.go
+++ b/internal/ui/strings.go
@@ -6,18 +6,20 @@ import (
 	"github.com/fatih/color"
 )
 
+var primary = color.New(color.FgHiCyan)
+
 var yellow = color.New(color.FgYellow)
 var red = color.New(color.FgHiRed)
 var green = color.New(color.FgHiGreen)
-var blue = color.New(color.FgHiBlue)
-var magenta = color.New(color.FgHiCyan)
 
 var bold = color.New(color.Bold)
 var faint = color.New(color.Faint)
 var underline = color.New(color.Underline)
 
+var primaryLink = color.New(color.Underline).Add(color.Bold)
+
 func PrimaryString(msg string) string {
-	return magenta.Sprint(msg)
+	return primary.Sprint(msg)
 }
 
 func PrimaryStringf(msg string, a ...interface{}) string {
@@ -49,11 +51,19 @@ func WarningStringf(msg string, a ...interface{}) string {
 }
 
 func LinkString(msg string) string {
-	return blue.Sprint(msg)
+	return primaryLink.Sprint(msg)
 }
 
 func LinkStringf(msg string, a ...interface{}) string {
 	return LinkString(fmt.Sprintf(msg, a...))
+}
+
+func SecondaryLinkString(msg string) string {
+	return underline.Sprint(msg)
+}
+
+func SecondaryLinkStringf(msg string, a ...interface{}) string {
+	return SecondaryLinkString(fmt.Sprintf(msg, a...))
 }
 
 func BoldString(msg string) string {


### PR DESCRIPTION
Colored links have poor readability in terminals that don't support high
contrast colors.

Black background:
![image](https://user-images.githubusercontent.com/87082/155720688-73289797-17a9-4dda-8d05-b91a73206185.png)

White background:
![image](https://user-images.githubusercontent.com/87082/155720742-80041314-9189-4263-9435-39410846f49c.png)

Windows Command Prompt:
![image](https://user-images.githubusercontent.com/87082/155721096-811d98ff-ebcc-423b-ac10-7b7f9d0c0fc8.png)


With `--no-color` flag:
![image](https://user-images.githubusercontent.com/87082/155720652-ed412dba-a2e0-4c8f-99ae-02cf700072e5.png)
