### PR TITLE
fix(hcl): module outputs evaluated before count expansion

### DIFF
--- a/cmd/infracost/hcl_test.go
+++ b/cmd/infracost/hcl_test.go
@@ -41,3 +41,15 @@ func TestHCLProviderAlias(t *testing.T) {
 		&GoldenFileOptions{RunHCL: true},
 	)
 }
+
+func TestHCLModuleOutputCounts(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		&GoldenFileOptions{RunHCL: true},
+	)
+}

--- a/cmd/infracost/testdata/hclmodule_output_counts/hclmodule_output_counts.golden
+++ b/cmd/infracost/testdata/hclmodule_output_counts/hclmodule_output_counts.golden
@@ -1,0 +1,10 @@
+Project: infracost/infracost/cmd/infracost/testdata/hclmodule_output_counts
+
+ Name  Monthly Qty  Unit  Monthly Cost 
+                                       
+ OVERALL TOTAL                   $0.00 
+──────────────────────────────────
+No cloud resources were detected
+
+Err:
+

--- a/cmd/infracost/testdata/hclmodule_output_counts/main.tf
+++ b/cmd/infracost/testdata/hclmodule_output_counts/main.tf
@@ -1,0 +1,20 @@
+provider "aws" {
+  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+module "this" {
+  source  = "./modules/test"
+  enabled = false
+}
+
+resource "aws_eip" "t" {
+  count = module.this.enabled ? 1 : 0
+
+  tags = {
+    "test" : module.this.enabled
+  }
+}

--- a/cmd/infracost/testdata/hclmodule_output_counts/modules/test/main.tf
+++ b/cmd/infracost/testdata/hclmodule_output_counts/modules/test/main.tf
@@ -1,0 +1,13 @@
+locals {
+  enabled = var.enabled
+}
+
+variable "enabled" {
+  type    = bool
+  default = null
+}
+
+output "enabled" {
+  value       = local.enabled
+  description = "True if module is enabled, false otherwise"
+}

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -107,6 +107,7 @@ func (e *Evaluator) Run() ([]*Module, error) {
 
 	// let's load the modules now we have our top level context.
 	e.moduleCalls = e.loadModules()
+	e.evaluate(lastContext)
 
 	// expand out resources and modules via count and evaluate again so that we can include
 	// any module outputs and or count references.


### PR DESCRIPTION
fixes issue where module outputs used in count evaluation were not available when expanding counts. This meant that the resources that were marked as disabled were being falsely generated. e.g:

```
module "this" {
  source  = "./modules/test"
  enabled = false
}

resource "aws_eip" "t" {
  count = module.this.enabled ? 1 : 0

  tags = {
    "test" : module.this.enabled
  }
}
```

in this case `module.this.enabled` would not be in the evaluation context meaning that we would use a fallback and expand the block to a count of 1.

---

Depends on https://github.com/infracost/infracost/pull/1542