### PR TITLE
fix: issues with multiple exclude-path flags being used

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -66,8 +66,23 @@ func TestBreakdownMultiProjectSkipPaths(t *testing.T) {
 		[]string{
 			"breakdown",
 			"--path", dir,
-			"--exclude-path", "glob/*/ignored",
+			"--exclude-path", "glob/*/shown",
 			"--exclude-path", "ignored",
+		}, nil,
+	)
+}
+
+func TestBreakdownMultiProjectSkipPathsRootLevel(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", dir,
+			"--exclude-path", "dev",
+			"--exclude-path", "prod",
 		}, nil,
 	)
 }

--- a/cmd/infracost/testdata/breakdown_multi_project_skip_paths_root_level/breakdown_multi_project_skip_paths_root_level.golden
+++ b/cmd/infracost/testdata/breakdown_multi_project_skip_paths_root_level/breakdown_multi_project_skip_paths_root_level.golden
@@ -1,4 +1,4 @@
-Project: infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_skip_paths/shown
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_skip_paths_root_level/shown
 
  Name                                                   Monthly Qty  Unit   Monthly Cost 
                                                                                          

--- a/cmd/infracost/testdata/breakdown_multi_project_skip_paths_root_level/dev/main.tf
+++ b/cmd/infracost/testdata/breakdown_multi_project_skip_paths_root_level/dev/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/cmd/infracost/testdata/breakdown_multi_project_skip_paths_root_level/prod/main.tf
+++ b/cmd/infracost/testdata/breakdown_multi_project_skip_paths_root_level/prod/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/cmd/infracost/testdata/breakdown_multi_project_skip_paths_root_level/shown/main.tf
+++ b/cmd/infracost/testdata/breakdown_multi_project_skip_paths_root_level/shown/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.8xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -170,10 +170,10 @@ type Parser struct {
 // in the given initialPath and returns a Parser for each directory it locates a Terraform project within. If
 // the initialPath contains Terraform files at the top level parsers will be len 1.
 func LoadParsers(initialPath string, excludePaths []string, options ...Option) ([]*Parser, error) {
-	pl := newProjectLocator(excludePaths...)
+	pl := &projectLocator{moduleCalls: make(map[string]struct{}), excludedDirs: excludePaths}
 	rootPaths := pl.findRootModules(initialPath)
 	if len(rootPaths) == 0 {
-		return nil, errors.New("No valid Terraform files found given path, try a different directory")
+		return nil, errors.New("No valid Terraform files found at the given path, try a different directory")
 	}
 
 	var parsers = make([]*Parser, len(rootPaths))
@@ -483,29 +483,60 @@ func loadDirectory(fullPath string, stopOnHCLError bool) ([]file, error) {
 
 type projectLocator struct {
 	moduleCalls  map[string]struct{}
-	excludedDirs []isExcludedFunc
+	excludedDirs []string
 }
 
-type isExcludedFunc func(string) bool
+func (p *projectLocator) buildMatches(fullPath string) func(string) bool {
+	var matches []string
+	globMatches := make(map[string]struct{})
 
-func newProjectLocator(excludedPaths ...string) *projectLocator {
-	skippedPatterns := make([]isExcludedFunc, len(excludedPaths))
-	for i, p := range excludedPaths {
-		skippedPatterns[i] = func(s string) bool {
-			match, _ := filepath.Match(p, s)
+	for _, dir := range p.excludedDirs {
+		var absoluteDir string
+		if dir == filepath.Base(dir) {
+			matches = append(matches, dir)
+		}
 
-			return match
+		if filepath.IsAbs(dir) {
+			absoluteDir = dir
+		} else {
+			absoluteDir = filepath.Join(fullPath, dir)
+		}
+
+		globs, err := filepath.Glob(absoluteDir)
+		if err == nil {
+			for _, m := range globs {
+				globMatches[m] = struct{}{}
+			}
 		}
 	}
 
-	return &projectLocator{moduleCalls: make(map[string]struct{}), excludedDirs: skippedPatterns}
+	return func(dir string) bool {
+		if _, ok := globMatches[dir]; ok {
+			return true
+		}
+
+		base := filepath.Base(dir)
+		for _, match := range matches {
+			if match == base {
+				return true
+			}
+		}
+
+		return false
+	}
 }
 
 func (p *projectLocator) findRootModules(fullPath string) []string {
+	isSkipped := p.buildMatches(fullPath)
 	dirs := p.walkPaths(fullPath, 0)
 
 	var filtered []string
 	for _, dir := range dirs {
+		if isSkipped(dir) {
+			log.Debugf("skipping directory %s as it is marked as exluded by --exclude-path", dir)
+			continue
+		}
+
 		if _, ok := p.moduleCalls[dir]; !ok {
 			filtered = append(filtered, dir)
 		}
@@ -585,10 +616,6 @@ func (p *projectLocator) walkPaths(fullPath string, level int) []string {
 
 	for _, info := range fileInfos {
 		if info.IsDir() {
-			if p.isSkipped(info) {
-				continue
-			}
-
 			if strings.HasPrefix(info.Name(), ".") {
 				continue
 			}
@@ -601,15 +628,4 @@ func (p *projectLocator) walkPaths(fullPath string, level int) []string {
 	}
 
 	return dirs
-}
-
-func (p *projectLocator) isSkipped(info os.DirEntry) bool {
-	for _, isSkipped := range p.excludedDirs {
-		if isSkipped(info.Name()) {
-			log.Debugf("skipping directory %s as it is marked as exluded by --exclude-path", info.Name())
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
Fixes: https://github.com/infracost/infracost/issues/1713#issue-1256882215

* Solves issue with `--exclude-path` being used with multiple directories. Before we were assigning variables to a function in a loop. This meant that the excluded patterns were always being used as the last value in the loop. I've reworked the logic to build all matches into a single evaluation step.
* Reworks internals to parse all directories before filtering so that we don't show module pricing. Before we were doing the ignored directory check at a lower level. This meant that we weren't properly filtering out modules that were used in skipped directories. We now do it at the top level once all directories have been evaluated. 