### PR TITLE
fix: add dummy return types for attributes that cannot be evaluated

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -281,6 +281,9 @@ func TestBreakdownTerragruntGetEnv(t *testing.T) {
 		os.Unsetenv("CUSTOM_OS_VAR_PROD")
 	}()
 
+}
+
+func TestBreakdownTerragruntHCLDepsOutputMocked(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())}, nil)
 }
 

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/prod2/config.yml
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/prod2/config.yml
@@ -1,0 +1,2 @@
+---
+instance_type: "m5.4xlarge"

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/prod2/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/prod2/terragrunt.hcl
@@ -2,15 +2,21 @@ include {
   path = find_in_parent_folders()
 }
 
+locals {
+  local_config = {
+    root_block_device_volume_size = 100
+    block_device_volume_size = 1000
+    block_device_iops = 800
+
+    hello_world_function_memory_size = 1024
+  }
+
+  loaded_config = yamldecode(file("./config.yml"))
+  config = merge(local.local_config, local.loaded_config)
+}
+
 terraform {
   source = "..//modules/example2"
 }
 
-inputs = {
-  instance_type = "m5.4xlarge"
-  root_block_device_volume_size = 100
-  block_device_volume_size = 1000
-  block_device_iops = 800
-  
-  hello_world_function_memory_size = 1024
-}
+inputs = local.config

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/breakdown_terragrunt_hcldeps_output_mocked.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/breakdown_terragrunt_hcldeps_output_mocked.golden
@@ -1,0 +1,63 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/dev
+
+ Name                                                         Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                    
+ aws_instance.web_app                                                                                               
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)                  730  hours                              $8.47 
+ ├─ root_block_device                                                                                               
+ │  └─ Storage (general purpose SSD, gp2)                              50  GB                                 $5.00 
+ └─ ebs_block_device[0]                                                                                             
+    ├─ Storage (provisioned IOPS SSD, io1)                            100  GB                                $12.50 
+    └─ Provisioned IOPS                                               600  IOPS                              $39.00 
+                                                                                                                    
+ aws_lambda_function.hello_world                                                                                    
+ ├─ Requests                                          Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration                                          Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                    
+ Project total                                                                                               $64.97 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+ ├─ root_block_device                                                                                                 
+ │  └─ Storage (general purpose SSD, gp2)                               100  GB                                $10.00 
+ └─ ebs_block_device[0]                                                                                               
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration                                            Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ Project total                                                                                                $747.64 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod2
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+ ├─ root_block_device                                                                                                 
+ │  └─ Storage (general purpose SSD, gp2)                               100  GB                                $10.00 
+ └─ ebs_block_device[0]                                                                                               
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration                                            Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ Project total                                                                                                $747.64 
+
+ OVERALL TOTAL                                                                                              $1,560.25 
+──────────────────────────────────
+6 cloud resources were detected:
+∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/breakdown_terragrunt_hcldeps_output_mocked.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/breakdown_terragrunt_hcldeps_output_mocked.golden
@@ -1,4 +1,5 @@
 Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/dev
+Module path: dev
 
  Name                                                         Monthly Qty  Unit                        Monthly Cost 
                                                                                                                     
@@ -18,6 +19,7 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps
 
 ──────────────────────────────────
 Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod
+Module path: prod
 
  Name                                                           Monthly Qty  Unit                        Monthly Cost 
                                                                                                                       
@@ -37,6 +39,7 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps
 
 ──────────────────────────────────
 Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod2
+Module path: prod2
 
  Name                                                           Monthly Qty  Unit                        Monthly Cost 
                                                                                                                       

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/dev/template.yml
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/dev/template.yml
@@ -1,0 +1,3 @@
+%{ for key,value in ingresses ~}
+key ${key} value ${value}
+%{ endfor ~}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/dev/terragrunt.hcl
@@ -14,9 +14,9 @@ terraform {
   source = "..//modules/example"
 }
 
