### PR TITLE
feat(azure): Add MySQL Flexible Server resources

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -948,6 +948,9 @@ resource_usage:
     long_term_retention_storage_gb: 1000 # Number of GBs used by long-term retention backup storage.
     extra_data_storage_gb: 250           # Override number of GBs used by extra data storage.
 
+  azurerm_mysql_flexible_server.my_flexible_server:
+    additional_backup_storage_gb: 5000 # Additional backup storage in GB. If geo-redundancy is enabled, you should set this to twice the required storage capacity.
+
   azurerm_mysql_server.my_server:
     additional_backup_storage_gb: 2000 # Additional consumption of backup storage in GB.
 
@@ -958,7 +961,7 @@ resource_usage:
     monthly_p2s_connections_hrs: 2000 # Monthly connection hours to the point to site gateway
 
   azurerm_postgresql_flexible_server.my_flexible_server:
-    additional_backup_storage_gb: 5000 # Additional consumption of backup storage in GB.
+    additional_backup_storage_gb: 5000 # Additional backup storage in GB. If geo-redundancy is enabled, you should set this to twice the required storage capacity.
 
   azurerm_postgresql_server.my_server:
     additional_backup_storage_gb: 3000 # Additional consumption of backup storage in GB.

--- a/internal/providers/terraform/azure/mysql_flexible_server.go
+++ b/internal/providers/terraform/azure/mysql_flexible_server.go
@@ -1,0 +1,70 @@
+package azure
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+	log "github.com/sirupsen/logrus"
+)
+
+func getMySQLFlexibleServerRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_mysql_flexible_server",
+		RFunc: newMySQLFlexibleServer,
+	}
+}
+
+func newMySQLFlexibleServer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("location").String()
+	sku := d.Get("sku_name").String()
+	storage := d.GetInt64OrDefault("storage.0.size_gb", 0)
+	iops := d.GetInt64OrDefault("storage.0.iops", 0)
+
+	var tier, size, version string
+
+	s := strings.Split(sku, "_")
+	if len(s) < 3 || len(s) > 4 {
+		log.Warnf("Unrecognised MySQL Flexible Server SKU format for resource %s: %s", d.Address, sku)
+		return nil
+	}
+
+	if len(s) > 2 {
+		tier = strings.ToLower(s[0])
+		size = s[2]
+	}
+
+	if len(s) > 3 {
+		version = s[3]
+	}
+
+	supportedTiers := []string{"b", "gp", "mo"}
+	if !contains(supportedTiers, tier) {
+		log.Warnf("Unrecognised MySQL Flexible Server tier prefix for resource %s: %s", d.Address, sku)
+		return nil
+	}
+
+	if tier != "b" {
+		coreRegex := regexp.MustCompile(`(\d+)`)
+		match := coreRegex.FindStringSubmatch(size)
+		if len(match) < 1 {
+			log.Warnf("Unrecognised MySQL Flexible Server size for resource %s: %s", d.Address, sku)
+			return nil
+		}
+	}
+
+	r := &azure.MySQLFlexibleServer{
+		Address:         d.Address,
+		Region:          region,
+		SKU:             sku,
+		Tier:            tier,
+		InstanceType:    size,
+		InstanceVersion: version,
+		Storage:         storage,
+		IOPS:            iops,
+	}
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/azure/mysql_flexible_server_test.go
+++ b/internal/providers/terraform/azure/mysql_flexible_server_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestMySQLFlexibleServer(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "mysql_flexible_server_test")
+}

--- a/internal/providers/terraform/azure/postgresql_flexible_server.go
+++ b/internal/providers/terraform/azure/postgresql_flexible_server.go
@@ -1,30 +1,27 @@
 package azure
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
+	"github.com/infracost/infracost/internal/resources/azure"
 	"github.com/infracost/infracost/internal/schema"
 	log "github.com/sirupsen/logrus"
-	"github.com/tidwall/gjson"
-
-	"github.com/shopspring/decimal"
 )
 
-func GetAzureRMPostgreSQLFlexibleServerRegistryItem() *schema.RegistryItem {
+func getAzureRMPostgreSQLFlexibleServerRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "azurerm_postgresql_flexible_server",
-		RFunc: NewAzureRMPostrgreSQLFlexibleServer,
+		RFunc: newPostgreSQLFlexibleServer,
 	}
 }
 
