### PR TITLE
refactor: rework reference mapping

### DIFF
--- a/internal/providers/terraform/aws/aws.go
+++ b/internal/providers/terraform/aws/aws.go
@@ -1,0 +1,84 @@
+package aws
+
+import (
+	"strings"
+
+	"github.com/infracost/infracost/internal/schema"
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+)
+
+var DefaultProviderRegion = "us-east-1"
+var arnAttributeMap = map[string]string{
+	"aws_cloudwatch_dashboard":     "dashboard_arn",
+	"aws_db_snapshot":              "db_snapshot_arn",
+	"aws_db_cluster_snapshot":      "db_cluster_snapshot_arn",
+	"aws_ecs_service":              "id",
+	"aws_neptune_cluster_snapshot": "db_cluster_snapshot_arn",
+	"aws_docdb_cluster_snapshot":   "db_cluster_snapshot_arn",
+	"aws_dms_certificate":          "certificate_arn",
+	"aws_dms_endpoint":             "endpoint_arn",
+	"aws_dms_replication_instance": "replication_instance_arn",
+	"aws_dms_replication_task":     "replication_task_arn",
+}
+
+func GetDefaultRefIDFunc(d *schema.ResourceData) []string {
+
+	defaultRefs := []string{d.Get("id").String()}
+
+	arnAttr, ok := arnAttributeMap[d.Type]
+	if !ok {
+		arnAttr = "arn"
+	}
+
+	if d.Get(arnAttr).Exists() {
+		defaultRefs = append(defaultRefs, d.Get(arnAttr).String())
+	}
+
+	return defaultRefs
+}
+
+func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {
+
+	specialContexts := make(map[string]interface{})
+
+	if strings.HasPrefix(d.Get("region").String(), "cn-") {
+		specialContexts["isAWSChina"] = true
+	}
+
+	return specialContexts
+}
+
+func GetResourceRegion(resourceType string, v gjson.Result) string {
+	// If a region key exists in the values use that
+	if v.Get("region").Exists() && v.Get("region").String() != "" {
+		return v.Get("region").String()
+	}
+
+	// Otherwise try and parse the ARN from the values
+	arnAttr, ok := arnAttributeMap[resourceType]
+	if !ok {
+		arnAttr = "arn"
+	}
+
+	if !v.Get(arnAttr).Exists() {
+		return ""
+	}
+
+	arn := v.Get(arnAttr).String()
+	p := strings.Split(arn, ":")
+	if len(p) < 4 {
+		log.Debugf("Unexpected ARN format for %s", arn)
+		return ""
+	}
+
+	return p[3]
+}
+
+func ParseTags(resourceType string, v gjson.Result) map[string]string {
+	tags := make(map[string]string)
+	for k, v := range v.Get("tags").Map() {
+		tags[k] = v.String()
+	}
+	return tags
+}

--- a/internal/providers/terraform/azure/azure.go
+++ b/internal/providers/terraform/azure/azure.go
@@ -1,0 +1,28 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/tidwall/gjson"
+)
+
+var DefaultProviderRegion = "eastus"
+
+func GetDefaultRefIDFunc(d *schema.ResourceData) []string {
+	return []string{d.Get("id").String()}
+}
+
+func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func GetResourceRegion(resourceType string, v gjson.Result) string {
+	return ""
+}
+
+func ParseTags(resourceType string, v gjson.Result) map[string]string {
+	tags := make(map[string]string)
+	for k, v := range v.Get("tags").Map() {
+		tags[k] = v.String()
+	}
+	return tags
+}

--- a/internal/providers/terraform/google/compute_instance_group_manager.go
+++ b/internal/providers/terraform/google/compute_instance_group_manager.go
@@ -12,7 +12,7 @@ func getComputeInstanceGroupManagerRegistryItem() *schema.RegistryItem {
 		Notes:               []string{"Multiple versions are not supported."},
 		ReferenceAttributes: []string{"version.0.instance_template", "google_compute_per_instance_config.instance_group_manager"},
 		CustomRefIDFunc: func(d *schema.ResourceData) []string {
-			return []string{d.Get("self_link").String(), d.Get("name").String()}
+			return []string{d.Get("name").String()}
 		},
 	}
 }

--- a/internal/providers/terraform/google/compute_region_instance_group_manager.go
+++ b/internal/providers/terraform/google/compute_region_instance_group_manager.go
@@ -12,7 +12,7 @@ func getComputeRegionInstanceGroupManagerRegistryItem() *schema.RegistryItem {
 		Notes:               []string{"Multiple versions are not supported."},
 		ReferenceAttributes: []string{"version.0.instance_template", "google_compute_region_per_instance_config.region_instance_group_manager"},
 		CustomRefIDFunc: func(d *schema.ResourceData) []string {
-			return []string{d.Get("self_link").String(), d.Get("name").String()}
+			return []string{d.Get("name").String()}
 		},
 	}
 }