-
 inputs = {
   tags                          = merge({ "test" : "m5.4xlarge" }, dependency.test.outputs.instance_types)
+  k8s_template                  = templatefile("template.yml", { ingresses = dependency.test.outputs.certificates })
   instance_type                 = dependency.test.outputs.aws_instance_type
   root_block_device_volume_size = 50
   block_device_volume_size      = 100

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/dev/terragrunt.hcl
@@ -1,0 +1,26 @@
+include {
+  path = find_in_parent_folders()
+}
+
+dependency "test" {
+  config_path = "../prod"
+}
+
+dependency "test2" {
+  config_path = "../prod2"
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+
+inputs = {
+  tags                          = merge({ "test" : "m5.4xlarge" }, dependency.test.outputs.instance_types)
+  instance_type                 = dependency.test.outputs.aws_instance_type
+  root_block_device_volume_size = 50
+  block_device_volume_size      = 100
+  block_device_iops             = dependency.test2.outputs.block_iops
+
+  hello_world_function_memory_size = 512
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/modules/example/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/modules/example/main.tf
@@ -61,6 +61,16 @@ locals {
   }
 }
 
+variable "dnsnames" {
+  default = ["one", "two"]
+}
+
+output "certificates" {
+  value = {
+  for name in var.dnsnames :
+  name => aws_instance.web_app.this_attr_does_not_exist
+  }
+}
 
 output "instance_types" {
   value = {

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/modules/example/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/modules/example/main.tf
@@ -1,0 +1,73 @@
+variable "instance_type" {
+  description = "The EC2 instance type for the web app"
+  type        = string
+}
+
+variable "tags" {
+  type    = any
+  default = {}
+}
+
+variable "root_block_device_volume_size" {
+  description = "The size of the root block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_volume_size" {
+  description = "The size of the block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_iops" {
+  description = "The number of IOPS for the block device for the web app EC2 instance"
+  type        = number
+}
+
+variable "hello_world_function_memory_size" {
+  description = "The memory to allocate to the hello world Lambda function"
+  type        = number
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = var.root_block_device_volume_size
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = var.block_device_volume_size
+    iops        = var.block_device_iops
+  }
+
+  tags = var.tags
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  memory_size   = var.hello_world_function_memory_size
+}
+
+// locals blocks to test that dynamic attributes and terraform functions work with the hcl Terragrunt functionality.
+locals {
+  instances = {
+    "m5.4xlarge" = "t2.micro"
+  }
+}
+
+
+output "instance_types" {
+  value = {
+    "test2" : aws_instance.web_app.this_attr_does_not_exist
+  }
+}
+
+output "aws_instance_type" {
+  value = lookup(local.instances, var.instance_type, "t2.medium")
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/modules/example2/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/modules/example2/main.tf
@@ -1,0 +1,56 @@
+variable "instance_type" {
+  description = "The EC2 instance type for the web app"
+  type        = string
+}
+
+variable "root_block_device_volume_size" {
+  description = "The size of the root block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_volume_size" {
+  description = "The size of the block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_iops" {
+  description = "The number of IOPS for the block device for the web app EC2 instance"
+  type        = number
+}
+
+variable "hello_world_function_memory_size" {
+  description = "The memory to allocate to the hello world Lambda function"
+  type        = number
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = var.root_block_device_volume_size
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = var.block_device_volume_size
+    iops        = var.block_device_iops
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  memory_size   = var.hello_world_function_memory_size
+}
+
+output "block_iops" {
+  value = 600
+}
+
+output "test_object_type" {
+  value = aws_instance.web_app
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod/terragrunt.hcl
@@ -1,0 +1,16 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type = "m5.4xlarge"
+  root_block_device_volume_size = 100
+  block_device_volume_size = 1000
+  block_device_iops = 800
+  
+  hello_world_function_memory_size = 1024
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod/terragrunt.hcl
@@ -11,6 +11,7 @@ inputs = {
   root_block_device_volume_size = 100
   block_device_volume_size = 1000
   block_device_iops = 800
-  
+  dnsnames = "test"
+
   hello_world_function_memory_size = 1024
 }

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod2/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/prod2/terragrunt.hcl
@@ -1,0 +1,16 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example2"
+}
+
+inputs = {
+  instance_type = "m5.4xlarge"
+  root_block_device_volume_size = 100
+  block_device_volume_size = 1000
+  block_device_iops = 800
+  
+  hello_world_function_memory_size = 1024
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output_mocked/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+  aws_region = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+}
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region                      = "${local.aws_region}"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+EOF
+}

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -136,6 +136,34 @@ func (blocks Blocks) OfType(t string) Blocks {
 	return results
 }
 
+// BlockMatcher defines a struct that can be used to filter a list of blocks to a single Block.
+type BlockMatcher struct {
+	Type  string
+	Label string
+}
+
+// Matching returns a single block filtered from the given pattern.
+// If more than one Block is filtered by the pattern, Matching returns the first Block found.
+func (blocks Blocks) Matching(pattern BlockMatcher) *Block {
+	search := blocks
+
+	if pattern.Type != "" {
+		search = blocks.OfType(pattern.Type)
+	}
+
+	for _, block := range search {
+		if pattern.Label == block.Label() {
+			return block
+		}
+	}
+
+	if len(search) > 0 {
+		return search[0]
+	}
+
+	return nil
+}
+
 // Outputs returns a map of all the evaluated outputs from the list of Blocks.
 func (blocks Blocks) Outputs(suppressNil bool) cty.Value {
 	data := make(map[string]cty.Value)

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -826,6 +826,18 @@ func (b *Block) Index() *int64 {
 	return nil
 }
 
+// Key returns the foreach key of the block using the name label.
+// Key returns nil if the block has no each key.
+func (b *Block) Key() *string {
+	m := foreachRegex.FindStringSubmatch(b.NameLabel())
+
+	if len(m) > 0 {
+		return &m[1]
+	}
+
+	return nil
+}
+
 func (b *Block) Label() string {
 	return strings.Join(b.hclBlock.Labels, ".")
 }

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -238,11 +238,13 @@ type Block struct {
 	childBlocks Blocks
 	// verbose determines whether the block uses verbose debug logging.
 	verbose  bool
+	newMock  func(attr *Attribute) cty.Value
 	Filename string
 }
 
 // BlockBuilder handles generating new Blocks as part of the parsing and evaluation process.
 type BlockBuilder struct {
+	MockFunc      func(a *Attribute) cty.Value
 	SetAttributes []SetAttributesFunc
 }
 
@@ -270,6 +272,7 @@ func (b BlockBuilder) NewBlock(filename string, hclBlock *hcl.Block, ctx *Contex
 			moduleBlock: moduleBlock,
 			childBlocks: children,
 			verbose:     isLoggingVerbose,
+			newMock:     b.MockFunc,
 		}
 	}
 
@@ -285,6 +288,7 @@ func (b BlockBuilder) NewBlock(filename string, hclBlock *hcl.Block, ctx *Contex
 			moduleBlock: moduleBlock,
 			childBlocks: children,
 			verbose:     isLoggingVerbose,
+			newMock:     b.MockFunc,
 		}
 	}
 
@@ -298,6 +302,7 @@ func (b BlockBuilder) NewBlock(filename string, hclBlock *hcl.Block, ctx *Contex
 		moduleBlock: moduleBlock,
 		childBlocks: children,
 		verbose:     isLoggingVerbose,
+		newMock:     b.MockFunc,
 	}
 }
 
@@ -640,7 +645,7 @@ func (b *Block) GetAttributes() []*Attribute {
 	}
 
 	for _, attr := range b.getHCLAttributes() {
-		results = append(results, &Attribute{HCLAttr: attr, Ctx: b.context, Verbose: b.verbose})
+		results = append(results, &Attribute{newMock: b.newMock, HCLAttr: attr, Ctx: b.context, Verbose: b.verbose})
 	}
 
 	return results

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -460,6 +460,14 @@ func (b *Block) IsCountExpanded() bool {
 	return b.expanded
 }
 
+func (b Block) ShouldExpand() bool {
+	if b.IsCountExpanded() {
+		return false
+	}
+
+	return b.Type() == "resource" || b.Type() == "module" || b.Type() == "data"
+}
+
 // SetContext sets the Block.context to the provided ctx. This ctx is also set on the child Blocks as
 // a child Context. Meaning that it can be used in traversal evaluation when looking up Context variables.
 func (b *Block) SetContext(ctx *Context) {

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -319,15 +319,16 @@ func (e *Evaluator) expandBlockCounts(blocks Blocks) Blocks {
 	var countFiltered Blocks
 	for _, block := range blocks {
 		countAttr := block.GetAttribute("count")
-		if countAttr == nil || block.IsCountExpanded() || (block.Type() != "resource" && block.Type() != "module") {
+		if countAttr == nil || !block.ShouldExpand() {
 			countFiltered = append(countFiltered, block)
 			continue
 		}
 
 		count := 1
-		if !countAttr.Value().IsNull() && countAttr.Value().IsKnown() {
-			if countAttr.Value().Type() == cty.Number {
-				f, _ := countAttr.Value().AsBigFloat().Float64()
+		value := countAttr.Value()
+		if !value.IsNull() && value.IsKnown() {
+			if value.Type() == cty.Number {
+				f, _ := value.AsBigFloat().Float64()
 				count = int(f)
 			}
 		}
@@ -535,7 +536,7 @@ func expandCountBlockToValue(b *Block, existingValues map[string]cty.Value) cty.
 	}
 
 	elements = append(elements, b.Values())
-	return cty.ListVal(elements)
+	return cty.TupleVal(elements)
 }
 
 func expandedEachBlockToValue(b *Block, existingValues map[string]cty.Value) cty.Value {

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -178,13 +178,13 @@ func LoadParsers(initialPath string, excludePaths []string, options ...Option) (
 
 	var parsers = make([]*Parser, len(rootPaths))
 	for i, rootPath := range rootPaths {
-		parsers[i] = newParser(rootPath, options)
+		parsers[i] = newParser(rootPath, options...)
 	}
 
 	return parsers, nil
 }
 
-func newParser(initialPath string, options []Option) *Parser {
+func newParser(initialPath string, options ...Option) *Parser {
 	p := &Parser{
 		initialPath:   initialPath,
 		workspaceName: "default",

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -108,6 +108,30 @@ func OptionWithInputVars(vars map[string]string) Option {
 	}
 }
 
+// OptionWithRawCtyInput sets the input variables for the parser using a cty.Value.
+// OptionWithRawCtyInput expects that this input is a ObjectValue that can be transformed to a map.
+func OptionWithRawCtyInput(input cty.Value) Option {
+	defer func() {
+		err := recover()
+		if err != nil {
+			log.Debugf("recovering from panic using raw input cty value %s", err)
+		}
+	}()
+
+	asMap := input.AsValueMap()
+
+	return func(p *Parser) {
+		if p.inputVars == nil {
+			p.inputVars = asMap
+			return
+		}
+
+		for k, v := range asMap {
+			p.inputVars[k] = v
+		}
+	}
+}
+
 // OptionWithRemoteVarLoader accepts Terraform Cloud/Enterprise host and token
 // values to load remote execution variables.
 func OptionWithRemoteVarLoader(host, token, localWorkspace string) Option {

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -161,7 +161,12 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 				testPath,
 				[]string{},
 				hcl.OptionWithBlockBuilder(
-					hcl.BlockBuilder{SetAttributes: []hcl.SetAttributesFunc{setMockAttributes(tt.attrs)}},
+					hcl.BlockBuilder{
+						MockFunc: func(a *hcl.Attribute) cty.Value {
+							return cty.StringVal(fmt.Sprintf("mocked-%s", a.Name()))
+						},
+						SetAttributes: []hcl.SetAttributesFunc{setMockAttributes(tt.attrs)},
+					},
 				),
 			)
 			require.NoError(t, err)

--- a/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/expected.json
@@ -57,7 +57,7 @@
                 "id": "svc-1",
                 "launch_type": "FARGATE",
                 "name": "ecs_service_module_1",
-                "task_definition": null
+                "task_definition": "ecs_task_module_1:mocked-task_definition"
               },
               "infracost_metadata": {
                 "calls": [
@@ -133,7 +133,7 @@
                     "id": "svc-2",
                     "launch_type": "FARGATE",
                     "name": "ecs_service_module_2",
-                    "task_definition": null
+                    "task_definition": "ecs_task_module_2:mocked-task_definition"
                   },
                   "infracost_metadata": {
                     "calls": [
@@ -211,7 +211,7 @@
           "id": "svc-1",
           "launch_type": "FARGATE",
           "name": "ecs_service_module_1",
-          "task_definition": null
+          "task_definition": "ecs_task_module_1:mocked-task_definition"
         }
       }
     },
@@ -264,7 +264,7 @@
           "id": "svc-2",
           "launch_type": "FARGATE",
           "name": "ecs_service_module_2",
-          "task_definition": null
+          "task_definition": "ecs_task_module_2:mocked-task_definition"
         }
       }
     }

--- a/internal/resources/aws/rds_cluster_instance.go
+++ b/internal/resources/aws/rds_cluster_instance.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/infracost/infracost/internal/resources"
-	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
 )
 
 type RDSClusterInstance struct {
@@ -116,14 +117,11 @@ func (r *RDSClusterInstance) BuildResource() *schema.Resource {
 }
 
 func (r *RDSClusterInstance) databaseEngineValue() string {
-	switch r.Engine {
-	case "aurora", "aurora-mysql", "":
-		return "Aurora MySQL"
-	case "aurora-postgresql":
+	if r.Engine == "aurora-postgresql" {
 		return "Aurora PostgreSQL"
 	}
 
-	return ""
+	return "Aurora MySQL"
 }
 
 func (r *RDSClusterInstance) cpuCreditsCostComponent(databaseEngine, instanceFamily string, vCPUCount decimal.Decimal) *schema.CostComponent {


### PR DESCRIPTION
closes https://github.com/infracost/infracost/issues/1718, https://github.com/infracost/infracost/issues/1641, https://github.com/infracost/infracost/issues/1756

Fixes various issues that have been exposed by trying to fetch values for attributes that don't exist.

1. When fetching an attribute value we now check `diags` error returned. If the message returned is an instance of "Unsupported Attribute" we attempt to set a dummy attribute on the global evaluation context.
2. If the message returned is an "Iteration over non-iterable value" then we change the dummy attribute to a list
3. Fixes issues with each & count attributes being set as the wrong context value when running in the evaluation loop. We now set them correctly within the `evaluation` step
4. Inits the `HCLProvider` with raw input vars so that dependencies can get the correct vars when fetching outputs