### PR TITLE
fix: add better error reporting around Terragrunt errors

### DIFF
--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -187,7 +187,7 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 				err.Error(),
 				fmt.Sprintf("For a list of known issues and workarounds, see: %s", ui.LinkString("https://infracost.io/docs/features/terragrunt/")),
 			),
-			"Error parsing the Terragrunt code using the Terragrunt library",
+			fmt.Sprintf("Error parsing the Terragrunt code using the Terragrunt library: %s", err),
 		)
 	}
 	p.outputs = map[string]cty.Value{}


### PR DESCRIPTION
Changes Terragrunt error string from:

```
Error parsing the Terragrunt code using the Terragrunt library
```

to:

```
Error parsing the Terragrunt code using the Terragrunt library: 2 errors occurred:
	* REPLACED_PATH:11,41-54: Unsupported attribute; This object does not have an attribute named "aws_regiondd"., and 1 other diagnostic(s)
	* REPLACED_PATH:11,41-54: Unsupported attribute; This object does not have an attribute named "aws_regiondd"., and 1 other diagnostic(s)
```