### PR TITLE
fix: Check status of API requests before unmarshaling response body

### DIFF
--- a/internal/comment/azure_repos.go
+++ b/internal/comment/azure_repos.go
@@ -169,12 +169,16 @@ func (h *azureReposPRHandler) CallFindMatchingComments(ctx context.Context, tag 
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return []Comment{}, errors.Wrap(err, "Error retrieving comments")
+		return []Comment{}, errors.Wrap(err, "Error getting comments")
 	}
 
 	res, err := h.httpClient.Do(req)
 	if err != nil {
-		return []Comment{}, errors.Wrap(err, "Error retrieving comments")
+		return []Comment{}, errors.Wrap(err, "Error getting comments")
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return []Comment{}, errors.Errorf("Error getting comments: %s", res.Status)
 	}
 
 	if res.Body != nil {

--- a/internal/comment/bitbucket.go
+++ b/internal/comment/bitbucket.go
@@ -175,12 +175,16 @@ func (h *bitbucketPRHandler) CallFindMatchingComments(ctx context.Context, tag s
 	for {
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
-			return []Comment{}, errors.Wrap(err, "Error retrieving comments")
+			return []Comment{}, errors.Wrap(err, "Error getting comments")
 		}
 
 		res, err := h.httpClient.Do(req)
 		if err != nil {
-			return []Comment{}, errors.Wrap(err, "Error retrieving comments")
+			return []Comment{}, errors.Wrap(err, "Error getting comments")
+		}
+
+		if res.StatusCode != http.StatusOK {
+			return []Comment{}, errors.Errorf("Error getting comments: %s", res.Status)
 		}
 
 		if res.Body != nil {
@@ -376,12 +380,16 @@ func (h *bitbucketCommitHandler) CallFindMatchingComments(ctx context.Context, t
 	for {
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
-			return []Comment{}, errors.Wrap(err, "Error retrieving comments")
+			return []Comment{}, errors.Wrap(err, "Error getting comments")
 		}
 
 		res, err := h.httpClient.Do(req)
 		if err != nil {
-			return []Comment{}, errors.Wrap(err, "Error retrieving comments")
+			return []Comment{}, errors.Wrap(err, "Error getting comments")
+		}
+
+		if res.StatusCode != http.StatusOK {
+			return []Comment{}, errors.Errorf("Error getting comments: %s", res.Status)
 		}
 
 		if res.Body != nil {
@@ -583,12 +591,16 @@ func (h *bitbucketServerPRHandler) CallFindMatchingComments(ctx context.Context,
 
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
-			return []Comment{}, errors.Wrap(err, "Error retrieving comments")
+			return []Comment{}, errors.Wrap(err, "Error getting comments")
 		}
 
 		res, err := h.httpClient.Do(req)
 		if err != nil {
-			return []Comment{}, errors.Wrap(err, "Error retrieving comments")
+			return []Comment{}, errors.Wrap(err, "Error getting comments")
+		}
+
+		if res.StatusCode != http.StatusOK {
+			return []Comment{}, errors.Errorf("Error getting comments: %s", res.Status)
 		}
 
 		if res.Body != nil {
@@ -758,7 +770,11 @@ func (h *bitbucketServerPRHandler) fetchServerComment(commentURL string) (*bitbu
 
 	res, err := h.httpClient.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "Error fetching comment")
+		return nil, errors.Wrap(err, "Error getting comment")
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("Error getting comment: %s", res.Status)
 	}
 
 	if res.Body != nil {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -142,6 +142,10 @@ func getLatestBrewVersion() (string, error) {
 		return "", err
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Errorf("Error getting latest version: %s", resp.Status)
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
If request fails the response body may not contain a proper JSON object
thus the unmarshaling error message may be confusing for users.

Example of response:
```
Error: Error getting comments: 401 Unauthorized
```