### PR TITLE
fix(hcl): count references not evaluating

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -29,8 +29,6 @@ type Evaluator struct {
 	// ctx is the master Context for evaluating the current set of Blocks. This is extremely important
 	// and gets slowly built up as the Evaluator runs across the list of Blocks.
 	ctx *Context
-	// blocks is the list of Blocks that the Evaluator will evaluate over.
-	blocks Blocks
 	// inputVars are the given input variables for this Evaluator run. At the root module level these are variables
 	// provided by the user as tfvars. Further down the config tree these input vars are module variables provided in
 	// HCL attributes.
@@ -42,32 +40,31 @@ type Evaluator struct {
 	moduleMetadata *modules.Manifest
 	// visitedModules is a lookup map to hold information by the Evaluator of modules that it has already evaluated.
 	visitedModules map[string]struct{}
-	// projectRootPath is the path to the root module for this project.
-	projectRootPath string
-	// modulePath is the path to the local representation of the module as defined in ModulesManifest.
-	modulePath string
+	// module defines the input and module path for the Evaluator. It is the root module of the config.
+	module Module
 	// workingDir is the current directory the evaluator is running within. This is used to set Context information on
 	// child modules that the evaluator visits.
 	workingDir string
 	// workspace is the Terraform workspace that the Evaluator is running within.
 	workspace string
+	// blockBuilder handles generating blocks in the evaluation step.
+	blockBuilder BlockBuilder
 }
 
 // NewEvaluator returns an Evaluator with Context initialised with top level variables.
 // This Context is then passed to all Blocks as child Context so that variables built in Evaluation
 // are propagated to the Block Attributes.
 func NewEvaluator(
-	projectRootPath string,
-	modulePath string,
+	module Module,
 	workingDir string,
-	blocks Blocks,
 	inputVars map[string]cty.Value,
 	moduleMetadata *modules.Manifest,
 	visitedModules map[string]struct{},
 	workspace string,
+	blockBuilder BlockBuilder,
 ) *Evaluator {
 	ctx := NewContext(&hcl.EvalContext{
-		Functions: expFunctions(modulePath),
+		Functions: expFunctions(module.ModulePath),
 	}, nil)
 
 	if visitedModules == nil {
@@ -76,31 +73,30 @@ func NewEvaluator(
 
 	// set the global evaluation parameters.
 	ctx.SetByDot(cty.StringVal(workspace), "terraform.workspace")
-	ctx.SetByDot(cty.StringVal(projectRootPath), "path.root")
-	ctx.SetByDot(cty.StringVal(modulePath), "path.module")
+	ctx.SetByDot(cty.StringVal(module.RootPath), "path.root")
+	ctx.SetByDot(cty.StringVal(module.ModulePath), "path.module")
 	ctx.SetByDot(cty.StringVal(workingDir), "path.cwd")
 
-	for _, b := range blocks {
+	for _, b := range module.Blocks {
 		b.SetContext(ctx.NewChild())
 	}
 
 	return &Evaluator{
-		modulePath:      modulePath,
-		projectRootPath: projectRootPath,
-		ctx:             ctx,
-		blocks:          blocks,
-		inputVars:       inputVars,
-		moduleMetadata:  moduleMetadata,
-		visitedModules:  visitedModules,
-		workspace:       workspace,
+		module:         module,
+		ctx:            ctx,
+		inputVars:      inputVars,
+		moduleMetadata: moduleMetadata,
+		visitedModules: visitedModules,
+		workspace:      workspace,
+		blockBuilder:   blockBuilder,
 	}
 }
 
 // Run builds the Evaluator Context using all the provided Blocks. It will build up the Context to hold
 // variable and reference information so that this can be used by Attribute evaluation. Run will also
 // parse and build up and child modules that are referenced in the Blocks and runs child Evaluator on
-// these Modules.
-func (e *Evaluator) Run() ([]*Module, error) {
+// this Module.
+func (e *Evaluator) Run() (*Module, error) {
 	var lastContext hcl.EvalContext
 	// first we need to evaluate the top level Context - so this can be passed to any child modules that are found.
 	e.evaluate(lastContext)
@@ -111,22 +107,19 @@ func (e *Evaluator) Run() ([]*Module, error) {
 
 	// expand out resources and modules via count and evaluate again so that we can include
 	// any module outputs and or count references.
-	e.blocks = e.expandBlocks(e.blocks)
+	e.module.Blocks = e.expandBlocks(e.module.Blocks)
 	e.evaluate(lastContext)
 
-	// returns all the evaluated Blocks under their given Modules.
+	// returns all the evaluated Blocks under their given Module.
 	return e.collectModules(), nil
 }
 
-func (e *Evaluator) collectModules() []*Module {
-	rootModule := &Module{Blocks: e.blocks, RootPath: e.projectRootPath, ModulePath: e.modulePath}
-	modules := []*Module{rootModule}
-
+func (e *Evaluator) collectModules() *Module {
 	for _, definition := range e.moduleCalls {
-		modules = append(modules, definition.Modules...)
+		e.module.Modules = append(e.module.Modules, definition.Module)
 	}
 
-	return modules
+	return &e.module
 }
 
 func (e *Evaluator) evaluate(lastContext hcl.EvalContext) {
@@ -155,7 +148,7 @@ func (e *Evaluator) evaluate(lastContext hcl.EvalContext) {
 // evaluateStep gets the values for all the Block types in the current Module that affect Context.
 // It then sets these values on the Context so that they can be used in Block Attribute evaluation.
 func (e *Evaluator) evaluateStep(i int) {
-	log.Debugf("Starting context evaluation for module %s iteration %d", e.modulePath, i+1)
+	log.Debugf("Starting context evaluation for module %s iteration %d", e.module.ModulePath, i+1)
 
 	e.ctx.Set(e.getValuesByBlockType("variable"), "var")
 	e.ctx.Set(e.getValuesByBlockType("locals"), "local")
@@ -175,27 +168,34 @@ func (e *Evaluator) evaluateStep(i int) {
 // evaluateModules loops over each of the moduleCalls in this Module and set a child Evaluator
 // to run on the child Module Blocks. It passes the Evaluator the top level module Attributes as input variables.
 func (e *Evaluator) evaluateModules() {
-	for _, module := range e.moduleCalls {
-		if _, ok := e.visitedModules[module.Definition.FullName()]; ok {
+	for _, moduleCall := range e.moduleCalls {
+		if _, ok := e.visitedModules[moduleCall.Definition.FullName()]; ok {
 			continue
 		}
 
-		e.visitedModules[module.Definition.FullName()] = struct{}{}
+		e.visitedModules[moduleCall.Definition.FullName()] = struct{}{}
 
-		vars := module.Definition.Values().AsValueMap()
+		vars := moduleCall.Definition.Values().AsValueMap()
 		moduleEvaluator := NewEvaluator(
-			e.projectRootPath,
-			module.Path,
+			Module{
+				Name:       moduleCall.Definition.FullName(),
+				Source:     moduleCall.Module.Source,
+				Blocks:     moduleCall.Module.Blocks,
+				RootPath:   e.module.RootPath,
+				ModulePath: moduleCall.Path,
+				Modules:    nil,
+				Parent:     &e.module,
+			},
 			e.workingDir,
-			module.Modules[0].Blocks,
 			vars,
 			e.moduleMetadata,
 			e.visitedModules,
 			e.workspace,
+			e.blockBuilder,
 		)
-		module.Modules, _ = moduleEvaluator.Run()
 
-		e.ctx.Set(moduleEvaluator.exportOutputs(), "module", module.Name)
+		moduleCall.Module, _ = moduleEvaluator.Run()
+		e.ctx.Set(moduleEvaluator.exportOutputs(), "module", moduleCall.Name)
 	}
 }
 
@@ -203,7 +203,7 @@ func (e *Evaluator) evaluateModules() {
 func (e *Evaluator) exportOutputs() cty.Value {
 	data := make(map[string]cty.Value)
 
-	for _, block := range e.blocks.OfType("output") {
+	for _, block := range e.module.Blocks.OfType("output") {
 		attr := block.GetAttribute("value")
 		if attr == nil {
 			continue
@@ -254,7 +254,7 @@ func (e *Evaluator) expandBlockForEaches(blocks Blocks) Blocks {
 
 		if !forEachAttr.Value().IsNull() && forEachAttr.Value().IsKnown() && forEachAttr.IsIterable() {
 			forEachAttr.Value().ForEachElement(func(key cty.Value, val cty.Value) bool {
-				clone := block.Clone(key)
+				clone := e.blockBuilder.CloneBlock(block, key)
 
 				ctx := clone.Context()
 
@@ -297,7 +297,7 @@ func (e *Evaluator) expandBlockCounts(blocks Blocks) Blocks {
 		vals := make([]cty.Value, count)
 		for i := 0; i < count; i++ {
 			c, _ := gocty.ToCtyValue(i, cty.Number)
-			clone := block.Clone(c)
+			clone := e.blockBuilder.CloneBlock(block, c)
 
 			log.Debugf("Added %s from count var", clone.Reference())
 			countFiltered = append(countFiltered, clone)
@@ -370,7 +370,7 @@ func (e *Evaluator) evaluateOutput(b *Block) (cty.Value, error) {
 }
 
 func (e *Evaluator) getValuesByBlockType(blockType string) cty.Value {
-	blocksOfType := e.blocks.OfType(blockType)
+	blocksOfType := e.module.Blocks.OfType(blockType)
 	values := make(map[string]cty.Value)
 
 	for _, b := range blocksOfType {
@@ -450,7 +450,7 @@ func (e *Evaluator) loadModule(b *Block) (*ModuleCall, error) {
 		for _, module := range e.moduleMetadata.Modules {
 			reg := "registry.terraform.io/" + source
 			if module.Source == source || module.Source == reg {
-				modulePath = filepath.Clean(filepath.Join(e.projectRootPath, module.Dir))
+				modulePath = filepath.Clean(filepath.Join(e.module.RootPath, module.Dir))
 				break
 			}
 		}
@@ -463,10 +463,10 @@ func (e *Evaluator) loadModule(b *Block) (*ModuleCall, error) {
 		}
 
 		// combine the current calling module with relative source of the module
-		modulePath = filepath.Join(e.modulePath, source)
+		modulePath = filepath.Join(e.module.ModulePath, source)
 	}
 
-	blocks, err := b.getModuleBlocks(modulePath)
+	blocks, err := e.blockBuilder.BuildModuleBlocks(b, modulePath)
 	if err != nil {
 		return nil, err
 	}
@@ -476,18 +476,22 @@ func (e *Evaluator) loadModule(b *Block) (*ModuleCall, error) {
 		Name:       b.Label(),
 		Path:       modulePath,
 		Definition: b,
-		Modules: []*Module{
-			{RootPath: e.projectRootPath, ModulePath: modulePath, Blocks: blocks},
+		Module: &Module{
+			Name:       b.TypeLabel(),
+			Source:     source,
+			Blocks:     blocks,
+			RootPath:   e.module.RootPath,
+			ModulePath: modulePath,
+			Parent:     &e.module,
 		},
 	}, nil
 }
 
 // loadModules reads all module blocks and loads the underlying modules, adding blocks to moduleCalls.
 func (e *Evaluator) loadModules() []*ModuleCall {
-	blocks := e.blocks
 	var moduleDefinitions []*ModuleCall
 
-	expanded := e.expandBlocks(blocks.OfType("module"))
+	expanded := e.expandBlocks(e.module.Blocks.OfType("module"))
 
 	for _, moduleBlock := range expanded {
 		if moduleBlock.Label() == "" {

--- a/internal/hcl/module.go
+++ b/internal/hcl/module.go
@@ -1,11 +1,5 @@
 package hcl
 
-import (
-	"fmt"
-
-	"github.com/hashicorp/hcl/v2"
-)
-
 // ModuleCall represents a call to a defined Module by a parent Module.
 type ModuleCall struct {
 	// Name the name of the module as specified a the point of definition.
@@ -14,42 +8,19 @@ type ModuleCall struct {
 	Path string
 	// Definition is the actual Block where the ModuleCall happens in a hcl.File
 	Definition *Block
-	// Modules contains the parsed modules that are part of this ModuleCall. This can contain
-	// more than one Module as it will also contain a list of the child Modules that have been
-	// called within this Module. The Module at position 0 is the root Module.
-	Modules []*Module
+	// Module contains the parsed root module that represents this ModuleCall.
+	Module *Module
 }
 
 // Module encapsulates all the Blocks that are part of a Module in a Terraform project.
 type Module struct {
+	Name   string
+	Source string
+
 	Blocks     Blocks
 	RootPath   string
 	ModulePath string
-}
 
-// getModuleBlocks loads all the Blocks for the module at the given path
-func (b *Block) getModuleBlocks(modulePath string) (Blocks, error) {
-	var blocks Blocks
-	moduleFiles, err := loadDirectory(modulePath, true)
-	if err != nil {
-		return blocks, fmt.Errorf("failed to load module %s: %w", b.Label(), err)
-	}
-
-	moduleCtx := NewContext(&hcl.EvalContext{}, nil)
-	for _, file := range moduleFiles {
-		fileBlocks, err := loadBlocksFromFile(file)
-		if err != nil {
-			return blocks, err
-		}
-
-		if len(fileBlocks) > 0 {
-			log.Debugf("Added %d blocks from %s...", len(fileBlocks), fileBlocks[0].DefRange.Filename)
-		}
-
-		for _, fileBlock := range fileBlocks {
-			blocks = append(blocks, NewHCLBlock(fileBlock, moduleCtx, b))
-		}
-	}
-
-	return blocks, err
+	Modules []*Module
+	Parent  *Module
 }

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func Test_BasicParsing(t *testing.T) {
-
 	path := createTestFile("test.tf", `
 
 locals {
@@ -46,13 +45,12 @@ data "cats_cat" "the-cats-mother" {
 `)
 
 	parser := New(filepath.Dir(path), OptionStopOnHCLError())
-	modules, err := parser.ParseDirectory()
+	module, err := parser.ParseDirectory()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	blocks := modules[0].Blocks
-
+	blocks := module.Blocks
 	// variable
 	variables := blocks.OfType("variable")
 	require.Len(t, variables, 1)
@@ -130,12 +128,11 @@ output "mod_result" {
 	)
 
 	parser := New(path, OptionStopOnHCLError())
-	modules, err := parser.ParseDirectory()
+	rootModule, err := parser.ParseDirectory()
 	if err != nil {
 		t.Fatal(err)
 	}
-	rootModule := modules[0]
-	childModule := modules[1]
+	childModule := rootModule.Modules[0]
 
 	moduleBlocks := rootModule.Blocks.OfType("module")
 	require.Len(t, moduleBlocks, 1)
@@ -190,12 +187,11 @@ output "mod_result" {
 	)
 
 	parser := New(path, OptionStopOnHCLError())
-	modules, err := parser.ParseDirectory()
+	rootModule, err := parser.ParseDirectory()
 	if err != nil {
 		t.Fatal(err)
 	}
-	rootModule := modules[0]
-	childModule := modules[1]
+	childModule := rootModule.Modules[0]
 
 	moduleBlocks := rootModule.Blocks.OfType("module")
 	require.Len(t, moduleBlocks, 1)

--- a/internal/hcl/reference.go
+++ b/internal/hcl/reference.go
@@ -72,6 +72,28 @@ func (r *Reference) SetKey(key cty.Value) {
 	}
 }
 
+// JSONString returns the reference so that it's possible to use in the plan JSON file.
+// This strips any count keys from the reference.
+func (r *Reference) JSONString() string {
+	base := fmt.Sprintf("%s.%s", r.typeLabel, r.nameLabel)
+
+	if !r.blockType.removeTypeInReference {
+		base = r.blockType.Name()
+		if r.blockType.Name() == "variable" {
+			base = "var"
+		}
+
+		if r.typeLabel != "" {
+			base += "." + r.typeLabel
+		}
+		if r.nameLabel != "" {
+			base += "." + r.nameLabel
+		}
+	}
+
+	return base
+}
+
 func (r *Reference) String() string {
 	base := fmt.Sprintf("%s.%s", r.typeLabel, r.nameLabel)
 

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -1,0 +1,183 @@
+package terraform
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"strings"
+	"testing"
+	"text/template"
+
+	hcl2 "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/infracost/infracost/internal/hcl"
+)
+
+func setMockAttributes(blockAtts map[string]map[string]string) hcl.SetAttributesFunc {
+	count := map[string]int{}
+
+	return func(moduleBlock *hcl.Block, block *hcl2.Block) {
+		if v, ok := block.Body.(*hclsyntax.Body); ok {
+			body := *v
+			nat := hclsyntax.Attributes{}
+			for k, a := range body.Attributes {
+				b := *a
+				nat[k] = &b
+			}
+
+			body.Attributes = nat
+
+			if block.Type == "resource" || block.Type == "data" {
+				fullName := strings.Join(block.Labels, ".")
+				module := moduleBlock.FullName()
+				if module != "" {
+					fullName = module + "." + fullName
+				}
+
+				if attrs, ok := blockAtts[fullName]; ok {
+					addAttrs(attrs, &body)
+					block.Body = &body
+				}
+
+				withCount := fullName + "[0]"
+				if i, ok := count[fullName]; ok {
+					withCount = fmt.Sprintf("%s[%d]", fullName, i)
+					count[fullName]++
+				} else {
+					count[fullName] = 0
+				}
+
+				if attrs, ok := blockAtts[withCount]; ok {
+					addAttrs(attrs, &body)
+					block.Body = &body
+				}
+			}
+		}
+	}
+}
+
+func addAttrs(attrs map[string]string, body *hclsyntax.Body) {
+	for k, v := range attrs {
+		body.Attributes[k] = &hclsyntax.Attribute{
+			Name: k,
+			Expr: &hclsyntax.LiteralValueExpr{
+				Val: cty.StringVal(v),
+			},
+		}
+	}
+}
+
+func TestHCLProvider_LoadPlanJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		attrs map[string]map[string]string
+	}{
+		{
+			name: "structures module expressions correctly with count",
+			attrs: map[string]map[string]string{
+				"module.module1.aws_ecs_task_definition.ecs_task": {
+					"id":  "task-1",
+					"arn": "task-1-arn",
+				},
+				"module.module1.module.module2.aws_ecs_task_definition.ecs_task": {
+					"id":  "task-2",
+					"arn": "task-2-arn",
+				},
+				"module.module1.aws_ecs_service.ecs_service": {
+					"id":  "svc-1",
+					"arn": "svc-1-arn",
+				},
+				"module.module1.module.module2.aws_ecs_service.ecs_service": {
+					"id":  "svc-2",
+					"arn": "svc-2-arn",
+				},
+			},
+		},
+		{
+			name: "renders multiple count resources correctly",
+			attrs: map[string]map[string]string{
+				"aws_eip.test[0]": {
+					"id":  "eip",
+					"arn": "eip-arn",
+				},
+				"aws_eip.test[1]": {
+					"id":  "eip-1",
+					"arn": "eip-1-arn",
+				},
+				"module.autos.aws_autoscaling_group.test[0]": {
+					"id":  "auto",
+					"arn": "auto-arn",
+				},
+				"module.autos.aws_autoscaling_group.test[1]": {
+					"id":  "auto-1",
+					"arn": "auto-1-arn",
+				},
+				"module.autos.aws_autoscaling_group.test[2]": {
+					"id":  "auto-2",
+					"arn": "auto-2-arn",
+				},
+				"module.autos.aws_launch_configuration.test[0]": {
+					"id":  "lc",
+					"arn": "lc-arn",
+				},
+				"module.autos.aws_launch_configuration.test[1]": {
+					"id":  "lc-1",
+					"arn": "lc-1-arn",
+				},
+				"module.autos.aws_launch_configuration.test[2]": {
+					"id":  "lc-2",
+					"arn": "lc-2-arn",
+				},
+			},
+		},
+		{
+			name: "renders module resources",
+			attrs: map[string]map[string]string{
+				"aws_vpn_connection.example": {
+					"id":  "vpn-id",
+					"arn": "vpn-arn",
+				},
+				"module.gateway.aws_customer_gateway.example": {
+					"id":  "c-gw-id",
+					"arn": "c-gw-arn",
+				},
+				"module.gateway.aws_ec2_transit_gateway.example": {
+					"id":  "t-gw-id",
+					"arn": "t-gw-arn",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pathName := strings.ReplaceAll(strings.ToLower(tt.name), " ", "_")
+			testPath := path.Join("testdata/hcl_provider_test", pathName)
+
+			p := HCLProvider{
+				Parser: hcl.New(
+					testPath,
+					hcl.OptionWithBlockBuilder(
+						hcl.BlockBuilder{SetAttributes: []hcl.SetAttributesFunc{setMockAttributes(tt.attrs)}},
+					),
+				),
+			}
+			got, err := p.LoadPlanJSON()
+			require.NoError(t, err)
+
+			tmpl, err := template.ParseFiles(path.Join(testPath, "expected.json"))
+			require.NoError(t, err)
+
+			exp := bytes.NewBuffer([]byte{})
+			err = tmpl.Execute(exp, map[string]interface{}{"attrs": tt.attrs})
+			require.NoError(t, err)
+
+			expected := exp.String()
+			actual := string(got)
+			assert.JSONEq(t, expected, actual)
+		})
+	}
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/expected.json
@@ -1,0 +1,180 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.1.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_vpn_connection.example",
+          "mode": "managed",
+          "type": "aws_vpn_connection",
+          "name": "example",
+          "schema_version": 0,
+          "values": {
+            "arn": "vpn-arn",
+            "customer_gateway_id": "c-gw-id",
+            "id": "vpn-id",
+            "transit_gateway_id": "t-gw-id",
+            "type": "ipsec.1"
+          }
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.gateway.aws_ec2_transit_gateway.example",
+              "mode": "managed",
+              "type": "aws_ec2_transit_gateway",
+              "name": "example",
+              "schema_version": 0,
+              "values": {
+                "arn": "t-gw-arn",
+                "id": "t-gw-id"
+              }
+            },
+            {
+              "address": "module.gateway.aws_customer_gateway.example",
+              "mode": "managed",
+              "type": "aws_customer_gateway",
+              "name": "example",
+              "schema_version": 0,
+              "values": {
+                "arn": "c-gw-arn",
+                "bgp_asn": 65000,
+                "id": "c-gw-id",
+                "ip_address": "172.0.0.1",
+                "type": "ipsec.1"
+              }
+            }
+          ],
+          "address": "module.gateway"
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_vpn_connection.example",
+      "mode": "managed",
+      "type": "aws_vpn_connection",
+      "name": "example",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "vpn-arn",
+          "customer_gateway_id": "c-gw-id",
+          "id": "vpn-id",
+          "transit_gateway_id": "t-gw-id",
+          "type": "ipsec.1"
+        }
+      }
+    },
+    {
+      "address": "module.gateway.aws_ec2_transit_gateway.example",
+      "module_address": "module.gateway",
+      "mode": "managed",
+      "type": "aws_ec2_transit_gateway",
+      "name": "example",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "t-gw-arn",
+          "id": "t-gw-id"
+        }
+      }
+    },
+    {
+      "address": "module.gateway.aws_customer_gateway.example",
+      "module_address": "module.gateway",
+      "mode": "managed",
+      "type": "aws_customer_gateway",
+      "name": "example",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "c-gw-arn",
+          "bgp_asn": 65000,
+          "id": "c-gw-id",
+          "ip_address": "172.0.0.1",
+          "type": "ipsec.1"
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_vpn_connection.example",
+          "mode": "managed",
+          "type": "aws_vpn_connection",
+          "name": "example",
+          "provider_config_key": "aws",
+          "expressions": {
+            "customer_gateway_id": {
+              "references": [
+                "module.gateway.aws_customer_gateway_id"
+              ]
+            },
+            "transit_gateway_id": {
+              "references": [
+                "module.gateway.aws_ec2_transit_gateway_id"
+              ]
+            },
+            "type": {
+              "references": [
+                "module.gateway.aws_customer_gateway_type"
+              ]
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "module_calls": {
+        "gateway": {
+          "source": "./module/gateway",
+          "module": {
+            "resources": [
+              {
+                "address": "aws_ec2_transit_gateway.example",
+                "mode": "managed",
+                "type": "aws_ec2_transit_gateway",
+                "name": "example",
+                "provider_config_key": "gateway:aws",
+                "schema_version": 0
+              },
+              {
+                "address": "aws_customer_gateway.example",
+                "mode": "managed",
+                "type": "aws_customer_gateway",
+                "name": "example",
+                "provider_config_key": "gateway:aws",
+                "schema_version": 0
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/main.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+module "gateway" {
+  source = "./module/gateway"
+}
+
+resource "aws_vpn_connection" "example" {
+  customer_gateway_id = module.gateway.aws_customer_gateway_id
+  transit_gateway_id  = module.gateway.aws_ec2_transit_gateway_id
+  type                = module.gateway.aws_customer_gateway_type
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/module/gateway/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/module/gateway/main.tf
@@ -1,0 +1,19 @@
+resource "aws_ec2_transit_gateway" "example" {}
+
+resource "aws_customer_gateway" "example" {
+  bgp_asn    = 65000
+  ip_address = "172.0.0.1"
+  type       = "ipsec.1"
+}
+
+output "aws_ec2_transit_gateway_id" {
+  value = aws_ec2_transit_gateway.example.id
+}
+
+output "aws_customer_gateway_id" {
+  value = aws_customer_gateway.example.id
+}
+
+output "aws_customer_gateway_type" {
+  value = aws_customer_gateway.example.type
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/renders_multiple_count_resources_correctly/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/renders_multiple_count_resources_correctly/expected.json
@@ -1,0 +1,371 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.1.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_eip.test[0]",
+          "mode": "managed",
+          "type": "aws_eip",
+          "name": "test",
+          "index": 0,
+          "schema_version": 0,
+          "values": {
+            "arn": "eip-arn",
+            "id": "eip"
+          }
+        },
+        {
+          "address": "aws_eip.test[1]",
+          "mode": "managed",
+          "type": "aws_eip",
+          "name": "test",
+          "index": 1,
+          "schema_version": 0,
+          "values": {
+            "arn": "eip-1-arn",
+            "id": "eip-1"
+          }
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.autos.aws_autoscaling_group.test[0]",
+              "mode": "managed",
+              "type": "aws_autoscaling_group",
+              "name": "test",
+              "index": 0,
+              "schema_version": 0,
+              "values": {
+                "arn": "auto-arn",
+                "desired_capacity": 2,
+                "id": "auto",
+                "launch_configuration": "lc",
+                "max_size": 3,
+                "min_size": 1
+              }
+            },
+            {
+              "address": "module.autos.aws_autoscaling_group.test[1]",
+              "mode": "managed",
+              "type": "aws_autoscaling_group",
+              "name": "test",
+              "index": 1,
+              "schema_version": 0,
+              "values": {
+                "arn": "auto-1-arn",
+                "desired_capacity": 2,
+                "id": "auto-1",
+                "launch_configuration": "lc-1",
+                "max_size": 3,
+                "min_size": 1
+              }
+            },
+            {
+              "address": "module.autos.aws_autoscaling_group.test[2]",
+              "mode": "managed",
+              "type": "aws_autoscaling_group",
+              "name": "test",
+              "index": 2,
+              "schema_version": 0,
+              "values": {
+                "arn": "auto-2-arn",
+                "desired_capacity": 2,
+                "id": "auto-2",
+                "launch_configuration": "lc-2",
+                "max_size": 3,
+                "min_size": 1
+              }
+            },
+            {
+              "address": "module.autos.aws_launch_configuration.test[0]",
+              "mode": "managed",
+              "type": "aws_launch_configuration",
+              "name": "test",
+              "index": 0,
+              "schema_version": 0,
+              "values": {
+                "arn": "lc-arn",
+                "id": "lc",
+                "image_id": "fake_ami",
+                "instance_type": "t2.micro"
+              }
+            },
+            {
+              "address": "module.autos.aws_launch_configuration.test[1]",
+              "mode": "managed",
+              "type": "aws_launch_configuration",
+              "name": "test",
+              "index": 1,
+              "schema_version": 0,
+              "values": {
+                "arn": "lc-1-arn",
+                "id": "lc-1",
+                "image_id": "fake_ami",
+                "instance_type": "t2.medium"
+              }
+            },
+            {
+              "address": "module.autos.aws_launch_configuration.test[2]",
+              "mode": "managed",
+              "type": "aws_launch_configuration",
+              "name": "test",
+              "index": 2,
+              "schema_version": 0,
+              "values": {
+                "arn": "lc-2-arn",
+                "id": "lc-2",
+                "image_id": "fake_ami",
+                "instance_type": "t2.large"
+              }
+            }
+          ],
+          "address": "module.autos"
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_eip.test[0]",
+      "mode": "managed",
+      "type": "aws_eip",
+      "name": "test",
+      "index": 0,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "eip-arn",
+          "id": "eip"
+        }
+      }
+    },
+    {
+      "address": "aws_eip.test[1]",
+      "mode": "managed",
+      "type": "aws_eip",
+      "name": "test",
+      "index": 1,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "eip-1-arn",
+          "id": "eip-1"
+        }
+      }
+    },
+    {
+      "address": "module.autos.aws_autoscaling_group.test[0]",
+      "module_address": "module.autos",
+      "mode": "managed",
+      "type": "aws_autoscaling_group",
+      "name": "test",
+      "index": 0,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "auto-arn",
+          "desired_capacity": 2,
+          "id": "auto",
+          "launch_configuration": "lc",
+          "max_size": 3,
+          "min_size": 1
+        }
+      }
+    },
+    {
+      "address": "module.autos.aws_autoscaling_group.test[1]",
+      "module_address": "module.autos",
+      "mode": "managed",
+      "type": "aws_autoscaling_group",
+      "name": "test",
+      "index": 1,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "auto-1-arn",
+          "desired_capacity": 2,
+          "id": "auto-1",
+          "launch_configuration": "lc-1",
+          "max_size": 3,
+          "min_size": 1
+        }
+      }
+    },
+    {
+      "address": "module.autos.aws_autoscaling_group.test[2]",
+      "module_address": "module.autos",
+      "mode": "managed",
+      "type": "aws_autoscaling_group",
+      "name": "test",
+      "index": 2,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "auto-2-arn",
+          "desired_capacity": 2,
+          "id": "auto-2",
+          "launch_configuration": "lc-2",
+          "max_size": 3,
+          "min_size": 1
+        }
+      }
+    },
+    {
+      "address": "module.autos.aws_launch_configuration.test[0]",
+      "module_address": "module.autos",
+      "mode": "managed",
+      "type": "aws_launch_configuration",
+      "name": "test",
+      "index": 0,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "lc-arn",
+          "id": "lc",
+          "image_id": "fake_ami",
+          "instance_type": "t2.micro"
+        }
+      }
+    },
+    {
+      "address": "module.autos.aws_launch_configuration.test[1]",
+      "module_address": "module.autos",
+      "mode": "managed",
+      "type": "aws_launch_configuration",
+      "name": "test",
+      "index": 1,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "lc-1-arn",
+          "id": "lc-1",
+          "image_id": "fake_ami",
+          "instance_type": "t2.medium"
+        }
+      }
+    },
+    {
+      "address": "module.autos.aws_launch_configuration.test[2]",
+      "module_address": "module.autos",
+      "mode": "managed",
+      "type": "aws_launch_configuration",
+      "name": "test",
+      "index": 2,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "lc-2-arn",
+          "id": "lc-2",
+          "image_id": "fake_ami",
+          "instance_type": "t2.large"
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_eip.test",
+          "mode": "managed",
+          "type": "aws_eip",
+          "name": "test",
+          "provider_config_key": "aws",
+          "schema_version": 0,
+          "count_expression": {
+            "constant_value": 2
+          }
+        }
+      ],
+      "module_calls": {
+        "autos": {
+          "source": "./modules/autoscaling",
+          "module": {
+            "resources": [
+              {
+                "address": "aws_autoscaling_group.test",
+                "mode": "managed",
+                "type": "aws_autoscaling_group",
+                "name": "test",
+                "provider_config_key": "autos:aws",
+                "expressions": {
+                  "launch_configuration": {
+                    "references": [
+                      "aws_launch_configuration.test",
+                      "count.index"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "var.amount"
+                  ]
+                }
+              },
+              {
+                "address": "aws_launch_configuration.test",
+                "mode": "managed",
+                "type": "aws_launch_configuration",
+                "name": "test",
+                "provider_config_key": "autos:aws",
+                "expressions": {
+                  "instance_type": {
+                    "references": [
+                      "var.types",
+                      "count.index"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "var.amount"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/renders_multiple_count_resources_correctly/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/renders_multiple_count_resources_correctly/main.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_eip" "test" {
+  count = 2
+}
+
+module "autos" {
+  source = "./modules/autoscaling"
+
+  types = ["t2.micro", "t2.medium", "t2.large"]
+  amount = 3
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/renders_multiple_count_resources_correctly/modules/autoscaling/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/renders_multiple_count_resources_correctly/modules/autoscaling/main.tf
@@ -1,0 +1,22 @@
+variable "types" {
+  type = list(string)
+}
+
+variable "amount" {
+  type    = number
+  default = 2
+}
+
+resource "aws_autoscaling_group" "test" {
+  count                = var.amount
+  desired_capacity     = 2
+  max_size             = 3
+  min_size             = 1
+  launch_configuration = aws_launch_configuration.test.*.id[count.index]
+}
+
+resource "aws_launch_configuration" "test" {
+  count         = var.amount
+  image_id      = "fake_ami"
+  instance_type = var.types[count.index]
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/expected.json
@@ -1,0 +1,312 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.1.0",
+  "planned_values": {
+    "root_module": {
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.module1.aws_ecs_task_definition.ecs_task[0]",
+              "mode": "managed",
+              "type": "aws_ecs_task_definition",
+              "name": "ecs_task",
+              "index": 0,
+              "schema_version": 0,
+              "values": {
+                "arn": "task-1-arn",
+                "container_definitions": "\t\t\t[\n\t\t\t\t{\n\t\t\t\t\t\t\"command\": [\"sleep\", \"10\"],\n\t\t\t\t\t\t\"entryPoint\": [\"/\"],\n\t\t\t\t\t\t\"essential\": true,\n\t\t\t\t\t\t\"image\": \"alpine\",\n\t\t\t\t\t\t\"name\": \"alpine\",\n\t\t\t\t\t\t\"network_mode\": \"none\"\n\t\t\t\t}\n\t\t\t]\n",
+                "cpu": "1 vCPU",
+                "family": "ecs_task_module_1",
+                "id": "task-1",
+                "inference_accelerator": [
+                  {
+                    "device_name": "device1",
+                    "device_type": "eia2.medium"
+                  }
+                ],
+                "memory": "2 GB",
+                "requires_compatibilities": [
+                  "FARGATE"
+                ]
+              }
+            },
+            {
+              "address": "module.module1.aws_ecs_service.ecs_service[0]",
+              "mode": "managed",
+              "type": "aws_ecs_service",
+              "name": "ecs_service",
+              "index": 0,
+              "schema_version": 0,
+              "values": {
+                "arn": "svc-1-arn",
+                "desired_count": 1,
+                "id": "svc-1",
+                "launch_type": "FARGATE",
+                "name": "ecs_service_module_1",
+                "task_definition": null
+              }
+            }
+          ],
+          "address": "module.module1",
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.module1.module.module2.aws_ecs_task_definition.ecs_task[0]",
+                  "mode": "managed",
+                  "type": "aws_ecs_task_definition",
+                  "name": "ecs_task",
+                  "index": 0,
+                  "schema_version": 0,
+                  "values": {
+                    "arn": "task-2-arn",
+                    "container_definitions": "\t\t\t[\n\t\t\t\t{\n\t\t\t\t\t\t\"command\": [\"sleep\", \"10\"],\n\t\t\t\t\t\t\"entryPoint\": [\"/\"],\n\t\t\t\t\t\t\"essential\": true,\n\t\t\t\t\t\t\"image\": \"alpine\",\n\t\t\t\t\t\t\"name\": \"alpine\",\n\t\t\t\t\t\t\"network_mode\": \"none\"\n\t\t\t\t}\n\t\t\t]\n",
+                    "cpu": "1 vCPU",
+                    "family": "ecs_task_module_2",
+                    "id": "task-2",
+                    "inference_accelerator": [
+                      {
+                        "device_name": "device1",
+                        "device_type": "eia2.medium"
+                      }
+                    ],
+                    "memory": "2 GB",
+                    "requires_compatibilities": [
+                      "FARGATE"
+                    ]
+                  }
+                },
+                {
+                  "address": "module.module1.module.module2.aws_ecs_service.ecs_service[0]",
+                  "mode": "managed",
+                  "type": "aws_ecs_service",
+                  "name": "ecs_service",
+                  "index": 0,
+                  "schema_version": 0,
+                  "values": {
+                    "arn": "svc-2-arn",
+                    "desired_count": 1,
+                    "id": "svc-2",
+                    "launch_type": "FARGATE",
+                    "name": "ecs_service_module_2",
+                    "task_definition": null
+                  }
+                }
+              ],
+              "address": "module.module1.module.module2"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "module.module1.aws_ecs_task_definition.ecs_task[0]",
+      "module_address": "module.module1",
+      "mode": "managed",
+      "type": "aws_ecs_task_definition",
+      "name": "ecs_task",
+      "index": 0,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "task-1-arn",
+          "container_definitions": "\t\t\t[\n\t\t\t\t{\n\t\t\t\t\t\t\"command\": [\"sleep\", \"10\"],\n\t\t\t\t\t\t\"entryPoint\": [\"/\"],\n\t\t\t\t\t\t\"essential\": true,\n\t\t\t\t\t\t\"image\": \"alpine\",\n\t\t\t\t\t\t\"name\": \"alpine\",\n\t\t\t\t\t\t\"network_mode\": \"none\"\n\t\t\t\t}\n\t\t\t]\n",
+          "cpu": "1 vCPU",
+          "family": "ecs_task_module_1",
+          "id": "task-1",
+          "inference_accelerator": [
+            {
+              "device_name": "device1",
+              "device_type": "eia2.medium"
+            }
+          ],
+          "memory": "2 GB",
+          "requires_compatibilities": [
+            "FARGATE"
+          ]
+        }
+      }
+    },
+    {
+      "address": "module.module1.aws_ecs_service.ecs_service[0]",
+      "module_address": "module.module1",
+      "mode": "managed",
+      "type": "aws_ecs_service",
+      "name": "ecs_service",
+      "index": 0,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "svc-1-arn",
+          "desired_count": 1,
+          "id": "svc-1",
+          "launch_type": "FARGATE",
+          "name": "ecs_service_module_1",
+          "task_definition": null
+        }
+      }
+    },
+    {
+      "address": "module.module1.module.module2.aws_ecs_task_definition.ecs_task[0]",
+      "module_address": "module.module1.module.module2",
+      "mode": "managed",
+      "type": "aws_ecs_task_definition",
+      "name": "ecs_task",
+      "index": 0,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "task-2-arn",
+          "container_definitions": "\t\t\t[\n\t\t\t\t{\n\t\t\t\t\t\t\"command\": [\"sleep\", \"10\"],\n\t\t\t\t\t\t\"entryPoint\": [\"/\"],\n\t\t\t\t\t\t\"essential\": true,\n\t\t\t\t\t\t\"image\": \"alpine\",\n\t\t\t\t\t\t\"name\": \"alpine\",\n\t\t\t\t\t\t\"network_mode\": \"none\"\n\t\t\t\t}\n\t\t\t]\n",
+          "cpu": "1 vCPU",
+          "family": "ecs_task_module_2",
+          "id": "task-2",
+          "inference_accelerator": [
+            {
+              "device_name": "device1",
+              "device_type": "eia2.medium"
+            }
+          ],
+          "memory": "2 GB",
+          "requires_compatibilities": [
+            "FARGATE"
+          ]
+        }
+      }
+    },
+    {
+      "address": "module.module1.module.module2.aws_ecs_service.ecs_service[0]",
+      "module_address": "module.module1.module.module2",
+      "mode": "managed",
+      "type": "aws_ecs_service",
+      "name": "ecs_service",
+      "index": 0,
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "svc-2-arn",
+          "desired_count": 1,
+          "id": "svc-2",
+          "launch_type": "FARGATE",
+          "name": "ecs_service_module_2",
+          "task_definition": null
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "module_calls": {
+        "module1": {
+          "source": "./modules/module1",
+          "module": {
+            "resources": [
+              {
+                "address": "aws_ecs_task_definition.ecs_task",
+                "mode": "managed",
+                "type": "aws_ecs_task_definition",
+                "name": "ecs_task",
+                "provider_config_key": "module1:aws",
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "var.enabled"
+                  ]
+                }
+              },
+              {
+                "address": "aws_ecs_service.ecs_service",
+                "mode": "managed",
+                "type": "aws_ecs_service",
+                "name": "ecs_service",
+                "provider_config_key": "module1:aws",
+                "expressions": {
+                  "task_definition": {
+                    "references": [
+                      "aws_ecs_task_definition.ecs_task",
+                      "aws_ecs_task_definition.ecs_task"
+                    ]
+                  }
+                },
+                "schema_version": 0,
+                "count_expression": {
+                  "references": [
+                    "var.enabled"
+                  ]
+                }
+              }
+            ],
+            "module_calls": {
+              "module2": {
+                "source": "./modules/module2",
+                "module": {
+                  "resources": [
+                    {
+                      "address": "aws_ecs_task_definition.ecs_task",
+                      "mode": "managed",
+                      "type": "aws_ecs_task_definition",
+                      "name": "ecs_task",
+                      "provider_config_key": "module2:aws",
+                      "schema_version": 0,
+                      "count_expression": {
+                        "references": [
+                          "var.enabled"
+                        ]
+                      }
+                    },
+                    {
+                      "address": "aws_ecs_service.ecs_service",
+                      "mode": "managed",
+                      "type": "aws_ecs_service",
+                      "name": "ecs_service",
+                      "provider_config_key": "module2:aws",
+                      "expressions": {
+                        "task_definition": {
+                          "references": [
+                            "aws_ecs_task_definition.ecs_task",
+                            "aws_ecs_task_definition.ecs_task"
+                          ]
+                        }
+                      },
+                      "schema_version": 0,
+                      "count_expression": {
+                        "references": [
+                          "var.enabled"
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+module "module1" {
+  source  = "./modules/module1"
+  enabled = true
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/modules/module1/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/modules/module1/main.tf
@@ -1,0 +1,44 @@
+variable "enabled" {
+  type = bool
+  default = false
+}
+
+resource "aws_ecs_task_definition" "ecs_task" {
+  count = var.enabled ? 1 : 0
+
+  requires_compatibilities = ["FARGATE"]
+  family                   = "ecs_task_module_1"
+  memory                   = "2 GB"
+  cpu                      = "1 vCPU"
+  inference_accelerator {
+    device_name = "device1"
+    device_type = "eia2.medium"
+  }
+
+  container_definitions = <<TASK_DEFINITION
+			[
+				{
+						"command": ["sleep", "10"],
+						"entryPoint": ["/"],
+						"essential": true,
+						"image": "alpine",
+						"name": "alpine",
+						"network_mode": "none"
+				}
+			]
+			TASK_DEFINITION
+}
+
+resource "aws_ecs_service" "ecs_service" {
+  count = var.enabled ? 1 : 0
+
+  name            = "ecs_service_module_1"
+  launch_type     = "FARGATE"
+  task_definition = "${join("", aws_ecs_task_definition.ecs_task.*.family)}:${join("", aws_ecs_task_definition.ecs_task.*.revision)}"
+  desired_count   = 1
+}
+
+module "module2" {
+  source  = "./modules/module2"
+  enabled = true
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/modules/module1/modules/module2/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/modules/module1/modules/module2/main.tf
@@ -1,0 +1,39 @@
+variable "enabled" {
+  type    = bool
+  default = false
+}
+
+resource "aws_ecs_task_definition" "ecs_task" {
+  count = var.enabled ? 1 : 0
+
+  requires_compatibilities = ["FARGATE"]
+  family                   = "ecs_task_module_2"
+  memory                   = "2 GB"
+  cpu                      = "1 vCPU"
+  inference_accelerator {
+    device_name = "device1"
+    device_type = "eia2.medium"
+  }
+
+  container_definitions = <<TASK_DEFINITION
+			[
+				{
+						"command": ["sleep", "10"],
+						"entryPoint": ["/"],
+						"essential": true,
+						"image": "alpine",
+						"name": "alpine",
+						"network_mode": "none"
+				}
+			]
+			TASK_DEFINITION
+}
+
+resource "aws_ecs_service" "ecs_service" {
+  count = var.enabled ? 1 : 0
+
+  name            = "ecs_service_module_2"
+  launch_type     = "FARGATE"
+  task_definition = "${join("", aws_ecs_task_definition.ecs_task.*.family)}:${join("", aws_ecs_task_definition.ecs_task.*.revision)}"
+  desired_count   = 1
+}

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -380,7 +380,7 @@ func CreateTerraformProject(tmpDir string, tfProject TerraformProject) (string, 
 	return writeToTmpDir(tmpDir, tfProject)
 }
 
-func newHCLProvider(t *testing.T, runCtx *config.RunContext, tfdir string) terraform.HCLProvider {
+func newHCLProvider(t *testing.T, runCtx *config.RunContext, tfdir string) *terraform.HCLProvider {
 	t.Helper()
 
 	projectCtx := config.NewProjectContext(


### PR DESCRIPTION
This fixes issue where resources built with HCL were not able to fetch references for a non `id` or `arn` attribute if the resource had a count. For example a resource like:

```
resource "aws_ecs_service" "test" {
  count                              = 2
  name                               = "test"
  task_definition                = "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}"
  ...
}
```

would be unable to resolve the `aws_ecs_task_definition`. This was because the Plan JSON generated by the `hcl_provider` had some discrepancies. Especially in the `configuration` section of the plan JSON. 

1. Resources were being added to the `resources` list in the configuration block and not being deduped for their index:

```
    [
        {
          "address": "aws_eip.test[0]",
          "mode": "managed",
          "type": "aws_eip",
          "name": "test[0]",
          "provider_config_key": "aws",
          "schema_version": 0,
          "count_expression": {
            "constant_value": 2
          }
        },
        {
          "address": "aws_eip.test[1]",
          "mode": "managed",
          "type": "aws_eip",
          "name": "test[1]",
          "provider_config_key": "aws",
          "schema_version": 0,
          "count_expression": {
            "constant_value": 2
          }
        }
   ]
  ```  
  
  should instead be:
  
  ```
  [        
        {
          "address": "aws_eip.test",
          "mode": "managed",
          "type": "aws_eip",
          "name": "test",
          "provider_config_key": "aws",
          "schema_version": 0,
          "count_expression": {
            "constant_value": 2
          }
        }
 ]
```

2. Expression which used a count would not contain the count in the references array:

```
  "expressions": {
    "launch_configuration": {
      "references": [
        "aws_launch_configuration.test[0]"
      ]
    }
  },
 ```
 
 should be:
 
```
  "expressions": {
    "launch_configuration": {
      "references": [
        "aws_launch_configuration.test",
        "count.index"
      ]
    }
  },
```
3. recursive modules were not nesting in the planned resources or configuration sections. So they were all being assigned to the top-level module. This wasn't an issue per-say, however it was hard to compare Terraform JSON and HCL JSON to look for discrepancies 
---

In order to fix the above I've:

1. added function expression evaluation, as this was not properly covered when evaluating references. Meaning expressions like `coalesce(var.task_definition, "${join("", aws_ecs_task_definition.default.*.family)}:${join("", aws_ecs_task_definition.default.*.revision)}")` would not evaluate to a reference.
2. Refactored the `Evaluator` to return a single `Module` with child `Modules` to more accurately represent the HCL config tree. This makes it easier to generate the plan JSON structure in the `HCLProvider`
3. Refactored the `HCLProvider` to generate the proper plan JSON structure.
4. Added tests to cover the `HCLProvider` to make sure that we are generating the correct output. This meant refactoring the `Block` generation process a little into a `BlockBuilder` struct that we can set a dynamic list of `SetAttributesFunc` on. This enables us to mock the uuid generation to keep it static for the test files. It also enables us in the future to build a list of `SetAttributesFunc` with each being specific to certain resources. E.g. `aws_ecs_task_definition` has an output attribute of `revision` which is generated on apply. We could generate this with a `SetAttributesFunc` which is scoped to just that resource.