### PR TITLE
fix: hcl panic errors

### DIFF
--- a/internal/hcl/reference.go
+++ b/internal/hcl/reference.go
@@ -58,6 +58,10 @@ func newReference(parts []string) (*Reference, error) {
 }
 
 func (r *Reference) SetKey(key cty.Value) {
+	if !key.IsKnown() {
+		return
+	}
+
 	switch key.Type() {
 	case cty.Number:
 		f := key.AsBigFloat()

--- a/internal/providers/terraform/aws/eks_node_group.go
+++ b/internal/providers/terraform/aws/eks_node_group.go
@@ -57,7 +57,12 @@ func NewEKSNodeGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resour
 		}
 
 		if data.Get("instance_type").Type == gjson.Null {
-			data.Set("instance_type", d.Get("instance_types").Array()[0].String())
+			instanceType := "t3.medium"
+			types := d.Get("instance_types").Array()
+			if len(types) > 0 {
+				instanceType = types[0].String()
+			}
+			data.Set("instance_type", instanceType)
 		}
 
 		a.LaunchTemplate = newLaunchTemplate(data, u, region, instanceCount, int64(0), onDemandPercentageAboveBaseCount)

--- a/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
@@ -1,67 +1,74 @@
 
- Name                                                     Monthly Qty  Unit        Monthly Cost 
-                                                                                                
- aws_eks_node_group.example                                                                     
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)             730  hours             $30.37 
- └─ Storage (general purpose SSD, gp2)                             20  GB                 $2.00 
-                                                                                                
- aws_eks_node_group.example2                                                                    
- ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)             730  hours             $33.87 
- └─ Storage (general purpose SSD, gp2)                             30  GB                 $3.00 
-                                                                                                
- aws_eks_node_group.example_defaultCpuCredits                                                   
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)           2,190  hours             $91.10 
- └─ Storage (general purpose SSD, gp2)                             60  GB                 $6.00 
-                                                                                                
- aws_eks_node_group.example_with_launch_template                                                
- └─ aws_launch_template.foo                                                                     
-    ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)        2,190  hours             $91.10 
-    ├─ Inference accelerator (eia1.medium)                      2,190  hours            $284.70 
-    ├─ CPU credits                                              2,100  vCPU-hours       $105.00 
-    └─ block_device_mapping[0]                                                                  
-       └─ Storage (general purpose SSD, gp2)                       60  GB                 $6.00 
-                                                                                                
- aws_eks_node_group.example_with_launch_template_2                                              
- └─ aws_launch_template.foo2                                                                    
-    ├─ Instance usage (Linux/UNIX, on-demand, m5.xlarge)        2,190  hours            $420.48 
-    ├─ EBS-optimized usage                                      2,190  hours              $0.00 
-    ├─ Inference accelerator (eia1.medium)                      2,190  hours            $284.70 
-    └─ block_device_mapping[0]                                                                  
-       └─ Storage (general purpose SSD, gp2)                       60  GB                 $6.00 
-                                                                                                
- aws_eks_node_group.example_with_launch_template_3                                              
- └─ aws_launch_template.foo3                                                                    
-    ├─ Instance usage (Linux/UNIX, on-demand, m5.xlarge)        2,190  hours            $420.48 
-    ├─ EBS-optimized usage                                      2,190  hours              $0.00 
-    ├─ Inference accelerator (eia1.medium)                      2,190  hours            $284.70 
-    └─ block_device_mapping[0]                                                                  
-       └─ Storage (general purpose SSD, gp2)                       60  GB                 $6.00 
-                                                                                                
- aws_eks_node_group.lt_usage                                                                    
- └─ aws_launch_template.lt_usage                                                                
-    ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)        4,380  hours            $203.23 
-    └─ block_device_mapping[0]                                                                  
-       └─ Storage (general purpose SSD, gp2)                       60  GB                 $6.00 
-                                                                                                
- aws_eks_node_group.reserved                                                                    
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)              730  hours             $19.05 
- ├─ CPU credits                                                   700  vCPU-hours        $35.00 
- └─ Storage (general purpose SSD, gp2)                             20  GB                 $2.00 
-                                                                                                
- aws_eks_node_group.usage                                                                       
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)           4,380  hours            $182.21 
- └─ Storage (general purpose SSD, gp2)                            120  GB                $12.00 
-                                                                                                
- aws_eks_node_group.windows                                                                     
- ├─ Instance usage (Windows, on-demand, t3.medium)                730  hours             $43.80 
- ├─ CPU credits                                                   200  vCPU-hours        $10.00 
- └─ Storage (general purpose SSD, gp2)                             20  GB                 $2.00 
-                                                                                                
- OVERALL TOTAL                                                                        $2,590.80 
+ Name                                                                    Monthly Qty  Unit        Monthly Cost 
+                                                                                                               
+ aws_eks_node_group.example                                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                            730  hours             $30.37 
+ └─ Storage (general purpose SSD, gp2)                                            20  GB                 $2.00 
+                                                                                                               
+ aws_eks_node_group.example2                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                            730  hours             $33.87 
+ └─ Storage (general purpose SSD, gp2)                                            30  GB                 $3.00 
+                                                                                                               
+ aws_eks_node_group.example_defaultCpuCredits                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                          2,190  hours             $91.10 
+ └─ Storage (general purpose SSD, gp2)                                            60  GB                 $6.00 
+                                                                                                               
+ aws_eks_node_group.example_with_launch_template                                                               
+ └─ aws_launch_template.foo                                                                                    
+    ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       2,190  hours             $91.10 
+    ├─ Inference accelerator (eia1.medium)                                     2,190  hours            $284.70 
+    ├─ CPU credits                                                             2,100  vCPU-hours       $105.00 
+    └─ block_device_mapping[0]                                                                                 
+       └─ Storage (general purpose SSD, gp2)                                      60  GB                 $6.00 
+                                                                                                               
+ aws_eks_node_group.example_with_launch_template_2                                                             
+ └─ aws_launch_template.foo2                                                                                   
+    ├─ Instance usage (Linux/UNIX, on-demand, m5.xlarge)                       2,190  hours            $420.48 
+    ├─ EBS-optimized usage                                                     2,190  hours              $0.00 
+    ├─ Inference accelerator (eia1.medium)                                     2,190  hours            $284.70 
+    └─ block_device_mapping[0]                                                                                 
+       └─ Storage (general purpose SSD, gp2)                                      60  GB                 $6.00 
+                                                                                                               
+ aws_eks_node_group.example_with_launch_template_3                                                             
+ └─ aws_launch_template.foo3                                                                                   
+    ├─ Instance usage (Linux/UNIX, on-demand, m5.xlarge)                       2,190  hours            $420.48 
+    ├─ EBS-optimized usage                                                     2,190  hours              $0.00 
+    ├─ Inference accelerator (eia1.medium)                                     2,190  hours            $284.70 
+    └─ block_device_mapping[0]                                                                                 
+       └─ Storage (general purpose SSD, gp2)                                      60  GB                 $6.00 
+                                                                                                               
+ aws_eks_node_group.example_with_launch_template_instance_types_default                                        
+ └─ aws_launch_template.bar                                                                                    
+    ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       2,190  hours             $91.10 
+    ├─ Inference accelerator (eia1.medium)                                     2,190  hours            $284.70 
+    └─ block_device_mapping[0]                                                                                 
+       └─ Storage (general purpose SSD, gp2)                                      60  GB                 $6.00 
+                                                                                                               
+ aws_eks_node_group.lt_usage                                                                                   
+ └─ aws_launch_template.lt_usage                                                                               
+    ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                       4,380  hours            $203.23 
+    └─ block_device_mapping[0]                                                                                 
+       └─ Storage (general purpose SSD, gp2)                                      60  GB                 $6.00 
+                                                                                                               
+ aws_eks_node_group.reserved                                                                                   
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                             730  hours             $19.05 
+ ├─ CPU credits                                                                  700  vCPU-hours        $35.00 
+ └─ Storage (general purpose SSD, gp2)                                            20  GB                 $2.00 
+                                                                                                               
+ aws_eks_node_group.usage                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                          4,380  hours            $182.21 
+ └─ Storage (general purpose SSD, gp2)                                           120  GB                $12.00 
+                                                                                                               
+ aws_eks_node_group.windows                                                                                    
+ ├─ Instance usage (Windows, on-demand, t3.medium)                               730  hours             $43.80 
+ ├─ CPU credits                                                                  200  vCPU-hours        $10.00 
+ └─ Storage (general purpose SSD, gp2)                                            20  GB                 $2.00 
+                                                                                                               
+ OVERALL TOTAL                                                                                       $2,972.61 
 ──────────────────────────────────
