### PR TITLE
chore: Add post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,28 @@
+on:
+  release:
+    types: [published]
+
+name: Upload post-release assets
+
+jobs:
+  update-choco-version:
+    name: Update Chocolatey version
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://api.github.com/repos/infracost/chocolatey-packages/dispatches \
+            -d '{"event_type":"infracost_choco"}'
+
+  update-atlantis-versions:
+    name: Update Atlantis versions
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            https://api.github.com/repos/infracost/infracost-atlantis/dispatches \
+            -d '{"event_type":"infracost_atlantis"}'


### PR DESCRIPTION
After the new release is published we can safely trigger release
workflows in other repos.

Atlantis repo: https://github.com/infracost/infracost-atlantis/pull/51
Related: https://github.com/infracost/infracost/pull/1560