### PR TITLE
feat(aws): add elastic beanstalk environment

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -161,6 +161,11 @@ resource_usage:
     monthly_cpu_credit_hrs: 350 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     vcpu_count: 2 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
 
+  aws_elastic_beanstalk_environment.my_eb_environment:
+    monthly_data_ingested_gb: 50  # Cloudwatch log stream ingest in GB
+    monthly_data_scanned_gb: 50   # Cloudwatch data scanned in GB
+    storage_gb: 100               # Cloudwatch storage used in GB
+
   aws_elasticache_cluster.my_redis_snapshot:
     snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB.
 

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -162,14 +162,24 @@ resource_usage:
     vcpu_count: 2 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
 
   aws_elastic_beanstalk_environment.my_eb_environment:
-    monthly_data_ingested_gb: 50  # Cloudwatch log stream ingest in GB
-    monthly_data_scanned_gb: 50   # Cloudwatch data scanned in GB
-    storage_gb: 100               # Cloudwatch storage used in GB
-    new_connections: 500000    # Loadbalancer newly established connections per second on average.
-    active_connections: 100000 # Loadbalancer active connections per minute on average.
-    processed_bytes_gb: 25000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
-    rule_evaluations: 10000 # Loadbalancer rule evaulations
-
+    db:
+      additional_backup_storage_gb: 1000  # Amount of backup storage used that is in excess of 100% of the storage size for all databases in GB.
+      monthly_standard_io_requests: 10000 # Monthly number of input/output requests for database.
+      monthly_additional_performance_insights_requests: 10000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
+    ec2:
+      monthly_cpu_credit_hrs: 350 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
+    cloudwatch:
+      storage_gb: 1000               # Total data stored by CloudWatch logs in GB.
+      monthly_data_ingested_gb: 1000 # Monthly data ingested by CloudWatch logs in GB.
+      monthly_data_scanned_gb: 200   # Monthly data scanned by CloudWatch logs insights in GB.
+    lb:
+      new_connections: 500000    # Number of newly established connections per second on average.
+      active_connections: 100000 # Number of active connections per minute on average.
+      processed_bytes_gb: 25000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
+      rule_evaluations: 10000    # Number of rule evaluations on application/network load balancers
+    elb:
+      monthly_data_processed_gb: 10000 # Monthly data processed on classic loadbalaner
+    
   aws_elasticache_cluster.my_redis_snapshot:
     snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB.
 

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -165,6 +165,10 @@ resource_usage:
     monthly_data_ingested_gb: 50  # Cloudwatch log stream ingest in GB
     monthly_data_scanned_gb: 50   # Cloudwatch data scanned in GB
     storage_gb: 100               # Cloudwatch storage used in GB
+    new_connections: 500000    # Loadbalancer newly established connections per second on average.
+    active_connections: 100000 # Loadbalancer active connections per minute on average.
+    processed_bytes_gb: 25000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
+    rule_evaluations: 10000 # Loadbalancer rule evaulations
 
   aws_elasticache_cluster.my_redis_snapshot:
     snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB.