--- a/internal/providers/terraform/google/google.go
+++ b/internal/providers/terraform/google/google.go
@@ -1,0 +1,35 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/tidwall/gjson"
+)
+
+var DefaultProviderRegion = "us-central1"
+
+func GetDefaultRefIDFunc(d *schema.ResourceData) []string {
+
+	defaultRefs := []string{d.Get("id").String()}
+
+	if d.Get("self_link").Exists() {
+		defaultRefs = append(defaultRefs, d.Get("self_link").String())
+	}
+
+	return defaultRefs
+}
+
+func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+func GetResourceRegion(resourceType string, v gjson.Result) string {
+	return ""
+}
+
+func ParseTags(resourceType string, v gjson.Result) map[string]string {
+	tags := make(map[string]string)
+	for k, v := range v.Get("labels").Map() {
+		tags[k] = v.String()
+	}
+	return tags
+}

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -12,30 +12,14 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/providers/terraform/aws"
+	"github.com/infracost/infracost/internal/providers/terraform/azure"
+	"github.com/infracost/infracost/internal/providers/terraform/google"
 	"github.com/infracost/infracost/internal/schema"
 )
 
 // These show differently in the plan JSON for Terraform 0.12 and 0.13.
 var infracostProviderNames = []string{"infracost", "registry.terraform.io/infracost/infracost"}
