### PR TITLE
fix: support for references with for_each

### DIFF
--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -524,7 +524,7 @@ func (p *Parser) parseConfReferences(resData map[string]*schema.ResourceData, co
 	found := false
 
 	for _, ref := range refs {
-		if ref == "count.index" || strings.HasPrefix(ref, "var.") {
+		if ref == "count.index" || ref == "each.key" || strings.HasPrefix(ref, "var.") {
 			continue
 		}
 
@@ -537,12 +537,21 @@ func (p *Parser) parseConfReferences(resData map[string]*schema.ResourceData, co
 		refData, ok := resData[refAddr]
 
 		// if there's a count ref value then try with the array index of the count ref
-		if !ok && containsString(refs, "count.index") {
-			a := fmt.Sprintf("%s[%d]", refAddr, addressCountIndex(d.Address))
-			refData, ok = resData[a]
+		if !ok {
+			if containsString(refs, "count.index") {
+				a := fmt.Sprintf("%s[%d]", refAddr, addressCountIndex(d.Address))
+				refData, ok = resData[a]
 
-			if ok {
-				log.Debugf("reference specifies a count: using resource %s for %s.%s", a, d.Address, attr)
+				if ok {
+					log.Debugf("reference specifies a count: using resource %s for %s.%s", a, d.Address, attr)
+				}
+			} else if containsString(refs, "each.key") {
+				a := fmt.Sprintf("%s[\"%s\"]", refAddr, addressKey(d.Address))
+				refData, ok = resData[a]
+
+				if ok {
+					log.Debugf("reference specifies a key: using resource %s for %s.%s", a, d.Address, attr)
+				}
 			}
 		}
 
@@ -670,6 +679,17 @@ func addressCountIndex(addr string) int {
 	}
 
 	return -1
+}
+
+func addressKey(addr string) string {
+	r := regexp.MustCompile(`\["([^"]+)"\]`)
+	m := r.FindStringSubmatch(addr)
+
+	if len(m) > 0 {
+		return m[1]
+	}
+
+	return ""
 }
 
 func removeAddressArrayPart(addr string) string {

--- a/internal/providers/terraform/parser_test.go
+++ b/internal/providers/terraform/parser_test.go
@@ -47,6 +47,34 @@ func TestParseJSONResources(t *testing.T) {
 		},
 		{
 			expected: &schema.Resource{
+				Name:         "aws_cloudwatch_log_group.each_resource[\"0\"]",
+				ResourceType: "aws_cloudwatch_log_group",
+				IsSkipped:    false,
+				NoPrice:      false,
+				CostComponents: []*schema.CostComponent{
+					{
+						Name:            "Data ingested",
+						MonthlyQuantity: &decimal.Zero,
+					},
+				},
+			},
+		},
+		{
+			expected: &schema.Resource{
+				Name:         "aws_cloudwatch_log_group.each_resource[\"1\"]",
+				ResourceType: "aws_cloudwatch_log_group",
+				IsSkipped:    false,
+				NoPrice:      false,
+				CostComponents: []*schema.CostComponent{
+					{
+						Name:            "Data ingested",
+						MonthlyQuantity: &decimal.Zero,
+					},
+				},
+			},
+		},
+		{
+			expected: &schema.Resource{
 				Name:         "aws_cloudwatch_log_group.non_array_resource",
 				ResourceType: "aws_cloudwatch_log_group",
 				IsSkipped:    false,
@@ -95,6 +123,38 @@ func TestParseJSONResources(t *testing.T) {
 						"values": {
 							"kms_key_id":null,
 							"name":"log-group1",
+							"name_prefix":null,
+							"retention_in_days":0,
+							"tags":null
+						}
+					},
+					{
+						"address":"aws_cloudwatch_log_group.each_resource[\"0\"]",
+						"mode":"managed",
+						"type":"aws_cloudwatch_log_group",
+						"name":"each_resource",
+						"index":"0",
+						"provider_name":"registry.terraform.io/hashicorp/aws",
+						"schema_version":0,
+						"values": {
+							"kms_key_id":null,
+							"name":"log-group0",
+							"name_prefix":null,
+							"retention_in_days":0,
+							"tags":null
+						}
+					},
+					{
+						"address":"aws_cloudwatch_log_group.each_resource[\"1\"]",
+						"mode":"managed",
+						"type":"aws_cloudwatch_log_group",
+						"name":"each_resource",
+						"index":"1",
+						"provider_name":"registry.terraform.io/hashicorp/aws",
+						"schema_version":0,
+						"values": {
+							"kms_key_id":null,
+							"name":"log-group0",
 							"name_prefix":null,
 							"retention_in_days":0,
 							"tags":null
@@ -159,6 +219,56 @@ func TestParseJSONResources(t *testing.T) {
 					"after": {
 						"kms_key_id":null,
 						"name":"log-group1",
+						"name_prefix":null,
+						"retention_in_days":0,
+						"tags":null
+					},
+					"after_unknown": {
+						"arn":true,
+						"id":true
+					}
+				}
+			},
+			{
+				"address":"aws_cloudwatch_log_group.each_resource[\"0\"]",
+				"mode":"managed",
+				"type":"aws_cloudwatch_log_group",
+				"name":"each_resource",
+				"index":"0",
+				"provider_name":"registry.terraform.io/hashicorp/aws",
+				"change": {
+					"actions": [
+						"create"
+					],
+					"before":null,
+					"after": {
+						"kms_key_id":null,
+						"name":"log-group0",
+						"name_prefix":null,
+						"retention_in_days":0,
+						"tags":null
+					},
+					"after_unknown": {
+						"arn":true,
+						"id":true
+					}
+				}
+			},
+			{
+				"address":"aws_cloudwatch_log_group.each_resource[\"1\"]",
+				"mode":"managed",
+				"type":"aws_cloudwatch_log_group",
+				"name":"each_resource",
+				"index":"1",
+				"provider_name":"registry.terraform.io/hashicorp/aws",
+				"change": {
+					"actions": [
+						"create"
+					],
+					"before":null,
+					"after": {
+						"kms_key_id":null,
+						"name":"log-group0",
 						"name_prefix":null,
 						"retention_in_days":0,
 						"tags":null
@@ -247,6 +357,27 @@ func TestParseJSONResources(t *testing.T) {
 							}
 						},
 						{
+							"address":"aws_cloudwatch_log_group.each_resource",
+							"mode":"managed",
+							"type":"aws_cloudwatch_log_group",
+							"name":"each_resource",
+							"provider_config_key":"aws",
+							"expressions": {
+								"name": {
+									"references": [
+										"each.key"
+									]
+								}
+							},
+							"schema_version":0,
+							"for_each_expression": {
+								"references": [
+									"0",
+									"1"
+								]
+							}
+						},
+						{
 							"address":"aws_cloudwatch_log_group.non_array_resource",
 							"mode":"managed",
 							"type":"aws_cloudwatch_log_group",
@@ -269,6 +400,9 @@ func TestParseJSONResources(t *testing.T) {
 
 	usage := schema.NewUsageMap(map[string]interface{}{
 		"aws_cloudwatch_log_group.array_resource[*]": map[string]interface{}{
+			"monthly_data_ingested_gb": 0,
+		},
+		"aws_cloudwatch_log_group.each_resource[*]": map[string]interface{}{
 			"monthly_data_ingested_gb": 0,
 		},
 	})


### PR DESCRIPTION
Fixes #1545.

As described in the issue, terraform resources created via `for_each` and referenced with `each.key` are ignored due to the address not matching.
This PR adds support for `each.key` references the exact same way it was done with `count.index`, bringing the expected results to the two examples provided in the issue:

## Example 1
**Terraform code:**

```terraform
provider "aws" {
  region                      = "us-east-1"
  skip_credentials_validation = true
  skip_requesting_account_id  = true
  access_key                  = "mock_access_key"
  secret_key                  = "mock_secret_key"
}

resource "aws_ebs_volume" "my_volume" {
  for_each          = toset(["us-east-1a", "us-east-1b"])
  availability_zone = each.key
  size              = 20
}

resource "aws_ebs_snapshot" "my_snapshot" {
  for_each  = aws_ebs_volume.my_volume
  volume_id = aws_ebs_volume.my_volume[each.key].id
}
```

**Current infracost result:** 
```
Name                                                            Monthly Qty  Unit                        Monthly Cost 
                                                                                                                       
 aws_ebs_snapshot.my_snapshot["us-east-1a"]                                                                            
 ├─ EBS snapshot storage                                                   8  GB                                 $0.40 
 ├─ Fast snapshot restore                                Monthly cost depends on usage: $0.75 per DSU-hours            
 ├─ ListChangedBlocks & ListSnapshotBlocks API requests  Monthly cost depends on usage: $0.0006 per 1k requests        
 ├─ GetSnapshotBlock API requests                        Monthly cost depends on usage: $0.003 per 1k SnapshotAPIUnits 
 └─ PutSnapshotBlock API requests                        Monthly cost depends on usage: $0.006 per 1k SnapshotAPIUnits 
                                                                                                                       
 aws_ebs_snapshot.my_snapshot["us-east-1b"]                                                                            
 ├─ EBS snapshot storage                                                   8  GB                                 $0.40 
 ├─ Fast snapshot restore                                Monthly cost depends on usage: $0.75 per DSU-hours            
 ├─ ListChangedBlocks & ListSnapshotBlocks API requests  Monthly cost depends on usage: $0.0006 per 1k requests        
 ├─ GetSnapshotBlock API requests                        Monthly cost depends on usage: $0.003 per 1k SnapshotAPIUnits 
 └─ PutSnapshotBlock API requests                        Monthly cost depends on usage: $0.006 per 1k SnapshotAPIUnits 
                                                                                                                       
 aws_ebs_volume.my_volume["us-east-1a"]                                                                                
 └─ Storage (general purpose SSD, gp2)                                    20  GB                                 $2.00 
                                                                                                                       
 aws_ebs_volume.my_volume["us-east-1b"]                                                                                
 └─ Storage (general purpose SSD, gp2)                                    20  GB                                 $2.00 
                                                                                                                       
 OVERALL TOTAL                                                                                                   $4.80 
──────────────────────────────────
4 cloud resources were detected:
∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
```

**Result with the fix provided by this PR:**
```
 Name                                                            Monthly Qty  Unit                        Monthly Cost 
                                                                                                                       
 aws_ebs_snapshot.my_snapshot["us-east-1a"]                                                                            
 ├─ EBS snapshot storage                                                  20  GB                                 $1.00 
 ├─ Fast snapshot restore                                Monthly cost depends on usage: $0.75 per DSU-hours            
 ├─ ListChangedBlocks & ListSnapshotBlocks API requests  Monthly cost depends on usage: $0.0006 per 1k requests        
 ├─ GetSnapshotBlock API requests                        Monthly cost depends on usage: $0.003 per 1k SnapshotAPIUnits 
 └─ PutSnapshotBlock API requests                        Monthly cost depends on usage: $0.006 per 1k SnapshotAPIUnits 
                                                                                                                       
 aws_ebs_snapshot.my_snapshot["us-east-1b"]                                                                            
 ├─ EBS snapshot storage                                                  20  GB                                 $1.00 
 ├─ Fast snapshot restore                                Monthly cost depends on usage: $0.75 per DSU-hours            
 ├─ ListChangedBlocks & ListSnapshotBlocks API requests  Monthly cost depends on usage: $0.0006 per 1k requests        
 ├─ GetSnapshotBlock API requests                        Monthly cost depends on usage: $0.003 per 1k SnapshotAPIUnits 
 └─ PutSnapshotBlock API requests                        Monthly cost depends on usage: $0.006 per 1k SnapshotAPIUnits 
                                                                                                                       
 aws_ebs_volume.my_volume["us-east-1a"]                                                                                
 └─ Storage (general purpose SSD, gp2)                                    20  GB                                 $2.00 
                                                                                                                       
 aws_ebs_volume.my_volume["us-east-1b"]                                                                                
 └─ Storage (general purpose SSD, gp2)                                    20  GB                                 $2.00 
                                                                                                                       
 OVERALL TOTAL                                                                                                   $6.00 
──────────────────────────────────
4 cloud resources were detected:
∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
```

## Example 2
**Terraform code:**

```terraform
provider "aws" {
  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
  skip_credentials_validation = true
  skip_requesting_account_id  = true
  access_key                  = "mock_access_key"
  secret_key                  = "mock_secret_key"
}

resource "aws_launch_configuration" "my_lc" {
  for_each      = toset(["t2.micro", "t3.medium"])
  image_id      = "fake_ami"
  instance_type = each.key
}

resource "aws_autoscaling_group" "my_asg" {
  for_each             = aws_launch_configuration.my_lc
  desired_capacity     = 2
  max_size             = 3
  min_size             = 1
  launch_configuration = aws_launch_configuration.my_lc[each.key].id
}
```

**Current infracost result:** 
```
 Name  Monthly Qty  Unit  Monthly Cost 
                                       
 OVERALL TOTAL                   $0.00 
──────────────────────────────────
4 cloud resources were detected:
∙ 2 were estimated
∙ 2 were free, rerun with --show-skipped to see details
```

**Result with the fix provided by this PR:**
```
Name                                                     Monthly Qty  Unit     Monthly Cost 
                                                                                             
 aws_autoscaling_group.my_asg["t2.micro"]                                                    
 └─ aws_launch_configuration.my_lc["t2.micro"]                                               
    ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)         1,460  hours          $16.94 
    ├─ EC2 detailed monitoring                                     14  metrics         $4.20 
    └─ root_block_device                                                                     
       └─ Storage (general purpose SSD, gp2)                       16  GB              $1.60 
                                                                                             
 aws_autoscaling_group.my_asg["t3.medium"]                                                   
 └─ aws_launch_configuration.my_lc["t3.medium"]                                              
    ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)        1,460  hours          $60.74 
    ├─ EC2 detailed monitoring                                     14  metrics         $4.20 
    └─ root_block_device                                                                     
       └─ Storage (general purpose SSD, gp2)                       16  GB              $1.60 
                                                                                             
 OVERALL TOTAL                                                                        $89.27 
──────────────────────────────────
4 cloud resources were detected:
∙ 2 were estimated
∙ 2 were free, rerun with --show-skipped to see details
```