### PR TITLE
feat: Enable -no-color option by default for CI

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -215,6 +215,9 @@ func handleUpdateMessage(updateMessageChan chan *update.Info) {
 }
 
 func loadGlobalFlags(ctx *config.RunContext, cmd *cobra.Command) error {
+	if ctx.IsCIRun() {
+		ctx.Config.NoColor = true
+	}
 	if cmd.Flags().Changed("no-color") {
 		ctx.Config.NoColor, _ = cmd.Flags().GetBool("no-color")
 	}


### PR DESCRIPTION
Atlantis before the fix:
```
time="2022-05-06T16:33:09Z" level=info msg="Detected Terraform directory (HCL) at ."
time="2022-05-06T16:33:09Z" level=info msg="Starting: Downloading Terraform modules"
time="2022-05-06T16:33:09Z" level=info msg="Starting: Evaluating Terraform directory"
time="2022-05-06T16:33:09Z" level=info msg="Starting: Retrieving cloud prices to calculate costs"
time="2022-05-06T16:33:11Z" level=info msg="Output saved to /tmp/infracost.json"

�[33mUpdate:�[0m A new version of Infracost is available: �[96m0.9.23�[0m → �[96mv0.9.24�[0m
  $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh

Comment posted to GitHub

�[33mUpdate:�[0m A new version of Infracost is available: �[96m0.9.23�[0m → �[96mv0.9.24�[0m
  $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
```

Atlantis after fix:
```
time="2022-05-06T16:38:42Z" level=info msg="Detected Terraform directory (HCL) at ."
time="2022-05-06T16:38:42Z" level=info msg="Starting: Downloading Terraform modules"
time="2022-05-06T16:38:42Z" level=info msg="Starting: Evaluating Terraform directory"
time="2022-05-06T16:38:42Z" level=info msg="Starting: Retrieving cloud prices to calculate costs"
time="2022-05-06T16:38:43Z" level=info msg="Output saved to /tmp/infracost.json"

Update: A new version of Infracost is available: 0.9.23 → v0.9.24
  $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh

Comment posted to GitHub

Update: A new version of Infracost is available: 0.9.23 → v0.9.24
  $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
```

It is still possible to enforce colors when setting `--no-color=false`:
```
time="2022-05-06T16:39:31Z" level=info msg="Detected Terraform directory (HCL) at ."
time="2022-05-06T16:39:31Z" level=info msg="Starting: Downloading Terraform modules"
time="2022-05-06T16:39:31Z" level=info msg="Starting: Evaluating Terraform directory"
time="2022-05-06T16:39:31Z" level=info msg="Starting: Retrieving cloud prices to calculate costs"
time="2022-05-06T16:39:33Z" level=info msg="Output saved to /tmp/infracost.json"

�[33mUpdate:�[0m A new version of Infracost is available: �[96m0.9.23�[0m → �[96mv0.9.24�[0m
  $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh

Comment posted to GitHub

Update: A new version of Infracost is available: 0.9.23 → v0.9.24
  $ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh
```