-14 cloud resources were detected:
-∙ 10 were estimated, 10 include usage-based costs, see https://infracost.io/usage-file
-∙ 4 were free:
-  ∙ 4 x aws_launch_template
+16 cloud resources were detected:
+∙ 11 were estimated, 11 include usage-based costs, see https://infracost.io/usage-file
+∙ 5 were free:
+  ∙ 5 x aws_launch_template
 
 Add cost estimates to your pull requests: https://infracost.io/cicd

--- a/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.tf
+++ b/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.tf
@@ -55,6 +55,95 @@ resource "aws_eks_node_group" "example_with_launch_template" {
   }
 }
 
+resource "aws_eks_node_group" "example_with_launch_template_instance_types_default" {
+  cluster_name    = "test_aws_eks_node_group"
+  node_group_name = "example"
+  node_role_arn   = "node_role_arn"
+  subnet_ids      = ["subnet_id"]
+
+  scaling_config {
+    desired_size = 3
+    max_size     = 1
+    min_size     = 1
+  }
+
+  launch_template {
+    id      = aws_launch_template.bar.id
+    version = "default_version"
+  }
+}
+
+resource "aws_launch_template" "bar" {
+  name = "foo"
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_size = 20
+    }
+  }
+
+  capacity_reservation_specification {
+    capacity_reservation_preference = "open"
+  }
+
+  cpu_options {
+    core_count       = 4
+    threads_per_core = 2
+  }
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+
+  disable_api_termination = true
+
+  ebs_optimized = true
+
+  elastic_gpu_specifications {
+    type = "test"
+  }
+
+  elastic_inference_accelerator {
+    type = "eia1.medium"
+  }
+
+  iam_instance_profile {
+    name = "test"
+  }
+
+  image_id = "ami-test"
+
+  instance_initiated_shutdown_behavior = "terminate"
+
+  kernel_id = "test"
+
+  key_name = "test"
+
+  license_specification {
+    license_configuration_arn = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef"
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  network_interfaces {
+    associate_public_ip_address = true
+  }
+
+  placement {
+    availability_zone = "us-west-2a"
+  }
+
+  ram_disk_id = "test"
+
+  vpc_security_group_ids = ["example"]
+}
+
 resource "aws_launch_template" "foo" {
   name = "foo"
 


### PR DESCRIPTION
* Fixes issue with `aws_eks_node_group` where  `instance_types` was not set https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group we now use the default `t3.medium`
* Fixes issue where `cty.Value` was unknown and causing panic when trying to set attribute