### PR TITLE
fix: get the correct instance type for EKS node groups

### DIFF
--- a/internal/providers/terraform/aws/eks_node_group.go
+++ b/internal/providers/terraform/aws/eks_node_group.go
@@ -3,11 +3,11 @@ package aws
 import (
 	"strings"
 
-	"github.com/tidwall/gjson"
-
 	"github.com/infracost/infracost/internal/resources/aws"
 	"github.com/infracost/infracost/internal/schema"
 )
+
+var defaultEKSInstanceType = "t3.medium"
 
 func getNewEKSNodeGroupItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
@@ -48,6 +48,9 @@ func NewEKSNodeGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resour
 		launchTemplateRef = launchTemplateRefName
 	}
 
+	// The instance types in the eks_node_group resource overrides any in the launch template
+	instanceType := strings.ToLower(d.Get("instance_types.0").String())
+
 	if len(launchTemplateRef) > 0 {
 		data := launchTemplateRef[0]
 
@@ -56,20 +59,18 @@ func NewEKSNodeGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resour
 			onDemandPercentageAboveBaseCount = int64(0)
 		}
 
-		if data.Get("instance_type").Type == gjson.Null {
-			instanceType := "t3.medium"
-			types := d.Get("instance_types").Array()
-			if len(types) > 0 {
-				instanceType = types[0].String()
-			}
+		if instanceType != "" {
 			data.Set("instance_type", instanceType)
+		}
+
+		if data.IsEmpty("instance_type") {
+			data.Set("instance_type", defaultEKSInstanceType)
 		}
 
 		a.LaunchTemplate = newLaunchTemplate(data, u, region, instanceCount, int64(0), onDemandPercentageAboveBaseCount)
 	} else {
-		instanceType := strings.ToLower(d.Get("instance_types.0").String())
 		if instanceType == "" {
-			instanceType = "t3.medium"
+			instanceType = defaultEKSInstanceType
 		}
 
 		a.InstanceType = instanceType

--- a/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
@@ -31,7 +31,7 @@
                                                                                                                
  aws_eks_node_group.example_with_launch_template_3                                                             
  └─ aws_launch_template.foo3                                                                                   
-    ├─ Instance usage (Linux/UNIX, on-demand, m5.xlarge)                       2,190  hours            $420.48 
+    ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                        2,190  hours            $210.24 
     ├─ EBS-optimized usage                                                     2,190  hours              $0.00 
     ├─ Inference accelerator (eia1.medium)                                     2,190  hours            $284.70 
     └─ block_device_mapping[0]                                                                                 
@@ -64,7 +64,7 @@
  ├─ CPU credits                                                                  200  vCPU-hours        $10.00 
  └─ Storage (general purpose SSD, gp2)                                            20  GB                 $2.00 
                                                                                                                
- OVERALL TOTAL                                                                                       $2,972.61 
+ OVERALL TOTAL                                                                                       $2,762.37 
 ──────────────────────────────────
 16 cloud resources were detected:
 ∙ 11 were estimated, 11 include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.tf
+++ b/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.tf
@@ -328,6 +328,8 @@ resource "aws_eks_node_group" "example_with_launch_template_3" {
   node_role_arn   = "node_role_arn"
   subnet_ids      = ["subnet_id"]
 
+  instance_types = ["m5.large"]
+
   scaling_config {
     desired_size = 3
     max_size     = 1


### PR DESCRIPTION
This fixes two issues:
1. When the instance type is not specified and the Terraform is applied, it was being set as an empty string instead of null so we weren't using the default.
2. The instance type specified in the EKS node group wasn't overriding the instance type in the launch template