### PR TITLE
enhance: add a better error message for errors originating from the Terragrunt libs

### DIFF
--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -13,7 +13,10 @@ import (
 	tgerrors "github.com/gruntwork-io/terragrunt/errors"
 	tgoptions "github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/infracost/infracost/internal/clierror"
 	"github.com/infracost/infracost/internal/hcl"
+	"github.com/infracost/infracost/internal/ui"
+	"github.com/pkg/errors"
 
 	"os"
 	"path/filepath"
@@ -171,7 +174,15 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 
 	err = s.Run(terragruntOptions)
 	if err != nil {
-		return nil, err
+		return nil, clierror.NewSanitizedError(
+			errors.Errorf(
+				"%s\n%v%s",
+				"Failed to parse the Terragrunt code using the Terragrunt library:",
+				err.Error(),
+				fmt.Sprintf("Try setting --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot")),
+			),
+			"Error parsing the Terragrunt code using the Terragrunt library",
+		)
 	}
 
 	return workingDirsToEstimate, nil


### PR DESCRIPTION
If someone runs into an error when running HCL parsing with Terragrunt, we weren't clarifying that the errors were from the Terragrunt libs. This updates that and points them to generate a plan JSON for just now.

Example:
<img width="1000" alt="Screenshot 2022-05-18 at 12 04 34" src="https://user-images.githubusercontent.com/158824/169024961-1778c97d-21b8-4a04-b202-7219899a5d1e.png">