--- a/internal/providers/terraform/aws/elastic_beanstalk_environment.go
+++ b/internal/providers/terraform/aws/elastic_beanstalk_environment.go
@@ -13,10 +13,9 @@ func getElasticBeanstalkEnvironmentRegistryItem() *schema.RegistryItem {
 }
 
 func newElasticBeanstalkEnvironment(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-
 	var region = d.Get("region").String()
-	var StreamLogs = false
-	var DBIncluded = false
+	var streamLogs = false
+	var dBIncluded = false
 
 	r := &aws.ElasticBeanstalkEnvironment{
 		Address: d.Address,
@@ -29,22 +28,27 @@ func newElasticBeanstalkEnvironment(d *schema.ResourceData, u *schema.UsageData)
 		Region:  region,
 		Tenancy: "dedicated",
 	}
+
 	volume := &aws.EBSVolume{
 		Address: "aws_ebs_volume",
 		Region:  region,
 	}
+
 	db := &aws.DBInstance{
 		Address: "aws_db_instance",
 		Region:  region,
 	}
+
 	cwlg := &aws.CloudwatchLogGroup{
 		Address: "aws_cloudwatch_log_group",
 		Region:  region,
 	}
+
 	elb := &aws.ELB{
 		Address: "aws_elb",
 		Region:  region,
 	}
+
 	lb := &aws.LB{
 		Address: "aws_loadbalancer",
 		Region:  region,
@@ -65,9 +69,9 @@ func newElasticBeanstalkEnvironment(d *schema.ResourceData, u *schema.UsageData)
 		case "LoadBalancerType":
 			r.LoadBalancerType = setting.Get("value").String()
 		case "StreamLogs":
-			StreamLogs = true
+			streamLogs = true
 		case "DBInstanceClass":
-			DBIncluded = true
+			dBIncluded = true
 			db.InstanceClass = setting.Get("value").String()
 		case "MultiAZDatabase":
 			db.MultiAZ = true
@@ -79,12 +83,15 @@ func newElasticBeanstalkEnvironment(d *schema.ResourceData, u *schema.UsageData)
 	}
 	r.LaunchConfiguration = lc
 	r.LaunchConfiguration.RootBlockDevice = volume
-	if DBIncluded {
+
+	if dBIncluded {
 		r.DBInstance = db
 	}
-	if StreamLogs {
+
+	if streamLogs {
 		r.CloudwatchLogGroup = cwlg
 	}
+
 	if r.LoadBalancerType == "classic" {
 		r.ElasticLoadBalancer = elb
 	} else {

--- a/internal/providers/terraform/aws/elastic_beanstalk_environment.go
+++ b/internal/providers/terraform/aws/elastic_beanstalk_environment.go
@@ -1,0 +1,50 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/resources/aws"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getElasticBeanstalkEnvironmentRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_elastic_beanstalk_environment",
+		RFunc: newElasticBeanstalkEnvironment,
+	}
+}
+
+func newElasticBeanstalkEnvironment(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	var nodeType = ""
+	var nodes = int64(0)
+	var loadBalancerType = ""
+	var streamLogs = false
+	purchaseOption := "on_demand"
+
+	for _, setting := range d.Get("setting").Array() {
+		if setting.Get("name").String() == "InstanceTypes" {
+			nodeType = setting.Get("value").String()
+		}
+		if setting.Get("name").String() == "MinSize" {
+			nodes = setting.Get("value").Int()
+		}
+		if setting.Get("name").String() == "LoadBalancerType" {
+			loadBalancerType = setting.Get("value").String()
+		}
+		if setting.Get("name").String() == "StreamLogs" {
+			streamLogs = setting.Get("value").Bool()
+		}
+	}
+
+	region := d.Get("region").String()
+	r := &aws.ElasticBeanstalkEnvironment{
+		LoadBalancerType: loadBalancerType,
+		Address:          d.Address,
+		Region:           region,
+		InstanceType:     nodeType,
+		Nodes:            nodes,
+		PurchaseOption:   purchaseOption,
+		StreamLogs:       streamLogs,
+	}
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/aws/elastic_beanstalk_environment.go
+++ b/internal/providers/terraform/aws/elastic_beanstalk_environment.go
@@ -13,38 +13,137 @@ func getElasticBeanstalkEnvironmentRegistryItem() *schema.RegistryItem {
 }
 
 func newElasticBeanstalkEnvironment(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	var nodeType = ""
-	var nodes = int64(0)
+
 	var loadBalancerType = ""
-	var streamLogs = false
-	purchaseOption := "on_demand"
+	var instanceType = ""
+	var instanceCount int64
+	var streamLogs bool
+	var rdsIncluded bool
+	var rootVolumeSize int64
+	var rootVolumeType = "gp2"
+	var rootVolumeIOPS int64
+
+	autoscalingGroup := &schema.ResourceData{}
+	data := autoscalingGroup
 
 	for _, setting := range d.Get("setting").Array() {
 		if setting.Get("name").String() == "InstanceTypes" {
-			nodeType = setting.Get("value").String()
+			instanceType = setting.Get("value").String()
 		}
 		if setting.Get("name").String() == "MinSize" {
-			nodes = setting.Get("value").Int()
+			instanceCount = setting.Get("value").Int()
+		}
+		if setting.Get("name").String() == "RootVolumeSize" {
+			rootVolumeSize = setting.Get("value").Int()
+		}
+		if setting.Get("name").String() == "RootVolumeIOPS" {
+			rootVolumeIOPS = setting.Get("value").Int()
+		}
+		if setting.Get("name").String() == "RootVolumeType" {
+			rootVolumeType = setting.Get("value").String()
 		}
 		if setting.Get("name").String() == "LoadBalancerType" {
+			data.Set("load_balancer_type", setting.Get("value").String())
 			loadBalancerType = setting.Get("value").String()
 		}
 		if setting.Get("name").String() == "StreamLogs" {
-			streamLogs = setting.Get("value").Bool()
+			streamLogs = true
+		}
+		if setting.Get("name").String() == "DBInstanceClass" {
+			rdsIncluded = true
+			data.Set("db_instance_class", setting.Get("value").String())
+		}
+		if setting.Get("name").String() == "MultiAZDatabase" {
+			data.Set("multi_az", true)
+		}
+		if setting.Get("name").String() == "DBEngine" {
+			data.Set("engine", setting.Get("value").String())
+		}
+		if setting.Get("name").String() == "DBAllocatedStorage" {
+			data.Set("allocated_storage", setting.Get("value").Float())
 		}
 	}
+	data.Set("region", d.Get("region").String())
+	data.Set("name", d.Get("name").String())
 
-	region := d.Get("region").String()
 	r := &aws.ElasticBeanstalkEnvironment{
-		LoadBalancerType: loadBalancerType,
 		Address:          d.Address,
-		Region:           region,
-		InstanceType:     nodeType,
-		Nodes:            nodes,
-		PurchaseOption:   purchaseOption,
+		Region:           d.Get("region").String(),
+		Name:             d.Get("name").String(),
+		InstanceType:     instanceType,
+		InstanceCount:    instanceCount,
+		LoadBalancerType: loadBalancerType,
 		StreamLogs:       streamLogs,
+		RDSIncluded:      rdsIncluded,
+		RootVolumeSize:   &rootVolumeSize,
+		RootVolumeType:   rootVolumeType,
+		RootVolumeIOPS:   rootVolumeIOPS,
 	}
+
+	if loadBalancerType == "classic" {
+		r.ElasticLoadBalancer = newELB(data, u)
+	} else {
+		r.LoadBalancer = newLB(data, u)
+	}
+
+	if streamLogs {
+		r.CloudwatchLogGroup = newCloudwatchLogGroup(data, u)
+	}
+
+	if rdsIncluded {
+		r.DBInstance = newDBInstance(data, u)
+	}
+
 	r.PopulateUsage(u)
 
 	return r.BuildResource()
+}
+
+func newLB(d *schema.ResourceData, u *schema.UsageData) *aws.LB {
+	loadBalancerType := d.Get("load_balancer_type").String()
+
+	r := &aws.LB{
+		Address:          "aws_load_balancer",
+		Region:           d.Get("region").String(),
+		LoadBalancerType: loadBalancerType,
+	}
+	r.PopulateUsage(u)
+	return r
+}
+
+func newELB(d *schema.ResourceData, u *schema.UsageData) *aws.ELB {
+	r := &aws.ELB{
+		Address: "aws_elb",
+		Region:  d.Get("region").String(),
+	}
+	r.PopulateUsage(u)
+	return r
+}
+
+func newCloudwatchLogGroup(d *schema.ResourceData, u *schema.UsageData) *aws.CloudwatchLogGroup {
+	r := &aws.CloudwatchLogGroup{
+		Address: "aws_cloudwatch_log_group",
+		Region:  d.Get("region").String(),
+	}
+
+	r.PopulateUsage(u)
+	return r
+}
+
+func newDBInstance(d *schema.ResourceData, u *schema.UsageData) *aws.DBInstance {
+
+	r := &aws.DBInstance{
+		Address:       "aws_db_instance",
+		Region:        d.Get("region").String(),
+		InstanceClass: d.Get("db_instance_class").String(),
+		Engine:        d.Get("engine").String(),
+		MultiAZ:       d.Get("multi_az").Bool(),
+	}
+
+	if !d.IsEmpty("allocated_storage") {
+		r.AllocatedStorageGB = floatPtr(d.Get("allocated_storage").Float())
+	}
+
+	r.PopulateUsage(u)
+	return r
 }

--- a/internal/providers/terraform/aws/elastic_beanstalk_environment_test.go
+++ b/internal/providers/terraform/aws/elastic_beanstalk_environment_test.go
@@ -1,0 +1,18 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestElasticBeanstalkEnvironmentGoldenFile(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+	opts := tftest.DefaultGoldenFileOptions()
+	opts.CaptureLogs = true
+	tftest.GoldenFileResourceTestsWithOpts(t, "elastic_beanstalk_environment_test", opts)
+
+}

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -95,6 +95,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getStepFunctionRegistryItem(),
 	getDirectoryServiceDirectory(),
 	getTransferServerRegistryItem(),
+	getElasticBeanstalkEnvironmentRegistryItem(),
 }
 
 // FreeResources grouped alphabetically
@@ -196,6 +197,9 @@ var FreeResources = []string{
 	// AWS ECR
 	"aws_ecr_lifecycle_policy",
 	"aws_ecr_repository_policy",
+
+	// AWS Elastic Beanstalk
+	"aws_elastic_beanstalk_application",
 
 	// AWS Elastic Container Service
 	"aws_ecs_capacity_provider",

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -45,6 +45,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getECSServiceRegistryItem(),
 	getEFSFileSystemRegistryItem(),
 	getEIPRegistryItem(),
+	getElasticBeanstalkEnvironmentRegistryItem(),
 	getElastiCacheClusterItem(),
 	getElastiCacheReplicationGroupItem(),
 	getElasticsearchDomainRegistryItem(),
@@ -95,7 +96,6 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getStepFunctionRegistryItem(),
 	getDirectoryServiceDirectory(),
 	getTransferServerRegistryItem(),
-	getElasticBeanstalkEnvironmentRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
@@ -15,8 +15,8 @@
  OVERALL TOTAL                                                                            $411.38 
 ──────────────────────────────────
 3 cloud resources were detected:
-∙ 2 were estimated
-∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free:
   ∙ 1 x aws_elastic_beanstalk_application
 
 Add cost estimates to your pull requests: https://infracost.io/cicd

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
@@ -1,46 +1,62 @@
 
- Name                                                               Monthly Qty  Unit              Monthly Cost 
-                                                                                                                
- aws_elastic_beanstalk_environment.my_eb_environment                                                            
- ├─ aws_launch_configuration                                                                                    
- │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                     730  hours                   $17.74 
- │  └─ aws_ebs_volume                                                                                           
- │     └─ Storage (general purpose SSD, gp2)                                  8  GB                       $0.88 
- └─ aws_loadbalancer                                                                                            
-    ├─ Network load balancer                                                730  hours                   $18.40 
-    └─ Load balancer capacity units                              Monthly cost depends on usage: $4.38 per LCU   
-                                                                                                                
- aws_elastic_beanstalk_environment.my_eb_environment_with_rds                                                   
- ├─ aws_launch_configuration                                                                                    
- │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                   1,460  hours                   $35.48 
- │  └─ aws_ebs_volume                                                                                           
- │     └─ Storage (general purpose SSD, gp2)                                 16  GB                       $1.76 
- ├─ aws_db_instance                                                                                             
- │  ├─ Database instance (on-demand, Multi-AZ, db.m6g.xlarge)               730  hours                  $513.92 
- │  ├─ Storage (general purpose SSD, gp2)                                   100  GB                      $25.30 
- │  └─ Additional backup storage                                          1,000  GB                      $95.00 
- └─ aws_loadbalancer                                                                                            
-    ├─ Network load balancer                                                730  hours                   $18.40 
-    └─ Load balancer capacity units                                     34.2465  LCU                    $150.00 
-                                                                                                                
- aws_elastic_beanstalk_environment.my_eb_environment_with_usage                                                 
- ├─ aws_launch_configuration                                                                                    
- │  ├─ Instance usage (Linux/UNIX, on-demand, c4.large)                   2,920  hours                  $362.08 
- │  └─ aws_ebs_volume                                                                                           
- │     ├─ Storage (provisioned IOPS SSD, io1)                                32  GB                       $4.42 
- │     └─ Provisioned IOPS                                                1,200  IOPS                    $86.40 
- ├─ aws_cloudwatch_log_group                                                                                    
- │  ├─ Data ingested                                                      1,000  GB                     $570.00 
- │  ├─ Archival Storage                                                   1,000  GB                      $30.00 
- │  └─ Insights queries data scanned                                        200  GB                       $1.14 
- └─ aws_elb                                                                                                     
-    ├─ Classic load balancer                                                730  hours                   $20.44 
-    └─ Data processed                                                    10,000  GB                      $80.00 
-                                                                                                                
- OVERALL TOTAL                                                                                        $2,031.35 
+ Name                                                                      Monthly Qty  Unit              Monthly Cost 
+                                                                                                                       
+ aws_elastic_beanstalk_environment.my_eb_environment                                                                   
+ ├─ aws_launch_configuration                                                                                           
+ │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                            730  hours                   $17.74 
+ │  └─ aws_ebs_volume                                                                                                  
+ │     └─ Storage (general purpose SSD, gp2)                                         8  GB                       $0.88 
+ └─ aws_loadbalancer                                                                                                   
+    ├─ Network load balancer                                                       730  hours                   $18.40 
+    └─ Load balancer capacity units                                     Monthly cost depends on usage: $4.38 per LCU   
+                                                                                                                       
+ aws_elastic_beanstalk_environment.my_eb_environment_with_rds                                                          
+ ├─ aws_launch_configuration                                                                                           
+ │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                          1,460  hours                   $35.48 
+ │  └─ aws_ebs_volume                                                                                                  
+ │     └─ Storage (general purpose SSD, gp2)                                        16  GB                       $1.76 
+ ├─ aws_db_instance                                                                                                    
+ │  ├─ Database instance (on-demand, Multi-AZ, db.m6g.xlarge)                      730  hours                  $513.92 
+ │  ├─ Storage (general purpose SSD, gp2)                                          100  GB                      $25.30 
+ │  └─ Additional backup storage                                                 1,000  GB                      $95.00 
+ └─ aws_loadbalancer                                                                                                   
+    ├─ Network load balancer                                                       730  hours                   $18.40 
+    └─ Load balancer capacity units                                            34.2465  LCU                    $150.00 
+                                                                                                                       
+ aws_elastic_beanstalk_environment.my_eb_environment_with_rds_no_usage                                                 
+ ├─ aws_launch_configuration                                                                                           
+ │  ├─ Instance usage (Linux/UNIX, on-demand, t3.large)                          1,460  hours                  $142.20 
+ │  └─ aws_ebs_volume                                                                                                  
+ │     └─ Storage (general purpose SSD, gp2)                                        16  GB                       $1.76 
+ ├─ aws_db_instance                                                                                                    
+ │  ├─ Database instance (on-demand, Multi-AZ, db.m6g.xlarge)                      730  hours                  $513.92 
+ │  └─ Storage (general purpose SSD, gp2)                                           20  GB                       $5.06 
+ ├─ aws_cloudwatch_log_group                                                                                           
+ │  ├─ Data ingested                                                    Monthly cost depends on usage: $0.57 per GB    
+ │  ├─ Archival Storage                                                 Monthly cost depends on usage: $0.03 per GB    
+ │  └─ Insights queries data scanned                                    Monthly cost depends on usage: $0.0057 per GB  
+ └─ aws_loadbalancer                                                                                                   
+    ├─ Network load balancer                                                       730  hours                   $18.40 
+    └─ Load balancer capacity units                                     Monthly cost depends on usage: $4.38 per LCU   
+                                                                                                                       
+ aws_elastic_beanstalk_environment.my_eb_environment_with_usage                                                        
+ ├─ aws_launch_configuration                                                                                           
+ │  ├─ Instance usage (Linux/UNIX, on-demand, c4.large)                          2,920  hours                  $362.08 
+ │  └─ aws_ebs_volume                                                                                                  
+ │     ├─ Storage (provisioned IOPS SSD, io1)                                       32  GB                       $4.42 
+ │     └─ Provisioned IOPS                                                       1,200  IOPS                    $86.40 
+ ├─ aws_cloudwatch_log_group                                                                                           
+ │  ├─ Data ingested                                                             1,000  GB                     $570.00 
+ │  ├─ Archival Storage                                                          1,000  GB                      $30.00 
+ │  └─ Insights queries data scanned                                               200  GB                       $1.14 
+ └─ aws_elb                                                                                                            
+    ├─ Classic load balancer                                                       730  hours                   $20.44 
+    └─ Data processed                                                           10,000  GB                      $80.00 
+                                                                                                                       
+ OVERALL TOTAL                                                                                               $2,712.69 
 ──────────────────────────────────
-4 cloud resources were detected:
-∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
+5 cloud resources were detected:
+∙ 4 were estimated, 4 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x aws_elastic_beanstalk_application
 

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
@@ -1,0 +1,22 @@
+
+ Name                                                            Monthly Qty  Unit   Monthly Cost 
+                                                                                                  
+ aws_elastic_beanstalk_environment.my_eb_environment                                              
+ ├─ Instance usage (Linux/UNIX, on_demand, t3.small)                   1,460  hours        $35.48 
+ └─ Network load balancer                                                730  hours        $18.40 
+                                                                                                  
+ aws_elastic_beanstalk_environment.my_eb_environment_with_usage                                   
+ ├─ Instance usage (Linux/UNIX, on_demand, c4.large)                   1,460  hours       $181.04 
+ ├─ Application load balancer                                            730  hours        $18.40 
+ ├─ Cloudwatch Data ingested                                             250  GB          $142.50 
+ ├─ Cloudwatch Archival Storage                                          500  GB           $15.00 
+ └─ Cloudwatch Insights queries data scanned                             100  GB            $0.57 
+                                                                                                  
+ OVERALL TOTAL                                                                            $411.38 
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 2 were estimated
+∙ 1 wasn't estimated, report it in https://github.com/infracost/infracost:
+  ∙ 1 x aws_elastic_beanstalk_application
+
+Add cost estimates to your pull requests: https://infracost.io/cicd

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
@@ -30,14 +30,14 @@
  │     ├─ Storage (provisioned IOPS SSD, io1)                                32  GB                       $4.42 
  │     └─ Provisioned IOPS                                                1,200  IOPS                    $86.40 
  ├─ aws_cloudwatch_log_group                                                                                    
- │  ├─ Data ingested                                                        250  GB                     $142.50 
- │  ├─ Archival Storage                                                     500  GB                      $15.00 
- │  └─ Insights queries data scanned                                        100  GB                       $0.57 
+ │  ├─ Data ingested                                                      1,000  GB                     $570.00 
+ │  ├─ Archival Storage                                                   1,000  GB                      $30.00 
+ │  └─ Insights queries data scanned                                        200  GB                       $1.14 
  └─ aws_elb                                                                                                     
     ├─ Classic load balancer                                                730  hours                   $20.44 
     └─ Data processed                                                    10,000  GB                      $80.00 
                                                                                                                 
- OVERALL TOTAL                                                                                        $1,588.28 
+ OVERALL TOTAL                                                                                        $2,031.35 
 ──────────────────────────────────
 4 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
@@ -3,39 +3,40 @@
                                                                                                                 
  aws_elastic_beanstalk_environment.my_eb_environment                                                            
  ├─ aws_launch_configuration                                                                                    
- │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                     730  hours                   $16.64 
- └─ aws_load_balancer                                                                                           
+ │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                     730  hours                   $17.74 
+ │  └─ aws_ebs_volume                                                                                           
+ │     └─ Storage (general purpose SSD, gp2)                                  8  GB                       $0.88 
+ └─ aws_loadbalancer                                                                                            
     ├─ Network load balancer                                                730  hours                   $18.40 
     └─ Load balancer capacity units                              Monthly cost depends on usage: $4.38 per LCU   
                                                                                                                 
  aws_elastic_beanstalk_environment.my_eb_environment_with_rds                                                   
  ├─ aws_launch_configuration                                                                                    
- │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                   1,460  hours                   $33.29 
- ├─ aws_load_balancer                                                                                           
- │  ├─ Network load balancer                                                730  hours                   $18.40 
- │  └─ Load balancer capacity units                              Monthly cost depends on usage: $4.38 per LCU   
+ │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                   1,460  hours                   $35.48 
+ │  └─ aws_ebs_volume                                                                                           
+ │     └─ Storage (general purpose SSD, gp2)                                 16  GB                       $1.76 
+ ├─ aws_db_instance                                                                                             
+ │  ├─ Database instance (on-demand, Multi-AZ, db.m6g.xlarge)               730  hours                  $513.92 
+ │  └─ Storage (general purpose SSD, gp2)                                   100  GB                      $25.30 
+ └─ aws_loadbalancer                                                                                            
+    ├─ Network load balancer                                                730  hours                   $18.40 
+    └─ Load balancer capacity units                              Monthly cost depends on usage: $4.38 per LCU   
+                                                                                                                
+ aws_elastic_beanstalk_environment.my_eb_environment_with_usage                                                 
+ ├─ aws_launch_configuration                                                                                    
+ │  ├─ Instance usage (Linux/UNIX, on-demand, c4.large)                   2,920  hours                  $362.08 
+ │  └─ aws_ebs_volume                                                                                           
+ │     ├─ Storage (provisioned IOPS SSD, io1)                                32  GB                       $4.42 
+ │     └─ Provisioned IOPS                                                1,200  IOPS                    $86.40 
  ├─ aws_cloudwatch_log_group                                                                                    
  │  ├─ Data ingested                                             Monthly cost depends on usage: $0.57 per GB    
  │  ├─ Archival Storage                                          Monthly cost depends on usage: $0.03 per GB    
  │  └─ Insights queries data scanned                             Monthly cost depends on usage: $0.0057 per GB  
- └─ aws_db_instance                                                                                             
-    ├─ Database instance (on-demand, Multi-AZ, db.m6g.xlarge)               730  hours                  $513.92 
-    └─ Storage (general purpose SSD, gp2)                                   100  GB                      $25.30 
+ └─ aws_loadbalancer                                                                                            
+    ├─ Network load balancer                                                730  hours                   $18.40 
+    └─ Load balancer capacity units                              Monthly cost depends on usage: $4.38 per LCU   
                                                                                                                 
- aws_elastic_beanstalk_environment.my_eb_environment_with_usage                                                 
- ├─ aws_launch_configuration                                                                                    
- │  ├─ Instance usage (Linux/UNIX, on-demand, c4.large)                   2,920  hours                  $329.96 
- │  └─ aws_ebs_volume                                                                                           
- │     └─ Provisioned IOPS                                                1,200  IOPS                    $86.40 
- ├─ aws_load_balancer                                                                                           
- │  ├─ Application load balancer                                            730  hours                   $18.40 
- │  └─ Load balancer capacity units                                     34.2465  LCU                    $200.00 
- └─ aws_cloudwatch_log_group                                                                                    
-    ├─ Data ingested                                                        250  GB                     $142.50 
-    ├─ Archival Storage                                                     500  GB                      $15.00 
-    └─ Insights queries data scanned                                        100  GB                       $0.57 
-                                                                                                                
- OVERALL TOTAL                                                                                        $1,418.77 
+ OVERALL TOTAL                                                                                        $1,103.16 
 ──────────────────────────────────
 4 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
@@ -17,10 +17,11 @@
  │     └─ Storage (general purpose SSD, gp2)                                 16  GB                       $1.76 
  ├─ aws_db_instance                                                                                             
  │  ├─ Database instance (on-demand, Multi-AZ, db.m6g.xlarge)               730  hours                  $513.92 
- │  └─ Storage (general purpose SSD, gp2)                                   100  GB                      $25.30 
+ │  ├─ Storage (general purpose SSD, gp2)                                   100  GB                      $25.30 
+ │  └─ Additional backup storage                                          1,000  GB                      $95.00 
  └─ aws_loadbalancer                                                                                            
     ├─ Network load balancer                                                730  hours                   $18.40 
-    └─ Load balancer capacity units                              Monthly cost depends on usage: $4.38 per LCU   
+    └─ Load balancer capacity units                                     34.2465  LCU                    $150.00 
                                                                                                                 
  aws_elastic_beanstalk_environment.my_eb_environment_with_usage                                                 
  ├─ aws_launch_configuration                                                                                    
@@ -29,14 +30,14 @@
  │     ├─ Storage (provisioned IOPS SSD, io1)                                32  GB                       $4.42 
  │     └─ Provisioned IOPS                                                1,200  IOPS                    $86.40 
  ├─ aws_cloudwatch_log_group                                                                                    
- │  ├─ Data ingested                                             Monthly cost depends on usage: $0.57 per GB    
- │  ├─ Archival Storage                                          Monthly cost depends on usage: $0.03 per GB    
- │  └─ Insights queries data scanned                             Monthly cost depends on usage: $0.0057 per GB  
- └─ aws_loadbalancer                                                                                            
-    ├─ Network load balancer                                                730  hours                   $18.40 
-    └─ Load balancer capacity units                              Monthly cost depends on usage: $4.38 per LCU   
+ │  ├─ Data ingested                                                        250  GB                     $142.50 
+ │  ├─ Archival Storage                                                     500  GB                      $15.00 
+ │  └─ Insights queries data scanned                                        100  GB                       $0.57 
+ └─ aws_elb                                                                                                     
+    ├─ Classic load balancer                                                730  hours                   $20.44 
+    └─ Data processed                                                    10,000  GB                      $80.00 
                                                                                                                 
- OVERALL TOTAL                                                                                        $1,103.16 
+ OVERALL TOTAL                                                                                        $1,588.28 
 ──────────────────────────────────
 4 cloud resources were detected:
 ∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.golden
@@ -1,21 +1,44 @@
 
- Name                                                            Monthly Qty  Unit   Monthly Cost 
-                                                                                                  
- aws_elastic_beanstalk_environment.my_eb_environment                                              
- ├─ Instance usage (Linux/UNIX, on_demand, t3.small)                   1,460  hours        $35.48 
- └─ Network load balancer                                                730  hours        $18.40 
-                                                                                                  
- aws_elastic_beanstalk_environment.my_eb_environment_with_usage                                   
- ├─ Instance usage (Linux/UNIX, on_demand, c4.large)                   1,460  hours       $181.04 
- ├─ Application load balancer                                            730  hours        $18.40 
- ├─ Cloudwatch Data ingested                                             250  GB          $142.50 
- ├─ Cloudwatch Archival Storage                                          500  GB           $15.00 
- └─ Cloudwatch Insights queries data scanned                             100  GB            $0.57 
-                                                                                                  
- OVERALL TOTAL                                                                            $411.38 
+ Name                                                               Monthly Qty  Unit              Monthly Cost 
+                                                                                                                
+ aws_elastic_beanstalk_environment.my_eb_environment                                                            
+ ├─ aws_launch_configuration                                                                                    
+ │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                     730  hours                   $16.64 
+ └─ aws_load_balancer                                                                                           
+    ├─ Network load balancer                                                730  hours                   $18.40 
+    └─ Load balancer capacity units                              Monthly cost depends on usage: $4.38 per LCU   
+                                                                                                                
+ aws_elastic_beanstalk_environment.my_eb_environment_with_rds                                                   
+ ├─ aws_launch_configuration                                                                                    
+ │  ├─ Instance usage (Linux/UNIX, on-demand, t3.small)                   1,460  hours                   $33.29 
+ ├─ aws_load_balancer                                                                                           
+ │  ├─ Network load balancer                                                730  hours                   $18.40 
+ │  └─ Load balancer capacity units                              Monthly cost depends on usage: $4.38 per LCU   
+ ├─ aws_cloudwatch_log_group                                                                                    
+ │  ├─ Data ingested                                             Monthly cost depends on usage: $0.57 per GB    
+ │  ├─ Archival Storage                                          Monthly cost depends on usage: $0.03 per GB    
+ │  └─ Insights queries data scanned                             Monthly cost depends on usage: $0.0057 per GB  
+ └─ aws_db_instance                                                                                             
+    ├─ Database instance (on-demand, Multi-AZ, db.m6g.xlarge)               730  hours                  $513.92 
+    └─ Storage (general purpose SSD, gp2)                                   100  GB                      $25.30 
+                                                                                                                
+ aws_elastic_beanstalk_environment.my_eb_environment_with_usage                                                 
+ ├─ aws_launch_configuration                                                                                    
+ │  ├─ Instance usage (Linux/UNIX, on-demand, c4.large)                   2,920  hours                  $329.96 
+ │  └─ aws_ebs_volume                                                                                           
+ │     └─ Provisioned IOPS                                                1,200  IOPS                    $86.40 
+ ├─ aws_load_balancer                                                                                           
+ │  ├─ Application load balancer                                            730  hours                   $18.40 
+ │  └─ Load balancer capacity units                                     34.2465  LCU                    $200.00 
+ └─ aws_cloudwatch_log_group                                                                                    
+    ├─ Data ingested                                                        250  GB                     $142.50 
+    ├─ Archival Storage                                                     500  GB                      $15.00 
+    └─ Insights queries data scanned                                        100  GB                       $0.57 
+                                                                                                                
+ OVERALL TOTAL                                                                                        $1,418.77 
 ──────────────────────────────────
-3 cloud resources were detected:
-∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+4 cloud resources were detected:
+∙ 3 were estimated, 3 include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x aws_elastic_beanstalk_application
 

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
@@ -1,0 +1,85 @@
+provider "aws" {
+  region                      = "eu-west-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+# Add example resources for ElasticBeanstalkEnvironment below
+
+resource "aws_elastic_beanstalk_application" "my_eb_application" {
+  name        = "eb_application"
+  description = "description"
+}
+
+resource "aws_elastic_beanstalk_environment" "my_eb_environment_with_usage" {
+  name                = "eb_environment_with_usage"
+  application         = aws_elastic_beanstalk_application.my_eb_application.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.4.11 running Docker"
+
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "InstanceTypes"
+    value     = "c4.large"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MinSize"
+    value     = 2
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MaxSize"
+    value     = 4
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "LoadBalancerType"
+    value     = "application"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "StreamLogs"
+    value     = true
+  }
+
+}
+
+resource "aws_elastic_beanstalk_environment" "my_eb_environment" {
+  name                = "eb_environment"
+  application         = aws_elastic_beanstalk_application.my_eb_application.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.4.11 running Docker"
+
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "InstanceTypes"
+    value     = "t3.small"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MinSize"
+    value     = 2
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MaxSize"
+    value     = 4
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "LoadBalancerType"
+    value     = "network"
+  }
+
+}

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
@@ -42,7 +42,7 @@ resource "aws_elastic_beanstalk_environment" "my_eb_environment_with_usage" {
   setting {
     namespace = "aws:elasticbeanstalk:environment"
     name      = "LoadBalancerType"
-    value     = "application"
+    value     = "classic"
   }
 
   setting {

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
@@ -30,13 +30,13 @@ resource "aws_elastic_beanstalk_environment" "my_eb_environment_with_usage" {
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MinSize"
-    value     = 2
+    value     = 4
   }
 
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MaxSize"
-    value     = 4
+    value     = 6
   }
 
   setting {
@@ -51,10 +51,53 @@ resource "aws_elastic_beanstalk_environment" "my_eb_environment_with_usage" {
     value     = true
   }
 
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "RootVolumeType"
+    value     = "io1"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "RootVolumeIOPS"
+    value     = 300
+  }
+
 }
 
 resource "aws_elastic_beanstalk_environment" "my_eb_environment" {
   name                = "eb_environment"
+  application         = aws_elastic_beanstalk_application.my_eb_application.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.4.11 running Docker"
+
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "InstanceTypes"
+    value     = "t3.small"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MinSize"
+    value     = 1
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MaxSize"
+    value     = 4
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "LoadBalancerType"
+    value     = "network"
+  }
+
+}
+
+resource "aws_elastic_beanstalk_environment" "my_eb_environment_with_rds" {
+  name                = "eb_environment_with_rds"
   application         = aws_elastic_beanstalk_application.my_eb_application.name
   solution_stack_name = "64bit Amazon Linux 2 v3.4.11 running Docker"
 
@@ -80,6 +123,36 @@ resource "aws_elastic_beanstalk_environment" "my_eb_environment" {
     namespace = "aws:elasticbeanstalk:environment"
     name      = "LoadBalancerType"
     value     = "network"
+  }
+
+  setting {
+    namespace = "aws:rds:dbinstance"
+    name      = "DBInstanceClass"
+    value     = "db.m6g.xlarge"
+  }
+
+  setting {
+    namespace = "aws:rds:dbinstance"
+    name      = "DBEngine"
+    value     = "postgres"
+  }
+
+  setting {
+    namespace = "aws:rds:dbinstance"
+    name      = "MultiAZDatabase"
+    value     = true
+  }
+
+  setting {
+    namespace = "aws:rds:dbinstance"
+    name      = "DBAllocatedStorage"
+    value     = 100
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "StreamLogs"
+    value     = true
   }
 
 }

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
@@ -150,3 +150,58 @@ resource "aws_elastic_beanstalk_environment" "my_eb_environment_with_rds" {
   }
 
 }
