### PR TITLE
fix: parse outputs from Terragrunt dependencies

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -227,6 +227,10 @@ func TestBreakdownTerragruntHCLMulti(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../../examples/terragrunt"}, nil)
 }
 
+func TestBreakdownTerragruntHCLDepsOutput(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())}, nil)
+}
+
 func TestBreakdownTerragruntHCLMultiNoSource(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "./testdata/breakdown_terragrunt_hclmulti_no_source/example"}, nil)
 }

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -535,7 +535,7 @@ func (r *parallelRunner) runHCLProvider(wg *sync.WaitGroup, ctx *config.ProjectC
 
 	t1 := time.Now()
 
-	hclProvider, err := terraform.NewHCLProvider(ctx, true)
+	hclProvider, err := terraform.NewHCLProvider(ctx, &terraform.HCLProviderConfig{SuppressLogging: true})
 	if err != nil {
 		log.Debugf("Could not init HCL provider: %s", err)
 		return

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/breakdown_terragrunt_hcldeps_output.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/breakdown_terragrunt_hcldeps_output.golden
@@ -1,0 +1,44 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev
+
+ Name                                                         Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                    
+ aws_instance.web_app                                                                                               
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)                  730  hours                              $8.47 
+ ├─ root_block_device                                                                                               
+ │  └─ Storage (general purpose SSD, gp2)                              50  GB                                 $5.00 
+ └─ ebs_block_device[0]                                                                                             
+    ├─ Storage (provisioned IOPS SSD, io1)                            100  GB                                $12.50 
+    └─ Provisioned IOPS                                               400  IOPS                              $26.00 
+                                                                                                                    
+ aws_lambda_function.hello_world                                                                                    
+ ├─ Requests                                          Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration                                          Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                    
+ Project total                                                                                               $51.97 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/prod
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+ ├─ root_block_device                                                                                                 
+ │  └─ Storage (general purpose SSD, gp2)                               100  GB                                $10.00 
+ └─ ebs_block_device[0]                                                                                               
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration                                            Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ Project total                                                                                                $747.64 
+
+ OVERALL TOTAL                                                                                                $799.61 
+──────────────────────────────────
+4 cloud resources were detected:
+∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
@@ -1,0 +1,20 @@
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "test" {
+  config_path = "../prod"
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type = dependency.test.outputs.aws_instance_type
+  root_block_device_volume_size = 50
+  block_device_volume_size = 100
+  block_device_iops = 400
+  
+  hello_world_function_memory_size = 512
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example/main.tf
@@ -1,0 +1,59 @@
+variable "instance_type" {
+  description = "The EC2 instance type for the web app"
+  type        = string
+}
+
+variable "root_block_device_volume_size" {
+  description = "The size of the root block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_volume_size" {
+  description = "The size of the block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_iops" {
+  description = "The number of IOPS for the block device for the web app EC2 instance"
+  type        = number
+}
+
+variable "hello_world_function_memory_size" {
+  description = "The memory to allocate to the hello world Lambda function"
+  type        = number
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = var.root_block_device_volume_size
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = var.block_device_volume_size
+    iops        = var.block_device_iops
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  memory_size   = var.hello_world_function_memory_size
+}
+
+// locals blocks to test that dynamic attributes and terraform functions work with the hcl Terragrunt functionality.
+locals {
+  instances = {
+    "m5.4xlarge" = "t2.micro"
+  }
+}
+
+output "aws_instance_type" {
+  value = lookup(local.instances, var.instance_type, "t2.medium")
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/prod/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/prod/terragrunt.hcl
@@ -1,0 +1,16 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type = "m5.4xlarge"
+  root_block_device_volume_size = 100
+  block_device_volume_size = 1000
+  block_device_iops = 800
+  
+  hello_world_function_memory_size = 1024
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+  aws_region = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+}
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region                      = "${local.aws_region}"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+EOF
+}

--- a/examples/terraform/main.tf
+++ b/examples/terraform/main.tf
@@ -29,3 +29,7 @@ resource "aws_lambda_function" "hello_world" {
   runtime       = "nodejs12.x"
   memory_size   = 1024 # <<<<< Try changing this to 512 to compare costs
 }
+
+output "aws_instance_type" {
+  value = aws_instance.web_app.instance_type
+}

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -140,6 +140,22 @@ func (blocks Blocks) OfType(t string) Blocks {
 	return results
 }
 
+// Outputs returns a map of all the evaluated outputs from the list of Blocks.
+func (blocks Blocks) Outputs() cty.Value {
+	data := make(map[string]cty.Value)
+
+	for _, block := range blocks.OfType("output") {
+		attr := block.GetAttribute("value")
+		if attr == nil {
+			continue
+		}
+
+		data[block.Label()] = attr.Value()
+	}
+
+	return cty.ObjectVal(data)
+}
+
 // Block wraps a hcl.Block type with additional methods and context.
 // A Block is a core piece of HCL schema and represents a set of data.
 // Most importantly a Block directly corresponds to a schema.Resource.

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -150,7 +150,17 @@ func (blocks Blocks) Outputs() cty.Value {
 			continue
 		}
 
-		data[block.Label()] = attr.Value()
+		// resolve the attribute value. This will evaluate any expressions that
+		// the attribute uses and try and return the final value. If the end
+		// value can't be resolved we set it as a blank string. This is
+		// safe to use for callers and won't cause panics when marshalling
+		// the returned cty.Value.
+		value := attr.Value()
+		if value == cty.NilVal {
+			value = cty.StringVal("")
+		}
+
+		data[block.Label()] = value
 	}
 
 	return cty.ObjectVal(data)

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -230,18 +230,7 @@ func (e *Evaluator) evaluateModules() {
 
 // exportOutputs exports module outputs so that it can be used in Context evaluation.
 func (e *Evaluator) exportOutputs() cty.Value {
-	data := make(map[string]cty.Value)
-
-	for _, block := range e.module.Blocks.OfType("output") {
-		attr := block.GetAttribute("value")
-		if attr == nil {
-			continue
-		}
-
-		data[block.Label()] = attr.Value()
-	}
-
-	return cty.ObjectVal(data)
+	return e.module.Blocks.Outputs()
 }
 
 func (e *Evaluator) expandBlocks(blocks Blocks) Blocks {

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -182,7 +182,7 @@ type Parser struct {
 
 // LoadParsers inits a list of Parser with the provided option and initialPath. LoadParsers locates Terraform files
 // in the given initialPath and returns a Parser for each directory it locates a Terraform project within. If
-// the initialPath contains Terraform files at the top level Parsers will be len 1.
+// the initialPath contains Terraform files at the top level parsers will be len 1.
 func LoadParsers(initialPath string, options ...Option) ([]*Parser, error) {
 	pl := &projectLocator{moduleCalls: make(map[string]struct{})}
 	rootPaths := pl.findRootModules(initialPath)

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -56,7 +56,7 @@ func Detect(ctx *config.ProjectContext, includePastResources bool) (schema.Provi
 	case "terraform_dir":
 		h, providerErr := terraform.NewHCLProvider(
 			ctx,
-			false,
+			nil,
 			hcl.OptionWithSpinner(ctx.RunContext.NewSpinner),
 			hcl.OptionWithWarningFunc(ctx.RunContext.NewWarningWriter()),
 		)

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -166,7 +166,7 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 			require.NoError(t, err)
 
 			p := HCLProvider{
-				Parsers: parsers,
+				parsers: parsers,
 			}
 			got, err := p.LoadPlanJSONs()
 			require.NoError(t, err)

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -16,14 +16,15 @@ import (
 	tgerrors "github.com/gruntwork-io/terragrunt/errors"
 	tgoptions "github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
-
-	"github.com/infracost/infracost/internal/hcl"
-
 	"github.com/hashicorp/go-getter"
-
+	hcl2 "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclparse"
 	log "github.com/sirupsen/logrus"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/hcl"
 	"github.com/infracost/infracost/internal/schema"
 )
 
@@ -31,6 +32,8 @@ type TerragruntHCLProvider struct {
 	ctx                  *config.ProjectContext
 	Path                 string
 	includePastResources bool
+	outputs              map[string]cty.Value
+	stack                *tgconfigstack.Stack
 }
 
 // NewTerragruntHCLProvider creates a new provider intialized with the configured project path (usually the terragrunt
@@ -40,6 +43,7 @@ func NewTerragruntHCLProvider(ctx *config.ProjectContext, includePastResources b
 		ctx:                  ctx,
 		Path:                 ctx.ProjectConfig.Path,
 		includePastResources: includePastResources,
+		outputs:              map[string]cty.Value{},
 	}
 }
 
@@ -56,15 +60,15 @@ func (p *TerragruntHCLProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 }
 
 type terragruntWorkingDirInfo struct {
-	ConfigDir  string
-	WorkingDir string
-	Inputs     map[string]interface{}
+	configDir  string
+	workingDir string
+	provider   *HCLProvider
 }
 
 // LoadResources finds any Terragrunt projects, prepares them by downloading any required source files, then
 // process each with an HCLProvider.
 func (p *TerragruntHCLProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
-	workingDirInfos, err := p.prepWorkingDirs()
+	dirs, err := p.prepWorkingDirs()
 	if err != nil {
 		return nil, err
 	}
@@ -72,36 +76,20 @@ func (p *TerragruntHCLProvider) LoadResources(usage map[string]*schema.UsageData
 	var allProjects []*schema.Project
 
 	// Sort the dirs so they are consistent in the output
-	sort.Slice(workingDirInfos, func(i, j int) bool {
-		return workingDirInfos[i].ConfigDir < workingDirInfos[j].ConfigDir
+	sort.Slice(dirs, func(i, j int) bool {
+		return dirs[i].configDir < dirs[j].configDir
 	})
 
-	for _, di := range workingDirInfos {
-		log.Debugf("Found terragrunt HCL working dir: %v", di.WorkingDir)
+	for _, di := range dirs {
+		log.Debugf("Found terragrunt HCL working dir: %v", di.workingDir)
 
-		pconfig := *p.ctx.ProjectConfig // clone the projectConfig
-		pconfig.Path = di.WorkingDir
-		pconfig.TerraformVars = p.initTerraformVars(pconfig.TerraformVars, di.Inputs)
-
-		pctx := config.NewProjectContext(p.ctx.RunContext, &pconfig)
-		h, err := NewHCLProvider(
-			pctx,
-			false,
-			hcl.OptionWithSpinner(p.ctx.RunContext.NewSpinner),
-			hcl.OptionWithWarningFunc(p.ctx.RunContext.NewWarningWriter()),
-		)
-
-		if err != nil {
-			return nil, err
-		}
-
-		projects, err := h.LoadResources(usage)
+		projects, err := di.provider.LoadResources(usage)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, project := range projects {
-			project.Metadata = config.DetectProjectMetadata(di.ConfigDir)
+			project.Metadata = config.DetectProjectMetadata(di.configDir)
 			project.Metadata.Type = p.Type()
 			p.AddMetadata(project.Metadata)
 			project.Name = schema.GenerateProjectName(project.Metadata, p.ctx.RunContext.Config.EnableDashboard)
@@ -143,14 +131,6 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 		TerraformCliArgs:           []string{tgcli.CMD_TERRAGRUNT_INFO},
 		IgnoreExternalDependencies: true,
 		RunTerragrunt: func(terragruntOptions *tgoptions.TerragruntOptions) error {
-			if terragruntOptions.Writer != nil {
-				// RunTerragrunt must have been invoked as part of a dependency block to get the outputs.
-				// Since we're parsing HCL, outputs are not available anyway.  We return some fake outputs
-				// here so Terragrunt does error with a "No outputs detected error.
-				// See getTerragruntOutputIfAppliedElseConfiguredDefault in terragrunt dependency.go
-				_, _ = terragruntOptions.Writer.Write([]byte(`{ "infracost_mock_output": { "type": "string", "value": "" } }`))
-				return nil
-			}
 			workingDirInfo, err := p.runTerragrunt(terragruntOptions)
 			if workingDirInfo != nil {
 				workingDirsToEstimate = append(workingDirsToEstimate, workingDirInfo)
@@ -164,91 +144,165 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 	if err != nil {
 		return nil, err
 	}
+	p.stack = s
 
 	err = s.Run(terragruntOptions)
 	if err != nil {
 		return nil, err
 	}
+	p.outputs = map[string]cty.Value{}
 
 	return workingDirsToEstimate, nil
 }
 
-// Downloads terraform source if necessary, then runs terraform with the given options and CLI args.
-// This will forward all the args and extra_arguments directly to Terraform.
-// Mostly copied from github.com/gruntwork-io/terragrunt
-func (p *TerragruntHCLProvider) runTerragrunt(terragruntOptions *tgoptions.TerragruntOptions) (*terragruntWorkingDirInfo, error) {
-	terragruntConfig, err := tgconfig.ReadTerragruntConfig(terragruntOptions)
+// runTerragrunt evaluates a Terragrunt directory with the given opts. This method is called from the
+// Terragrunt internal libs as part of the Terraform project evaluation. runTerragrunt is called with for all of the folders
+// in a Terragrunt project. Folders that have outputs that are used by other folders are evaluated first.
+//
+// runTerragrunt will
+//		1. build a valid Terraform run env from the opts provided.
+//		2. download source modules that are required for the project.
+// 		3. we then evaluate the Terraform project built by Terragrunt storing any outputs so that we can use
+//			these for further runTerragrunt calls that use the dependency outputs.
+func (p *TerragruntHCLProvider) runTerragrunt(opts *tgoptions.TerragruntOptions) (*terragruntWorkingDirInfo, error) {
+	outputs, err := p.fetchDependencyOutputs(opts)
 	if err != nil {
 		return nil, err
 	}
 
-	terragruntOptionsClone := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
+	terragruntConfig, err := tgconfig.ParseConfigFile(opts.TerragruntConfigPath, opts, nil, &outputs)
+	if err != nil {
+		return nil, err
+	}
+
+	terragruntOptionsClone := opts.Clone(opts.TerragruntConfigPath)
 	terragruntOptionsClone.TerraformCommand = tgcli.CMD_TERRAGRUNT_READ_CONFIG
 
 	if terragruntConfig.Skip {
-		terragruntOptions.Logger.Infof(
+		opts.Logger.Infof(
 			"Skipping terragrunt module %s due to skip = true.",
-			terragruntOptions.TerragruntConfigPath,
+			opts.TerragruntConfigPath,
 		)
 		return nil, nil
 	}
 
 	// We merge the OriginalIAMRoleOptions into the one from the config, because the CLI passed IAMRoleOptions has
 	// precedence.
-	terragruntOptions.IAMRoleOptions = tgoptions.MergeIAMRoleOptions(
+	opts.IAMRoleOptions = tgoptions.MergeIAMRoleOptions(
 		terragruntConfig.GetIAMRoleOptions(),
-		terragruntOptions.OriginalIAMRoleOptions,
+		opts.OriginalIAMRoleOptions,
 	)
 
-	if err := aws_helper.AssumeRoleAndUpdateEnvIfNecessary(terragruntOptions); err != nil {
+	if err := aws_helper.AssumeRoleAndUpdateEnvIfNecessary(opts); err != nil {
 		return nil, err
 	}
 
 	// get the default download dir
-	_, defaultDownloadDir, err := tgoptions.DefaultWorkingAndDownloadDirs(terragruntOptions.TerragruntConfigPath)
+	_, defaultDownloadDir, err := tgoptions.DefaultWorkingAndDownloadDirs(opts.TerragruntConfigPath)
 	if err != nil {
 		return nil, err
 	}
 
 	// if the download dir hasn't been changed from default, and is set in the config,
 	// then use it
-	if terragruntOptions.DownloadDir == defaultDownloadDir && terragruntConfig.DownloadDir != "" {
-		terragruntOptions.DownloadDir = terragruntConfig.DownloadDir
+	if opts.DownloadDir == defaultDownloadDir && terragruntConfig.DownloadDir != "" {
+		opts.DownloadDir = terragruntConfig.DownloadDir
 	}
 
 	// Override the default value of retryable errors using the value set in the config file
 	if terragruntConfig.RetryableErrors != nil {
-		terragruntOptions.RetryableErrors = terragruntConfig.RetryableErrors
+		opts.RetryableErrors = terragruntConfig.RetryableErrors
 	}
 
 	if terragruntConfig.RetryMaxAttempts != nil {
 		if *terragruntConfig.RetryMaxAttempts < 1 {
 			return nil, fmt.Errorf("Cannot have less than 1 max retry, but you specified %d", *terragruntConfig.RetryMaxAttempts)
 		}
-		terragruntOptions.RetryMaxAttempts = *terragruntConfig.RetryMaxAttempts
+		opts.RetryMaxAttempts = *terragruntConfig.RetryMaxAttempts
 	}
 
 	if terragruntConfig.RetrySleepIntervalSec != nil {
 		if *terragruntConfig.RetrySleepIntervalSec < 0 {
 			return nil, fmt.Errorf("Cannot sleep for less than 0 seconds, but you specified %d", *terragruntConfig.RetrySleepIntervalSec)
 		}
-		terragruntOptions.RetrySleepIntervalSec = time.Duration(*terragruntConfig.RetrySleepIntervalSec) * time.Second
+		opts.RetrySleepIntervalSec = time.Duration(*terragruntConfig.RetrySleepIntervalSec) * time.Second
 	}
 
-	sourceURL, err := tgconfig.GetTerraformSourceUrl(terragruntOptions, terragruntConfig)
+	info := &terragruntWorkingDirInfo{configDir: opts.WorkingDir, workingDir: opts.WorkingDir}
+
+	sourceURL, err := tgconfig.GetTerraformSourceUrl(opts, terragruntConfig)
 	if err != nil {
 		return nil, err
 	}
 	if sourceURL != "" {
-		updatedTerragruntOptions, err := p.downloadTerraformSource(sourceURL, terragruntOptions, terragruntConfig)
+		updatedTerragruntOptions, err := p.downloadTerraformSource(sourceURL, opts, terragruntConfig)
 		if err != nil {
 			return nil, err
 		}
 		if updatedTerragruntOptions != nil && updatedTerragruntOptions.WorkingDir != "" {
-			return &terragruntWorkingDirInfo{ConfigDir: terragruntOptions.WorkingDir, WorkingDir: updatedTerragruntOptions.WorkingDir, Inputs: terragruntConfig.Inputs}, nil
+			info = &terragruntWorkingDirInfo{configDir: opts.WorkingDir, workingDir: updatedTerragruntOptions.WorkingDir}
 		}
 	}
-	return &terragruntWorkingDirInfo{ConfigDir: terragruntOptions.WorkingDir, WorkingDir: terragruntOptions.WorkingDir, Inputs: terragruntConfig.Inputs}, nil
+
+	pconfig := *p.ctx.ProjectConfig // clone the projectConfig
+	pconfig.Path = info.workingDir
+	pconfig.TerraformVars = p.initTerraformVars(pconfig.TerraformVars, terragruntConfig.Inputs)
+
+	h, err := NewHCLProvider(
+		config.NewProjectContext(p.ctx.RunContext, &pconfig),
+		&HCLProviderConfig{CacheParsingModules: true},
+		hcl.OptionWithSpinner(p.ctx.RunContext.NewSpinner),
+		hcl.OptionWithWarningFunc(p.ctx.RunContext.NewWarningWriter()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("could not create provider for Terragrunt generated dir %w", err)
+	}
+
+	mods, err := h.Modules()
+	if err != nil {
+		return nil, fmt.Errorf("could not parse generated Terraform dir from Terragrunt generated dir %w", err)
+	}
+
+	for _, mod := range mods {
+		p.outputs[opts.TerragruntConfigPath] = mod.Blocks.Outputs()
+	}
+
+	info.provider = h
+	return info, nil
+}
+
+// fetchDependencyOutputs returns the Terraform outputs from the dependencies of Terragrunt file provided in the opts input.
+func (p *TerragruntHCLProvider) fetchDependencyOutputs(opts *tgoptions.TerragruntOptions) (cty.Value, error) {
+	outputs := cty.MapVal(map[string]cty.Value{
+		"mock": cty.StringVal("val"),
+	})
+
+	if p.stack != nil {
+		var mod *tgconfigstack.TerraformModule
+		for _, module := range p.stack.Modules {
+			if module.TerragruntOptions.TerragruntConfigPath == opts.TerragruntConfigPath {
+				mod = module
+			}
+		}
+
+		if mod != nil && len(mod.Dependencies) > 0 {
+			blocks, err := decodeDependencyBlocks(mod.TerragruntOptions.TerragruntConfigPath, opts, nil)
+			if err != nil {
+				return cty.Value{}, fmt.Errorf("could not parse dependency blocks for Terragrunt file %s %w", mod.TerragruntOptions.TerragruntConfigPath, err)
+			}
+
+			out := map[string]cty.Value{}
+			for dir, dep := range blocks {
+				out[dep.Name] = cty.MapVal(map[string]cty.Value{
+					"outputs": p.outputs[dir],
+				})
+			}
+
+			outputs = cty.MapVal(out)
+		}
+	}
+
+	return outputs, nil
 }
 
 // 1. Download the given source URL, which should use Terraform's module source syntax, into a temporary folder
@@ -455,4 +509,56 @@ func (p *TerragruntHCLProvider) alreadyHaveLatestCode(terraformSource *tfsource.
 // Copied from github.com/gruntwork-io/terragrunt
 func (p *TerragruntHCLProvider) readVersionFile(terraformSource *tfsource.TerraformSource) (string, error) {
 	return util.ReadFileAsString(terraformSource.VersionFile)
+}
+
+type terragruntDependency struct {
+	Dependencies []tgconfig.Dependency `hcl:"dependency,block"`
+	Remain       hcl2.Body             `hcl:",remain"`
+}
+
+// decodeDependencyBlocks parses the file at filename and returns a map containing all the hcl blocks with the "dependency" label.
+// The map is keyed by the full path of the config_path attribute specified in the dependency block.
+func decodeDependencyBlocks(filename string, terragruntOptions *tgoptions.TerragruntOptions, dependencyOutputs *cty.Value) (map[string]tgconfig.Dependency, error) {
+	parser := hclparse.NewParser()
+	file, _ := parser.ParseHCLFile(filename)
+	localsAsCty, trackInclude, err := tgconfig.DecodeBaseBlocks(terragruntOptions, parser, file, filename, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	contextExtensions := tgconfig.EvalContextExtensions{
+		Locals:              localsAsCty,
+		TrackInclude:        trackInclude,
+		DecodedDependencies: dependencyOutputs,
+	}
+
+	evalContext, err := tgconfig.CreateTerragruntEvalContext(filename, terragruntOptions, contextExtensions)
+	if err != nil {
+		return nil, err
+	}
+
+	var deps terragruntDependency
+	decodeDiagnostics := gohcl.DecodeBody(file.Body, evalContext, &deps)
+	if decodeDiagnostics != nil && decodeDiagnostics.HasErrors() {
+		return nil, decodeDiagnostics
+	}
+
+	depmap := make(map[string]tgconfig.Dependency)
+	for _, dep := range deps.Dependencies {
+		depmap[getCleanedTargetConfigPath(dep.ConfigPath, filename)] = dep
+	}
+
+	return depmap, nil
+}
+
+func getCleanedTargetConfigPath(configPath string, workingPath string) string {
+	cwd := filepath.Dir(workingPath)
+	targetConfig := configPath
+	if !filepath.IsAbs(targetConfig) {
+		targetConfig = util.JoinPath(cwd, targetConfig)
+	}
+	if util.IsDir(targetConfig) {
+		targetConfig = tgconfig.GetDefaultConfigPath(targetConfig)
+	}
+	return util.CleanPath(targetConfig)
 }

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -395,7 +395,7 @@ func newHCLProvider(t *testing.T, runCtx *config.RunContext, tfdir string) *terr
 		},
 	)
 
-	provider, err := terraform.NewHCLProvider(projectCtx, true)
+	provider, err := terraform.NewHCLProvider(projectCtx, &terraform.HCLProviderConfig{SuppressLogging: true})
 	require.NoError(t, err)
 
 	return provider


### PR DESCRIPTION
fixes: https://github.com/infracost/infracost/issues/1641

Changes the Terragrunt HCL parser to build `outputs` for each Terragrunt project run. These outputs are then used by Terragrunt projects that make use of `dependency` blocks. How this works:

1. TerragruntHCLParser has the Terragrunt stack output set on it every run. This contains tree information about which Terragrunt projects there are, and which of those have dependencies.
2. `runTerragrunt` method now evaluates the blocks for the project rather than just returning directory information. This allows us to fetch the `output` blocks.
3. `runTerragrunt` uses `ParseConfigFile` and explicitly passes a `cty.Value` of the `outputs` from any dependency projects used. If none are used we have a mock `cty.Value` which bypasses the Terragrunt call to Terraform.
4. I've changed the HCLProvider to expose a `Modules` method which returns the raw HCL blocks instead of the JSON, so that we can use it in the Terragrunt provider