### PR TITLE
feat: Add google_service_networking_connection

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -687,6 +687,16 @@ resource_usage:
   google_secret_manager_secret_version.my_secret_version:
     monthly_access_operations: 25000 # Monthly number of access operations
 
+  google_service_networking_connection.my_connection:
+    monthly_egress_data_transfer_gb: # Monthly VM-VM data transfer from VPN gateway to the following, in GB:
+      same_region: 250                # VMs in the same Google Cloud region.
+      us_or_canada: 100               # From a Google Cloud region in the US or Canada to another Google Cloud region in the US or Canada.
+      europe: 70                      # Between Google Cloud regions within Europe.
+      asia: 50                        # Between Google Cloud regions within Asia.
+      south_america: 100              # Between Google Cloud regions within South America.
+      oceania: 50                     # Indonesia and Oceania to/from any Google Cloud region.
+      worldwide: 200                  # to a Google Cloud region on another continent.
+
   google_sql_database_instance.my_instance:
     backup_storage_gb: 1000 # Amount of backup storage in GB.
 

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -50,6 +50,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getRedisInstanceRegistryItem(),
 	getSecretManagerSecretRegistryItem(),
 	getSecretManagerSecretVersionRegistryItem(),
+	getServiceNetworkingConnectionRegistryItem(),
 	GetSQLInstanceRegistryItem(),
 	GetStorageBucketRegistryItem(),
 }

--- a/internal/providers/terraform/google/service_networking_connection.go
+++ b/internal/providers/terraform/google/service_networking_connection.go
@@ -1,0 +1,22 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getServiceNetworkingConnectionRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "google_service_networking_connection",
+		RFunc: newServiceNetworkingConnection,
+	}
+}
+
+func newServiceNetworkingConnection(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+	return &schema.Resource{
+		Name: d.Address,
+		SubResources: []*schema.Resource{
+			networkEgress(region, u, "Network egress", "Traffic", ComputeVPNGateway),
+		},
+	}
+}

--- a/internal/providers/terraform/google/service_networking_connection_test.go
+++ b/internal/providers/terraform/google/service_networking_connection_test.go
@@ -1,0 +1,16 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestServiceNetworkingConnection(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "service_networking_connection_test")
+}

--- a/internal/providers/terraform/google/service_networking_connection_test.go
+++ b/internal/providers/terraform/google/service_networking_connection_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
 )
 
-func TestServiceNetworkingConnection(t *testing.T) {
+func TestServiceNetworkingConnectionGoldenFile(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")

--- a/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.golden
+++ b/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.golden
@@ -24,7 +24,7 @@
  OVERALL TOTAL                                                                                  $38.90 
 ──────────────────────────────────
 4 cloud resources were detected:
-∙ 2 were estimated
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 2 were free:
   ∙ 1 x google_compute_global_address
   ∙ 1 x google_compute_network

--- a/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.golden
+++ b/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.golden
@@ -1,0 +1,30 @@
+
+ Name                                                        Monthly Qty  Unit            Monthly Cost 
+                                                                                                       
+ google_service_networking_connection.my_connection                                                    
+ └─ Network egress                                                                                     
+    ├─ Traffic within the same region                      Monthly cost depends on usage: $0.01 per GB 
+    ├─ Traffic within the US or Canada                     Monthly cost depends on usage: $0.01 per GB 
+    ├─ Traffic within Europe                               Monthly cost depends on usage: $0.02 per GB 
+    ├─ Traffic within Asia                                 Monthly cost depends on usage: $0.05 per GB 
+    ├─ Traffic within South America                        Monthly cost depends on usage: $0.08 per GB 
+    ├─ Traffic to/from Indonesia and Oceania               Monthly cost depends on usage: $0.15 per GB 
+    └─ Traffic between continents (excludes Oceania)       Monthly cost depends on usage: $0.08 per GB 
+                                                                                                       
+ google_service_networking_connection.my_usage_connection                                              
+ └─ Network egress                                                                                     
+    ├─ Traffic within the same region                                250  GB                     $2.50 
+    ├─ Traffic within the US or Canada                               100  GB                     $1.00 
+    ├─ Traffic within Europe                                          70  GB                     $1.40 
+    ├─ Traffic within Asia                                            50  GB                     $2.50 
+    ├─ Traffic within South America                                  100  GB                     $8.00 
+    ├─ Traffic to/from Indonesia and Oceania                          50  GB                     $7.50 
+    └─ Traffic between continents (excludes Oceania)                 200  GB                    $16.00 
+                                                                                                       
+ OVERALL TOTAL                                                                                  $38.90 
+──────────────────────────────────
+4 cloud resources were detected:
+∙ 2 were estimated
+∙ 2 were free:
+  ∙ 1 x google_compute_global_address
+  ∙ 1 x google_compute_network

--- a/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.tf
+++ b/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.tf
@@ -1,0 +1,28 @@
+provider "google" {
+  credentials = "{\"type\":\"service_account\"}"
+  region      = "us-central1"
+}
+
+resource "google_compute_network" "peering_network" {
+  name = "peering-network"
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  name          = "private-ip-alloc"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.peering_network.id
+}
+
+resource "google_service_networking_connection" "my_connection" {
+  network                 = google_compute_network.peering_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+}
+
+resource "google_service_networking_connection" "my_usage_connection" {
+  network                 = google_compute_network.peering_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+}

--- a/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.usage.yml
+++ b/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.usage.yml
@@ -1,0 +1,11 @@
+version: 0.1
+resource_usage:
+  google_service_networking_connection.my_usage_connection:
+    monthly_egress_data_transfer_gb:
+      same_region: 250
+      us_or_canada: 100
+      europe: 70
+      asia: 50
+      south_america: 100
+      oceania: 50
+      worldwide: 200


### PR DESCRIPTION
## Objective:

Add support for google_service_networking_connection. Fixes #1360.

## Pricing details:

Private service connections are essentially VPC to VPC connections and and can generate "internal" egress costs in the same manner as a VPN Gateway.  Therefore this resource has the same usage cost components for egress traffic as VPN gateway:
```
    monthly_egress_data_transfer_gb: # Monthly VM-VM data transfer from VPN gateway to the following, in GB:
      same_region: 250                # VMs in the same Google Cloud region.
      us_or_canada: 100               # From a Google Cloud region in the US or Canada to another Google Cloud region in the US or Canada.
      europe: 70                      # Between Google Cloud regions within Europe.
      asia: 50                        # Between Google Cloud regions within Asia.
      south_america: 100              # Between Google Cloud regions within South America.
      oceania: 50                     # Indonesia and Oceania to/from any Google Cloud region.
      worldwide: 200                  # to a Google Cloud region on another continent.
```

## Status:

- [x] Generated the resource files
- [ ] ~~Updated the internal/resources file~~
- [x] Updated the internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [ ] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/191)