### PR TITLE
feat(aws): Add launch template support for Instance resource

### DIFF
--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
@@ -65,6 +65,24 @@
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
+ aws_instance.instance_withLaunchTemplateById                                                               
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               730  hours                       $32.19 
+ ├─ EC2 detailed monitoring                                           7  metrics                      $2.10 
+ ├─ CPU credits                                                   1,460  vCPU-hours                  $73.00 
+ └─ root_block_device                                                                                       
+    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
+                                                                                                            
+ aws_instance.instance_withLaunchTemplateByName                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               730  hours                       $32.19 
+ ├─ EC2 detailed monitoring                                           7  metrics                      $2.10 
+ └─ root_block_device                                                                                       
+    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
+                                                                                                            
+ aws_instance.instance_withLaunchTemplateOverride                                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.large)                730  hours                       $60.74 
+ └─ root_block_device                                                                                       
+    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
+                                                                                                            
  aws_instance.std_1yr_all_upfront                                                                           
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
  └─ root_block_device                                                                                       
@@ -127,10 +145,12 @@
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
- OVERALL TOTAL                                                                                      $992.14 
+ OVERALL TOTAL                                                                                    $1,196.86 
 ──────────────────────────────────
-23 cloud resources were detected:
-∙ 22 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+27 cloud resources were detected:
+∙ 25 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free:
+  ∙ 1 x aws_launch_template
 ∙ 1 is not supported yet, see https://infracost.io/requested-resources:
   ∙ 1 x aws_instance
 Logs:

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
@@ -164,3 +164,52 @@ resource "aws_instance" "cnvr_3yr_all_upfront" {
   ami           = "fake_ami"
   instance_type = "t3.medium"
 }
+
+resource "aws_launch_template" "example" {
+  name = "example-lt"
+
+  image_id      = "fake_ami"
+  instance_type = "t3.medium"
+  ebs_optimized = true
+
+  monitoring {
+    enabled = true
+  }
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+
+  placement {
+    tenancy = "dedicated"
+  }
+}
+
+resource "aws_instance" "instance_withLaunchTemplateById" {
+  launch_template {
+    id = aws_launch_template.example.id
+  }
+}
+
+resource "aws_instance" "instance_withLaunchTemplateByName" {
+  launch_template {
+    name = aws_launch_template.example.name
+  }
+}
+
+resource "aws_instance" "instance_withLaunchTemplateOverride" {
+  ami           = "overriden-fake_ami"
+  instance_type = "t3.large"
+  ebs_optimized = false
+
+  monitoring = false
+  tenancy    = "default"
+
+  credit_specification {
+    cpu_credits = "standard"
+  }
+
+  launch_template {
+    id = aws_launch_template.example.id
+  }
+}

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
@@ -71,3 +71,11 @@ resource_usage:
     reserved_instance_type: convertible
     reserved_instance_term: 3_year
     reserved_instance_payment_option: all_upfront
+
+  aws_instance.instance_withLaunchTemplateById:
+    monthly_cpu_credit_hrs: 730
+    vcpu_count: 2
+
+  aws_instance.instance_withLaunchTemplateOverride:
+    monthly_cpu_credit_hrs: 730
+    vcpu_count: 2


### PR DESCRIPTION
Launch template can also define EBS volumes that can be overriden by Instance's block. This will be addressed separately.