### PR TITLE
fix: remove spinner if workspace does not use remote execution

### DIFF
--- a/internal/hcl/remote_variables_loader.go
+++ b/internal/hcl/remote_variables_loader.go
@@ -141,7 +141,7 @@ func (r *RemoteVariablesLoader) Load(blocks Blocks) (map[string]cty.Value, error
 	}
 
 	if workspaceResponse.Data.Attributes.ExecutionMode != "remote" {
-		log.Debugf("Terraform workspace %s does not use remote execution continuing with local execution", config.workspace)
+		log.Debugf("Terraform workspace %s does not use remote execution, skipping downloading remote variables", config.workspace)
 		return vars, nil
 	}
 


### PR DESCRIPTION
only new up a spinner if the execution mode is remote