+
+resource "aws_elastic_beanstalk_environment" "my_eb_environment_with_rds_no_usage" {
+  name                = "eb_environment_with_rds_no_usage"
+  application         = aws_elastic_beanstalk_application.my_eb_application.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.4.11 running Docker"
+
+  setting {
+    namespace = "aws:ec2:instances"
+    name      = "InstanceTypes"
+    value     = "t3.large"
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MinSize"
+    value     = 2
+  }
+
+  setting {
+    namespace = "aws:autoscaling:asg"
+    name      = "MaxSize"
+    value     = 4
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "LoadBalancerType"
+    value     = "network"
+  }
+
+  setting {
+    namespace = "aws:rds:dbinstance"
+    name      = "DBInstanceClass"
+    value     = "db.m6g.xlarge"
+  }
+
+  setting {
+    namespace = "aws:rds:dbinstance"
+    name      = "DBEngine"
+    value     = "postgres"
+  }
+
+  setting {
+    namespace = "aws:rds:dbinstance"
+    name      = "MultiAZDatabase"
+    value     = true
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "StreamLogs"
+    value     = true
+  }
+
+}

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.tf
@@ -149,10 +149,4 @@ resource "aws_elastic_beanstalk_environment" "my_eb_environment_with_rds" {
     value     = 100
   }
 