-func NewAzureRMPostrgreSQLFlexibleServer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	var costComponents []*schema.CostComponent
-
+func newPostgreSQLFlexibleServer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := d.Get("location").String()
 	sku := d.Get("sku_name").String()
-	var tier, size, skuName, meterName, version, series string
+	storage := d.Get("storage_mb").Int()
+
+	var tier, size, version string
 
 	s := strings.Split(sku, "_")
 	if len(s) < 3 || len(s) > 4 {
@@ -33,7 +30,7 @@ func NewAzureRMPostrgreSQLFlexibleServer(d *schema.ResourceData, u *schema.Usage
 	}
 
 	if len(s) > 2 {
-		tier = s[0]
+		tier = strings.ToLower(s[0])
 		size = s[2]
 	}
 
@@ -41,102 +38,31 @@ func NewAzureRMPostrgreSQLFlexibleServer(d *schema.ResourceData, u *schema.Usage
 		version = s[3]
 	}
 
-	tierName := map[string]string{
-		"B":  "Burstable",
-		"GP": "General Purpose",
-		"MO": "Memory Optimized",
-	}[strings.ToUpper(tier)]
-
-	if tierName == "" {
-		log.Warnf("Unrecognised PostgreSQL tier prefix for resource %s: %s", d.Address, tierName)
+	supportedTiers := []string{"b", "gp", "mo"}
+	if !contains(supportedTiers, tier) {
+		log.Warnf("Unrecognised PostgreSQL Flexible Server tier prefix for resource %s: %s", d.Address, sku)
 		return nil
 	}
 
-	if strings.ToLower(tierName) == "burstable" {
-		meterName = size
-		skuName = size
-		series = "BS"
-	} else {
-		meterName = "vCore"
-
+	if tier != "b" {
 		coreRegex := regexp.MustCompile(`(\d+)`)
 		match := coreRegex.FindStringSubmatch(size)
 		if len(match) < 1 {
-			log.Warnf("Unrecognised PostgreSQL flexible server size for resource %s: %s", d.Address, size)
+			log.Warnf("Unrecognised PostgreSQL Flexible Server size for resource %s: %s", d.Address, sku)
 			return nil
 		}
-		cores := match[1]
-		skuName = fmt.Sprintf("%s vCore", cores)
-
-		series = coreRegex.ReplaceAllString(size, "") + version
 	}
 
-	costComponents = append(costComponents, &schema.CostComponent{
-		Name:           fmt.Sprintf("Compute (%s)", sku),
-		Unit:           "hours",
-		UnitMultiplier: decimal.NewFromInt(1),
-		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("azure"),
-			Region:        strPtr(region),
-			Service:       strPtr("Azure Database for PostgreSQL"),
-			ProductFamily: strPtr("Databases"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/Azure Database for PostgreSQL Flexible Server %s %s/i", tierName, series))},
-				{Key: "skuName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", skuName))},
-				{Key: "meterName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", meterName))},
-			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			PurchaseOption: strPtr("Consumption"),
-		},
-	})
-
-	var storageGB *decimal.Decimal
-	if d.Get("storage_mb").Type != gjson.Null {
-		storageGB = decimalPtr(decimal.NewFromInt(d.Get("storage_mb").Int() / 1024))
+	r := &azure.PostgreSQLFlexibleServer{
+		Address:         d.Address,
+		Region:          region,
+		SKU:             sku,
+		Tier:            tier,
+		InstanceType:    size,
+		InstanceVersion: version,
+		Storage:         storage,
 	}
-	costComponents = append(costComponents, &schema.CostComponent{
-		Name:            "Storage",
-		Unit:            "GB",
-		UnitMultiplier:  decimal.NewFromInt(1),
-		MonthlyQuantity: storageGB,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("azure"),
-			Region:        strPtr(region),
-			Service:       strPtr("Azure Database for PostgreSQL"),
-			ProductFamily: strPtr("Databases"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr("Azure Database for PostgreSQL Flexible Server Storage")},
-				{Key: "meterName", Value: strPtr("Storage Data Stored")},
-			},
-		},
-	})
+	r.PopulateUsage(u)
 
