### PR TITLE
chore: improve hcl provider output messaging

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -301,6 +301,10 @@ func runProjectConfig(cmd *cobra.Command, runCtx *config.RunContext, ctx *config
 	}
 
 	provider, err := providers.Detect(ctx)
+	if _, ok := err.(*providers.ValidationError); ok {
+		return nil, err
+	}
+
 	if err != nil {
 		m := fmt.Sprintf("%s\n\n", err)
 		m += fmt.Sprintf("Try setting --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot"))

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -301,16 +301,20 @@ func runProjectConfig(cmd *cobra.Command, runCtx *config.RunContext, ctx *config
 	}
 
 	provider, err := providers.Detect(ctx)
-	if _, ok := err.(*providers.ValidationError); ok {
-		return nil, err
-	}
+	var warn *string
+	if v, ok := err.(*providers.ValidationError); ok {
+		if v.Warn() == nil {
+			return nil, err
+		}
 
-	if err != nil {
+		warn = v.Warn()
+	} else if err != nil {
 		m := fmt.Sprintf("%s\n\n", err)
 		m += fmt.Sprintf("Try setting --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot"))
 
 		return nil, clierror.NewSanitizedError(errors.New(m), "Could not detect path type")
 	}
+
 	ctx.SetContextValue("projectType", provider.Type())
 
 	if cmd.Name() == "diff" && provider.Type() == "terraform_state_json" {
@@ -325,6 +329,10 @@ func runProjectConfig(cmd *cobra.Command, runCtx *config.RunContext, ctx *config
 		log.Info(m)
 	} else {
 		fmt.Fprintln(os.Stderr, m)
+	}
+
+	if warn != nil {
+		ui.PrintWarning(runCtx.ErrWriter, *warn)
 	}
 
 	// Generate usage file

--- a/internal/config/run_context.go
+++ b/internal/config/run_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/infracost/infracost/internal/ui"
 	"github.com/infracost/infracost/internal/version"
 )
 
@@ -65,6 +66,15 @@ func EmptyRunContext() *RunContext {
 		ErrWriter:   os.Stderr,
 		Exit:        os.Exit,
 	}
+}
+
+// NewSpinner returns an ui.Spinner built from the RunContext.
+func (r *RunContext) NewSpinner(msg string) *ui.Spinner {
+	return ui.NewSpinner(msg, ui.SpinnerOptions{
+		EnableLogging: r.Config.IsLogging(),
+		NoColor:       r.Config.NoColor,
+		Indent:        "  ",
+	})
 }
 
 // Context returns the underlying context.

--- a/internal/config/run_context.go
+++ b/internal/config/run_context.go
@@ -68,12 +68,24 @@ func EmptyRunContext() *RunContext {
 	}
 }
 
