### PR TITLE
feat(cli): add env to disable output spinner

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -391,6 +391,7 @@ func runProjectConfig(cmd *cobra.Command, runCtx *config.RunContext, ctx *config
 	}
 
 	spinnerOpts := ui.SpinnerOptions{
+		Enabled:       runCtx.Config.EnabledSpinner(),
 		EnableLogging: runCtx.Config.IsLogging(),
 		NoColor:       runCtx.Config.NoColor,
 		Indent:        "  ",
@@ -517,6 +518,7 @@ func generateUsageFile(cmd *cobra.Command, runCtx *config.RunContext, projectCtx
 	}
 
 	spinnerOpts := ui.SpinnerOptions{
+		Enabled:       runCtx.Config.EnabledSpinner(),
 		EnableLogging: runCtx.Config.IsLogging(),
 		NoColor:       runCtx.Config.NoColor,
 		Indent:        "  ",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	Version         string `yaml:"version,omitempty" ignored:"true"`
 	LogLevel        string `yaml:"log_level,omitempty" envconfig:"INFRACOST_LOG_LEVEL"`
 	NoColor         bool   `yaml:"no_color,omitempty" envconfig:"INFRACOST_NO_COLOR"`
+	NoSpinner       bool   `yaml:"no_spinner,omitempty" envconfig:"INFRACOST_NO_SPINNER"`
 	SkipUpdateCheck bool   `yaml:"skip_update_check,omitempty" envconfig:"INFRACOST_SKIP_UPDATE_CHECK"`
 	Parallelism     *int   `envconfig:"INFRACOST_PARALLELISM"`
 
@@ -94,8 +95,9 @@ func init() {
 
 func DefaultConfig() *Config {
 	return &Config{
-		LogLevel: "",
-		NoColor:  false,
+		LogLevel:  "",
+		NoColor:   false,
+		NoSpinner: false,
 
 		DefaultPricingAPIEndpoint: "https://pricing.api.infracost.io",
 		PricingAPIEndpoint:        "",
@@ -207,6 +209,10 @@ func (c *Config) ConfigureLogger() error {
 
 func (c *Config) IsLogging() bool {
 	return c.LogLevel != ""
+}
+
+func (c *Config) EnabledSpinner() bool {
+	return !c.NoSpinner
 }
 
 func (c *Config) IsSelfHosted() bool {

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -56,6 +56,7 @@ func NewDirProvider(ctx *config.ProjectContext) schema.Provider {
 		ctx:  ctx,
 		Path: ctx.ProjectConfig.Path,
 		spinnerOpts: ui.SpinnerOptions{
+			Enabled:       ctx.RunContext.Config.EnabledSpinner(),
 			EnableLogging: ctx.RunContext.Config.IsLogging(),
 			NoColor:       ctx.RunContext.Config.NoColor,
 			Indent:        "  ",
@@ -139,6 +140,7 @@ func (p *DirProvider) LoadResources(usage map[string]*schema.UsageData) ([]*sche
 	}
 
 	spinner := ui.NewSpinner("Extracting only cost-related params from terraform", ui.SpinnerOptions{
+		Enabled:       p.ctx.RunContext.Config.EnabledSpinner(),
 		EnableLogging: p.ctx.RunContext.Config.IsLogging(),
 		NoColor:       p.ctx.RunContext.Config.NoColor,
 		Indent:        "  ",

--- a/internal/providers/terraform/plan_json_provider.go
+++ b/internal/providers/terraform/plan_json_provider.go
@@ -37,6 +37,7 @@ func (p *PlanJSONProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 
 func (p *PlanJSONProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
 	spinner := ui.NewSpinner("Extracting only cost-related params from terraform", ui.SpinnerOptions{
+		Enabled:       p.ctx.RunContext.Config.EnabledSpinner(),
 		EnableLogging: p.ctx.RunContext.Config.IsLogging(),
 		NoColor:       p.ctx.RunContext.Config.NoColor,
 		Indent:        "  ",

--- a/internal/providers/terraform/plan_provider.go
+++ b/internal/providers/terraform/plan_provider.go
@@ -44,6 +44,7 @@ func (p *PlanProvider) LoadResources(usage map[string]*schema.UsageData) ([]*sch
 	}
 
 	spinner := ui.NewSpinner("Extracting only cost-related params from terraform", ui.SpinnerOptions{
+		Enabled:       p.ctx.RunContext.Config.EnabledSpinner(),
 		EnableLogging: p.ctx.RunContext.Config.IsLogging(),
 		NoColor:       p.ctx.RunContext.Config.NoColor,
 		Indent:        "  ",

--- a/internal/providers/terraform/state_json_provider.go
+++ b/internal/providers/terraform/state_json_provider.go
@@ -36,6 +36,7 @@ func (p *StateJSONProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 
 func (p *StateJSONProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
 	spinner := ui.NewSpinner("Extracting only cost-related params from terraform", ui.SpinnerOptions{
+		Enabled:       p.ctx.RunContext.Config.EnabledSpinner(),
 		EnableLogging: p.ctx.RunContext.Config.IsLogging(),
 		NoColor:       p.ctx.RunContext.Config.NoColor,
 		Indent:        "  ",

--- a/internal/providers/terraform/terragrunt_provider.go
+++ b/internal/providers/terraform/terragrunt_provider.go
@@ -94,6 +94,7 @@ func (p *TerragruntProvider) LoadResources(usage map[string]*schema.UsageData) (
 	projects := make([]*schema.Project, 0, len(projectDirs))
 
 	spinner := ui.NewSpinner("Extracting only cost-related params from terragrunt plan", ui.SpinnerOptions{
+		Enabled:       p.ctx.RunContext.Config.EnabledSpinner(),
 		EnableLogging: p.ctx.RunContext.Config.IsLogging(),
 		NoColor:       p.ctx.RunContext.Config.NoColor,
 		Indent:        "  ",

--- a/internal/ui/spin.go
+++ b/internal/ui/spin.go
@@ -11,6 +11,7 @@ import (
 )
 
 type SpinnerOptions struct {
+	Enabled       bool
 	EnableLogging bool
 	NoColor       bool
 	Indent        string
@@ -33,6 +34,10 @@ func NewSpinner(msg string, opts SpinnerOptions) *Spinner {
 		opts:    opts,
 	}
 
+	if !opts.Enabled {
+		return s
+	}
+
 	if s.opts.EnableLogging {
 		log.Infof("Starting: %s", msg)
 	} else {
@@ -48,11 +53,14 @@ func NewSpinner(msg string, opts SpinnerOptions) *Spinner {
 }
 
 func (s *Spinner) Stop() {
+	if !s.opts.Enabled {
+		return
+	}
 	s.spinner.Stop()
 }
 
 func (s *Spinner) Fail() {
-	if s.spinner == nil || !s.spinner.Active() {
+	if s.spinner == nil || !s.spinner.Active() || !s.opts.Enabled {
 		return
 	}
 	s.Stop()
@@ -68,12 +76,15 @@ func (s *Spinner) Fail() {
 }
 
 func (s *Spinner) SuccessWithMessage(newMsg string) {
+	if !s.opts.Enabled {
+		return
+	}
 	s.msg = newMsg
 	s.Success()
 }
 
 func (s *Spinner) Success() {
-	if !s.spinner.Active() {
+	if !s.spinner.Active() || !s.opts.Enabled {
 		return
 	}
 	s.Stop()


### PR DESCRIPTION
Resolve #1450 

Example using this env:

```sh
$ export INFRACOST_NO_SPINNER=true
$ make run ARGS="breakdown --path examples/terraform --usage-file=examples/terraform/infracost-usage.yml"
env INFRACOST_ENV=dev go run -ldflags="-X 'github.com/infracost/infracost/internal/version.Version=v0.9.19+24-g01bfbe2d'" github.com/infracost/infracost/cmd/infracost breakdown --path examples/terraform --usage-file=examples/terraform/infracost-usage.yml
Detected Terraform directory at examples/terraform

Project: leonardobiffi/infracost/examples/terraform

 Name                                                   Monthly Qty  Unit         Monthly Cost 
                                                                                               
 aws_instance.web_app                                                                          
 ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours               $0.00 
 ├─ root_block_device                                                                          
 │  └─ Storage (general purpose SSD, gp2)                        50  GB                  $0.00 
 └─ ebs_block_device[0]                                                                        
    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB                  $0.00 
    └─ Provisioned IOPS                                         800  IOPS                $0.00 
                                                                                               
 aws_lambda_function.hello_world                                                               
 ├─ Requests                                                    100  1M requests         $0.00 
 └─ Duration                                             25,000,000  GB-seconds          $0.00 
                                                                                               
 OVERALL TOTAL                                                                           $0.00 
──────────────────────────────────
2 cloud resources were detected, rerun with --show-skipped to see details:
∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file

Add cost estimates to your pull requests: https://infracost.io/cicd
```