-	var backupStorageGB *decimal.Decimal
-	if u != nil && u.Get("additional_backup_storage_gb").Exists() {
-		backupStorageGB = decimalPtr(decimal.NewFromInt(u.Get("additional_backup_storage_gb").Int()))
-	}
-
-	costComponents = append(costComponents, &schema.CostComponent{
-		Name:            "Additional backup storage",
-		Unit:            "GB",
-		UnitMultiplier:  decimal.NewFromInt(1),
-		MonthlyQuantity: backupStorageGB,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("azure"),
-			Region:        strPtr(region),
-			Service:       strPtr("Azure Database for PostgreSQL"),
-			ProductFamily: strPtr("Databases"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr("Azure Database for PostgreSQL Flexible Server Backup Storage")},
-				{Key: "meterName", Value: strPtr("Backup Storage Data Stored")},
-			},
-		},
-	})
-
-	return &schema.Resource{
-		Name:           d.Address,
-		CostComponents: costComponents,
-	}
+	return r.BuildResource()
 }

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -74,7 +74,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMMySQLServerRegistryItem(),
 	GetAzureRMNotificationHubNamespaceRegistryItem(),
 	getAzureRMPointToSiteVpnGatewayRegistryItem(),
-	GetAzureRMPostgreSQLFlexibleServerRegistryItem(),
+	getAzureRMPostgreSQLFlexibleServerRegistryItem(),
 	GetAzureRMPostgreSQLServerRegistryItem(),
 	GetAzureRMPrivateDNSaRecordRegistryItem(),
 	GetAzureRMPrivateDNSaaaaRecordRegistryItem(),
@@ -203,6 +203,8 @@ var FreeResources = []string{
 	"azurerm_mysql_virtual_network_rule",
 	"azurerm_postgresql_configuration",
 	"azurerm_postgresql_firewall_rule",
+	"azurerm_postgresql_flexible_server_configuration",
+	"azurerm_postgresql_flexible_server_database",
 	"azurerm_postgresql_flexible_server_firewall_rule",
 	"azurerm_postgresql_virtual_network_rule",
 

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -103,6 +103,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMWindowsVirtualMachineScaleSetRegistryItem(),
 	getAzureRMVPNGatewayRegistryItem(),
 	getAzureRMVPNGatewayConnectionRegistryItem(),
+	getMySQLFlexibleServerRegistryItem(),
 }
 
 // FreeResources grouped alphabetically
