### PR TITLE
fix: change post release workflow to use PAT

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -12,7 +12,7 @@ jobs:
       - run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'authorization: Bearer ${{ secrets.POST_RELEASE_TRIGGERS_TOKEN }}' \
             https://api.github.com/repos/infracost/chocolatey-packages/dispatches \
             -d '{"event_type":"infracost_choco"}'
 
@@ -23,6 +23,6 @@ jobs:
       - run: |
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            -H 'authorization: Bearer ${{ secrets.POST_RELEASE_TRIGGERS_TOKEN }}' \
             https://api.github.com/repos/infracost/infracost-atlantis/dispatches \
             -d '{"event_type":"infracost_atlantis"}'


### PR DESCRIPTION
changes post release workflows to use a correctly scoped personal access token