### PR TITLE
chore: add explicit permission for release job

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Upload Release Asset
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go 1.x


### PR DESCRIPTION
This enables us to lock down our org-wide default to just `contents: read`.

See: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/

After this, I'll update the org-wide default, and then we can merge https://github.com/infracost/infracost/pull/1565.