@@ -200,6 +201,9 @@ var FreeResources = []string{
 	"azurerm_mariadb_firewall_rule",
 	"azurerm_mariadb_virtual_network_rule",
 	"azurerm_mysql_firewall_rule",
+	"azurerm_mysql_flexible_database",
+	"azurerm_mysql_flexible_server_configuration",
+	"azurerm_mysql_flexible_server_firewall_rule",
 	"azurerm_mysql_virtual_network_rule",
 	"azurerm_postgresql_configuration",
 	"azurerm_postgresql_firewall_rule",

--- a/internal/providers/terraform/azure/testdata/mysql_flexible_server_test/mysql_flexible_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/mysql_flexible_server_test/mysql_flexible_server_test.golden
@@ -1,0 +1,30 @@
+
+ Name                                           Monthly Qty  Unit              Monthly Cost 
+                                                                                            
+ azurerm_mysql_flexible_server.burstable                                                    
+ ├─ Compute (B_Standard_B1ms)                           730  hours                   $16.06 
+ ├─ Storage                                              30  GB                       $4.14 
+ └─ Additional backup storage                         1,000  GB                      $95.00 
+                                                                                            
+ azurerm_mysql_flexible_server.gp                                                           
+ ├─ Compute (GP_Standard_D4ds_v4)                       730  hours                  $284.70 
+ ├─ Storage                                              20  GB                       $2.76 
+ └─ Additional backup storage                         2,000  GB                     $190.00 
+                                                                                            
+ azurerm_mysql_flexible_server.mo                                                           
+ ├─ Compute (MO_Standard_E4ds_v4)                       730  hours                  $382.52 
+ ├─ Storage                                              20  GB                       $2.76 
+ ├─ Additional IOPS                                     140  IOPS                     $8.40 
+ └─ Additional backup storage                         3,000  GB                     $285.00 
+                                                                                            
+ azurerm_mysql_flexible_server.non_usage_gp                                                 
+ ├─ Compute (GP_Standard_D16ds_v4)                      730  hours                $1,138.80 
+ ├─ Storage                                              20  GB                       $2.76 
+ └─ Additional backup storage                Monthly cost depends on usage: $0.095 per GB   
+                                                                                            
+ OVERALL TOTAL                                                                    $2,412.90 
+──────────────────────────────────
+5 cloud resources were detected:
+∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free:
+  ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/mysql_flexible_server_test/mysql_flexible_server_test.tf
+++ b/internal/providers/terraform/azure/testdata/mysql_flexible_server_test/mysql_flexible_server_test.tf
@@ -1,0 +1,51 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "westus"
+}
+
+resource "azurerm_mysql_flexible_server" "gp" {
+  name                = "example-mysqlflexibleserver"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  sku_name = "GP_Standard_D4ds_v4"
+}
+
+resource "azurerm_mysql_flexible_server" "mo" {
+  name                = "example-mysqlflexibleserver"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  storage {
+    iops    = 500
+    size_gb = 20
+  }
+
+  sku_name = "MO_Standard_E4ds_v4"
+}
+
+resource "azurerm_mysql_flexible_server" "burstable" {
+  name                = "example-mysqlflexibleserver"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  storage {
+    iops    = 360
+    size_gb = 30
+  }
+
+  sku_name = "B_Standard_B1ms"
+}
+
+resource "azurerm_mysql_flexible_server" "non_usage_gp" {
+  name                = "example-mysqlflexibleserver"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  sku_name = "GP_Standard_D16ds_v4"
+}

--- a/internal/providers/terraform/azure/testdata/mysql_flexible_server_test/mysql_flexible_server_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/mysql_flexible_server_test/mysql_flexible_server_test.usage.yml
@@ -1,0 +1,10 @@
+version: 0.1
+resource_usage:
+  azurerm_mysql_flexible_server.burstable:
+    additional_backup_storage_gb: 1000
+
+  azurerm_mysql_flexible_server.gp:
+    additional_backup_storage_gb: 2000
+
+  azurerm_mysql_flexible_server.mo:
+    additional_backup_storage_gb: 3000

--- a/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.usage.yml
@@ -8,4 +8,3 @@ resource_usage:
 
   azurerm_postgresql_flexible_server.mo:
     additional_backup_storage_gb: 5000
-    

