### PR TITLE
chore(aws): Fix autoscaling group tests

### DIFF
--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
@@ -155,10 +155,11 @@
  module.asg-lt.aws_autoscaling_group.this[0]                                                       
  └─ module.asg-lt.aws_launch_template.this[0]                                                      
     ├─ Instance usage (Linux/UNIX, on-demand, t3.micro)              730  hours              $7.59 
+    ├─ EC2 detailed monitoring                                         7  metrics            $2.10 
     └─ block_device_mapping[0]                                                                     
        └─ Storage (general purpose SSD, gp2)                          10  GB                 $1.00 
                                                                                                    
- OVERALL TOTAL                                                                           $3,409.04 
+ OVERALL TOTAL                                                                           $3,411.14 
 ──────────────────────────────────
 48 cloud resources were detected:
 ∙ 25 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file


### PR DESCRIPTION
The default value of `enable_monitoring` has been changed to 'true' in
the terraform-aws-autoscaling module:
https://github.com/terraform-aws-modules/terraform-aws-autoscaling/commit/8e2e285b031faafe298de5d1d738e9743e607b3d#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR271