### PR TITLE
fix: vpc endpoint subnet_ids attribute empty without apply state

### DIFF
--- a/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
+++ b/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
@@ -23,7 +23,15 @@
  ├─ Data processed (first 1PB)            Monthly cost depends on usage: $0.01 per GB    
  └─ Endpoint (Interface)                           1,460  hours                   $14.60 
                                                                                          
- OVERALL TOTAL                                                                    $95.80 
+ aws_vpc_endpoint.with_dynamic_subnet                                                    
+ ├─ Data processed (first 1PB)            Monthly cost depends on usage: $0.01 per GB    
+ └─ Endpoint (Interface)                           1,460  hours                   $14.60 
+                                                                                         
+ OVERALL TOTAL                                                                   $110.40 
 ──────────────────────────────────
-5 cloud resources were detected:
-∙ 5 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+10 cloud resources were detected:
+∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+∙ 4 were free:
+  ∙ 2 x aws_subnet
+  ∙ 1 x aws_vpc
+  ∙ 1 x aws_vpc_endpoint

--- a/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.tf
+++ b/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.tf
@@ -9,6 +9,11 @@ provider "aws" {
   secret_key                  = "mock_secret_key"
 }
 
+resource "aws_vpc_endpoint" "default" {
+  service_name = "com.amazonaws.region.ec2"
+  vpc_id       = "vpc-123456"
+}
+
 resource "aws_vpc_endpoint" "interface" {
   service_name      = "com.amazonaws.region.ec2"
   vpc_id            = "vpc-123456"
@@ -37,8 +42,33 @@ resource "aws_vpc_endpoint" "multiple_interfaces" {
   service_name      = "com.amazonaws.region.ec2"
   vpc_id            = "vpc-123456"
   vpc_endpoint_type = "Interface"
-  subnet_ids = [
+  subnet_ids        = [
     "subnet-123456",
     "subnet-654321"
+  ]
+}
+
+resource "aws_vpc" "main" {
+  cidr_block       = "10.0.0.0/16"
+  instance_tenancy = "default"
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = "10.0.1.0/24"
+}
+
+resource "aws_subnet" "test2" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = "10.0.2.0/24"
+}
+
+resource "aws_vpc_endpoint" "with_dynamic_subnet" {
+  service_name      = "com.amazonaws.region.ec2"
+  vpc_id            = aws_vpc.main.id
+  vpc_endpoint_type = "Interface"
+  subnet_ids        = [
+    aws_subnet.test.id,
+    aws_subnet.test2.id
   ]
 }

--- a/internal/providers/terraform/aws/vpc_endpoint.go
+++ b/internal/providers/terraform/aws/vpc_endpoint.go
@@ -9,15 +9,26 @@ func getVPCEndpointRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_vpc_endpoint",
 		RFunc: NewVPCEndpoint,
+		ReferenceAttributes: []string{
+			"subnet_ids",
+		},
 	}
 }
 
 func NewVPCEndpoint(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	subnetIDs := d.Get("subnet_ids").Array()
+	subnetIDs := len(d.Get("subnet_ids").Array())
 
-	interfaces := int64(1)
-	if len(subnetIDs) > 0 {
-		interfaces = int64(len(subnetIDs))
+	// if the length of the subnet_ids attribute is zero this means that the attribute
+	// has been modified with a subnet id that is yet to exist. In this instance we'll
+	// use the reference attribute instead. In most cases this should have the accurate
+	// number of subnet_ids.
+	if subnetIDs == 0 {
+		subnetIDs = len(d.References("subnet_ids"))
+	}
+
+	var interfaces int64 = 1
+	if subnetIDs > 0 {
+		interfaces = int64(subnetIDs)
 	}
 
 	r := &aws.VPCEndpoint{


### PR DESCRIPTION
Fixes issue where the `subnet_ids` attribute was empty as it contained ids for subnets yet to be created. This meant that we were calculating the wrong number of interfaces for the cost component.