### PR TITLE
fix(hcl): evalute modules in order of reference

### DIFF
--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -133,8 +133,8 @@ func goldenFileCommandTest(t *testing.T, testName string, args []string, testOpt
 		_, err := os.Stat(hclFilePath)
 		if err == nil {
 			testutil.AssertGoldenFile(t, hclFilePath, actual)
+			return
 		}
-		return
 	}
 
 	testutil.AssertGoldenFile(t, goldenFilePath, actual)

--- a/cmd/infracost/hcl_test.go
+++ b/cmd/infracost/hcl_test.go
@@ -53,3 +53,15 @@ func TestHCLModuleOutputCounts(t *testing.T) {
 		&GoldenFileOptions{RunHCL: true},
 	)
 }
+
+func TestHCLModuleOutputCountsNested(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		&GoldenFileOptions{OnlyRunHCL: true},
+	)
+}

--- a/cmd/infracost/testdata/hclmodule_output_counts_nested/hclmodule_output_counts_nested.golden
+++ b/cmd/infracost/testdata/hclmodule_output_counts_nested/hclmodule_output_counts_nested.golden
@@ -1,0 +1,10 @@
+Project: infracost/infracost/cmd/infracost/testdata/hclmodule_output_counts_nested
+
+ Name  Monthly Qty  Unit  Monthly Cost 
+                                       
+ OVERALL TOTAL                   $0.00 
+──────────────────────────────────
+No cloud resources were detected
+
+Err:
+

--- a/cmd/infracost/testdata/hclmodule_output_counts_nested/main.tf
+++ b/cmd/infracost/testdata/hclmodule_output_counts_nested/main.tf
@@ -6,12 +6,9 @@ provider "aws" {
   secret_key                  = "mock_secret_key"
 }
 
-resource "aws_eip" "t" {
-  count = module.this.enabled ? 1 : 0
-
-  tags = {
-    "test" : module.this.enabled
-  }
+module "sub" {
+  source = "./modules/sub"
+  enabled = module.this.enabled
 }
 
 module "this" {

--- a/cmd/infracost/testdata/hclmodule_output_counts_nested/modules/sub/main.tf
+++ b/cmd/infracost/testdata/hclmodule_output_counts_nested/modules/sub/main.tf
@@ -1,0 +1,8 @@
+variable "enabled" {
+  type = bool
+  default = false
+}
+
+resource "aws_eip" "t" {
+  count = var.enabled ? 1 : 0
+}

--- a/cmd/infracost/testdata/hclmodule_output_counts_nested/modules/test/main.tf
+++ b/cmd/infracost/testdata/hclmodule_output_counts_nested/modules/test/main.tf
@@ -1,0 +1,13 @@
+locals {
+  enabled = var.enabled
+}
+
+variable "enabled" {
+  type    = bool
+  default = null
+}
+
+output "enabled" {
+  value       = local.enabled
+  description = "True if module is enabled, false otherwise"
+}

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -521,7 +521,8 @@ func (e *Evaluator) loadModule(b *Block) (*ModuleCall, error) {
 func (e *Evaluator) loadModules() []*ModuleCall {
 	var moduleDefinitions []*ModuleCall
 
-	expanded := e.expandBlocks(e.module.Blocks.OfType("module"))
+	// @todo if a module uses a count that depends on a module output, then the block expansion might be incorrect.
+	expanded := e.expandBlocks(e.module.Blocks.ModuleBlocks())
 
 	for _, moduleBlock := range expanded {
 		if moduleBlock.Label() == "" {

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -521,7 +521,7 @@ func (e *Evaluator) loadModule(b *Block) (*ModuleCall, error) {
 func (e *Evaluator) loadModules() []*ModuleCall {
 	var moduleDefinitions []*ModuleCall
 
-	// @todo if a module uses a count that depends on a module output, then the block expansion might be incorrect.
+	// TODO: if a module uses a count that depends on a module output, then the block expansion might be incorrect.
 	expanded := e.expandBlocks(e.module.Blocks.ModuleBlocks())
 
 	for _, moduleBlock := range expanded {


### PR DESCRIPTION
Fixed issue where modules that used outputs from a module that appeared after them in the file structure received null values. 

For example:

```
module "sub" {
  source = "./modules/sub"
  some_var = module.this.output
}

module "this" {
  source  = "./modules/test"
  enabled = false
}
```

`module.sub` would receive a `null` value for `some_var`. This caused discrepancies in HCL cost estimates as resources that depended on these module inputs were provided with incorrect values.

This problem was caused by the fact we evaluated module blocks by order of occurrence in the HCL file.

This PR resolves this issue by sorting module blocks by reference so that we evaluate blocks whose outputs are used by other modules first.
