### PR TITLE
feat: Add application autoscaling support for ElastiCache replication groups

### DIFF
--- a/internal/providers/terraform/aws/elasticache_replication_group.go
+++ b/internal/providers/terraform/aws/elasticache_replication_group.go
@@ -11,7 +11,7 @@ func getElastiCacheReplicationGroupItem() *schema.RegistryItem {
 		RFunc:               NewElastiCacheReplicationGroup,
 		ReferenceAttributes: []string{"aws_appautoscaling_target.resource_id"},
 		CustomRefIDFunc: func(d *schema.ResourceData) []string {
-			// returns a table name that will match the custom format used by aws_appautoscaling_target.resource_id
+			// returns a name that will match the custom format used by aws_appautoscaling_target.resource_id
 			name := d.Get("replication_group_id").String()
 			if name != "" {
 				return []string{"replication-group/" + name}

--- a/internal/providers/terraform/aws/elasticache_replication_group.go
+++ b/internal/providers/terraform/aws/elasticache_replication_group.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"github.com/infracost/infracost/internal/resources/aws"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/tidwall/gjson"
 )
 
 func getElastiCacheReplicationGroupItem() *schema.RegistryItem {
@@ -13,16 +12,32 @@ func getElastiCacheReplicationGroupItem() *schema.RegistryItem {
 	}
 }
 func NewElastiCacheReplicationGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	cacheClusters := d.Get("num_cache_clusters").Int()
+	if d.IsEmpty("num_cache_clusters") {
+		// check for deprecated attribute
+		cacheClusters = d.Get("number_cache_clusters").Int()
+	}
+
+	clusterNodeGroups := d.Get("num_node_groups").Int()
+	if d.IsEmpty("num_node_groups") {
+		// check for deprecated attribute
+		clusterNodeGroups = d.Get("cluster_mode.0.num_node_groups").Int()
+	}
+
+	clusterReplicasPerNodeGroup := d.Get("replicas_per_node_group").Int()
+	if d.IsEmpty("replicas_per_node_group") {
+		// check for deprecated attribute
+		clusterReplicasPerNodeGroup = d.Get("cluster_mode.0.replicas_per_node_group").Int()
+	}
+
 	r := &aws.ElastiCacheReplicationGroup{
 		Address:                     d.Address,
 		Region:                      d.Get("region").String(),
 		NodeType:                    d.Get("node_type").String(),
 		Engine:                      d.Get("engine").String(),
-		CacheClusters:               d.Get("number_cache_clusters").Int(),
-		ClusterDisabled:             d.Get("cluster_enabled").Type != gjson.Null && !d.Get("cluster_enabled").Bool(),
-		ClusterMode:                 d.Get("cluster_mode").String(),
-		ClusterNodeGroups:           d.Get("cluster_mode.0.num_node_groups").Int(),
-		ClusterReplicasPerNodeGroup: d.Get("cluster_mode.0.replicas_per_node_group").Int(),
+		CacheClusters:               cacheClusters,
+		ClusterNodeGroups:           clusterNodeGroups,
+		ClusterReplicasPerNodeGroup: clusterReplicasPerNodeGroup,
 		SnapshotRetentionLimit:      d.Get("snapshot_retention_limit").Int(),
 	}
 

--- a/internal/providers/terraform/aws/elasticache_replication_group.go
+++ b/internal/providers/terraform/aws/elasticache_replication_group.go
@@ -21,8 +21,8 @@ func getElastiCacheReplicationGroupItem() *schema.RegistryItem {
 	}
 }
 func NewElastiCacheReplicationGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	cacheClusters := d.Get("num_cache_clusters").Int()
-	if d.IsEmpty("num_cache_clusters") {
+	cacheClusters := d.GetInt64OrDefault("num_cache_clusters", 1)
+	if d.IsEmpty("num_cache_clusters") && !d.IsEmpty("number_cache_clusters") {
 		// check for deprecated attribute
 		cacheClusters = d.Get("number_cache_clusters").Int()
 	}

--- a/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.golden
@@ -1,19 +1,25 @@
 
- Name                                                       Monthly Qty  Unit              Monthly Cost 
-                                                                                                        
- aws_elasticache_replication_group.cluster                                                              
- └─ ElastiCache (on-demand, cache.m4.large)                      11,680  hours                $1,822.08 
-                                                                                                        
- aws_elasticache_replication_group.non-cluster                                                          
- └─ ElastiCache (on-demand, cache.r5.4xlarge)                     2,190  hours                $3,775.56 
-                                                                                                        
- aws_elasticache_replication_group.non-cluster-snapshot                                                 
- ├─ ElastiCache (on-demand, cache.m6g.12xlarge)                   2,190  hours                $7,789.83 
- └─ Backup storage                                       Monthly cost depends on usage: $0.085 per GB   
-                                                                                                        
- OVERALL TOTAL                                                                               $13,387.47 
+ Name                                                                 Monthly Qty  Unit              Monthly Cost 
+                                                                                                                  
+ aws_elasticache_replication_group.cluster                                                                        
+ └─ ElastiCache (on-demand, cache.m4.large)                                11,680  hours                $1,822.08 
+                                                                                                                  
+ aws_elasticache_replication_group.cluster-deprecated-attribs                                                     
+ └─ ElastiCache (on-demand, cache.m4.large)                                11,680  hours                $1,822.08 
+                                                                                                                  
+ aws_elasticache_replication_group.non-cluster                                                                    
+ └─ ElastiCache (on-demand, cache.r5.4xlarge)                               2,190  hours                $3,775.56 
+                                                                                                                  
+ aws_elasticache_replication_group.non-cluster-deprecated-attribs                                                 
+ └─ ElastiCache (on-demand, cache.r5.4xlarge)                               2,190  hours                $3,775.56 
+                                                                                                                  
+ aws_elasticache_replication_group.non-cluster-snapshot                                                           
+ ├─ ElastiCache (on-demand, cache.m6g.12xlarge)                             2,190  hours                $7,789.83 
+ └─ Backup storage                                                 Monthly cost depends on usage: $0.085 per GB   
+                                                                                                                  
+ OVERALL TOTAL                                                                                         $18,985.11 
 ──────────────────────────────────
-3 cloud resources were detected:
-∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
 
 Add cost estimates to your pull requests: https://infracost.io/cicd

--- a/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.golden
@@ -4,6 +4,12 @@
  aws_elasticache_replication_group.cluster                                                                        
  └─ ElastiCache (on-demand, cache.m4.large)                                11,680  hours                $1,822.08 
                                                                                                                   
+ aws_elasticache_replication_group.cluster-autoscale                                                              
+ └─ ElastiCache (on-demand, cache.m4.large, autoscaling)                   35,040  hours                $5,466.24 
+                                                                                                                  
+ aws_elasticache_replication_group.cluster-autoscale-usage                                                        
+ └─ ElastiCache (on-demand, cache.m4.large, autoscaling)                   29,200  hours                $4,555.20 
+                                                                                                                  
  aws_elasticache_replication_group.cluster-deprecated-attribs                                                     
  └─ ElastiCache (on-demand, cache.m4.large)                                11,680  hours                $1,822.08 
                                                                                                                   
@@ -17,9 +23,9 @@
  ├─ ElastiCache (on-demand, cache.m6g.12xlarge)                             2,190  hours                $7,789.83 
  └─ Backup storage                                                 Monthly cost depends on usage: $0.085 per GB   
                                                                                                                   
- OVERALL TOTAL                                                                                         $18,985.11 
+ OVERALL TOTAL                                                                                         $29,006.55 
 ──────────────────────────────────
-5 cloud resources were detected:
-∙ 5 were estimated, 5 include usage-based costs, see https://infracost.io/usage-file
+10 cloud resources were detected:
+∙ 10 were estimated, 7 include usage-based costs, see https://infracost.io/usage-file
 
 Add cost estimates to your pull requests: https://infracost.io/cicd

--- a/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.tf
+++ b/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.tf
@@ -17,10 +17,8 @@ resource "aws_elasticache_replication_group" "cluster" {
 
   engine = "redis"
 
-  cluster_mode {
-    num_node_groups         = 4
-    replicas_per_node_group = 3
-  }
+  num_node_groups         = 4
+  replicas_per_node_group = 3
 }
 
 resource "aws_elasticache_replication_group" "non-cluster" {
@@ -40,6 +38,30 @@ resource "aws_elasticache_replication_group" "non-cluster-snapshot" {
 
   engine = "redis"
 
-  node_type             = "cache.m6g.12xlarge"
+  node_type          = "cache.m6g.12xlarge"
+  num_cache_clusters = 3
+}
+
+resource "aws_elasticache_replication_group" "cluster-deprecated-attribs" {
+  replication_group_description = "This Replication Group"
+  replication_group_id          = "tf-rep-group-4"
+  automatic_failover_enabled    = true
+  node_type                     = "cache.m4.large"
+
+  engine = "redis"
+
+  cluster_mode {
+    num_node_groups         = 4
+    replicas_per_node_group = 3
+  }
+}
+
+resource "aws_elasticache_replication_group" "non-cluster-deprecated-attribs" {
+  replication_group_description = "This Replication Group"
+  replication_group_id          = "tf-rep-group-5"
+
+  engine = "redis"
+
+  node_type             = "cache.r5.4xlarge"
   number_cache_clusters = 3
 }

--- a/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.tf
+++ b/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.tf
@@ -65,3 +65,51 @@ resource "aws_elasticache_replication_group" "non-cluster-deprecated-attribs" {
   node_type             = "cache.r5.4xlarge"
   number_cache_clusters = 3
 }
+
+resource "aws_elasticache_replication_group" "cluster-autoscale" {
+  replication_group_description = "This Replication Group"
+  replication_group_id          = "tf-rep-group-6"
+  automatic_failover_enabled    = true
+  node_type                     = "cache.m4.large"
+
+  engine = "redis"
+
+  num_node_groups         = 4
+  replicas_per_node_group = 3
+}
+
+resource "aws_appautoscaling_target" "autoscale_node_groups" {
+  max_capacity       = 13
+  min_capacity       = 8
+  resource_id        = "replication-group/${aws_elasticache_replication_group.cluster-autoscale.replication_group_id}"
+  scalable_dimension = "elasticache:replication-group:NodeGroups"
+  service_namespace  = "elasticache"
+}
+
+resource "aws_appautoscaling_target" "autoscale_replicas" {
+  max_capacity       = 17
+  min_capacity       = 5
+  resource_id        = "replication-group/${aws_elasticache_replication_group.cluster-autoscale.replication_group_id}"
+  scalable_dimension = "elasticache:replication-group:Replicas"
+  service_namespace  = "elasticache"
+}
+
+resource "aws_elasticache_replication_group" "cluster-autoscale-usage" {
+  replication_group_description = "This Replication Group"
+  replication_group_id          = "tf-rep-group-7"
+  automatic_failover_enabled    = true
+  node_type                     = "cache.m4.large"
+
+  engine = "redis"
+
+  num_node_groups         = 4
+  replicas_per_node_group = 3
+}
+
+resource "aws_appautoscaling_target" "autoscale_node_groups_usage" {
+  max_capacity       = 2
+  min_capacity       = 1
+  resource_id        = "replication-group/tf-rep-group-7"
+  scalable_dimension = "elasticache:replication-group:NodeGroups"
+  service_namespace  = "elasticache"
+}

--- a/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/elasticache_replication_group_test/elasticache_replication_group_test.usage.yml
@@ -1,0 +1,4 @@
+version: 0.1
+resource_usage:
+  aws_appautoscaling_target.autoscale_node_groups_usage:
+    capacity: 10

--- a/internal/resources/aws/elasticache_cluster.go
+++ b/internal/resources/aws/elasticache_cluster.go
@@ -40,7 +40,7 @@ func (r *ElastiCacheCluster) BuildResource() *schema.Resource {
 	}
 
 	costComponents := []*schema.CostComponent{
-		r.elastiCacheCostComponent(),
+		r.elastiCacheCostComponent(false),
 	}
 
 	if strings.ToLower(r.Engine) == "redis" && r.SnapshotRetentionLimit > 1 {
@@ -53,9 +53,14 @@ func (r *ElastiCacheCluster) BuildResource() *schema.Resource {
 	}
 }
 
-func (r *ElastiCacheCluster) elastiCacheCostComponent() *schema.CostComponent {
+func (r *ElastiCacheCluster) elastiCacheCostComponent(autoscaling bool) *schema.CostComponent {
+	nameParams := []string{"on-demand", r.NodeType}
+	if autoscaling {
+		nameParams = append(nameParams, "autoscaling")
+	}
+
 	return &schema.CostComponent{
-		Name:           fmt.Sprintf("ElastiCache (on-demand, %s)", r.NodeType),
+		Name:           fmt.Sprintf("ElastiCache (%s)", strings.Join(nameParams, ", ")),
 		Unit:           "hours",
 		UnitMultiplier: decimal.NewFromInt(1),
 		HourlyQuantity: decimalPtr(decimal.NewFromInt(r.CacheNodes)),

--- a/internal/resources/aws/elasticache_replication_group.go
+++ b/internal/resources/aws/elasticache_replication_group.go
@@ -13,8 +13,6 @@ type ElastiCacheReplicationGroup struct {
 	NodeType                    string
 	Engine                      string
 	CacheClusters               int64
-	ClusterDisabled             bool
-	ClusterMode                 string
 	ClusterNodeGroups           int64
 	ClusterReplicasPerNodeGroup int64
 	SnapshotRetentionLimit      int64
@@ -36,8 +34,8 @@ func (r *ElastiCacheReplicationGroup) BuildResource() *schema.Resource {
 	}
 
 	cacheNodes := r.CacheClusters
-
-	if r.ClusterMode != "" && !r.ClusterDisabled {
+	if r.ClusterNodeGroups > 0 {
+		// CacheClusters is mutually exclusive with ClusterNodeGroups/ClusterReplicasPerNodeGroup
 		cacheNodes = (r.ClusterNodeGroups * r.ClusterReplicasPerNodeGroup) + r.ClusterNodeGroups
 	}
 


### PR DESCRIPTION
The first commit adds support for renamed terraform attributes related to the number of shards/replicas.  The second commit adds app autoscaling support.