### PR TITLE
feat(aws): add AWS Network Firewall resources

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -244,6 +244,9 @@ resource_usage:
   aws_neptune_cluster_snapshot.my_cluster_snapshot:
     backup_storage_gb: 1000        # Total storage used for backup snapshots in GB.
 
+  aws_networkfirewall_firewall.my_firewall:
+    monthly_data_processed_gb: 100 # Monthly data processed by the Network Firewall in GB.
+
   aws_mq_broker.my_aws_mq_broker:
     storage_size_gb: 12 # Data storage per instance in GB.
 

--- a/internal/providers/terraform/aws/networkfirewall_firewall.go
+++ b/internal/providers/terraform/aws/networkfirewall_firewall.go
@@ -1,0 +1,24 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/resources/aws"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getNetworkfirewallFirewallRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_networkfirewall_firewall",
+		RFunc: newNetworkfirewallFirewall,
+	}
+}
+
+func newNetworkfirewallFirewall(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+	r := &aws.NetworkfirewallFirewall{
+		Address: d.Address,
+		Region:  region,
+	}
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/aws/networkfirewall_firewall_test.go
+++ b/internal/providers/terraform/aws/networkfirewall_firewall_test.go
@@ -1,0 +1,16 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestNetworkfirewallFirewallGoldenFile(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "networkfirewall_firewall_test")
+}

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -96,6 +96,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getStepFunctionRegistryItem(),
 	getDirectoryServiceDirectory(),
 	getTransferServerRegistryItem(),
+	getNetworkfirewallFirewallRegistryItem(),
 }
 
 // FreeResources grouped alphabetically
@@ -291,6 +292,11 @@ var FreeResources = []string{
 	"aws_neptune_event_subscription",
 	"aws_neptune_parameter_group",
 	"aws_neptune_subnet_group",
+
+	// AWS Network Firewall
+	"aws_networkfirewall_rule_group",
+	"aws_networkfirewall_firewall_policy",
+	"aws_networkfirewall_logging_configuration",
 
 	// AWS Others
 	"aws_db_instance_role_association",

--- a/internal/providers/terraform/aws/testdata/networkfirewall_firewall_test/networkfirewall_firewall_test.golden
+++ b/internal/providers/terraform/aws/testdata/networkfirewall_firewall_test/networkfirewall_firewall_test.golden
@@ -1,0 +1,17 @@
+
+ Name                                                                 Monthly Qty  Unit              Monthly Cost 
+                                                                                                                  
+ aws_networkfirewall_firewall.networkfirewall_firewall                                                            
+ ├─ Network Firewall Endpoint                                                 730  hours                  $288.35 
+ └─ Data Processed                                                 Monthly cost depends on usage: $0.065 per GB   
+                                                                                                                  
+ aws_networkfirewall_firewall.networkfirewall_firewall_with_usage                                                 
+ ├─ Network Firewall Endpoint                                                 730  hours                  $288.35 
+ └─ Data Processed                                                            100  GB                       $6.50 
+                                                                                                                  
+ OVERALL TOTAL                                                                                            $583.20 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, 2 include usage-based costs, see https://infracost.io/usage-file
+
+Add cost estimates to your pull requests: https://infracost.io/cicd

--- a/internal/providers/terraform/aws/testdata/networkfirewall_firewall_test/networkfirewall_firewall_test.tf
+++ b/internal/providers/terraform/aws/testdata/networkfirewall_firewall_test/networkfirewall_firewall_test.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+# Add example resources for NetworkfirewallFirewall below
+
+resource "aws_networkfirewall_firewall" "networkfirewall_firewall" {
+  name                = "example"
+  firewall_policy_arn = "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/example-policy"
+  vpc_id              = "vpc-12345678"
+  subnet_mapping {
+    subnet_id = "subnet-12345678"
+  }
+}
+
+resource "aws_networkfirewall_firewall" "networkfirewall_firewall_with_usage" {
+  name                = "example"
+  firewall_policy_arn = "arn:aws:network-firewall:us-east-1:123456789012:firewall-policy/example-policy"
+  vpc_id              = "vpc-12345678"
+  subnet_mapping {
+    subnet_id = "subnet-12345678"
+  }
+}

--- a/internal/providers/terraform/aws/testdata/networkfirewall_firewall_test/networkfirewall_firewall_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/networkfirewall_firewall_test/networkfirewall_firewall_test.usage.yml
@@ -1,0 +1,4 @@
+version: 0.1
+resource_usage:
+  aws_networkfirewall_firewall.networkfirewall_firewall_with_usage:
+    monthly_data_processed_gb: 100

--- a/internal/resources/aws/networkfirewall_firewall.go
+++ b/internal/resources/aws/networkfirewall_firewall.go
@@ -1,0 +1,81 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// NetworkfirewallFirewall struct represents an AWS Network Firewall Firewall resource.
+//
+// Resource information: https://aws.amazon.com/network-firewall/
+// Pricing information: https://aws.amazon.com/network-firewall/pricing/
+type NetworkfirewallFirewall struct {
+	Address string
+	Region  string
+
+	MonthlyDataProcessedGB *float64 `infracost_usage:"monthly_data_processed_gb"`
+}
+
+// NetworkfirewallFirewallUsageSchema defines a list which represents the usage schema of NetworkfirewallFirewall.
+var NetworkfirewallFirewallUsageSchema = []*schema.UsageItem{
+	{Key: "monthly_data_processed_gb", DefaultValue: 0, ValueType: schema.Float64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the NetworkfirewallFirewall.
+// It uses the `infracost_usage` struct tags to populate data into the NetworkfirewallFirewall.
+func (r *NetworkfirewallFirewall) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid NetworkfirewallFirewall struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *NetworkfirewallFirewall) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{
+		r.endpointCostComponent(),
+		r.dataProcessedCostComponent(),
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    NetworkfirewallFirewallUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+func (r *NetworkfirewallFirewall) endpointCostComponent() *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:           "Network Firewall Endpoint",
+		Unit:           "hours",
+		UnitMultiplier: decimal.NewFromInt(1),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AWSNetworkFirewall"),
+			ProductFamily: strPtr("AWS Firewall"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: regexPtr("^[A-Z0-9]*-Endpoint-Hour$")},
+			},
+		},
+	}
+}
+
+func (r *NetworkfirewallFirewall) dataProcessedCostComponent() *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Data Processed",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: floatPtrToDecimalPtr(r.MonthlyDataProcessedGB),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AWSNetworkFirewall"),
+			ProductFamily: strPtr("AWS Firewall"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", ValueRegex: regexPtr("^[A-Z0-9]*-Traffic-GB-Processed$")},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Objective:

Add support for AWS Network Firewall resources.

## Pricing details:

Pricing information: https://aws.amazon.com/network-firewall/pricing/

The `aws_networkfirewall_firewall` resources is billed like a NAT gateway (hours + traffic).
All the others resources are free.

## Status:

- [x] Generated the resource files
- [x] Updated the internal/resources file
- [x] Updated the internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/184)

## Issues:

Not sure how to take into account the discount on the NAT gateway granted by Network Firewall:

> Use one hour & one GB of NAT gateway at no additional cost for every hour & GB charged for Network Firewall endpoints.