### PR TITLE
fix: fix polluting the OS env variables

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -368,10 +368,6 @@ func (r *parallelRunner) runProjectConfig(ctx *config.ProjectContext) (*projectO
 		defer mux.Unlock()
 	}
 
-	for k, v := range ctx.ProjectConfig.Env {
-		os.Setenv(k, v)
-	}
-
 	provider, err := providers.Detect(ctx, r.prior == nil)
 	var warn *string
 	if v, ok := err.(*providers.ValidationError); ok {
@@ -620,7 +616,7 @@ func (r *parallelRunner) generateUsageFile(ctx *config.ProjectContext, provider 
 	spinner := ui.NewSpinner("Syncing usage data from cloud", spinnerOpts)
 	defer spinner.Fail()
 
-	syncResult, err := usage.SyncUsageData(usageFile, providerProjects)
+	syncResult, err := usage.SyncUsageData(ctx, usageFile, providerProjects)
 
 	if err != nil {
 		spinner.Fail()

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -348,22 +348,27 @@ func goldenFileSyncTest(t *testing.T, pName, testName string) {
 		},
 	}
 
+	projectCtx := config.NewProjectContext(
+		runCtx,
+		&config.Project{},
+	)
+
 	usageFilePath := filepath.Join("testdata", testName, testName+"_existing_usage.yml")
 	projects := loadResources(t, pName, tfProject, runCtx, map[string]*schema.UsageData{})
 
-	actual := RunSyncUsage(t, projects, usageFilePath)
+	actual := RunSyncUsage(t, projectCtx, projects, usageFilePath)
 	require.NoError(t, err)
 
 	goldenFilePath := filepath.Join("testdata", testName, testName+".golden")
 	testutil.AssertGoldenFile(t, goldenFilePath, actual)
 }
 
-func RunSyncUsage(t *testing.T, projects []*schema.Project, usageFilePath string) []byte {
+func RunSyncUsage(t *testing.T, projectCtx *config.ProjectContext, projects []*schema.Project, usageFilePath string) []byte {
 	t.Helper()
 	usageFile, err := usage.LoadUsageFile(usageFilePath)
 	require.NoError(t, err)
 
-	_, err = usage.SyncUsageData(usageFile, projects)
+	_, err = usage.SyncUsageData(projectCtx, usageFile, projects)
 	require.NoError(t, err)
 
 	out := filepath.Join(t.TempDir(), "actual_usage.yml")

--- a/internal/usage/aws/configuration.go
+++ b/internal/usage/aws/configuration.go
@@ -3,6 +3,9 @@ package aws
 
 import (
 	"context"
+	"os"
+	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -11,6 +14,8 @@ import (
 type ctxConfigOptsKeyType struct{}
 
 var ctxConfigOptsKey = &ctxConfigOptsKeyType{}
+
+var configMux sync.Mutex
 
 func getConfig(ctx context.Context, region string) (aws.Config, error) {
 	opts := []func(*config.LoadOptions) error{
@@ -22,6 +27,33 @@ func getConfig(ctx context.Context, region string) (aws.Config, error) {
 		opts = append(opts, ctxOpts...)
 	}
 
+	// We want to set the OS env so that the AWS config loader picks up any AWS_*
+	// env vars set in the Infracost config file. We use a mutex for this since
+	// it's run in parallel and os.Setenv sets the global OS env for the process.
+	configMux.Lock()
+	defer configMux.Unlock()
+
+	var oldEnv []string
+
+	env, hasEnv := ctx.Value("env").(map[string]string)
+	if hasEnv {
+		oldEnv = os.Environ()
+		for k, v := range env {
+			os.Setenv(k, v)
+		}
+	}
+
 	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	resetEnv(oldEnv)
 	return cfg, err
+}
+
+func resetEnv(items []string) {
+	os.Clearenv()
+	for _, item := range items {
+		parts := strings.SplitN(item, "=", 2)
+		if len(parts) == 2 {
+			os.Setenv(parts[0], parts[1])
+		}
+	}
 }

--- a/internal/usage/sync.go
+++ b/internal/usage/sync.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/schema"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -51,7 +52,7 @@ func (s *SyncResult) ProjectContext() map[string]interface{} {
 	return r
 }
 
-func SyncUsageData(usageFile *UsageFile, projects []*schema.Project) (*SyncResult, error) {
+func SyncUsageData(projectCtx *config.ProjectContext, usageFile *UsageFile, projects []*schema.Project) (*SyncResult, error) {
 	referenceFile, err := LoadReferenceFile()
 	if err != nil {
 		return nil, err
@@ -64,7 +65,7 @@ func SyncUsageData(usageFile *UsageFile, projects []*schema.Project) (*SyncResul
 		resources = append(resources, project.Resources...)
 	}
 
-	syncResult := syncResourceUsages(usageFile, resources, referenceFile)
+	syncResult := syncResourceUsages(projectCtx, usageFile, resources, referenceFile)
 
 	return syncResult, nil
 }
@@ -74,7 +75,7 @@ type syncResourceResult struct {
 	sr *SyncResult
 }
 
-func syncResourceUsages(usageFile *UsageFile, resources []*schema.Resource, referenceFile *ReferenceFile) *SyncResult {
+func syncResourceUsages(projectCtx *config.ProjectContext, usageFile *UsageFile, resources []*schema.Resource, referenceFile *ReferenceFile) *SyncResult {
 	syncResult := &SyncResult{
 		EstimationErrors: make(map[string]error),
 	}
@@ -112,7 +113,7 @@ func syncResourceUsages(usageFile *UsageFile, resources []*schema.Resource, refe
 	for i := 0; i < numWorkers; i++ {
 		go func(jobs <-chan *schema.Resource, results chan<- syncResourceResult) {
 			for r := range jobs {
-				ru, sr := syncResource(r, referenceFile, existingResourceUsagesMap)
+				ru, sr := syncResource(projectCtx, r, referenceFile, existingResourceUsagesMap)
 				results <- syncResourceResult{ru, sr}
 			}
 		}(jobs, results)
@@ -174,7 +175,7 @@ func syncWildCardResource(wildCardResources map[string]bool, resource *schema.Re
 	return resourceUsage
 }
 
-func syncResource(resource *schema.Resource, referenceFile *ReferenceFile, existingResourceUsagesMap map[string]*ResourceUsage) (*ResourceUsage, *SyncResult) {
+func syncResource(projectCtx *config.ProjectContext, resource *schema.Resource, referenceFile *ReferenceFile, existingResourceUsagesMap map[string]*ResourceUsage) (*ResourceUsage, *SyncResult) {
 	syncResult := &SyncResult{
 		EstimationErrors: make(map[string]error),
 	}
@@ -208,7 +209,9 @@ func syncResource(resource *schema.Resource, referenceFile *ReferenceFile, exist
 		syncResult.EstimationCount++
 
 		resourceUsageMap := resourceUsage.Map()
-		err := resource.EstimateUsage(context.TODO(), resourceUsageMap)
+
+		ctx := context.WithValue(context.Background(), "env", projectCtx.ProjectConfig.Env)
+		err := resource.EstimateUsage(ctx, resourceUsageMap)
 		if err != nil {
 			syncResult.EstimationErrors[resource.Name] = err
 			log.Warnf("Error estimating usage for resource %s: %v", resource.Name, err)


### PR DESCRIPTION
We were setting os.Setenv at the top level to make sure that the sync usage functionality got any AWS_* creds set in the config file's env block. However, this can cause race conditions across goroutines, so instead we pass the project's env vars through to where we load the AWS config and use a mutex when loading this.