### PR TITLE
fix(aws): Fix usage schema for Elastic Beanstalk Environment

### DIFF
--- a/internal/resources/aws/elastic_beanstalk_environment.go
+++ b/internal/resources/aws/elastic_beanstalk_environment.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
 )
 
 // ElasticBeanstalkEnvironment struct represents AWS Elastic Beanstalk environments.
@@ -29,27 +30,27 @@ type ElasticBeanstalkEnvironment struct {
 var ElasticBeanstalkEnvironmentUsageSchema = []*schema.UsageItem{
 	{
 		Key:          "cloudwatch",
-		DefaultValue: CloudwatchLogGroupUsageSchema,
+		DefaultValue: &usage.ResourceUsage{Name: "cloudwatch", Items: CloudwatchLogGroupUsageSchema},
 		ValueType:    schema.SubResourceUsage,
 	},
 	{
 		Key:          "lb",
-		DefaultValue: LBUsageSchema,
+		DefaultValue: &usage.ResourceUsage{Name: "lb", Items: LBUsageSchema},
 		ValueType:    schema.SubResourceUsage,
 	},
 	{
 		Key:          "elb",
-		DefaultValue: ELBUsageSchema,
+		DefaultValue: &usage.ResourceUsage{Name: "elb", Items: ELBUsageSchema},
 		ValueType:    schema.SubResourceUsage,
 	},
 	{
 		Key:          "db",
-		DefaultValue: DBInstanceUsageSchema,
+		DefaultValue: &usage.ResourceUsage{Name: "db", Items: DBInstanceUsageSchema},
 		ValueType:    schema.SubResourceUsage,
 	},
 	{
 		Key:          "ec2",
-		DefaultValue: LaunchConfigurationUsageSchema,
+		DefaultValue: &usage.ResourceUsage{Name: "ec2", Items: LaunchConfigurationUsageSchema},
 		ValueType:    schema.SubResourceUsage,
 	},
 }


### PR DESCRIPTION
Fixes #1675.

Test:
1. Update `examples/terraform` to include:
   ```terraform
   resource "aws_elastic_beanstalk_application" "tftest" {
     name        = "tf-test-name"
     description = "tf-test-desc"
   }

   resource "aws_elastic_beanstalk_environment" "tfenvtest" {
     name                = "tf-test-name"
     application         = aws_elastic_beanstalk_application.tftest.name
     solution_stack_name = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
   }
   ```

2. Run
   ```
   make run ARGS="breakdown --path=examples/terraform --sync-usage-file --usage-file /tmp/infracost-usage.yml"
   ```

Result: shows breakdown
```
Evaluating Terraform directory at examples/terraform
  ✔ Downloading Terraform modules
  ✔ Evaluating Terraform directory
  ✔ Syncing usage data from cloud
    └─ Synced 0 of 2 resources
  ✔ Downloading Terraform modules
  ✔ Evaluating Terraform directory
  ✔ Retrieving cloud prices to calculate costs

Project: infracost/infracost/examples/terraform

 Name                                               Monthly Qty  Unit              Monthly Cost

 aws_elastic_beanstalk_environment.tfenvtest
 ├─ aws_launch_configuration
 │  ├─ Instance usage (Linux/UNIX, on-demand, )             730  hours                    $0.00
 │  └─ aws_ebs_volume
 │     └─ Storage (general purpose SSD, gp2)                  8  GB                       $0.80
 └─ aws_loadbalancer
    ├─ Network load balancer                                730  hours                   $16.43
    └─ Load balancer capacity units              Monthly cost depends on usage: $4.38 per LCU

 OVERALL TOTAL                                                                           $17.23
```

On master throws error:
```
Evaluating Terraform directory at .
  ✔ Downloading Terraform modules
  ✔ Evaluating Terraform directory
  ⠋ Syncing usage data from cloud panic: interface conversion: interface {} is []*schema.UsageItem, not *usage.ResourceUsage

goroutine 41 [running]:
github.com/infracost/infracost/internal/usage.replaceResourceUsages(0x140007a0690, 0x14000907f10, {0xb0?})
        github.com/infracost/infracost/internal/usage/sync.go:258 +0x618
github.com/infracost/infracost/internal/usage.syncResource(0x1400020b2c0, 0x140003ea630, 0x0?, 0x0?)
        github.com/infracost/infracost/internal/usage/sync.go:198 +0x11c
github.com/infracost/infracost/internal/usage.syncResourceUsages.func1(0x0?, 0x0?)
        github.com/infracost/infracost/internal/usage/sync.go:118 +0x5c
created by github.com/infracost/infracost/internal/usage.syncResourceUsages
        github.com/infracost/infracost/internal/usage/sync.go:116 +0x3b0
```