### PR TITLE
fix: aws_kinesis_firehose_delivery_stream subnet_ids attribute empty without apply state

### DIFF
--- a/internal/providers/terraform/aws/kinesis_firehose_delivery_stream.go
+++ b/internal/providers/terraform/aws/kinesis_firehose_delivery_stream.go
@@ -11,17 +11,31 @@ func getKinesisFirehoseDeliveryStreamRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:  "aws_kinesis_firehose_delivery_stream",
 		RFunc: NewKinesisFirehoseDeliveryStream,
+		ReferenceAttributes: []string{
+			"elasticsearch_configuration.0.vpc_config.0.subnet_ids",
+		},
 	}
 }
 
 func NewKinesisFirehoseDeliveryStream(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	formatConversionEnabled := d.GetBoolOrDefault("extended_s3_configuration.0.data_format_conversion_configuration.0.enabled", true)
+
+	subnetIDs := len(d.Get("elasticsearch_configuration.0.vpc_config.0.subnet_ids").Array())
+
+	// if the length of the subnet_ids attribute is zero this means that the attribute
+	// has been modified with a subnet id that is yet to exist. In this instance we'll
+	// use the reference attribute instead. In most cases this should have the accurate
+	// number of subnet_ids.
+	if subnetIDs == 0 {
+		subnetIDs = len(d.References("elasticsearch_configuration.0.vpc_config.0.subnet_ids"))
+	}
+
 	r := &aws.KinesisFirehoseDeliveryStream{
 		Address:                     d.Address,
 		Region:                      d.Get("region").String(),
 		DataFormatConversionEnabled: d.Get("extended_s3_configuration.0.data_format_conversion_configuration").Exists() && formatConversionEnabled,
 		VPCDeliveryEnabled:          d.Get("elasticsearch_configuration.0.vpc_config").Type != gjson.Null,
-		VPCDeliveryAZs:              int64(len(d.Get("elasticsearch_configuration.0.vpc_config.0.subnet_ids").Array())),
+		VPCDeliveryAZs:              int64(subnetIDs),
 	}
 
 	r.PopulateUsage(u)

--- a/internal/providers/terraform/aws/testdata/kinesis_firehose_delivery_stream_test/kinesis_firehose_delivery_stream_test.golden
+++ b/internal/providers/terraform/aws/testdata/kinesis_firehose_delivery_stream_test/kinesis_firehose_delivery_stream_test.golden
@@ -1,51 +1,59 @@
 
- Name                                                         Monthly Qty  Unit                    Monthly Cost 
-                                                                                                                
- aws_elasticsearch_domain.test_cluster                                                                          
- └─ Instance (on-demand, m4.large.elasticsearch)                      730  hours                        $134.32 
-                                                                                                                
- aws_kinesis_firehose_delivery_stream.EnabledFalse                                                              
- ├─ Data ingested (first 500TB)                                   512,000  GB                        $17,920.00 
- ├─ Data ingested (next 1.5PB)                                  1,536,000  GB                        $46,080.00 
- ├─ Data ingested (next 3PB)                                      952,000  GB                        $22,848.00 
- ├─ VPC data                                                    3,000,000  GB                        $30,000.00 
- └─ VPC AZ delivery                                                 1,460  hours                         $16.06 
-                                                                                                                
- aws_kinesis_firehose_delivery_stream.forTwoMilGB                                                               
- ├─ Data ingested (first 500TB)                                   512,000  GB                        $17,920.00 
- └─ Data ingested (next 1.5PB)                                  1,488,000  GB                        $44,640.00 
-                                                                                                                
- aws_kinesis_firehose_delivery_stream.onlyDataIngested                                                          
- ├─ Data ingested (first 500TB)                                   512,000  GB                        $17,920.00 
- ├─ Data ingested (next 1.5PB)                                  1,536,000  GB                        $46,080.00 
- └─ Data ingested (next 3PB)                                      952,000  GB                        $22,848.00 
-                                                                                                                
- aws_kinesis_firehose_delivery_stream.withAllTags                                                               
- ├─ Data ingested (first 500TB)                                   512,000  GB                        $17,920.00 
- ├─ Data ingested (next 1.5PB)                                  1,536,000  GB                        $46,080.00 
- ├─ Data ingested (next 3PB)                                    4,952,000  GB                       $118,848.00 
- ├─ Format conversion                                           7,000,000  GB                       $147,000.00 
- ├─ VPC data                                                    7,000,000  GB                        $70,000.00 
- └─ VPC AZ delivery                                                 1,460  hours                         $16.06 
-                                                                                                                
- aws_kinesis_firehose_delivery_stream.withoutUsage                                                              
- ├─ Data ingested (first 500TB)                         Monthly cost depends on usage: $0.035 per GB            
- ├─ Format conversion                                   Monthly cost depends on usage: $0.021 per GB            
- ├─ VPC data                                            Monthly cost depends on usage: $0.01 per GB             
- └─ VPC AZ delivery                                                 1,460  hours                         $16.06 
-                                                                                                                
- aws_s3_bucket.bucket                                                                                           
- └─ Standard                                                                                                    
-    ├─ Storage                                          Monthly cost depends on usage: $0.024 per GB            
-    ├─ PUT, COPY, POST, LIST requests                   Monthly cost depends on usage: $0.0053 per 1k requests  
-    ├─ GET, SELECT, and all other requests              Monthly cost depends on usage: $0.00042 per 1k requests 
-    ├─ Select data scanned                              Monthly cost depends on usage: $0.00225 per GB          
-    └─ Select data returned                             Monthly cost depends on usage: $0.0008 per GB           
-                                                                                                                
- OVERALL TOTAL                                                                                      $666,286.50 
+ Name                                                            Monthly Qty  Unit                    Monthly Cost 
+                                                                                                                   
+ aws_elasticsearch_domain.test_cluster                                                                             
+ └─ Instance (on-demand, m4.large.elasticsearch)                         730  hours                        $134.32 
+                                                                                                                   
+ aws_kinesis_firehose_delivery_stream.EnabledFalse                                                                 
+ ├─ Data ingested (first 500TB)                                      512,000  GB                        $17,920.00 
+ ├─ Data ingested (next 1.5PB)                                     1,536,000  GB                        $46,080.00 
+ ├─ Data ingested (next 3PB)                                         952,000  GB                        $22,848.00 
+ ├─ VPC data                                                       3,000,000  GB                        $30,000.00 
+ └─ VPC AZ delivery                                                    1,460  hours                         $16.06 
+                                                                                                                   
+ aws_kinesis_firehose_delivery_stream.forTwoMilGB                                                                  
+ ├─ Data ingested (first 500TB)                                      512,000  GB                        $17,920.00 
+ └─ Data ingested (next 1.5PB)                                     1,488,000  GB                        $44,640.00 
+                                                                                                                   
+ aws_kinesis_firehose_delivery_stream.onlyDataIngested                                                             
+ ├─ Data ingested (first 500TB)                                      512,000  GB                        $17,920.00 
+ ├─ Data ingested (next 1.5PB)                                     1,536,000  GB                        $46,080.00 
+ └─ Data ingested (next 3PB)                                         952,000  GB                        $22,848.00 
+                                                                                                                   
+ aws_kinesis_firehose_delivery_stream.withAllTags                                                                  
+ ├─ Data ingested (first 500TB)                                      512,000  GB                        $17,920.00 
+ ├─ Data ingested (next 1.5PB)                                     1,536,000  GB                        $46,080.00 
+ ├─ Data ingested (next 3PB)                                       4,952,000  GB                       $118,848.00 
+ ├─ Format conversion                                              7,000,000  GB                       $147,000.00 
+ ├─ VPC data                                                       7,000,000  GB                        $70,000.00 
+ └─ VPC AZ delivery                                                    1,460  hours                         $16.06 
+                                                                                                                   
+ aws_kinesis_firehose_delivery_stream.with_dynamic_subnet                                                          
+ ├─ Data ingested (first 500TB)                            Monthly cost depends on usage: $0.035 per GB            
+ ├─ Format conversion                                      Monthly cost depends on usage: $0.021 per GB            
+ ├─ VPC data                                               Monthly cost depends on usage: $0.01 per GB             
+ └─ VPC AZ delivery                                                    1,460  hours                         $16.06 
+                                                                                                                   
+ aws_kinesis_firehose_delivery_stream.withoutUsage                                                                 
+ ├─ Data ingested (first 500TB)                            Monthly cost depends on usage: $0.035 per GB            
+ ├─ Format conversion                                      Monthly cost depends on usage: $0.021 per GB            
+ ├─ VPC data                                               Monthly cost depends on usage: $0.01 per GB             
+ └─ VPC AZ delivery                                                    1,460  hours                         $16.06 
+                                                                                                                   
+ aws_s3_bucket.bucket                                                                                              
+ └─ Standard                                                                                                       
+    ├─ Storage                                             Monthly cost depends on usage: $0.024 per GB            
+    ├─ PUT, COPY, POST, LIST requests                      Monthly cost depends on usage: $0.0053 per 1k requests  
+    ├─ GET, SELECT, and all other requests                 Monthly cost depends on usage: $0.00042 per 1k requests 
+    ├─ Select data scanned                                 Monthly cost depends on usage: $0.00225 per GB          
+    └─ Select data returned                                Monthly cost depends on usage: $0.0008 per GB           
+                                                                                                                   
+ OVERALL TOTAL                                                                                         $666,302.56 
 ──────────────────────────────────
-9 cloud resources were detected:
-∙ 7 were estimated, 6 of which include usage-based costs, see https://infracost.io/usage-file
-∙ 2 were free:
+13 cloud resources were detected:
+∙ 8 were estimated, 7 of which include usage-based costs, see https://infracost.io/usage-file
+∙ 5 were free:
+  ∙ 2 x aws_subnet
   ∙ 1 x aws_iam_role
   ∙ 1 x aws_s3_bucket_acl
+  ∙ 1 x aws_vpc


### PR DESCRIPTION
Similar issue to https://github.com/infracost/infracost/pull/1504 where the `subnet_ids` attribute is empty if it contains ids for subnets yet to be created. This meant that we were wrongly excluding the `VPC AZ delivery` cost component.