### PR TITLE
enhance: add logging for the Terragrunt library logs

### DIFF
--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -2,6 +2,9 @@ package terraform
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/gruntwork-io/terragrunt/aws_helper"
 	tgcli "github.com/gruntwork-io/terragrunt/cli"
 	"github.com/gruntwork-io/terragrunt/cli/tfsource"
@@ -11,13 +14,12 @@ import (
 	tgoptions "github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
 	"github.com/infracost/infracost/internal/hcl"
-	"sort"
-	"strings"
 
-	"github.com/hashicorp/go-getter"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/hashicorp/go-getter"
 
 	log "github.com/sirupsen/logrus"
 
@@ -132,9 +134,13 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 
 	var workingDirsToEstimate []*terragruntWorkingDirInfo
 
+	tgLog := log.StandardLogger().WithField("library", "terragrunt")
+
 	terragruntOptions := &tgoptions.TerragruntOptions{
 		TerragruntConfigPath:       terragruntConfigPath,
-		Logger:                     log.WithField("library", "terragrunt"),
+		Logger:                     tgLog,
+		LogLevel:                   log.DebugLevel,
+		ErrWriter:                  tgLog.WriterLevel(log.DebugLevel),
 		MaxFoldersToCheck:          tgoptions.DEFAULT_MAX_FOLDERS_TO_CHECK,
 		WorkingDir:                 p.Path,
 		DownloadDir:                terragruntDownloadDir,


### PR DESCRIPTION
This only outputs the Terragrunt library logs when log-level is `debug`. It also outputs the full Terragrunt log so timestamps, etc are repeated, e.g:

```
infracost breakdown --path=/path/to/project --terraform-parse-hcl --log-level=debug
time="2022-05-11T16:24:49+01:00" level=info msg="Detected Terragrunt directory (HCL) at /path/to/project"
time="2022-05-11T16:24:49+01:00" level=debug library=terragrunt msg="time=2022-05-11T16:24:49+01:00 level=debug msg=Did not find any locals block: skipping evaluation. prefix=[/path/to/project/dev] "
```