### PR TITLE
fix: Honor cache enabled flag for API Gateway

### DIFF
--- a/internal/providers/terraform/aws/api_gateway_stage.go
+++ b/internal/providers/terraform/aws/api_gateway_stage.go
@@ -16,6 +16,7 @@ func NewAPIGatewayStage(d *schema.ResourceData, u *schema.UsageData) *schema.Res
 		Address:          d.Address,
 		Region:           d.Get("region").String(),
 		CacheClusterSize: d.Get("cache_cluster_size").Float(),
+		CacheEnabled:     d.GetBoolOrDefault("cache_cluster_enabled", false),
 	}
 
 	r.PopulateUsage(u)

--- a/internal/providers/terraform/aws/testdata/api_gateway_stage_test/api_gateway_stage_test.golden
+++ b/internal/providers/terraform/aws/testdata/api_gateway_stage_test/api_gateway_stage_test.golden
@@ -9,5 +9,7 @@
                                                                  
  OVERALL TOTAL                                         $2,788.60 
 ──────────────────────────────────
-2 cloud resources were detected:
+4 cloud resources were detected:
 ∙ 2 were estimated
+∙ 2 were free:
+  ∙ 2 x aws_api_gateway_stage

--- a/internal/providers/terraform/aws/testdata/api_gateway_stage_test/api_gateway_stage_test.tf
+++ b/internal/providers/terraform/aws/testdata/api_gateway_stage_test/api_gateway_stage_test.tf
@@ -24,3 +24,17 @@ resource "aws_api_gateway_stage" "cache_2" {
   cache_cluster_enabled = true
   cache_cluster_size    = 237
 }
+
+resource "aws_api_gateway_stage" "default_cache" {
+  rest_api_id   = "api-id-3"
+  stage_name    = "cache-stage-3"
+  deployment_id = "deployment-id-3"
+}
+
+resource "aws_api_gateway_stage" "disabled_cache" {
+  rest_api_id           = "api-id-4"
+  stage_name            = "cache-stage-4"
+  deployment_id         = "deployment-id-4"
+  cache_cluster_enabled = false
+  cache_cluster_size    = 237
+}

--- a/internal/resources/aws/api_gateway_stage.go
+++ b/internal/resources/aws/api_gateway_stage.go
@@ -13,6 +13,7 @@ type APIGatewayStage struct {
 	Address          string
 	Region           string
 	CacheClusterSize float64
+	CacheEnabled     bool
 }
 
 var APIGatewayStageUsageSchema = []*schema.UsageItem{}
@@ -22,6 +23,15 @@ func (r *APIGatewayStage) PopulateUsage(u *schema.UsageData) {
 }
 
 func (r *APIGatewayStage) BuildResource() *schema.Resource {
+	if !r.CacheEnabled {
+		return &schema.Resource{
+			Name:        r.Address,
+			NoPrice:     true,
+			IsSkipped:   true,
+			UsageSchema: APIGatewayStageUsageSchema,
+		}
+	}
+
 	region := r.Region
 
 	return &schema.Resource{


### PR DESCRIPTION
Fixes #1505 - Api Gateway should not estimate charges for cache unless the cache is enabled.