### PR TITLE
chore: update terraform-parse-hcl flag naming

### DIFF
--- a/cmd/infracost/breakdown.go
+++ b/cmd/infracost/breakdown.go
@@ -51,9 +51,9 @@ func breakdownCmd(ctx *config.RunContext) *cobra.Command {
 	cmd.Flags().String("format", "table", "Output format: json, table, html")
 	cmd.Flags().StringSlice("fields", []string{"monthlyQuantity", "unit", "monthlyCost"}, "Comma separated list of output fields: all,price,monthlyQuantity,unit,hourlyCost,monthlyCost.\nSupported by table and html output formats")
 
-	cmd.Flags().Bool("terraform-parse-hcl", false, "Parse the HCL directly instead of generating a Terraform plan. This option does not need credentials and is faster (experimental)")
-	cmd.Flags().StringSlice("terraform-var-file", nil, "Load variable files from the given file, similar to Terraform's -var-file flag. Only supported with --terraform-parse-hcl (experimental)")
-	cmd.Flags().StringSlice("terraform-var", nil, "Set a value for one of the input variables, similar to Terraform's -var flag. Only supported with --terraform-parse-hcl (experimental)")
+	cmd.Flags().Bool("terraform-parse-hcl", false, "Parse HCL code instead of generating a Terraform plan. This does not need credentials and is faster (experimental)")
+	cmd.Flags().StringSlice("terraform-var-file", nil, "Load variable files, similar to Terraform’s -var-file flag. Applicable with --terraform-parse-hcl (experimental)")
+	cmd.Flags().StringSlice("terraform-var", nil, "Set value for an input variable, similar to Terraform’s -var flag. Applicable with --terraform-parse-hcl (experimental)")
 
 	_ = cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return validRunFormats, cobra.ShellCompDirectiveDefault

--- a/cmd/infracost/testdata/breakdown_help/breakdown_help.golden
+++ b/cmd/infracost/testdata/breakdown_help/breakdown_help.golden
@@ -26,11 +26,11 @@ FLAGS
       --show-skipped                  List unsupported and free resources
       --sync-usage-file               Sync usage-file with missing resources, needs usage-file too (experimental)
       --terraform-init-flags string   Flags to pass to 'terraform init'. Applicable when path is a Terraform directory
-      --terraform-parse-hcl           Parse the HCL directly instead of generating a Terraform plan. This option does not need credentials and is faster (experimental)
+      --terraform-parse-hcl           Parse HCL code instead of generating a Terraform plan. This does not need credentials and is faster (experimental)
       --terraform-plan-flags string   Flags to pass to 'terraform plan'. Applicable when path is a Terraform directory
       --terraform-use-state           Use Terraform state instead of generating a plan. Applicable when path is a Terraform directory
-      --terraform-var strings         Set a value for one of the input variables, similar to Terraform's -var flag. Only supported with --terraform-parse-hcl (experimental)
-      --terraform-var-file strings    Load variable files from the given file, similar to Terraform's -var-file flag. Only supported with --terraform-parse-hcl (experimental)
+      --terraform-var strings         Set value for an input variable, similar to Terraform’s -var flag. Applicable with --terraform-parse-hcl (experimental)
+      --terraform-var-file strings    Load variable files, similar to Terraform’s -var-file flag. Applicable with --terraform-parse-hcl (experimental)
       --terraform-workspace string    Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string             Path to Infracost usage file that specifies values for usage-based resources
 

--- a/cmd/infracost/testdata/flag_errors_config_file_and_terraform_workspace/flag_errors_config_file_and_terraform_workspace.golden
+++ b/cmd/infracost/testdata/flag_errors_config_file_and_terraform_workspace/flag_errors_config_file_and_terraform_workspace.golden
@@ -28,11 +28,11 @@ FLAGS
       --show-skipped                  List unsupported and free resources
       --sync-usage-file               Sync usage-file with missing resources, needs usage-file too (experimental)
       --terraform-init-flags string   Flags to pass to 'terraform init'. Applicable when path is a Terraform directory
-      --terraform-parse-hcl           Parse the HCL directly instead of generating a Terraform plan. This option does not need credentials and is faster (experimental)
+      --terraform-parse-hcl           Parse HCL code instead of generating a Terraform plan. This does not need credentials and is faster (experimental)
       --terraform-plan-flags string   Flags to pass to 'terraform plan'. Applicable when path is a Terraform directory
       --terraform-use-state           Use Terraform state instead of generating a plan. Applicable when path is a Terraform directory
-      --terraform-var strings         Set a value for one of the input variables, similar to Terraform's -var flag. Only supported with --terraform-parse-hcl (experimental)
-      --terraform-var-file strings    Load variable files from the given file, similar to Terraform's -var-file flag. Only supported with --terraform-parse-hcl (experimental)
+      --terraform-var strings         Set value for an input variable, similar to Terraform’s -var flag. Applicable with --terraform-parse-hcl (experimental)
+      --terraform-var-file strings    Load variable files, similar to Terraform’s -var-file flag. Applicable with --terraform-parse-hcl (experimental)
       --terraform-workspace string    Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string             Path to Infracost usage file that specifies values for usage-based resources
 

--- a/cmd/infracost/testdata/flag_errors_no_path/flag_errors_no_path.golden
+++ b/cmd/infracost/testdata/flag_errors_no_path/flag_errors_no_path.golden
@@ -28,11 +28,11 @@ FLAGS
       --show-skipped                  List unsupported and free resources
       --sync-usage-file               Sync usage-file with missing resources, needs usage-file too (experimental)
       --terraform-init-flags string   Flags to pass to 'terraform init'. Applicable when path is a Terraform directory
-      --terraform-parse-hcl           Parse the HCL directly instead of generating a Terraform plan. This option does not need credentials and is faster (experimental)
+      --terraform-parse-hcl           Parse HCL code instead of generating a Terraform plan. This does not need credentials and is faster (experimental)
       --terraform-plan-flags string   Flags to pass to 'terraform plan'. Applicable when path is a Terraform directory
       --terraform-use-state           Use Terraform state instead of generating a plan. Applicable when path is a Terraform directory
-      --terraform-var strings         Set a value for one of the input variables, similar to Terraform's -var flag. Only supported with --terraform-parse-hcl (experimental)
-      --terraform-var-file strings    Load variable files from the given file, similar to Terraform's -var-file flag. Only supported with --terraform-parse-hcl (experimental)
+      --terraform-var strings         Set value for an input variable, similar to Terraform’s -var flag. Applicable with --terraform-parse-hcl (experimental)
+      --terraform-var-file strings    Load variable files, similar to Terraform’s -var-file flag. Applicable with --terraform-parse-hcl (experimental)
       --terraform-workspace string    Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string             Path to Infracost usage file that specifies values for usage-based resources
 

--- a/cmd/infracost/testdata/flag_errors_path_and_config_file/flag_errors_path_and_config_file.golden
+++ b/cmd/infracost/testdata/flag_errors_path_and_config_file/flag_errors_path_and_config_file.golden
@@ -28,11 +28,11 @@ FLAGS
       --show-skipped                  List unsupported and free resources
       --sync-usage-file               Sync usage-file with missing resources, needs usage-file too (experimental)
       --terraform-init-flags string   Flags to pass to 'terraform init'. Applicable when path is a Terraform directory
-      --terraform-parse-hcl           Parse the HCL directly instead of generating a Terraform plan. This option does not need credentials and is faster (experimental)
+      --terraform-parse-hcl           Parse HCL code instead of generating a Terraform plan. This does not need credentials and is faster (experimental)
       --terraform-plan-flags string   Flags to pass to 'terraform plan'. Applicable when path is a Terraform directory
       --terraform-use-state           Use Terraform state instead of generating a plan. Applicable when path is a Terraform directory
-      --terraform-var strings         Set a value for one of the input variables, similar to Terraform's -var flag. Only supported with --terraform-parse-hcl (experimental)
-      --terraform-var-file strings    Load variable files from the given file, similar to Terraform's -var-file flag. Only supported with --terraform-parse-hcl (experimental)
+      --terraform-var strings         Set value for an input variable, similar to Terraform’s -var flag. Applicable with --terraform-parse-hcl (experimental)
+      --terraform-var-file strings    Load variable files, similar to Terraform’s -var-file flag. Applicable with --terraform-parse-hcl (experimental)
       --terraform-workspace string    Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string             Path to Infracost usage file that specifies values for usage-based resources
 


### PR DESCRIPTION
updates flag description to be more consistent and shorter