-  setting {
-    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
-    name      = "StreamLogs"
-    value     = true
-  }
-
 }

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
@@ -1,11 +1,21 @@
 version: 0.1
 resource_usage:
   aws_elastic_beanstalk_environment.my_eb_environment_with_usage:
-    cloudwatch_monthly_data_ingested_gb: 250
-    cloudwatch_monthly_data_scanned_gb: 100
-    cloudwatch_storage_gb: 500
-    monthly_data_processed_gb: 10000
-    lb_new_connections: 500000    # Number of newly established connections per second on average.
-    lb_active_connections: 100000 # Number of active connections per minute on average.
-    lb_processed_bytes_gb: 25000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
-    lb_rule_evaluations: 10000
+    cloudwatch:
+      monthly_data_ingested_gb: 250
+      monthly_data_scanned_gb: 100
+      storage_gb: 500
+    elb:
+      monthly_data_processed_gb: 10000
+  aws_elastic_beanstalk_environment.my_eb_environment_with_rds:
+    lb:
+      new_connections: 500000    # Number of newly established connections per second on average.
+      active_connections: 100000 # Number of active connections per minute on average.
+      processed_bytes_gb: 25000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
+      rule_evaluations: 10000
+    db:
+      additional_backup_storage_gb: 1000  # Amount of backup storage used that is in excess of 100% of the storage size for all databases in GB.
+      monthly_standard_io_requests: 10000 # Monthly number of input/output requests for database.
+      monthly_additional_performance_insights_requests: 10000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
+    ec2:
+      monthly_cpu_credit_hrs: 350 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
@@ -4,3 +4,8 @@ resource_usage:
     monthly_data_ingested_gb: 250
     monthly_data_scanned_gb: 100
     storage_gb: 500
