### PR TITLE
chore: Update test naming in resourcegen templates

### DIFF
--- a/cmd/resourcegen/embed/providers/terraform/$cloud_provider$/$filename$_test.go.tmpl
+++ b/cmd/resourcegen/embed/providers/terraform/$cloud_provider$/$filename$_test.go.tmpl
@@ -6,7 +6,7 @@ import (
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
 )
 
-func Test{{ .ResourceName }}GoldenFile(t *testing.T) {
+func Test{{ .ResourceName }}(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")


### PR DESCRIPTION
As we test resources using golden files by default, having `GoldenFile`
in the test names seems redundant.