### PR TITLE
fix: dont use cty.Null values as problematic for type checking

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -412,7 +412,7 @@ func convertType(val cty.Value, attribute *Attribute) cty.Value {
 
 func valueToType(val cty.Value, want cty.Type) cty.Value {
 	if val == cty.NilVal {
-		return cty.NullVal(want)
+		return val
 	}
 
 	newVal, err := convert.Convert(val, want)

--- a/internal/hcl/reference.go
+++ b/internal/hcl/reference.go
@@ -62,6 +62,10 @@ func (r *Reference) SetKey(key cty.Value) {
 		return
 	}
 
+	if key.IsNull() {
+		return
+	}
+
 	switch key.Type() {
 	case cty.Number:
 		f := key.AsBigFloat()

--- a/internal/hcl/reference_test.go
+++ b/internal/hcl/reference_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func Test_ReferenceParsing(t *testing.T) {
@@ -46,6 +47,36 @@ func Test_ReferenceParsing(t *testing.T) {
 		t.Run(test.expected, func(t *testing.T) {
 			ref, err := newReference(test.input)
 			require.NoError(t, err)
+			assert.Equal(t, test.expected, ref.String())
+		})
+	}
+}
+
+func TestReference_SetKey(t *testing.T) {
+	cases := []struct {
+		input    cty.Value
+		expected string
+	}{
+		{
+			input:    cty.NullVal(cty.String),
+			expected: "test.test",
+		},
+		{
+			input:    cty.NilVal,
+			expected: "test.test",
+		},
+		{
+			input:    cty.StringVal("0"),
+			expected: "test.test[\"0\"]",
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.expected, func(t *testing.T) {
+			ref, err := newReference([]string{"resource", "test", "test"})
+			require.NoError(t, err)
+
+			ref.SetKey(test.input)
 			assert.Equal(t, test.expected, ref.String())
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/infracost/infracost/issues/1715

I changed variable evaluation in 0.10.1 to try and convert variable types to what the variable `type` attribute. This introduced a regression where `cty.Nil` values were changed to `cty.String` or `cty.Number` or `cty.Bool` but having their underlying value as nil. 

This means that expressions like:

```
switch key.Type() {
    case cty.String:
        r.key = fmt.Sprintf("[%q]", key.AsString())
}
```

Will panic. `cty.NullValue` should not be used and instead, we should fall back to how it was before with `cty.Nil`.