### PR TITLE
feat(azure): Set default capacity for Azure App Service Plan

### DIFF
--- a/internal/providers/terraform/azure/app_service_plan.go
+++ b/internal/providers/terraform/azure/app_service_plan.go
@@ -21,7 +21,7 @@ func NewAzureRMAppServicePlan(d *schema.ResourceData, u *schema.UsageData) *sche
 	sku := d.Get("sku.0.size").String()
 	skuRefactor := ""
 	os := "windows"
-	capacity := d.Get("sku.0.capacity").Int()
+	capacity := d.GetInt64OrDefault("sku.0.capacity", 1)
 	productName := "Standard Plan"
 
 	// These are used by azurerm_function_app, their costs are calculated there as they don't have prices in the azurerm_app_service_plan resource

--- a/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.golden
@@ -1,31 +1,34 @@
 
- Name                                  Monthly Qty  Unit   Monthly Cost 
-                                                                        
- azurerm_app_service_plan.basic                                         
- └─ Instance usage (B2)                        730  hours        $24.82 
-                                                                        
- azurerm_app_service_plan.pc2                                           
- └─ Instance usage (PC2)                       730  hours       $118.59 
-                                                                        
- azurerm_app_service_plan.pc3                                           
- └─ Instance usage (PC3)                    10,950  hours     $3,557.57 
-                                                                        
- azurerm_app_service_plan.premium_v1                                    
- └─ Instance usage (P1v1)                      730  hours       $219.00 
-                                                                        
- azurerm_app_service_plan.premium_v2                                    
- └─ Instance usage (P1v2)                    7,300  hours       $737.30 
-                                                                        
- azurerm_app_service_plan.standard_s1                                   
- └─ Instance usage (S1)                        730  hours        $73.00 
-                                                                        
- azurerm_app_service_plan.standard_s2                                   
- └─ Instance usage (S1)                      3,650  hours       $365.00 
-                                                                        
- OVERALL TOTAL                                                $5,095.27 
+ Name                                       Monthly Qty  Unit   Monthly Cost 
+                                                                             
+ azurerm_app_service_plan.basic                                              
+ └─ Instance usage (B2)                             730  hours        $24.82 
+                                                                             
+ azurerm_app_service_plan.default_capacity                                   
+ └─ Instance usage (B2)                             730  hours        $24.82 
+                                                                             
+ azurerm_app_service_plan.pc2                                                
+ └─ Instance usage (PC2)                            730  hours       $118.59 
+                                                                             
+ azurerm_app_service_plan.pc3                                                
+ └─ Instance usage (PC3)                         10,950  hours     $3,557.57 
+                                                                             
+ azurerm_app_service_plan.premium_v1                                         
+ └─ Instance usage (P1v1)                           730  hours       $219.00 
+                                                                             
+ azurerm_app_service_plan.premium_v2                                         
+ └─ Instance usage (P1v2)                         7,300  hours       $737.30 
+                                                                             
+ azurerm_app_service_plan.standard_s1                                        
+ └─ Instance usage (S1)                             730  hours        $73.00 
+                                                                             
+ azurerm_app_service_plan.standard_s2                                        
+ └─ Instance usage (S1)                           3,650  hours       $365.00 
+                                                                             
+ OVERALL TOTAL                                                     $5,120.09 
 ──────────────────────────────────
-8 cloud resources were detected:
-∙ 7 were estimated
+9 cloud resources were detected:
+∙ 8 were estimated
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
 

--- a/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.tf
+++ b/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.tf
@@ -105,3 +105,16 @@ resource "azurerm_app_service_plan" "pc3" {
     capacity = 15
   }
 }
+
+resource "azurerm_app_service_plan" "default_capacity" {
+  name                = "api-appserviceplan-pro"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  kind                = "Linux"
+  reserved            = false
+
+  sku {
+    tier     = "Basic"
+    size     = "B2"
+  }
+}


### PR DESCRIPTION
`capacity` is an optional argument. If not specified the resource is not
estimated. The pricing calculator starts with 1 instances, thus we
assume the default capacity would be 1 as well.

Fixes #1384 and #1433.