### PR TITLE
fix: fix google_container_cluster duplicating node pools when applied

### DIFF
--- a/internal/providers/terraform/google/util.go
+++ b/internal/providers/terraform/google/util.go
@@ -37,3 +37,12 @@ func zoneToRegion(zone string) string {
 	s := strings.Split(zone, "-")
 	return strings.Join(s[:len(s)-1], "-")
 }
+
+func contains(a []string, x string) bool {
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resources/google/container_cluster.go
+++ b/internal/resources/google/container_cluster.go
@@ -1,8 +1,6 @@
 package google
 
 import (
-	"fmt"
-
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
@@ -48,9 +46,9 @@ func (r *ContainerCluster) PopulateUsage(u *schema.UsageData) {
 		r.DefaultNodePool.PopulateUsage(u)
 	}
 
-	for i, nodePool := range r.NodePools {
+	for _, nodePool := range r.NodePools {
 		nodePool.PopulateUsage(&schema.UsageData{
-			Attributes: u.Get(fmt.Sprintf("node_pool[%d]", i)).Map(),
+			Attributes: u.Get(nodePool.Address).Map(),
 		})
 	}
 }
@@ -72,12 +70,10 @@ func (r *ContainerCluster) BuildResource() *schema.Resource {
 	subresources := []*schema.Resource{}
 
 	if r.DefaultNodePool != nil {
-		r.DefaultNodePool.Address = "default_pool"
 		subresources = append(subresources, r.DefaultNodePool.BuildResource())
 	}
 
-	for i, nodePool := range r.NodePools {
-		nodePool.Address = fmt.Sprintf("node_pool[%d]", i)
+	for _, nodePool := range r.NodePools {
 		subresources = append(subresources, nodePool.BuildResource())
 	}
 


### PR DESCRIPTION
The `google_container_cluster` resource pulls all existing node pools into its `node_pool` attribute when deployed. This duplicates the default pool and any node pools defined in `google_container_node_pool` resources. To fix this we:
1. Only add the default node pool subresource if it doesn't already exist in the `node_pool` array. If it does exist in that array, we add it as part of that.
2. Check for node pools defined in other resources, and only add them as subresources if they are not.