### PR TITLE
fix: change default os disk size to 128

### DIFF
--- a/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
+++ b/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
@@ -1,11 +1,13 @@
 package azure
 
 import (
-	"github.com/infracost/infracost/internal/schema"
+	"strings"
+
 	"github.com/shopspring/decimal"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
-	"strings"
+
+	"github.com/infracost/infracost/internal/schema"
 )
 
 func GetAzureRMKubernetesClusterNodePoolRegistryItem() *schema.RegistryItem {
@@ -49,7 +51,7 @@ func aksClusterNodePool(name, region string, n gjson.Result, nodeCount decimal.D
 		osDiskType = n.Get("os_disk_type").String()
 	}
 	if strings.ToLower(osDiskType) == "managed" {
-		var diskSize int
+		diskSize := 128
 		if n.Get("os_disk_size_gb").Type != gjson.Null {
 			diskSize = int(n.Get("os_disk_size_gb").Int())
 		}

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
@@ -5,7 +5,7 @@
  └─ default_node_pool                                                                    
     ├─ Instance usage (pay as you go, Standard_D2_v2)          730  hours        $106.58 
     └─ os_disk                                                                           
-       └─ Storage (P1)                                           1  months         $0.60 
+       └─ Storage (P10)                                          1  months        $19.71 
                                                                                          
  azurerm_kubernetes_cluster_node_pool.Standard_DS2_v2                                    
  └─ Instance usage (pay as you go, Standard_DS2_v2)          1,460  hours        $213.16 
@@ -13,19 +13,19 @@
  azurerm_kubernetes_cluster_node_pool.basic_A2                                           
  ├─ Instance usage (pay as you go, Basic_A2)                   730  hours         $57.67 
  └─ os_disk                                                                              
-    └─ Storage (P1)                                              1  months         $0.60 
+    └─ Storage (P10)                                             1  months        $19.71 
                                                                                          
  azurerm_kubernetes_cluster_node_pool.example                                            
  ├─ Instance usage (pay as you go, Standard_DS2_v2)            730  hours        $106.58 
  └─ os_disk                                                                              
-    └─ Storage (P1)                                              1  months         $0.60 
+    └─ Storage (P10)                                             1  months        $19.71 
                                                                                          
  azurerm_kubernetes_cluster_node_pool.usage_basic_A2                                     
  ├─ Instance usage (pay as you go, Basic_A2)                 1,460  hours        $115.34 
  └─ os_disk                                                                              
-    └─ Storage (P1)                                              2  months         $1.20 
+    └─ Storage (P10)                                             2  months        $39.42 
                                                                                          
- OVERALL TOTAL                                                                   $602.33 
+ OVERALL TOTAL                                                                   $697.88 
 ──────────────────────────────────
 6 cloud resources were detected:
 ∙ 5 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
@@ -5,7 +5,7 @@
  └─ default_node_pool                                                                     
     ├─ Instance usage (pay as you go, Standard_D2_v2)           730  hours        $106.58 
     └─ os_disk                                                                            
-       └─ Storage (P1)                                            1  months         $0.60 
+       └─ Storage (P10)                                           1  months        $19.71 
                                                                                           
  azurerm_kubernetes_cluster.paid_5nc_32gb                                                 
  ├─ Uptime SLA                                                  730  hours         $73.00 
@@ -30,7 +30,7 @@
  └─ DNS                                                                                   
     └─ Hosted zone                                                1  months         $0.50 
                                                                                           
- OVERALL TOTAL                                                                  $1,478.51 
+ OVERALL TOTAL                                                                  $1,497.62 
 ──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file


### PR DESCRIPTION
fixes issue where the default os managed disk size for a cluster node is 128, this caused discrepancies between HCL and Plan JSON.