--- a/internal/providers/terraform/azure/util.go
+++ b/internal/providers/terraform/azure/util.go
@@ -114,3 +114,12 @@ func locationNameMapping(l string) string {
 func intPtr(i int64) *int64 {
 	return &i
 }
+
+func contains(arr []string, e string) bool {
+	for _, a := range arr {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resources/azure/mysql_flexible_server.go
+++ b/internal/resources/azure/mysql_flexible_server.go
@@ -1,0 +1,177 @@
+package azure
+
+import (
+	"fmt"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// MySQLFlexibleServer struct represents Azure MySQL Flexible Server resource.
+//
+// Resource information: https://docs.microsoft.com/en-gb/azure/mysql/flexible-server/
+// Pricing information: https://azure.microsoft.com/en-gb/pricing/details/mysql/flexible-server/
+type MySQLFlexibleServer struct {
+	Address string
+	Region  string
+
+	SKU             string
+	Tier            string
+	InstanceType    string
+	InstanceVersion string
+	Storage         int64
+	IOPS            int64
+
+	// "usage" args
+	AdditionalBackupStorageGB *float64 `infracost_usage:"additional_backup_storage_gb"`
+}
+
+// MySQLFlexibleServerUsageSchema defines a list which represents the usage schema of MySQLFlexibleServer.
+var MySQLFlexibleServerUsageSchema = []*schema.UsageItem{
+	{Key: "additional_backup_storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the MySQLFlexibleServer.
+// It uses the `infracost_usage` struct tags to populate data into the MySQLFlexibleServer.
+func (r *MySQLFlexibleServer) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid MySQLFlexibleServer struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *MySQLFlexibleServer) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{
+		r.computeCostComponent(),
+		r.storageCostComponent(),
+	}
+
+	if iopsCostComponent := r.iopsCostComponent(); iopsCostComponent != nil {
+		costComponents = append(costComponents, iopsCostComponent)
+	}
+
+	costComponents = append(costComponents, r.backupCostComponent())
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    MySQLFlexibleServerUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+// computeCostComponent returns a cost component for server compute requirements.
+func (r *MySQLFlexibleServer) computeCostComponent() *schema.CostComponent {
+	attrs := getFlexibleServerFilterAttributes(r.Tier, r.InstanceType, r.InstanceVersion)
+
+	// Eds series has two spaces in CPAPI hence '\s+'
+	productNameRegex := fmt.Sprintf("^Azure Database for MySQL Flexible Server %s\\s+%s", attrs.TierName, attrs.Series)
+
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("Compute (%s)", r.SKU),
+		Unit:           "hours",
+		UnitMultiplier: decimal.NewFromInt(1),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Azure Database for MySQL"),
+			ProductFamily: strPtr("Databases"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", ValueRegex: regexPtr(productNameRegex)},
+				{Key: "skuName", ValueRegex: regexPtr(fmt.Sprintf("^%s$", attrs.SKUName))},
+				{Key: "meterName", ValueRegex: regexPtr(fmt.Sprintf("^%s$", attrs.MeterName))},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	}
+}
+
+// storageCostComponent returns a cost component for server's storage. If
+// storage is not defined, it is assumed it is a minimum default of 20GB.
+func (r *MySQLFlexibleServer) storageCostComponent() *schema.CostComponent {
+	storage := r.Storage
+	if storage == 0 {
+		storage = 20 // minimum default
+	}
+
+	return &schema.CostComponent{
+		Name:            "Storage",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromInt(storage)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Azure Database for MySQL"),
+			ProductFamily: strPtr("Databases"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Azure Database for MySQL Flexible Server Storage")},
+				{Key: "meterName", Value: strPtr("Storage Data Stored")},
+			},
+		},
+	}
+}
+
+// iopsCostComponent returns a cost component for additional IOPS. Each server
+// includes free 300 IOPS and 3 IOPS per each storage GB. As minimum storage is
+// 20GB, the total free IOPS is 360. If no IOPS is defined it's assumed it is
+// the minimum of 360.
+func (r *MySQLFlexibleServer) iopsCostComponent() *schema.CostComponent {
+	var freeIOPS int64 = 360
+
+	iops := r.IOPS
+	if iops == 0 {
+		iops = freeIOPS
+	}
+
+	additionalIOPS := iops - freeIOPS
+
+	if additionalIOPS <= 0 {
+		return nil
+	}
+
+	return &schema.CostComponent{
+		Name:            "Additional IOPS",
+		Unit:            "IOPS",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromInt(additionalIOPS)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Azure Database for MySQL"),
+			ProductFamily: strPtr("Databases"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Azure Database for MySQL Flexible Server Storage")},
+				{Key: "skuName", Value: strPtr("Additional IOPS")},
+			},
+		},
+	}
+}
+
+// backupCostComponent returns a cost component for additional backup storage.
+func (r *MySQLFlexibleServer) backupCostComponent() *schema.CostComponent {
+	var quantity *decimal.Decimal
+	if r.AdditionalBackupStorageGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.AdditionalBackupStorageGB))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Additional backup storage",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Azure Database for MySQL"),
+			ProductFamily: strPtr("Databases"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Azure Database for MySQL Flexible Server Backup Storage")},
+				{Key: "meterName", Value: strPtr("Backup Storage Data Stored")},
+			},
+		},
+	}
+}