+    monthly_data_processed_gb: 10000
+    new_connections: 500000    # Number of newly established connections per second on average.
+    active_connections: 100000 # Number of active connections per minute on average.
+    processed_bytes_gb: 25000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
+    rule_evaluations: 10000

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
@@ -1,0 +1,6 @@
+version: 0.1
+resource_usage:
+  aws_elastic_beanstalk_environment.my_eb_environment_with_usage:
+    monthly_data_ingested_gb: 250
+    monthly_data_scanned_gb: 100
+    storage_gb: 500

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
@@ -2,17 +2,17 @@ version: 0.1
 resource_usage:
   aws_elastic_beanstalk_environment.my_eb_environment_with_usage:
     cloudwatch:
-      monthly_data_ingested_gb: 250
-      monthly_data_scanned_gb: 100
-      storage_gb: 500
+      storage_gb: 1000               # Total data stored by CloudWatch logs in GB.
+      monthly_data_ingested_gb: 1000 # Monthly data ingested by CloudWatch logs in GB.
+      monthly_data_scanned_gb: 200   # Monthly data scanned by CloudWatch logs insights in GB.
     elb:
-      monthly_data_processed_gb: 10000
+      monthly_data_processed_gb: 10000 # Classic lb data processed in GB
   aws_elastic_beanstalk_environment.my_eb_environment_with_rds:
     lb:
       new_connections: 500000    # Number of newly established connections per second on average.
       active_connections: 100000 # Number of active connections per minute on average.
       processed_bytes_gb: 25000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