-var defaultProviderRegions = map[string]string{
-	"aws":     "us-east-1",
-	"google":  "us-central1",
-	"azurerm": "eastus",
-}
-
-// ARN attribute mapping for resources that don't have a standard 'arn' attribute
-var arnAttributeMap = map[string]string{
-	"aws_cloudwatch_dashboard":     "dashboard_arn",
-	"aws_db_snapshot":              "db_snapshot_arn",
-	"aws_db_cluster_snapshot":      "db_cluster_snapshot_arn",
-	"aws_ecs_service":              "id",
-	"aws_neptune_cluster_snapshot": "db_cluster_snapshot_arn",
-	"aws_docdb_cluster_snapshot":   "db_cluster_snapshot_arn",
-	"aws_dms_certificate":          "certificate_arn",
-	"aws_dms_endpoint":             "endpoint_arn",
-	"aws_dms_replication_instance": "replication_instance_arn",
-	"aws_dms_replication_task":     "replication_task_arn",
-}
 
 type Parser struct {
 	ctx                  *config.ProjectContext
@@ -53,8 +37,8 @@ func NewParser(ctx *config.ProjectContext, includePastResources bool) *Parser {
 func (p *Parser) createResource(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	registryMap := GetResourceRegistryMap()
 
-	if isAwsChina(d) {
-		p.ctx.SetContextValue("isAWSChina", true)
+	for cKey, cValue := range getSpecialContext(d) {
+		p.ctx.SetContextValue(cKey, cValue)
 	}
 
 	if registryItem, ok := (*registryMap)[d.Type]; ok {
@@ -281,50 +265,54 @@ func (p *Parser) parseResourceData(isState bool, providerConf, planVals gjson.Re
 	return resources
 }
 
+func getSpecialContext(d *schema.ResourceData) map[string]interface{} {
+	providerPrefix := strings.Split(d.Type, "_")[0]
+
+	switch providerPrefix {
+	case "aws":
+		return aws.GetSpecialContext(d)
+	case "azurerm":
+		return azure.GetSpecialContext(d)
+	case "google":
+		return google.GetSpecialContext(d)
+	default:
+		log.Debugf("Unsupported provider %s", providerPrefix)
+		return map[string]interface{}{}
+	}
+}
+
 func parseTags(resourceType string, v gjson.Result) map[string]string {
-	tags := make(map[string]string)
 
-	a := "tags"
-	if strings.HasPrefix(resourceType, "google_") {
-		a = "labels"
+	providerPrefix := strings.Split(resourceType, "_")[0]
+
+	switch providerPrefix {
+	case "aws":
+		return aws.ParseTags(resourceType, v)
+	case "azurerm":
+		return azure.ParseTags(resourceType, v)
+	case "google":
+		return google.ParseTags(resourceType, v)
+	default:
+		log.Debugf("Unsupported provider %s", providerPrefix)
+		return map[string]string{}
 	}
-
-	for k, v := range v.Get(a).Map() {
-		tags[k] = v.String()
-	}
-
-	return tags
 }
 
 func resourceRegion(resourceType string, v gjson.Result) string {
+
 	providerPrefix := strings.Split(resourceType, "_")[0]
-	if providerPrefix != "aws" {
+
+	switch providerPrefix {
+	case "aws":
+		return aws.GetResourceRegion(resourceType, v)
+	case "azurerm":
+		return azure.GetResourceRegion(resourceType, v)
+	case "google":
+		return google.GetResourceRegion(resourceType, v)
+	default:
+		log.Debugf("Unsupported provider %s", providerPrefix)
 		return ""
 	}
-
-	// If a region key exists in the values use that
-	if v.Get("region").String() != "" {
-		return v.Get("region").String()
-	}
-
-	// Otherwise try and parse the ARN from the values
-	arnAttr, ok := arnAttributeMap[resourceType]
-	if !ok {
-		arnAttr = "arn"
-	}
-
-	if !v.Get(arnAttr).Exists() {
-		return ""
-	}
-
-	arn := v.Get(arnAttr).String()
-	p := strings.Split(arn, ":")
-	if len(p) < 4 {
-		log.Debugf("Unexpected ARN format for %s", arn)
-		return ""
-	}
-
-	return p[3]
 }
 
 func providerRegion(addr string, providerConf gjson.Result, vars gjson.Result, resourceType string, resConf gjson.Result) string {
@@ -344,7 +332,15 @@ func providerRegion(addr string, providerConf gjson.Result, vars gjson.Result, r
 		region = parseRegion(providerConf, vars, providerPrefix)
 
 		if region == "" {
-			region = defaultProviderRegions[providerPrefix]
+
+			switch providerPrefix {
+			case "aws":
+				region = aws.DefaultProviderRegion
+			case "azurerm":
+				region = azure.DefaultProviderRegion
+			case "google":
+				region = google.DefaultProviderRegion
+			}
 
 			// Don't show this log for azurerm users since they have a different method of looking up the region.
 			// A lot of Azure resources get their region from their referenced azurerm_resource_group resource
@@ -415,17 +411,20 @@ func (p *Parser) stripDataResources(resData map[string]*schema.ResourceData) {
 func (p *Parser) parseReferences(resData map[string]*schema.ResourceData, conf gjson.Result) {
 	registryMap := GetResourceRegistryMap()
 
-	// Create a map of id -> resource data and arn -> resource data so we can lookup references
+	// Create a map of id -> resource data so we can lookup references
 	idMap := make(map[string][]*schema.ResourceData)
-	arnMap := make(map[string][]*schema.ResourceData)
 
 	for _, d := range resData {
-		id := d.Get("id").String()
-		if _, ok := idMap[id]; !ok {
-			idMap[id] = []*schema.ResourceData{}
-		}
 
-		idMap[id] = append(idMap[id], d)
+		// check for any "default" ids declared by the provider for this resource
+		if f := registryMap.GetDefaultRefIDFunc(d.Type); f != nil {
+			for _, defaultID := range f(d) {
+				if _, ok := idMap[defaultID]; !ok {
+					idMap[defaultID] = []*schema.ResourceData{}
+				}
+				idMap[defaultID] = append(idMap[defaultID], d)
+			}
+		}
 
 		// check for any "custom" ids specified by the resource and add them.
 		if f := registryMap.GetCustomRefIDFunc(d.Type); f != nil {
@@ -437,17 +436,6 @@ func (p *Parser) parseReferences(resData map[string]*schema.ResourceData, conf g
 			}
 		}
 
-		arnAttr, ok := arnAttributeMap[d.Type]
-		if !ok {
-			arnAttr = "arn"
-		}
-
-		arn := d.Get(arnAttr).String()
-		if _, ok := arnMap[arn]; !ok {
-			arnMap[arn] = []*schema.ResourceData{}
-		}
-
-		arnMap[arn] = append(arnMap[arn], d)
 	}
 
 	parseKnownModuleRefs(resData, conf)
@@ -479,15 +467,6 @@ func (p *Parser) parseReferences(resData map[string]*schema.ResourceData, conf g
 				if ok {
 
 					for _, ref := range idRefs {
-						reverseRefAttrs := registryMap.GetReferenceAttributes(ref.Type)
-						d.AddReference(attr, ref, reverseRefAttrs)
-					}
-				}
-
-				// Check arn map
-				arnRefs, ok := arnMap[refVal.String()]
-				if ok {
-					for _, ref := range arnRefs {
 						reverseRefAttrs := registryMap.GetReferenceAttributes(ref.Type)
 						d.AddReference(attr, ref, reverseRefAttrs)
 					}
@@ -708,10 +687,6 @@ func splitAddress(addr string) []string {
 		}
 		return !quoted && r == '.'
 	})
-}
-
-func isAwsChina(d *schema.ResourceData) bool {
-	return strings.HasPrefix(d.Type, "aws_") && strings.HasPrefix(d.Get("region").String(), "cn-")
 }
 
 func containsString(a []string, s string) bool {

--- a/internal/schema/registry_item.go
+++ b/internal/schema/registry_item.go
@@ -9,5 +9,6 @@ type RegistryItem struct {
 	RFunc               ResourceFunc
 	ReferenceAttributes []string
 	CustomRefIDFunc     ReferenceIDFunc
+	DefaultRefIDFunc    ReferenceIDFunc
 	NoPrice             bool
 }


### PR DESCRIPTION
This PR closes #1652.

I tried to (at least partially) rework `parser.go` move the provider-specific logic out of this file and into the specific packages.

I feel that the `internal/providers/terraform/*` packages could deserve to be implemented as interfaces (with GetResources(), GetFreeResources(), GetUsageOnlyResources() on top of the funcs I added in the `internal/providers/terraform/*/[provider].go` files), though it means refactoring lots of stuff in `parser.go` and `registry.go` and I'm not sure this PR is the right one for that (+ I feel a bit lazy tonight...).

Let me know what you think!