### PR TITLE
fix: load manifest from .terraform if exists

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -467,20 +467,20 @@ func runHCLProvider(wg *sync.WaitGroup, ctx *config.ProjectContext, usageFile *u
 
 	hclProvider, err := terraform.NewHCLProvider(ctx, terraform.NewPlanJSONProvider(ctx))
 	if err != nil {
-		log.Debugf("could not init hcl provider %s", err)
+		log.Debugf("Could not init HCL provider: %s", err)
 		return
 	}
 
 	projects, err := hclProvider.LoadResources(usageFile.ToUsageDataMap())
 	if err != nil {
-		log.Debugf("error loading projects from hcl provider %s", err)
+		log.Debugf("Error loading projects from HCL provider: %s", err)
 		return
 	}
 
 	for _, project := range projects {
 		err := prices.PopulatePrices(runCtx, project)
 		if err != nil {
-			log.Debugf("error populating prices for hcl project %s", err)
+			log.Debugf("Error populating prices for HCL project: %s", err)
 			return
 		}
 

--- a/internal/hcl/modules/cache_test.go
+++ b/internal/hcl/modules/cache_test.go
@@ -20,6 +20,17 @@ func TestLookupModule(t *testing.T) {
 			Source: "git::https://github.com/namespace/module-b.git?v=0.5.0",
 			Dir:    ".infracost/module-b",
 		},
+		"submodule-a": {
+			Key:     "submodule-a",
+			Source:  "registry.terraform.io/namespace/module-a/aws//submodule/path",
+			Version: "1.0.0",
+			Dir:     ".infracost/module-a/submodule/path",
+		},
+		"submodule-b": {
+			Key:    "submodule-a",
+			Source: "git::https://github.com/namespace/module-b.git//submodule/path?v=0.5.0",
+			Dir:    ".infracost/module-b/submodule/path",
+		},
 	}
 	cache := &Cache{
 		keyMap: keyMap,
@@ -38,6 +49,12 @@ func TestLookupModule(t *testing.T) {
 		{"module-b", &tfconfig.ModuleCall{Source: "git::https://github.com/namespace/module-b.git?v=0.5.0"}, keyMap["module-b"], ""},
 		{"module-b", &tfconfig.ModuleCall{Source: "git::https://github.com/namespace/module-b.git?v=0.6.0"}, nil, "source has changed"},
 		{"module-c", &tfconfig.ModuleCall{Source: "git::https://github.com/namespace/module-c.git?v=0.6.0"}, nil, "not in cache"},
+		{"submodule-a", &tfconfig.ModuleCall{Source: "registry.terraform.io/namespace/module-a/aws//submodule/path", Version: ">=1.0"}, keyMap["submodule-a"], ""},
+		{"submodule-a", &tfconfig.ModuleCall{Source: "namespace/module-a/aws//submodule/path", Version: ">=1.0"}, keyMap["submodule-a"], ""},
+		{"submodule-a", &tfconfig.ModuleCall{Source: "registry.terraform.io/namespace/module-a/aws//submodule/path", Version: ">=2.0"}, nil, "version constraint doesn't match"},
+		{"submodule-a", &tfconfig.ModuleCall{Source: "registry.terraform.io/different-namespace/module-a-/aws//submodule/path", Version: "1.0.0"}, nil, "source has changed"},
+		{"submodule-b", &tfconfig.ModuleCall{Source: "git::https://github.com/namespace/module-b.git//submodule/path?v=0.5.0"}, keyMap["submodule-b"], ""},
+		{"submodule-b", &tfconfig.ModuleCall{Source: "git::https://github.com/namespace/module-b.git//submodule/path?v=0.6.0"}, nil, "source has changed"},
 	}
 
 	for _, test := range tests {

--- a/internal/hcl/modules/fetch.go
+++ b/internal/hcl/modules/fetch.go
@@ -35,7 +35,7 @@ func (r *PackageFetcher) fetch(moduleAddr string, dest string) error {
 			return fmt.Errorf("Failed to create directory '%s': %w", dest, err)
 		}
 
-		// Skip dotfiles and create new symlinks
+		// Skip dotfiles and create new symlinks to be consistent with what Terraform init does
 		opt := copy.Options{
 			Skip: func(src string) (bool, error) {
 				return strings.HasPrefix(filepath.Base(src), "."), nil

--- a/internal/hcl/modules/loader_test.go
+++ b/internal/hcl/modules/loader_test.go
@@ -117,6 +117,39 @@ func TestModuleMultipleUses(t *testing.T) {
 	}, true)
 }
 
+func TestModuleMultipleUsesMissingManifest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
+	expectedModules := []*ManifestModule{
+		{
+			Key:     "registry-module-1",
+			Source:  "registry.terraform.io/terraform-aws-modules/ec2-instance/aws",
+			Version: "3.4.0",
+			Dir:     ".infracost/terraform_modules/registry-module-1",
+		},
+		{
+			Key:     "registry-module-2",
+			Source:  "registry.terraform.io/terraform-aws-modules/ec2-instance/aws",
+			Version: "3.4.0",
+			Dir:     ".infracost/terraform_modules/registry-module-2",
+		},
+	}
+
+	// Run first time to download modules
+	testLoaderE2E(t, "./testdata/module_multiple_uses", expectedModules, true)
+
+	// Remove the manifest file to test we can still work with broken manifests
+	err := os.Remove("./testdata/module_multiple_uses/.infracost/terraform_modules/manifest.json")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	// Re-run without cleaning up the modules directory
+	testLoaderE2E(t, "./testdata/module_multiple_uses", expectedModules, false)
+}
+
 func TestWithCachedModules(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/hcl/modules"
 )
 
@@ -158,9 +157,7 @@ func (p *Parser) ParseDirectory() ([]*Module, error) {
 	// load the modules. This downloads any remote modules to the local file system
 	modulesManifest, err := p.moduleLoader.Load()
 	if err != nil {
-		if !config.IsTest() {
-			log.Warnf("Error loading modules. This is required for Infracost to get accurate results: %s", err)
-		}
+		return nil, fmt.Errorf("Error loading Terraform modules: %s", err)
 	}
 
 	log.Debug("Evaluating expressions...")


### PR DESCRIPTION
@aliscott I briefly tested this before running into the the module loader bugs that we discussed. Might need another test locally to make sure though.