### PR TITLE
fix(azure): Fix MSSQL Database License Type retrieval

### DIFF
--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/tidwall/gjson"
 
 	"github.com/infracost/infracost/internal/resources/azure"
 	"github.com/infracost/infracost/internal/schema"
@@ -60,27 +59,21 @@ func getAzureRMMSSQLDatabaseRegistryItem() *schema.RegistryItem {
 func newAzureRMMSSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	region := lookupRegion(d, []string{"server_id"})
 
-	var sku string
-	if d.Get("sku_name").Type != gjson.Null {
-		sku = d.Get("sku_name").String()
-	}
+	sku := d.GetStringOrDefault("sku_name", "")
 
 	var maxSize *float64
-	if d.Get("max_size_gb").Type != gjson.Null {
+	if !d.IsEmpty("max_size_gb") {
 		val := d.Get("max_size_gb").Float()
 		maxSize = &val
 	}
 
 	var replicaCount *int64
-	if d.Get("read_replica_count").Exists() {
+	if !d.IsEmpty("read_replica_count") {
 		val := d.Get("read_replica_count").Int()
 		replicaCount = &val
 	}
 
-	licenceType := "LicenseIncluded"
-	if d.Get("license_type").Exists() {
-		licenceType = d.Get("license_type").String()
-	}
+	licenceType := d.GetStringOrDefault("license_type", "LicenseIncluded")
 
 	r := &azure.SQLDatabase{
 		Address:          d.Address,


### PR DESCRIPTION
If the attribute was not specified, the plan JSON had the key with null
value thus `Exists()` method returned true and the attribute ended up
with an empty string.

Updated other attributes to follow the latest good practice to check for
empty values.