--- a/internal/resources/azure/postgresql_flexible_server.go
+++ b/internal/resources/azure/postgresql_flexible_server.go
@@ -1,0 +1,153 @@
+package azure
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// PostgreSQLFlexibleServer struct represents Azure PostgreSQL Flexible Server resource.
+//
+// Resource information: https://docs.microsoft.com/en-gb/azure/postgresql/flexible-server/
+// Pricing information: https://azure.microsoft.com/en-gb/pricing/details/postgresql/flexible-server/
+type PostgreSQLFlexibleServer struct {
+	Address string
+	Region  string
+
+	SKU             string
+	Tier            string
+	InstanceType    string
+	InstanceVersion string
+	Storage         int64
+
+	AdditionalBackupStorageGB *float64 `infracost_usage:"additional_backup_storage_gb"`
+}
+
+// PostgreSQLFlexibleServerUsageSchema defines a list which represents the usage schema of PostgreSQLFlexibleServer.
+var PostgreSQLFlexibleServerUsageSchema = []*schema.UsageItem{
+	{Key: "additional_backup_storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+}
+
+// PopulateUsage parses the u schema.UsageData into the PostgreSQLFlexibleServer.
+// It uses the `infracost_usage` struct tags to populate data into the PostgreSQLFlexibleServer.
+func (r *PostgreSQLFlexibleServer) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid PostgreSQLFlexibleServer struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *PostgreSQLFlexibleServer) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{
+		r.computeCostComponent(),
+		r.storageCostComponent(),
+		r.backupCostComponent(),
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    PostgreSQLFlexibleServerUsageSchema,
+		CostComponents: costComponents,
+	}
+}
+
+// computeCostComponent returns a cost component for server compute requirements.
+func (r *PostgreSQLFlexibleServer) computeCostComponent() *schema.CostComponent {
+	var skuName, meterName, series string
+
+	tierName := map[string]string{
+		"b":  "Burstable",
+		"gp": "General Purpose",
+		"mo": "Memory Optimized",
+	}[r.Tier]
+
+	if r.Tier == "b" {
+		meterName = r.InstanceType
+		skuName = r.InstanceType
+		series = "BS"
+	} else {
+		meterName = "vCore"
+
+		coreRegex := regexp.MustCompile(`(\d+)`)
+		match := coreRegex.FindStringSubmatch(r.InstanceType)
+		cores := match[1]
+		skuName = fmt.Sprintf("%s vCore", cores)
+
+		series = coreRegex.ReplaceAllString(r.InstanceType, "") + r.InstanceVersion
+	}
+
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("Compute (%s)", r.SKU),
+		Unit:           "hours",
+		UnitMultiplier: decimal.NewFromInt(1),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Azure Database for PostgreSQL"),
+			ProductFamily: strPtr("Databases"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/^Azure Database for PostgreSQL Flexible Server %s %s/i", tierName, series))},
+				{Key: "skuName", ValueRegex: regexPtr(fmt.Sprintf("^%s$", skuName))},
+				{Key: "meterName", ValueRegex: regexPtr(fmt.Sprintf("^%s$", meterName))},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr("Consumption"),
+		},
+	}
+}
+
+// storageCostComponent returns a cost component for server's storage.
+func (r *PostgreSQLFlexibleServer) storageCostComponent() *schema.CostComponent {
+	var quantity *decimal.Decimal
+	if r.Storage > 0 {
+		// Storage is in MB
+		quantity = decimalPtr(decimal.NewFromInt(r.Storage / 1024))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Storage",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Azure Database for PostgreSQL"),
+			ProductFamily: strPtr("Databases"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Azure Database for PostgreSQL Flexible Server Storage")},
+				{Key: "meterName", Value: strPtr("Storage Data Stored")},
+			},
+		},
+	}
+}
+
+// backupCostComponent returns a cost component for additional backup storage.
+func (r *PostgreSQLFlexibleServer) backupCostComponent() *schema.CostComponent {
+	var quantity *decimal.Decimal
+	if r.AdditionalBackupStorageGB != nil {
+		quantity = decimalPtr(decimal.NewFromFloat(*r.AdditionalBackupStorageGB))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Additional backup storage",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: quantity,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Azure Database for PostgreSQL"),
+			ProductFamily: strPtr("Databases"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Azure Database for PostgreSQL Flexible Server Backup Storage")},
+				{Key: "meterName", Value: strPtr("Backup Storage Data Stored")},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Objective:

Add support for Azure MySQL Flexible Server. Fixes #792.

## Pricing details:

https://azure.microsoft.com/en-gb/pricing/details/mysql/flexible-server/

## Status:

- [x] Generated the resource files
- [x] Updated the internal/resources file
- [x] Updated the internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/198)

## Issues:

None