### PR TITLE
chore: Install jq-1.6 in Dockerfile.ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ FROM alpine:3.15 as app
 # Tools needed for running diffs in CI integrations
 RUN apk --no-cache add ca-certificates openssl openssh-client curl git bash
 
-# The jq package provided by alpine:3.13 (jq 1.6-rc1) is flagged as a
+# The jq package provided by alpine:3.15 (jq 1.6-rc1) is flagged as a
 # high severity vulnerability, so we install the latest release ourselves
 # Reference: https://nvd.nist.gov/vuln/detail/CVE-2016-4074 (this is present on jq-1.6-rc1 as well)
 RUN \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -18,7 +18,16 @@ RUN chmod +x /app/build/infracost
 # Application
 FROM alpine:3.15 as app
 # Tools needed for running diffs in CI integrations
-RUN apk --no-cache add bash curl git jq nodejs npm
+RUN apk --no-cache add bash curl git nodejs npm
+
+# The jq package provided by alpine:3.15 (jq 1.6-rc1) is flagged as a
+# high severity vulnerability, so we install the latest release ourselves
+# Reference: https://nvd.nist.gov/vuln/detail/CVE-2016-4074 (this is present on jq-1.6-rc1 as well)
+RUN \
+    # Install jq-1.6 (final release)
+    curl -s -L -o /tmp/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
+    mv /tmp/jq /usr/local/bin/jq && \
+    chmod +x /usr/local/bin/jq
 
 # Install the latest compost version
 RUN npm install -g @infracost/compost


### PR DESCRIPTION
Current version: https://alpine.pkgs.org/3.15/alpine-main-aarch64/jq-1.6-r1.apk.html
Vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2016-4074