-      rule_evaluations: 10000
+      rule_evaluations: 10000    # Number of rule evaluations on application/network load balancers
     db:
       additional_backup_storage_gb: 1000  # Amount of backup storage used that is in excess of 100% of the storage size for all databases in GB.
       monthly_standard_io_requests: 10000 # Monthly number of input/output requests for database.

--- a/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/elastic_beanstalk_environment_test/elastic_beanstalk_environment_test.usage.yml
@@ -1,11 +1,11 @@
 version: 0.1
 resource_usage:
   aws_elastic_beanstalk_environment.my_eb_environment_with_usage:
-    monthly_data_ingested_gb: 250
-    monthly_data_scanned_gb: 100
-    storage_gb: 500
+    cloudwatch_monthly_data_ingested_gb: 250
+    cloudwatch_monthly_data_scanned_gb: 100
+    cloudwatch_storage_gb: 500
     monthly_data_processed_gb: 10000
-    new_connections: 500000    # Number of newly established connections per second on average.
-    active_connections: 100000 # Number of active connections per minute on average.
-    processed_bytes_gb: 25000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
-    rule_evaluations: 10000
+    lb_new_connections: 500000    # Number of newly established connections per second on average.
+    lb_active_connections: 100000 # Number of active connections per minute on average.
+    lb_processed_bytes_gb: 25000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
+    lb_rule_evaluations: 10000

--- a/internal/resources/aws/elastic_beanstalk_environment.go
+++ b/internal/resources/aws/elastic_beanstalk_environment.go
@@ -1,12 +1,8 @@
 package aws
 
 import (
-	"context"
-	"math"
-
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/infracost/infracost/internal/usage/aws"
 )
 
 // ElasticBeanstalkEnvironment struct represents <TODO: cloud service short description>.
