### PR TITLE
fix: Google SQL Database Instance default values

### DIFF
--- a/internal/providers/terraform/google/sql_database_instance.go
+++ b/internal/providers/terraform/google/sql_database_instance.go
@@ -31,7 +31,7 @@ func NewSQLInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 	var resource *schema.Resource
 
 	replica := false
-	if d.Get("replica_configuration").Exists() {
+	if !d.IsEmpty("replica_configuration") {
 		replica = true
 	}
 
@@ -91,7 +91,7 @@ func sqlDatabaseInstanceCostComponents(d *schema.ResourceData, u *schema.UsageDa
 		}
 		costComponents = append(costComponents, backupCostComponent(region, backupGB))
 
-		if d.Get("settings.0").Get("ip_configuration.0").Get("ipv4_enabled").Exists() {
+		if !d.Get("settings.0").Get("ip_configuration.0").Get("ipv4_enabled").Exists() || d.Get("settings.0").Get("ip_configuration.0").Get("ipv4_enabled").Bool() {
 			costComponents = append(costComponents, ipv4CostComponent())
 		}
 	}

--- a/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
@@ -1,72 +1,89 @@
 
- Name                                                    Monthly Qty  Unit            Monthly Cost 
-                                                                                                   
- google_sql_database_instance.HA_custom_postgres                                                   
- ├─ vCPUs (regional)                                          11,680  hours                $964.77 
- ├─ Memory (regional)                                         43,800  GB                   $613.20 
- ├─ Storage (SSD, regional)                                       10  GB                     $3.40 
- └─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
-                                                                                                   
- google_sql_database_instance.HA_small_mysql                                                       
- ├─ SQL instance (db-g1-small, regional)                         730  hours                 $51.10 
- ├─ Storage (SSD, regional)                                      100  GB                    $34.00 
- └─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
-                                                                                                   
- google_sql_database_instance.custom_postgres                                                      
- ├─ vCPUs (zonal)                                              1,460  hours                 $60.30 
- ├─ Memory (zonal)                                             9,490  GB                    $66.43 
- ├─ Storage (SSD, zonal)                                          10  GB                     $1.70 
- └─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
-                                                                                                   
- google_sql_database_instance.micro_mysql_HDD_storage                                              
- ├─ SQL instance (db-f1-micro, zonal)                            730  hours                  $7.67 
- ├─ Storage (HDD, zonal)                                          10  GB                     $0.90 
- └─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
-                                                                                                   
- google_sql_database_instance.micro_mysql_SSD_storage                                              
- ├─ SQL instance (db-f1-micro, zonal)                            730  hours                  $7.67 
- ├─ Storage (SSD, zonal)                                          10  GB                     $1.70 
- └─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
-                                                                                                   
- google_sql_database_instance.mysql_highmem                                                        
- ├─ SQL instance (db-n1-highmem-8, zonal)                        730  hours                $514.07 
- ├─ Storage (SSD, zonal)                                          10  GB                     $1.70 
- └─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
-                                                                                                   
- google_sql_database_instance.mysql_standard                                                       
- ├─ SQL instance (db-n1-standard-32, zonal)                      730  hours              $1,578.26 
- ├─ Storage (SSD, zonal)                                          10  GB                     $1.70 
- └─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
-                                                                                                   
- google_sql_database_instance.small_mysql                                                          
- ├─ SQL instance (db-g1-small, zonal)                            730  hours                 $25.55 
- ├─ Storage (SSD, zonal)                                          10  GB                     $1.70 
- └─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
-                                                                                                   
- google_sql_database_instance.sql_server                                                           
- ├─ vCPUs (zonal)                                             11,680  hours                $482.38 
- ├─ Memory (zonal)                                            43,800  GB                   $306.60 
- ├─ Storage (SSD, zonal)                                          10  GB                     $1.70 
- └─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
-                                                                                                   
- google_sql_database_instance.usage                                                                
- ├─ SQL instance (db-g1-small, zonal)                            730  hours                 $25.55 
- ├─ Storage (SSD, zonal)                                          10  GB                     $1.70 
- └─ Backups                                                    1,000  GB                    $80.00 
-                                                                                                   
- google_sql_database_instance.with_replica                                                         
- ├─ vCPUs (regional)                                          11,680  hours                $964.77 
- ├─ Memory (regional)                                         43,800  GB                   $613.20 
- ├─ Storage (SSD, regional)                                      500  GB                   $170.00 
- ├─ Backups                                            Monthly cost depends on usage: $0.08 per GB 
- └─ Replica                                                                                        
-    ├─ vCPUs (zonal)                                          11,680  hours                $482.38 
-    ├─ Memory (zonal)                                         43,800  GB                   $306.60 
-    └─ Storage (SSD, zonal)                                      500  GB                    $85.00 
-                                                                                                   
- OVERALL TOTAL                                                                           $7,455.69 
+ Name                                                        Monthly Qty  Unit            Monthly Cost 
+                                                                                                       
+ google_sql_database_instance.HA_custom_postgres                                                       
+ ├─ vCPUs (regional)                                              11,680  hours                $964.77 
+ ├─ Memory (regional)                                             43,800  GB                   $613.20 
+ ├─ Storage (SSD, regional)                                           10  GB                     $3.40 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.HA_small_mysql                                                           
+ ├─ SQL instance (db-g1-small, regional)                             730  hours                 $51.10 
+ ├─ Storage (SSD, regional)                                          100  GB                    $34.00 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.custom_postgres                                                          
+ ├─ vCPUs (zonal)                                                  1,460  hours                 $60.30 
+ ├─ Memory (zonal)                                                 9,490  GB                    $66.43 
+ ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.micro_mysql_HDD_storage                                                  
+ ├─ SQL instance (db-f1-micro, zonal)                                730  hours                  $7.67 
+ ├─ Storage (HDD, zonal)                                              10  GB                     $0.90 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.micro_mysql_SSD_storage                                                  
+ ├─ SQL instance (db-f1-micro, zonal)                                730  hours                  $7.67 
+ ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.mysql_highmem                                                            
+ ├─ SQL instance (db-n1-highmem-8, zonal)                            730  hours                $514.07 
+ ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.mysql_standard                                                           
+ ├─ SQL instance (db-n1-standard-32, zonal)                          730  hours              $1,578.26 
+ ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.mysql_standard_no_public_ip                                              
+ ├─ vCPUs (zonal)                                                 11,680  hours                $482.38 
+ ├─ Memory (zonal)                                                43,800  GB                   $306.60 
+ ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
+ └─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+                                                                                                       
+ google_sql_database_instance.small_mysql                                                              
+ ├─ SQL instance (db-g1-small, zonal)                                730  hours                 $25.55 
+ ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.sql_server                                                               
+ ├─ vCPUs (zonal)                                                 11,680  hours                $482.38 
+ ├─ Memory (zonal)                                                43,800  GB                   $306.60 
+ ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.usage                                                                    
+ ├─ SQL instance (db-g1-small, zonal)                                730  hours                 $25.55 
+ ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
+ ├─ Backups                                                        1,000  GB                    $80.00 
+ └─ IP address (if unused)                                           730  hours                  $7.30 
+                                                                                                       
+ google_sql_database_instance.with_replica                                                             
+ ├─ vCPUs (regional)                                              11,680  hours                $964.77 
+ ├─ Memory (regional)                                             43,800  GB                   $613.20 
+ ├─ Storage (SSD, regional)                                          500  GB                   $170.00 
+ ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
+ ├─ IP address (if unused)                                           730  hours                  $7.30 
+ └─ Replica                                                                                            
+    ├─ vCPUs (zonal)                                              11,680  hours                $482.38 
+    ├─ Memory (zonal)                                             43,800  GB                   $306.60 
+    └─ Storage (SSD, zonal)                                          500  GB                    $85.00 
+                                                                                                       
+ OVERALL TOTAL                                                                               $8,326.67 
 ──────────────────────────────────
-11 cloud resources were detected:
-∙ 11 were estimated, 11 include usage-based costs, see https://infracost.io/usage-file
+12 cloud resources were detected:
+∙ 12 were estimated, 12 include usage-based costs, see https://infracost.io/usage-file
 
 Add cost estimates to your pull requests: https://infracost.io/cicd

--- a/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.tf
+++ b/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.tf
@@ -89,6 +89,21 @@ resource "google_sql_database_instance" "mysql_highmem" {
   }
 }
 
+resource "google_sql_database_instance" "mysql_standard_no_public_ip" {
+  name             = "master-instance"
+  database_version = "SQLSERVER_2017_ENTERPRISE"
+
+  settings {
+    tier              = "db-custom-16-61440"
+    availability_type = "ZONAL"
+
+    ip_configuration {
+      ipv4_enabled = false
+    }
+  }
+}
+
+
 resource "google_sql_database_instance" "with_replica" {
   name             = "master-instance"
   database_version = "POSTGRES_11"


### PR DESCRIPTION
* When state was applied `replica_configuration` was set to an empty value, so this was adding a subresource for the replica when it shouldn't have been
* A public v4 IP is added to the DB instances by default