### PR TITLE
feat: add list of calls used to create the resource in output metadata

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -151,12 +151,11 @@ func (e *Evaluator) collectModules() *Module {
 	return &e.module
 }
 
+// evaluate runs a context evaluation loop until the context values are unchanged. We run this in a loop
+// because variables can change because of outputs from other blocks in the context. Once all outputs have
+// been evaluated and the context variables should remain unchanged. In reality 90% of cases will require
+// 2 loops, however other complex modules will take > 2.
 func (e *Evaluator) evaluate(lastContext hcl.EvalContext) {
-	// TODO: we need to work out why the evaluation step takes place in a loop. I have been unable to decipher
-	// why we need to evaluate the context at least twice. No tests that we've seen can replicated the scenario
-	// where lastContext.Variables change after the first `evaluateStep`. We should reach out to tfsec guys and
-	// work out why this loop was put in there. If they can't come up with a good reason we can nuke it and
-	// make the evaluate method much easier to understand.
 	for i := 0; i < maxContextIterations; i++ {
 		e.evaluateStep(i)
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -159,13 +159,13 @@ type CostComponent struct {
 }
 
 type Resource struct {
-	Name           string            `json:"name"`
-	Tags           map[string]string `json:"tags,omitempty"`
-	Metadata       map[string]string `json:"metadata"`
-	HourlyCost     *decimal.Decimal  `json:"hourlyCost"`
-	MonthlyCost    *decimal.Decimal  `json:"monthlyCost"`
-	CostComponents []CostComponent   `json:"costComponents,omitempty"`
-	SubResources   []Resource        `json:"subresources,omitempty"`
+	Name           string                 `json:"name"`
+	Tags           map[string]string      `json:"tags,omitempty"`
+	Metadata       map[string]interface{} `json:"metadata"`
+	HourlyCost     *decimal.Decimal       `json:"hourlyCost"`
+	MonthlyCost    *decimal.Decimal       `json:"monthlyCost"`
+	CostComponents []CostComponent        `json:"costComponents,omitempty"`
+	SubResources   []Resource             `json:"subresources,omitempty"`
 }
 
 func (r Resource) ResourceType() string {
@@ -288,10 +288,10 @@ func outputResource(r *schema.Resource) Resource {
 		subresources = append(subresources, outputResource(s))
 	}
 
-	metadata := make(map[string]string)
+	metadata := make(map[string]interface{})
 	if r.Metadata != nil {
 		for k, v := range r.Metadata {
-			metadata[k] = v.String()
+			metadata[k] = v.Value()
 		}
 	}
 
@@ -720,7 +720,7 @@ func sortResources(resources []Resource, groupKey string) {
 		}
 
 		// Sort by the group key
-		return resources[i].Metadata[groupKey] < resources[j].Metadata[groupKey]
+		return resources[i].Metadata[groupKey].(string) < resources[j].Metadata[groupKey].(string)
 	})
 }
 

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -310,6 +310,7 @@ func (p *HCLProvider) getResourceOutput(block *hcl.Block) ResourceOutput {
 		SchemaVersion: 0,
 		InfracostMetadata: map[string]interface{}{
 			"filename": block.Filename,
+			"calls":    block.CallDetails(),
 		},
 	}
 


### PR DESCRIPTION
Adds a list of block calls that are used in resource creation to the `metadata`, e.g:

```
{
  "calls": [
      {
        "blockName": "module.api_keys",
        "filename": "../infra/dev/main.tf"
      },
      {
        "blockName": "aws_dynamodb_table.api_keys",
        "filename": "../infra/modules/api_keys/main.tf"
      }
  ]
}
```

This is required for [vscode integration](https://github.com/infracost/vscode-infracost) to support costs on module blocks. 