### PR TITLE
fix: cleanup hcl debug for verbose messages

### DIFF
--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -32,6 +32,8 @@ type Attribute struct {
 	// Ctx is the context that the Attribute should be evaluated against. This propagates
 	// any references from variables into the attribute.
 	Ctx *Context
+	// Verbose defines if the attribute should log verbose diagnostics messages to debug.
+	Verbose bool
 }
 
 // IsIterable returns if the attribute can be ranged over.
@@ -56,7 +58,9 @@ func (attr *Attribute) Value() (ctyVal cty.Value) {
 	var diag hcl.Diagnostics
 	ctyVal, diag = attr.HCLAttr.Expr.Value(attr.Ctx.Inner())
 	if diag.HasErrors() {
-		log.Debugf("error diagnostic return from evaluating %s err: %s", attr.HCLAttr.Name, diag.Error())
+		if attr.Verbose {
+			log.Debugf("error diagnostic return from evaluating %s err: %s", attr.HCLAttr.Name, diag.Error())
+		}
 	}
 
 	if !ctyVal.IsKnown() {

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -132,7 +132,7 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *Context, moduleBlock *Block) *Block {
 			}
 
 			if _, ok := body.Attributes["arn"]; !ok {
-				body.Attributes["arn"] = newUniqueAttribute("arn")
+				body.Attributes["arn"] = newArnAttribute("arn")
 			}
 		}
 
@@ -178,6 +178,20 @@ func newUniqueAttribute(name string) *hclsyntax.Attribute {
 		Name: name,
 		Expr: &hclsyntax.LiteralValueExpr{
 			Val: cty.StringVal(uuid.NewString()),
+		},
+	}
+}
+
+func newArnAttribute(name string) *hclsyntax.Attribute {
+	// fakeARN replicates an aws arn string it deliberately leaves the
+	// region section (in between the 3rd and 4th semicolon) blank as
+	// Infracost will try and parse this region later down the line.
+	// Keeping it blank will defer the region to what the provider has defined.
+	fakeARN := fmt.Sprintf("arn:aws:hcl::%s", uuid.NewString())
+	return &hclsyntax.Attribute{
+		Name: name,
+		Expr: &hclsyntax.LiteralValueExpr{
+			Val: cty.StringVal(fakeARN),
 		},
 	}
 }

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -2,6 +2,7 @@ package hcl
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/google/uuid"
@@ -106,6 +107,8 @@ type Block struct {
 	// childBlocks holds information about any child Blocks that the Block may have. This can be empty.
 	// See Block docs for more information about child Blocks.
 	childBlocks Blocks
+	// verbose determines whether the block uses verbose debug logging.
+	verbose bool
 }
 
 // NewHCLBlock returns a Block with Context and child Blocks initialised.
@@ -114,6 +117,7 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *Context, moduleBlock *Block) *Block {
 		ctx = NewContext(&hcl.EvalContext{}, nil)
 	}
 
+	isLoggingVerbose := strings.TrimSpace(os.Getenv("INFRACOST_HCL_DEBUG_VERBOSE")) == "true"
 	var children Blocks
 	if body, ok := hclBlock.Body.(*hclsyntax.Body); ok {
 		for _, b := range body.Blocks {
@@ -137,6 +141,7 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *Context, moduleBlock *Block) *Block {
 			hclBlock:    hclBlock,
 			moduleBlock: moduleBlock,
 			childBlocks: children,
+			verbose:     isLoggingVerbose,
 		}
 	}
 
@@ -151,6 +156,7 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *Context, moduleBlock *Block) *Block {
 			hclBlock:    hclBlock,
 			moduleBlock: moduleBlock,
 			childBlocks: children,
+			verbose:     isLoggingVerbose,
 		}
 	}
 
@@ -163,6 +169,7 @@ func NewHCLBlock(hclBlock *hcl.Block, ctx *Context, moduleBlock *Block) *Block {
 		hclBlock:    hclBlock,
 		moduleBlock: moduleBlock,
 		childBlocks: children,
+		verbose:     isLoggingVerbose,
 	}
 }
 
@@ -384,7 +391,7 @@ func (b *Block) GetAttributes() []*Attribute {
 	}
 
 	for _, attr := range b.getHCLAttributes() {
-		results = append(results, &Attribute{HCLAttr: attr, Ctx: b.context})
+		results = append(results, &Attribute{HCLAttr: attr, Ctx: b.context, Verbose: b.verbose})
 	}
 
 	return results

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -154,7 +154,7 @@ func (e *Evaluator) evaluate(lastContext hcl.EvalContext) {
 // evaluateStep gets the values for all the Block types in the current Module that affect Context.
 // It then sets these values on the Context so that they can be used in Block Attribute evaluation.
 func (e *Evaluator) evaluateStep(i int) {
-	log.Debugf("Starting iteration %d of context evaluation...", i+1)
+	log.Debugf("Starting context evaluation for module %s iteration %d", e.modulePath, i+1)
 
 	e.ctx.Set(e.getValuesByBlockType("variable"), "var")
 	e.ctx.Set(e.getValuesByBlockType("locals"), "local")


### PR DESCRIPTION
* Removes attribute evaluation messages caused by partial context at time of evaluation
* Adds verbose env var `INFRACOST_HCL_DEBUG_VERBOSE` that can show these messages, as this could help us track a bug down in the future
* Change context evaluation log message to be more clear
* Changes fake "arn" attribute on hcl resources to be the format AWS defines so we skip the : `Unexpected ARN format` debug line