### PR TITLE
fix: panic errors not being reported to sentry

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -187,7 +187,7 @@ func handleCLIError(ctx *config.RunContext, cliErr error) {
 		ui.PrintError(ctx.ErrWriter, cliErr.Error())
 	}
 
-	err := apiclient.ReportCLIError(ctx, cliErr)
+	err := apiclient.ReportCLIError(ctx, cliErr, true)
 	if err != nil {
 		log.Warnf("Error reporting CLI error: %s", err)
 	}
@@ -196,7 +196,7 @@ func handleCLIError(ctx *config.RunContext, cliErr error) {
 func handleUnexpectedErr(ctx *config.RunContext, err error) {
 	ui.PrintUnexpectedErrorStack(ctx.ErrWriter, err)
 
-	err = apiclient.ReportCLIError(ctx, err)
+	err = apiclient.ReportCLIError(ctx, err, false)
 	if err != nil {
 		log.Warnf("Error reporting unexpected error: %s", err)
 	}

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -198,7 +198,7 @@ func formatHCLProjects(wg *sync.WaitGroup, ctx *config.RunContext, hclProjects [
 		wg.Done()
 
 		if err != nil {
-			err = apiclient.ReportCLIError(ctx, fmt.Errorf("hcl-runtime-error: formatting hcl projects %s\n%s", err, debug.Stack()))
+			err = apiclient.ReportCLIError(ctx, fmt.Errorf("hcl-runtime-error: formatting hcl projects %s\n%s", err, debug.Stack()), false)
 			if err != nil {
 				log.Debugf("error reporting unexpected hcl runtime error: %s", err)
 			}
@@ -523,7 +523,7 @@ func (r *parallelRunner) runHCLProvider(wg *sync.WaitGroup, ctx *config.ProjectC
 
 		if err != nil {
 			log.Debugf("recovered from hcl provider panic %s", err)
-			err = apiclient.ReportCLIError(r.runCtx, fmt.Errorf("hcl-runtime-error: loading resources %s\n%s", err, debug.Stack()))
+			err = apiclient.ReportCLIError(r.runCtx, fmt.Errorf("hcl-runtime-error: loading resources %s\n%s", err, debug.Stack()), false)
 			if err != nil {
 				log.Debugf("error reporting unexpected hcl runtime error: %s", err)
 			}

--- a/internal/apiclient/errors.go
+++ b/internal/apiclient/errors.go
@@ -15,7 +15,7 @@ import (
 // too many things, but it's a start.
 var pathRegex = regexp.MustCompile(`(\w+:)?[\.~\w]*[\/\\]+([^\s:'\"\]]+)|([\w+-]\.\w{2,})`)
 
-func ReportCLIError(ctx *config.RunContext, cliErr error) error {
+func ReportCLIError(ctx *config.RunContext, cliErr error, replacePath bool) error {
 	errMsg := ui.StripColor(cliErr.Error())
 	var sanitizedErr *clierror.SanitizedError
 
@@ -23,7 +23,9 @@ func ReportCLIError(ctx *config.RunContext, cliErr error) error {
 		errMsg = ui.StripColor(sanitizedErr.SanitizedError())
 	}
 
-	errMsg = pathRegex.ReplaceAllString(errMsg, "REPLACED_PATH")
+	if replacePath {
+		errMsg = pathRegex.ReplaceAllString(errMsg, "REPLACED_PATH")
+	}
 
 	d := ctx.EventEnv()
 	d["error"] = errMsg


### PR DESCRIPTION
This pr fixes two issues which were causing panics not to be reported to sentry:

1. The terragrunt process runs in a child goroutine so we need to properly recover from the panic
2. Stripping metadata from the panic errors caused sentry to not pick up on the `runtime/debug` error