### PR TITLE
fix(google): compute scratch disk for compute(_region)_instance_group_manager

### DIFF
--- a/internal/providers/terraform/google/testdata/compute_instance_group_manager_test/compute_instance_group_manager_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_instance_group_manager_test/compute_instance_group_manager_test.golden
@@ -4,9 +4,10 @@
  google_compute_instance_group_manager.default                                         
  ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)        2,920  hours        $15.53 
  ├─ SSD provisioned storage (pd-ssd)                        1,500  GB          $255.00 
+ ├─ Local SSD provisioned storage                           1,500  GB          $120.00 
  └─ NVIDIA Tesla K80 (on-demand)                            5,840  hours     $1,839.60 
                                                                                        
- OVERALL TOTAL                                                               $2,110.13 
+ OVERALL TOTAL                                                               $2,230.13 
 ──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/google/testdata/compute_instance_group_manager_test/compute_instance_group_manager_test.tf
+++ b/internal/providers/terraform/google/testdata/compute_instance_group_manager_test/compute_instance_group_manager_test.tf
@@ -20,6 +20,13 @@ resource "google_compute_instance_template" "appserver" {
     disk_size_gb = "375"
   }
 
+  disk {
+    interface    = "NVME"
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    disk_size_gb = "375"
+  }
+
   guest_accelerator {
     type  = "nvidia-tesla-k80"
     count = 2

--- a/internal/providers/terraform/google/testdata/compute_region_instance_group_manager_test/compute_region_instance_group_manager_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_region_instance_group_manager_test/compute_region_instance_group_manager_test.golden
@@ -3,9 +3,10 @@
                                                                                              
  google_compute_region_instance_group_manager.appserver                                      
  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)        2,190  hours     $1,165.07 
- └─ Balanced provisioned storage (pd-balanced)                    1,200  GB          $120.00 
+ ├─ Balanced provisioned storage (pd-balanced)                    1,200  GB          $120.00 
+ └─ Local SSD provisioned storage                                 1,125  GB           $90.00 
                                                                                              
- OVERALL TOTAL                                                                     $1,285.07 
+ OVERALL TOTAL                                                                     $1,375.07 
 ──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated

--- a/internal/providers/terraform/google/testdata/compute_region_instance_group_manager_test/compute_region_instance_group_manager_test.tf
+++ b/internal/providers/terraform/google/testdata/compute_region_instance_group_manager_test/compute_region_instance_group_manager_test.tf
@@ -19,6 +19,13 @@ resource "google_compute_instance_template" "standard" {
     disk_type    = "pd-balanced"
     disk_size_gb = "400"
   }
+
+  disk {
+    interface    = "NVME"
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    disk_size_gb = "375"
+  }
 }
 
 resource "google_compute_region_instance_group_manager" "appserver" {

--- a/internal/resources/google/compute_instance_group_manager.go
+++ b/internal/resources/google/compute_instance_group_manager.go
@@ -15,6 +15,7 @@ type ComputeInstanceGroupManager struct {
 	PurchaseOption    string
 	TargetSize        int64
 	Disks             []*ComputeDisk
+	ScratchDisks      int
 	GuestAccelerators []*ComputeGuestAccelerator
 }
 
@@ -37,6 +38,10 @@ func (r *ComputeInstanceGroupManager) BuildResource() *schema.Resource {
 
 	for _, disk := range r.Disks {
 		costComponents = append(costComponents, computeDiskCostComponent(r.Region, disk.Type, disk.Size, r.TargetSize))
+	}
+
+	if r.ScratchDisks > 0 {
+		costComponents = append(costComponents, scratchDiskCostComponent(r.Region, r.PurchaseOption, r.ScratchDisks*int(r.TargetSize)))
 	}
 
 	for _, guestAccel := range r.GuestAccelerators {

--- a/internal/resources/google/compute_region_instance_group_manager.go
+++ b/internal/resources/google/compute_region_instance_group_manager.go
@@ -14,6 +14,7 @@ type ComputeRegionInstanceGroupManager struct {
 	MachineType       string
 	PurchaseOption    string
 	TargetSize        int64
+	ScratchDisks      int
 	Disks             []*ComputeDisk
 	GuestAccelerators []*ComputeGuestAccelerator
 }
@@ -37,6 +38,10 @@ func (r *ComputeRegionInstanceGroupManager) BuildResource() *schema.Resource {
 
 	for _, disk := range r.Disks {
 		costComponents = append(costComponents, computeDiskCostComponent(r.Region, disk.Type, disk.Size, r.TargetSize))
+	}
+
+	if r.ScratchDisks > 0 {
+		costComponents = append(costComponents, scratchDiskCostComponent(r.Region, r.PurchaseOption, r.ScratchDisks*int(r.TargetSize)))
 	}
 
 	for _, guestAccel := range r.GuestAccelerators {


### PR DESCRIPTION
Closes #1654.

This PR fixes the computation of local scratch disk in GCP's zonal and regional instance group manager, by adding the scratch disk logic already existing in `google_compute_instance`.

The following output takes the issue example and shows the fix:

```
 Name                                                 Monthly Qty  Unit   Monthly Cost 
                                                                                       
 google_compute_instance_group_manager.default                                         
 ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)        2,920  hours        $15.53 
 ├─ SSD provisioned storage (pd-ssd)                        1,500  GB          $255.00 
 ├─ Local SSD provisioned storage                           1,500  GB          $120.00 
 └─ NVIDIA Tesla K80 (on-demand)                            5,840  hours     $1,839.60 
                                                                                       
 OVERALL TOTAL                                                               $2,230.13 
──────────────────────────────────
2 cloud resources were detected:
∙ 1 was estimated
∙ 1 was free, rerun with --show-skipped to see details
```