### PR TITLE
feat(azure): Add azurerm_storage_container resource as free

### DIFF
--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -317,9 +317,10 @@ var FreeResources = []string{
 	"azurerm_mssql_firewall_rule",
 
 	// Azure Storage
-	"azurerm_storage_table_entity",
-	"azurerm_storage_management_policy",
 	"azurerm_storage_blob_inventory_policy",
+	"azurerm_storage_container",
+	"azurerm_storage_management_policy",
+	"azurerm_storage_table_entity",
 
 	// Azure Virtual Desktop
 	"azurerm_virtual_desktop_application",


### PR DESCRIPTION
It represents a container in Storage Account (which can be treated as a folder).
`azurerm_storage_account` already includes "List and Create container
operations" cost component which includes the container creation. As
Azure billing page doesn't provide the data per container and only
cumulative operations count, we can treat this resource as free.

Docs: https://github.com/infracost/docs/pull/193/commits/a44334d5fd34c3b45cec958e5d732d2cb727196a

Resolves #1257.