### PR TITLE
fix: panic error if policy body is invalid

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,4 +22,8 @@ linters-settings:
   gocritic:
     disabled-checks:
       - ifElseChain
+  revive:
+    rules:
+      - name: error-strings
+        disabled: true
 

--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -133,7 +133,7 @@ func queryPolicy(policyPaths []string, input output.Root) (output.PolicyCheck, e
 
 	inputValue, err := ast.InterfaceToValue(input)
 	if err != nil {
-		return checks, fmt.Errorf("Unable to process Infracost output into rego input: %s", err.Error())
+		return checks, fmt.Errorf("Unable to process Infracost output into Rego input: %s", err.Error())
 	}
 
 	ctx := context.Background()
@@ -146,12 +146,16 @@ func queryPolicy(policyPaths []string, input output.Root) (output.PolicyCheck, e
 	)
 	pq, err := r.PrepareForEval(ctx)
 	if err != nil {
-		return checks, fmt.Errorf("Unable to query cost policy: %s", err.Error())
+		return checks, fmt.Errorf("Unable to query provided policies: %s", err.Error())
 	}
 
 	res, err := pq.Eval(ctx)
 	if err != nil {
 		return checks, err
+	}
+
+	if len(res) == 0 {
+		return checks, fmt.Errorf("The provided polices returned no valid data.infracost.deny rules. Please check that the policies are formatted correctly.")
 	}
 
 	for _, e := range res[0].Expressions {


### PR DESCRIPTION
Solves issue if a valid policy file type is provided in `--policy-path` but the contents is malformed.