### PR TITLE
fix: Use correct unit multiplier for state machine transitions

### DIFF
--- a/internal/providers/terraform/aws/testdata/sfn_state_machine_test/sfn_state_machine_test.golden
+++ b/internal/providers/terraform/aws/testdata/sfn_state_machine_test/sfn_state_machine_test.golden
@@ -21,10 +21,10 @@
  └─ Duration (first 1K)                      Monthly cost depends on usage: $0.060012 per GB-hours      
                                                                                                         
  aws_sfn_state_machine.standard                                                                         
- └─ Transitions                                           5,000  1K transitions                   $0.25 
+ └─ Transitions                                              10  1K transitions                   $0.25 
                                                                                                         
  aws_sfn_state_machine.standardWithoutUsage                                                             
- └─ Transitions                              Monthly cost depends on usage: $0.00005 per 1K transitions 
+ └─ Transitions                              Monthly cost depends on usage: $0.025 per 1K transitions   
                                                                                                         
  OVERALL TOTAL                                                                                  $758.95 
 ──────────────────────────────────

--- a/internal/resources/aws/sfn_state_machine.go
+++ b/internal/resources/aws/sfn_state_machine.go
@@ -87,7 +87,7 @@ func (r *SFnStateMachine) transistionsCostComponent(quantity *decimal.Decimal) *
 	return &schema.CostComponent{
 		Name:            "Transitions",
 		Unit:            "1K transitions",
-		UnitMultiplier:  decimal.NewFromInt(2),
+		UnitMultiplier:  decimal.NewFromInt(1000),
 		MonthlyQuantity: quantity,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("aws"),


### PR DESCRIPTION
Fixes https://github.com/infracost/cloud-pricing-api/issues/186