### PR TITLE
feat: Add support for google_compute_per_instance_config

### DIFF
--- a/internal/providers/terraform/google/compute_instance_group_manager.go
+++ b/internal/providers/terraform/google/compute_instance_group_manager.go
@@ -10,7 +10,10 @@ func getComputeInstanceGroupManagerRegistryItem() *schema.RegistryItem {
 		Name:                "google_compute_instance_group_manager",
 		RFunc:               newComputeInstanceGroupManager,
 		Notes:               []string{"Multiple versions are not supported."},
-		ReferenceAttributes: []string{"version.0.instance_template"},
+		ReferenceAttributes: []string{"version.0.instance_template", "google_compute_per_instance_config.instance_group_manager"},
+		CustomRefIDFunc: func(d *schema.ResourceData) []string {
+			return []string{d.Get("self_link").String(), d.Get("name").String()}
+		},
 	}
 }
 
@@ -24,6 +27,9 @@ func newComputeInstanceGroupManager(d *schema.ResourceData, u *schema.UsageData)
 	targetSize := int64(1)
 	if d.Get("target_size").Exists() {
 		targetSize = d.Get("target_size").Int()
+	}
+	if len(d.References("google_compute_per_instance_config.instance_group_manager")) > 0 {
+		targetSize += int64(len(d.References("google_compute_per_instance_config.instance_group_manager")))
 	}
 
 	var machineType string

--- a/internal/providers/terraform/google/compute_per_instance_config.go
+++ b/internal/providers/terraform/google/compute_per_instance_config.go
@@ -1,0 +1,14 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getComputePerInstanceConfigRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:                "google_compute_per_instance_config",
+		NoPrice:             true,
+		ReferenceAttributes: []string{"instance_group_manager"},
+		Notes:               []string{"Free resource."},
+	}
+}

--- a/internal/providers/terraform/google/compute_per_instance_config_test.go
+++ b/internal/providers/terraform/google/compute_per_instance_config_test.go
@@ -1,0 +1,16 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestComputePerInstanceConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "compute_per_instance_config_test")
+}

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -53,6 +53,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getServiceNetworkingConnectionRegistryItem(),
 	getSQLDatabaseInstanceRegistryItem(),
 	getStorageBucketRegistryItem(),
+	getComputePerInstanceConfigRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/google/testdata/compute_per_instance_config_test/compute_per_instance_config_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_per_instance_config_test/compute_per_instance_config_test.golden
@@ -1,0 +1,14 @@
+
+ Name                                                 Monthly Qty  Unit   Monthly Cost 
+                                                                                       
+ google_compute_instance_group_manager.default                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)          730  hours         $3.88 
+ └─ SSD provisioned storage (pd-ssd)                          375  GB           $63.75 
+                                                                                       
+ OVERALL TOTAL                                                                  $67.63 
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 1 was estimated
+∙ 2 were free:
+  ∙ 1 x google_compute_instance_template
+  ∙ 1 x google_compute_per_instance_config

--- a/internal/providers/terraform/google/testdata/compute_per_instance_config_test/compute_per_instance_config_test.tf
+++ b/internal/providers/terraform/google/testdata/compute_per_instance_config_test/compute_per_instance_config_test.tf
@@ -1,0 +1,49 @@
+provider "google" {
+  credentials = "{\"type\":\"service_account\"}"
+  region      = "us-central1"
+}
+
+resource "google_compute_instance_template" "appserver" {
+  name = "appserver-template"
+
+  machine_type = "f1-micro"
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+  }
+
+  disk {
+    source_image = "debian-cloud/debian-9"
+    boot         = true
+    disk_type    = "pd-ssd"
+    disk_size_gb = "375"
+  }
+
+}
+
+resource "google_compute_instance_group_manager" "default" {
+  name = "default"
+
+  base_instance_name = "app"
+  zone               = "us-central1-a"
+
+  version {
+    instance_template = google_compute_instance_template.appserver.id
+  }
+
+  target_size = 0
+}
+
+resource "google_compute_per_instance_config" "default" {
+	name = "instance-1"
+	zone = google_compute_instance_group_manager.default.zone
+
+	instance_group_manager = google_compute_instance_group_manager.default.name
+
+	preserved_state {
+	  metadata = {
+	    instance_template = google_compute_instance_template.appserver.id
+	  }
+	}
+}


### PR DESCRIPTION
Closes #1644.

I was not entirely sure on how to implement this as `google_compute_per_instance_config` is a free resource that will increase the cost of `google_compute_instance_group_manager`.

I added a reversed reference from the `google_compute_instance_group_manager` resource to the `google_compute_per_instance_config` to increase the `target_size` and compute the actual cost, and did not add any cost for the `google_compute_per_instance_config` resource.