### PR TITLE
fix: if no dep blocks found for terragrunt_hcl parsing then dont set output

### DIFF
--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -313,7 +313,9 @@ func (p *TerragruntHCLProvider) fetchDependencyOutputs(opts *tgoptions.Terragrun
 				})
 			}
 
-			outputs = cty.MapVal(out)
+			if len(out) > 0 {
+				outputs = cty.MapVal(out)
+			}
 		}
 	}
 


### PR DESCRIPTION
if no dependency blocks are found in the terragrunt hcl file then we still proceed to new up a `cty.Value` with an empty map. This causes a panic: `panic: must not call MapVal with empty map`. This change checks that the map is not empty before setting the value.