### PR TITLE
fix(hcl): properly evaluate count expressions

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -293,13 +293,17 @@ func (e *Evaluator) expandBlockCounts(blocks Blocks) Blocks {
 			}
 		}
 
+		vals := make([]cty.Value, count)
 		for i := 0; i < count; i++ {
 			c, _ := gocty.ToCtyValue(i, cty.Number)
 			clone := block.Clone(c)
-			block.TypeLabel()
+
 			log.Debugf("Added %s from count var", clone.Reference())
 			countFiltered = append(countFiltered, clone)
+			vals[i] = clone.Values()
 		}
+
+		e.ctx.SetByDot(cty.TupleVal(vals), block.Reference().String())
 	}
 
 	return countFiltered

--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
@@ -152,6 +152,20 @@
  └─ aws_launch_template.lt_mixed_instance_dynamic                                                  
     └─ Instance usage (Linux/UNIX, on-demand, t2.large)            2,190  hours            $203.23 
                                                                                                    
+ aws_autoscaling_group.test_count[0]                                                               
+ └─ aws_launch_configuration.test_count[0]                                                         
+    ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)            1,460  hours             $16.94 
+    ├─ EC2 detailed monitoring                                        14  metrics            $4.20 
+    └─ root_block_device                                                                           
+       └─ Storage (general purpose SSD, gp2)                          16  GB                 $1.60 
+                                                                                                   
+ aws_autoscaling_group.test_count[1]                                                               
+ └─ aws_launch_configuration.test_count[1]                                                         
+    ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)           1,460  hours             $67.74 
+    ├─ EC2 detailed monitoring                                        14  metrics            $4.20 
+    └─ root_block_device                                                                           
+       └─ Storage (general purpose SSD, gp2)                          16  GB                 $1.60 
+                                                                                                   
  module.asg-lt.aws_autoscaling_group.this[0]                                                       
  └─ module.asg-lt.aws_launch_template.this[0]                                                      
     ├─ Instance usage (Linux/UNIX, on-demand, t3.micro)              730  hours              $7.59 
@@ -159,13 +173,13 @@
     └─ block_device_mapping[0]                                                                     
        └─ Storage (general purpose SSD, gp2)                          10  GB                 $1.00 
                                                                                                    
- OVERALL TOTAL                                                                           $3,411.14 
+ OVERALL TOTAL                                                                           $3,507.42 
 ──────────────────────────────────
-48 cloud resources were detected:
-∙ 25 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
-∙ 21 were free:
+52 cloud resources were detected:
+∙ 27 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+∙ 23 were free:
   ∙ 12 x aws_launch_template
-  ∙ 9 x aws_launch_configuration
+  ∙ 11 x aws_launch_configuration
 ∙ 2 are not supported yet, see https://infracost.io/requested-resources:
   ∙ 2 x aws_autoscaling_group
 Logs:

--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.tf
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.tf
@@ -432,12 +432,31 @@ module "asg-lt" {
   min_size               = 0
   max_size               = 2
   desired_capacity       = 1
-  block_device_mappings = [
+  block_device_mappings  = [
     {
       device_name = "/dev/xvdf"
-      ebs = {
+      ebs         = {
         volume_size = 10
       }
     }
   ]
+}
+
+
+locals {
+  instance_types = ["t2.micro", "t2.medium"]
+}
+
+resource "aws_autoscaling_group" "test_count" {
+  count                = 2
+  desired_capacity     = 2
+  max_size             = 3
+  min_size             = 1
+  launch_configuration = aws_launch_configuration.test_count.*.id[count.index]
+}
+
+resource "aws_launch_configuration" "test_count" {
+  count         = 2
+  image_id      = "fake_ami"
+  instance_type = local.instance_types[count.index]
 }

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -291,17 +291,22 @@ func blockToReferences(block *hcl.Block) map[string]interface{} {
 
 func marshalBlock(block *hcl.Block, jsonValues map[string]interface{}) {
 	for _, b := range block.Children() {
-		childValues := marshalAttributeValues(b.Type(), b.Values())
+		key := b.Type()
+		if key == "dynamic" || key == "depends_on" {
+			continue
+		}
+
+		childValues := marshalAttributeValues(key, b.Values())
 		if len(b.Children()) > 0 {
 			marshalBlock(b, childValues)
 		}
 
-		if v, ok := jsonValues[b.Type()]; ok {
-			jsonValues[b.Type()] = append(v.([]interface{}), childValues)
+		if v, ok := jsonValues[key]; ok {
+			jsonValues[key] = append(v.([]interface{}), childValues)
 			continue
 		}
 
-		jsonValues[b.Type()] = []interface{}{childValues}
+		jsonValues[key] = []interface{}{childValues}
 	}
 }
 

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -159,7 +159,7 @@ func (p *Parser) parseJSON(j []byte, usage map[string]*schema.UsageData) ([]*sch
 	return pastResources, resources, nil
 }
 
-// StripTerraformWrapper removes any output added from the setup-terraform
+// StripSetupTerraformWrapper removes any output added from the setup-terraform
 // GitHub action terraform wrapper, so we can parse the output of this as
 // valid JSON. It returns the stripped out JSON and a boolean that is true
 // if the wrapper output was found and removed.


### PR DESCRIPTION
Fixes issues where `count` traversal expressions were not being properly evaluated. This was for two reasons:

1. When a block was cloned due to a count the context value was still an object. e.g:

```go
map[string]interface{
    "aws_launch_configuration": map[string]interface{
           "test_count": map[string]interface{
               "id": ...
            },
            "test_count[1]": map[string]interface{
               "id": ...
            }
    }
}
```

It should instead look like:

```go
map[string]interface{
    "aws_launch_configuration": map[string]interface{
           "test_count": []map[string]interface{
                {
                   "id": ...
                },
                {
                   "id": ...
                }
            }
        }
    }
}
```


This meant that only the first resource in the `count` was being pulled as a reference. All references that used a count > 0 were returning null as there were no items in the context value list past 1 (under the hood the hcl libraries were turning the object into a list of length 1).
2. The cloned block still had the id from the original block. So when we were evaluating the references in Infracost, the `idMap` was sometimes referencing incorrect resources.

---

I've solved the above by:

* adding greater support for expression evaluation in HCL
* when blocks are expanded as part of a count setting the context to be a Tuple type
* adding a dynamic `count.index` expression to the uuid we generate on the block