+var (
+	outputIndent = "  "
+)
+
+// NewWarningWriter returns a function that can be used to write a message to the RunContext.ErrWriter.
+// This can be useful to pass to functions or structs that don't use a full RunContext.
+func (r *RunContext) NewWarningWriter() ui.WriteWarningFunc {
+	return func(msg string) {
+		fmt.Fprintf(r.ErrWriter, "%s%s %s\n", outputIndent, ui.WarningString("Warning:"), msg)
+	}
+}
+
 // NewSpinner returns an ui.Spinner built from the RunContext.
 func (r *RunContext) NewSpinner(msg string) *ui.Spinner {
 	return ui.NewSpinner(msg, ui.SpinnerOptions{
 		EnableLogging: r.Config.IsLogging(),
 		NoColor:       r.Config.NoColor,
-		Indent:        "  ",
+		Indent:        outputIndent,
 	})
 }
 

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -86,7 +86,7 @@ func (m *ModuleLoader) tfManifestFilePath() string {
 // If not then it downloads the module from the registry or from a remote source and updates the module manifest with the latest metadata.
 func (m *ModuleLoader) Load() (*Manifest, error) {
 	if m.newSpinner != nil {
-		spin := m.newSpinner("Loading Terraform modules, if this is your first time running Infracost (HCL) in this directory this could take a while")
+		spin := m.newSpinner("Downloading Terraform modules")
 		defer spin.Success()
 	}
 

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -222,9 +222,9 @@ func (p *Parser) ParseDirectory() (*Module, error) {
 		if p.writeWarning != nil {
 			p.writeWarning(
 				fmt.Sprintf(
-					"Input values were not provided for the following Terraform variables: %s. %s",
+					"Input values were not provided for following Terraform variables: %s. %s",
 					strings.TrimRight(strings.Join(v, ", "), ", "),
-					"Use --terraform-var-file or --terraform-var to specify input vars.",
+					"Use --terraform-var-file or --terraform-var to specify them.",
 				),
 			)
 		}

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -83,7 +83,7 @@ func OptionWithBlockBuilder(blockBuilder BlockBuilder) Option {
 
 // OptionWithSpinner sets a SpinnerFunc onto the Parser. With this option enabled
 // the Parser will send progress to the Spinner. This is disabled by default as
-// we run the Parser concurrently underneath DirProvider and don't want to mess with it's output.
+// we run the Parser concurrently underneath DirProvider and don't want to mess with its output.
 func OptionWithSpinner(f ui.SpinnerFunc) Option {
 	return func(p *Parser) {
 		p.newSpinner = f
@@ -92,7 +92,7 @@ func OptionWithSpinner(f ui.SpinnerFunc) Option {
 
 // OptionWithWarningFunc will set the Parser writeWarning to the provided f.
 // This is disabled by default as we run the Parser concurrently underneath a
-// DirProvider and don't want to mess with it's output.
+// DirProvider and don't want to mess with its output.
 func OptionWithWarningFunc(f ui.WriteWarningFunc) Option {
 	return func(p *Parser) {
 		p.writeWarning = f

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -20,7 +20,7 @@ import (
 )
 
 // ValidationError represents an error that is raised because provider conditions are not met.
-// This error is commonly used to show requirements to as user running an Infracost command.
+// This error is commonly used to show requirements to a user running an Infracost command.
 type ValidationError struct {
 	err  string
 	warn string
@@ -29,7 +29,7 @@ type ValidationError struct {
 // Warn returns the ValidationError warning message. A warning highlights a potential issue with runtime
 // configuration but a condition that the Provider can proceed with.
 //
-// Warn can return nil if the there are no validation warnings.
+// Warn can return nil if there are no validation warnings.
 func (e ValidationError) Warn() *string {
 	if e.warn == "" {
 		return nil

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -60,7 +60,7 @@ func varsFromPlanFlags(planFlags string) (vars, error) {
 // NewHCLProvider returns a HCLProvider with a hcl.Parser initialised using the config.ProjectContext.
 // It will use input flags from either the terraform-plan-flags or top level var and var-file flags to
 // set input vars and files on the underlying hcl.Parser.
-func NewHCLProvider(ctx *config.ProjectContext, provider *PlanJSONProvider) (*HCLProvider, error) {
+func NewHCLProvider(ctx *config.ProjectContext, provider *PlanJSONProvider, opts ...hcl.Option) (*HCLProvider, error) {
 	v, err := varsFromPlanFlags(ctx.ProjectConfig.TerraformPlanFlags)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse vars from plan flags %w", err)
@@ -79,6 +79,7 @@ func NewHCLProvider(ctx *config.ProjectContext, provider *PlanJSONProvider) (*HC
 		options = append(options, withVars)
 	}
 
+	options = append(options, opts...)
 	p := hcl.New(ctx.ProjectConfig.Path, options...)
 
 	return &HCLProvider{

--- a/internal/ui/print.go
+++ b/internal/ui/print.go
@@ -9,6 +9,10 @@ import (
 	"github.com/infracost/infracost/internal/version"
 )
 
+// WriteWarningFunc defines an interface that writes the provided msg as a warning
+// to an underlying writer.
+type WriteWarningFunc func(msg string)
+
 func PrintSuccess(w io.Writer, msg string) {
 	fmt.Fprintf(w, "%s %s\n", SuccessString("Success:"), msg)
 }

--- a/internal/ui/spin.go
+++ b/internal/ui/spin.go
@@ -22,6 +22,10 @@ type Spinner struct {
 	opts    SpinnerOptions
 }
 
+// SpinnerFunc defines a function that returns a Spinner which can be used
+// to report the progress of a certain action.
+type SpinnerFunc func(msg string) *Spinner
+
 func NewSpinner(msg string, opts SpinnerOptions) *Spinner {
 	spinnerCharNumb := 14
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Improves HCL provider status outputs.

1. Adds two spinners to the HCL provider logic that loads modules and evaluates blocks. Output now looks like:

```
Detected Terraform directory (HCL) at ***
  ✔ Downloading Terraform modules
  ✔ Evaluating Terraform directory
  ✔ Retrieving cloud prices to calculate costs

Project: ***
```

2. adds warning log for missing vars:

```
  ✔ Downloading Terraform modules
  Warning: Input values were not provided for the following Terraform variables: 'variable.foo', 'variable.baz'. Use --terraform-var-file or --terraform-var to specify input vars.
  ✔ Evaluating Terraform directory
  ✔ Retrieving cloud prices to calculate costs
```

3. Adds error messaging for incompatible project types:

**terragrunt**
```
Error: Terragrunt projects are not yet supported by the parse HCL option.
```

**cloudformation**
```
Error: CloudFormation projects are not yet supported by the parse HCL option.
```

**use state**
```
Error: Flags terraform-use-state and terraform-parse-hcl are incompatible

Run again without --terraform-use-state.
```

**state or plan json path type**
```
Error: Path type cannot be a Terraform plan JSON file when using the parse HCL option

Set --path to a Terraform directory.
```
or 
```
Error: Path type cannot be a Terraform state file when using the parse HCL option

Set --path to a Terraform directory.
```

**TF_VARS** :

```
Detected Terraform directory (HCL) at examples/terraform
Warning: The parse HCL option does not support use of TF_VARS through environment variables, use --terraform-var-file or --terraform-var instead.
  ✔ Downloading Terraform modules
  ✔ Evaluating Terraform directory
  ✔ Retrieving cloud prices to calculate costs
```