@@ -21,45 +17,45 @@ type ElasticBeanstalkEnvironment struct {
 	Region  string
 	Name    string
 
-	InstanceCount  int64
-	InstanceType   string
-	RootVolumeIOPS int64
-	RootVolumeSize *int64
-	RootVolumeType string
-
-	RDSIncluded bool
-
+	InstanceCount    *int64
+	InstanceType     string
+	RDSIncluded      bool
 	LoadBalancerType string
-	AutoScalingGroup *AutoscalingGroup
 
 	StreamLogs            bool
-	instanceCount         int64
-	MonthlyDataIngestedGB *float64 `infracost_usage:"monthly_data_ingested_gb"`
-	StorageGB             *float64 `infracost_usage:"storage_gb"`
-	MonthlyDataScannedGB  *float64 `infracost_usage:"monthly_data_scanned_gb"`
-	CloudwatchLogGroup    *CloudwatchLogGroup
-	LoadBalancer          *LB
-	ElasticLoadBalancer   *ELB
-	DBInstance            *DBInstance
+	MonthlyDataIngestedGB *float64 `infracost_usage:"cloudwatch_monthly_data_ingested_gb"`
+	StorageGB             *float64 `infracost_usage:"cloudwatch_storage_gb"`
+	MonthlyDataScannedGB  *float64 `infracost_usage:"cloudwatch_monthly_data_scanned_gb"`
+	MonthlyDataProcessed  *float64 `infracost_usage:"monthly_data_processed_gb"`
+	LBNewConnections      *float64 `infracost_usage:"lb_new_connections"`
+	LBActiveConnections   *float64 `infracost_usage:"lb_active_connections"`
+	LBRuleEvaluations     *float64 `infracost_usage:"lb_rule_evaluations"`
+	LBProcessedBytesGB    *float64 `infracost_usage:"lb_processed_bytes_gb"`
+
+	RootBlockDevice     *EBSVolume
+	CloudwatchLogGroup  *CloudwatchLogGroup
+	LoadBalancer        *LB
+	ElasticLoadBalancer *ELB
+	DBInstance          *DBInstance
+	LaunchConfiguration *LaunchConfiguration
 }
 
 // ElasticBeanstalkEnvironmentUsageSchema defines a list which represents the usage schema of ElasticBeanstalkEnvironment.
 var ElasticBeanstalkEnvironmentUsageSchema = append([]*schema.UsageItem{
 	{Key: "monthly_data_processed_gb", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "new_connections", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "active_connections", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "rule_evaluations", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "processed_bytes_gb", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "monthly_data_ingested_gb", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "monthly_data_scanned_gb", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "lb_new_connections", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "lb_active_connections", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "lb_rule_evaluations", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "lb_processed_bytes_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "cloudwatch_monthly_data_ingested_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "cloudwatch_monthly_data_scanned_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "cloudwatch_storage_gb", DefaultValue: 0, ValueType: schema.Float64},
 	{Key: "instances", DefaultValue: 0, ValueType: schema.Int64},
-}, InstanceUsageSchema...)
+}, LaunchConfigurationUsageSchema...)
 
 // PopulateUsage parses the u schema.UsageData into the ElasticBeanstalkEnvironment.
 // It uses the `infracost_usage` struct tags to populate data into the ElasticBeanstalkEnvironment.
 func (r *ElasticBeanstalkEnvironment) PopulateUsage(u *schema.UsageData) {
-	resources.PopulateArgsWithUsage(r, u)
 	if r.LoadBalancerType == "classic" {
 		resources.PopulateArgsWithUsage(r.ElasticLoadBalancer, u)
 	} else {
@@ -71,28 +67,7 @@ func (r *ElasticBeanstalkEnvironment) PopulateUsage(u *schema.UsageData) {
 	if r.RDSIncluded {
 		resources.PopulateArgsWithUsage(r.DBInstance, u)
 	}
-}
-
-// getUsageSchemaWithDefaultInstanceCount is a temporary hack to make --sync-usage-file use the group's "desired_size"
-// as the default value for the "instances" usage param.  Without this, --sync-usage-file sets instances=0 causing the
-// costs for the node group to be $0.  This can be removed when --sync-usage-file creates the usage file with usgage keys
-// commented out by default.
-func (r *ElasticBeanstalkEnvironment) getUsageSchemaWithDefaultInstanceCount() []*schema.UsageItem {
-	var instanceCount = &r.instanceCount
-
-	if instanceCount == nil || *instanceCount == 0 {
-		return AutoscalingGroupUsageSchema
-	}
-
-	usageSchema := make([]*schema.UsageItem, 0, len(AutoscalingGroupUsageSchema))
-	for _, u := range AutoscalingGroupUsageSchema {
-		if u.Key == "instances" {
-			usageSchema = append(usageSchema, &schema.UsageItem{Key: "instances", DefaultValue: intVal(instanceCount), ValueType: schema.Int64})
-		} else {
-			usageSchema = append(usageSchema, u)
-		}
-	}
-	return usageSchema
+	resources.PopulateArgsWithUsage(r.LaunchConfiguration, u)
 }
 
 // BuildResource builds a schema.Resource from a valid ElasticBeanstalkEnvironment struct.
@@ -100,74 +75,29 @@ func (r *ElasticBeanstalkEnvironment) getUsageSchemaWithDefaultInstanceCount() [
 // See providers folder for more information.
 func (r *ElasticBeanstalkEnvironment) BuildResource() *schema.Resource {
 
-	subResources := make([]*schema.Resource, 0)
-
-	rootBlockDevice := &EBSVolume{
-		Address: "aws_ebs_volume",
-		Region:  r.Region,
-		Type:    r.RootVolumeType,
-		Size:    r.RootVolumeSize,
-		IOPS:    r.RootVolumeIOPS,
+	a := &schema.Resource{
+		Name:        r.Address,
+		UsageSchema: ElasticBeanstalkEnvironmentUsageSchema,
 	}
 
-	launchConfiguration := &LaunchConfiguration{
-		Address:         "aws_launch_configuration",
-		Region:          r.Region,
-		InstanceType:    r.InstanceType,
-		InstanceCount:   &r.InstanceCount,
-		RootBlockDevice: rootBlockDevice,
-	}
-
-	autoScalingGroup := &AutoscalingGroup{
-		Address:             "aws_autoscaling_group",
-		Region:              r.Region,
-		Name:                r.Name,
-		LaunchConfiguration: launchConfiguration,
-	}
-
-	autoScalingGroupResource := autoScalingGroup.BuildResource()
-
-	var estimateInstanceQualities = autoScalingGroupResource.EstimateUsage
-
-	subResources = append(subResources, autoScalingGroupResource.SubResources...)
-	if r.LoadBalancerType == "classic" {
-		subResources = append(subResources, r.ElasticLoadBalancer.BuildResource())
-	} else {
-		subResources = append(subResources, r.LoadBalancer.BuildResource())
-	}
-
-	if r.StreamLogs {
-		subResources = append(subResources, r.CloudwatchLogGroup.BuildResource())
-	}
-
+	a.SubResources = append(a.SubResources, r.LaunchConfiguration.BuildResource())
+	a.EstimateUsage = r.LaunchConfiguration.BuildResource().EstimateUsage
 	if r.RDSIncluded {
-		subResources = append(subResources, r.DBInstance.BuildResource())
+		dbInstance := r.DBInstance.BuildResource()
+		a.SubResources = append(a.SubResources, dbInstance)
+
+	}
+	if r.StreamLogs {
+		a.SubResources = append(a.SubResources, r.CloudwatchLogGroup.BuildResource())
+	}
+	switch r.LoadBalancerType {
+	case "classic":
+		a.SubResources = append(a.SubResources, r.ElasticLoadBalancer.BuildResource())
+
+	default:
+		a.SubResources = append(a.SubResources, r.LoadBalancer.BuildResource())
 	}
 
-	estimate := func(ctx context.Context, u map[string]interface{}) error {
-		if estimateInstanceQualities != nil {
-			err := estimateInstanceQualities(ctx, u)
-			if err != nil {
-				return err
-			}
-		}
-		if r.Name != "" {
-			count, err := aws.AutoscalingGetInstanceCount(ctx, r.Region, r.Name)
-			if err != nil {
-				return err
-			}
-			if count > 0 {
-				u["instances"] = int64(math.Round(count))
-			}
-		}
-		return nil
-	}
-	return &schema.Resource{
-		Name:           r.Address,
-		UsageSchema:    r.getUsageSchemaWithDefaultInstanceCount(),
-		CostComponents: autoScalingGroupResource.CostComponents,
-		SubResources:   subResources,
-		EstimateUsage:  estimate,
-	}
+	return a
 
 }

--- a/internal/resources/aws/elastic_beanstalk_environment.go
+++ b/internal/resources/aws/elastic_beanstalk_environment.go
@@ -21,16 +21,7 @@ type ElasticBeanstalkEnvironment struct {
 	InstanceType     string
 	RDSIncluded      bool
 	LoadBalancerType string
-
-	StreamLogs            bool
-	MonthlyDataIngestedGB *float64 `infracost_usage:"cloudwatch_monthly_data_ingested_gb"`
-	StorageGB             *float64 `infracost_usage:"cloudwatch_storage_gb"`
-	MonthlyDataScannedGB  *float64 `infracost_usage:"cloudwatch_monthly_data_scanned_gb"`
-	MonthlyDataProcessed  *float64 `infracost_usage:"monthly_data_processed_gb"`
-	LBNewConnections      *float64 `infracost_usage:"lb_new_connections"`
-	LBActiveConnections   *float64 `infracost_usage:"lb_active_connections"`
-	LBRuleEvaluations     *float64 `infracost_usage:"lb_rule_evaluations"`
-	LBProcessedBytesGB    *float64 `infracost_usage:"lb_processed_bytes_gb"`
+	StreamLogs       bool
 
 	RootBlockDevice     *EBSVolume
 	CloudwatchLogGroup  *CloudwatchLogGroup
@@ -41,33 +32,56 @@ type ElasticBeanstalkEnvironment struct {
 }
 
 // ElasticBeanstalkEnvironmentUsageSchema defines a list which represents the usage schema of ElasticBeanstalkEnvironment.
-var ElasticBeanstalkEnvironmentUsageSchema = append([]*schema.UsageItem{
-	{Key: "monthly_data_processed_gb", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "lb_new_connections", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "lb_active_connections", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "lb_rule_evaluations", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "lb_processed_bytes_gb", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "cloudwatch_monthly_data_ingested_gb", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "cloudwatch_monthly_data_scanned_gb", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "cloudwatch_storage_gb", DefaultValue: 0, ValueType: schema.Float64},
-	{Key: "instances", DefaultValue: 0, ValueType: schema.Int64},
-}, LaunchConfigurationUsageSchema...)
+var ElasticBeanstalkEnvironmentUsageSchema = []*schema.UsageItem{
+
+	{
+		Key:          "cloudwatch",
+		DefaultValue: CloudwatchLogGroupUsageSchema,
+		ValueType:    schema.SubResourceUsage,
+	},
+	{
+		Key:          "lb",
+		DefaultValue: LBUsageSchema,
+		ValueType:    schema.SubResourceUsage,
+	},
+	{
+		Key:          "elb",
+		DefaultValue: ELBUsageSchema,
+		ValueType:    schema.SubResourceUsage,
+	},
+	{
+		Key:          "db",
+		DefaultValue: DBInstanceUsageSchema,
+		ValueType:    schema.SubResourceUsage,
+	},
+	{
+		Key:          "ec2",
+		DefaultValue: LaunchConfigurationUsageSchema,
+		ValueType:    schema.SubResourceUsage,
+	},
+}
 
 // PopulateUsage parses the u schema.UsageData into the ElasticBeanstalkEnvironment.
 // It uses the `infracost_usage` struct tags to populate data into the ElasticBeanstalkEnvironment.
 func (r *ElasticBeanstalkEnvironment) PopulateUsage(u *schema.UsageData) {
-	if r.LoadBalancerType == "classic" {
-		resources.PopulateArgsWithUsage(r.ElasticLoadBalancer, u)
-	} else {
-		resources.PopulateArgsWithUsage(r.LoadBalancer, u)
+
+	if u == nil {
+		return
 	}
-	if r.StreamLogs {
-		resources.PopulateArgsWithUsage(r.CloudwatchLogGroup, u)
+
+	if r.ElasticLoadBalancer != nil {
+		resources.PopulateArgsWithUsage(r.ElasticLoadBalancer, schema.NewUsageData("elb", u.Get("elb").Map()))
 	}
-	if r.RDSIncluded {
-		resources.PopulateArgsWithUsage(r.DBInstance, u)
+	if r.LoadBalancer != nil {
+		resources.PopulateArgsWithUsage(r.LoadBalancer, schema.NewUsageData("lb", u.Get("lb").Map()))
 	}
-	resources.PopulateArgsWithUsage(r.LaunchConfiguration, u)
+	if r.DBInstance != nil {
+		resources.PopulateArgsWithUsage(r.DBInstance, schema.NewUsageData("db", u.Get("db").Map()))
+	}
+	if r.CloudwatchLogGroup != nil {
+		resources.PopulateArgsWithUsage(r.CloudwatchLogGroup, schema.NewUsageData("cloudwatch", u.Get("cloudwatch").Map()))
+	}
+	resources.PopulateArgsWithUsage(r.LaunchConfiguration, schema.NewUsageData("ec2", u.Get("ec2").Map()))
 }
 
 // BuildResource builds a schema.Resource from a valid ElasticBeanstalkEnvironment struct.
@@ -81,19 +95,17 @@ func (r *ElasticBeanstalkEnvironment) BuildResource() *schema.Resource {
 	}
 
 	a.SubResources = append(a.SubResources, r.LaunchConfiguration.BuildResource())
-	a.EstimateUsage = r.LaunchConfiguration.BuildResource().EstimateUsage
-	if r.RDSIncluded {
-		dbInstance := r.DBInstance.BuildResource()
-		a.SubResources = append(a.SubResources, dbInstance)
+
+	if r.DBInstance != nil {
+		a.SubResources = append(a.SubResources, r.DBInstance.BuildResource())
 
 	}
-	if r.StreamLogs {
+	if r.CloudwatchLogGroup != nil {
 		a.SubResources = append(a.SubResources, r.CloudwatchLogGroup.BuildResource())
 	}
 	switch r.LoadBalancerType {
 	case "classic":
 		a.SubResources = append(a.SubResources, r.ElasticLoadBalancer.BuildResource())
-
 	default:
 		a.SubResources = append(a.SubResources, r.LoadBalancer.BuildResource())
 	}

--- a/internal/resources/aws/elastic_beanstalk_environment.go
+++ b/internal/resources/aws/elastic_beanstalk_environment.go
@@ -1,0 +1,223 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+
+	"github.com/shopspring/decimal"
+)
+
+// ElasticBeanstalkEnvironment struct represents <TODO: cloud service short description>.
+//
+// <TODO: Add any important information about the resource and links to the
+// pricing pages or documentation that might be useful to developers in the future, e.g:>
+//
+// Resource information: https://aws.amazon.com/elasticbeanstalk/
+// Pricing information: https://aws.amazon.com/elasticbeanstalk/pricing/
+type ElasticBeanstalkEnvironment struct {
+	Address               string
+	Region                string
+	InstanceType          string
+	LoadBalancerType      string
+	Nodes                 int64
+	PurchaseOption        string
+	StreamLogs            bool
+	MonthlyDataIngestedGB *float64 `infracost_usage:"monthly_data_ingested_gb"`
+	StorageGB             *float64 `infracost_usage:"storage_gb"`
+	MonthlyDataScannedGB  *float64 `infracost_usage:"monthly_data_scanned_gb"`
+}
+
+// ElasticBeanstalkEnvironmentUsageSchema defines a list which represents the usage schema of ElasticBeanstalkEnvironment.
+var ElasticBeanstalkEnvironmentUsageSchema = []*schema.UsageItem{
+	{Key: "monthly_data_ingested_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "monthly_data_scanned_gb", DefaultValue: 0, ValueType: schema.Float64},
+	{Key: "storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the ElasticBeanstalkEnvironment.
+// It uses the `infracost_usage` struct tags to populate data into the ElasticBeanstalkEnvironment.
+func (r *ElasticBeanstalkEnvironment) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid ElasticBeanstalkEnvironment struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *ElasticBeanstalkEnvironment) BuildResource() *schema.Resource {
+	costComponents := make([]*schema.CostComponent, 0)
+
+	costComponents = append(costComponents, r.instanceCostComponent())
+
+	// Load balancer definition type
+	if strings.ToLower(r.LoadBalancerType) == "application" {
+		costComponents = append(costComponents, r.applicationLBCostComponents())
+	} else if strings.ToLower(r.LoadBalancerType) == "network" {
+		costComponents = append(costComponents, r.networkLBCostComponents())
+	} else {
+		costComponents = append(costComponents, r.classicLBCostComponents())
+	}
+
+	// Log streaming to cloudwatch
+	if r.StreamLogs {
+		costComponents = append(
+			costComponents,
+			r.cloudwatchDataIngestionCostComponents(),
+			r.cloudwatchArchivalStorageCostComponents(),
+			r.cloudwatchInsightsCostComponents(),
+		)
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    ElasticBeanstalkEnvironmentUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+func (r *ElasticBeanstalkEnvironment) instanceCostComponent() *schema.CostComponent {
+
+	osLabel := "Linux/UNIX"
+
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("Instance usage (%s, %s, %s)", osLabel, r.PurchaseOption, r.InstanceType),
+		Unit:           "hours",
+		UnitMultiplier: decimal.NewFromInt(1),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(r.Nodes)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AmazonEC2"),
+			ProductFamily: strPtr("Compute Instance"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "instanceType", Value: strPtr(r.InstanceType)},
+				{Key: "tenancy", Value: strPtr("Dedicated")},
+				{Key: "preInstalledSw", Value: strPtr("NA")},
+				{Key: "capacitystatus", Value: strPtr("Used")},
+				{Key: "operatingSystem", Value: strPtr("Linux")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr(r.PurchaseOption),
+		},
+	}
+}
+
+func (r *ElasticBeanstalkEnvironment) applicationLBCostComponents() *schema.CostComponent {
+
+	return &schema.CostComponent{
+		Name:           "Application load balancer",
+		Unit:           "hours",
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		UnitMultiplier: decimal.NewFromInt(1),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AWSELB"),
+			ProductFamily: strPtr("Load Balancer-Application"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "locationType", Value: strPtr("AWS Region")},
+				{Key: "usagetype", ValueRegex: strPtr("/LoadBalancerUsage/")},
+			},
+		},
+	}
+}
+
+func (r *ElasticBeanstalkEnvironment) networkLBCostComponents() *schema.CostComponent {
+
+	return &schema.CostComponent{
+		Name:           "Network load balancer",
+		Unit:           "hours",
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		UnitMultiplier: decimal.NewFromInt(1),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AWSELB"),
+			ProductFamily: strPtr("Load Balancer-Network"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "locationType", Value: strPtr("AWS Region")},
+				{Key: "usagetype", ValueRegex: strPtr("/LoadBalancerUsage/")},
+			},
+		},
+	}
+}
+
+func (r *ElasticBeanstalkEnvironment) classicLBCostComponents() *schema.CostComponent {
+
+	return &schema.CostComponent{
+		Name:           "Classic load balancer",
+		Unit:           "hours",
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		UnitMultiplier: decimal.NewFromInt(1),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AWSELB"),
+			ProductFamily: strPtr("Load Balancer"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "locationType", Value: strPtr("AWS Region")},
+				{Key: "usagetype", ValueRegex: strPtr("/LoadBalancerUsage/")},
+			},
+		},
+	}
+}
+
+func (r *ElasticBeanstalkEnvironment) cloudwatchDataIngestionCostComponents() *schema.CostComponent {
+
+	return &schema.CostComponent{
+		Name:            "Cloudwatch Data ingested",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: floatPtrToDecimalPtr(r.MonthlyDataIngestedGB),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AmazonCloudWatch"),
+			ProductFamily: strPtr("Data Payload"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr("/-DataProcessing-Bytes/")},
+			},
+		},
+	}
+}
+
+func (r *ElasticBeanstalkEnvironment) cloudwatchArchivalStorageCostComponents() *schema.CostComponent {
+
+	return &schema.CostComponent{
+		Name:            "Cloudwatch Archival Storage",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: floatPtrToDecimalPtr(r.StorageGB),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AmazonCloudWatch"),
+			ProductFamily: strPtr("Storage Snapshot"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr("/-TimedStorage-ByteHrs/")},
+			},
+		},
+	}
+}
+
+func (r *ElasticBeanstalkEnvironment) cloudwatchInsightsCostComponents() *schema.CostComponent {
+
+	return &schema.CostComponent{
+		Name:            "Cloudwatch Insights queries data scanned",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: floatPtrToDecimalPtr(r.MonthlyDataScannedGB),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AmazonCloudWatch"),
+			ProductFamily: strPtr("Data Payload"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: strPtr("/-DataScanned-Bytes/")},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Objective:

Add support for `aws_elastic_beanstalk_environment` and `aws_elastic_beanstalk_application` as FREE. Fixes #1410.

## Pricing details:

Price breakdown for elastic beanstalk environments is ec2 instances associated with the environment multiplied by the minimum ASG numbers.

Additional costs are associated for the load balancer type. If StreamLogs is enabled, there can be usage costs for cloudwatch metrics, including ingest, scanning and storage in GB.

## Status:

- [x] Generated the resource files
- [x] Updated the internal/resources file
- [x] Updated the internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/175)

## Issues:

None