### PR TITLE
feat: Don't run docker process as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,12 @@ COPY --from=builder /usr/bin/terraform* /usr/bin/
 COPY --from=builder /usr/bin/terragrunt /usr/bin/
 COPY --from=builder /app/build/infracost /usr/bin/
 
+RUN addgroup --gid 1000 infracost; \
+  adduser infracost --uid 1000 -G infracost -H -D -s /sbin/nologin; \
+  mkdir -p /infracost; \
+  chown infracost:infracost /infracost
+
+USER infracost
+WORKDIR /infracost
+
 ENTRYPOINT [ "infracost" ]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -43,4 +43,12 @@ ENV INFRACOST_CI_IMAGE=true
 ENV INFRACOST_SKIP_UPDATE_CHECK='true'
 ENV INFRACOST_LOG_LEVEL=info
 
+RUN addgroup --gid 1000 infracost; \
+  adduser infracost --uid 1000 -G infracost -H -D -s /sbin/nologin; \
+  mkdir -p /infracost; \
+  chown infracost:infracost /infracost
+
+USER infracost
+WORKDIR /infracost
+
 ENTRYPOINT ["infracost"]


### PR DESCRIPTION
### Objective

This PR makes the docker process run as a non root user.

### Background

Some state and cache files are created when running the infracost docker process and I noticed that on my CI/CD server those files became owned by root causing some issues when trying to clean them up afterwards on subsequent pipeline runs.

As best practice we try to run docker processes with a non-privileged user in order to prevent any security issues and I took this opportunity to tackle it on infracost.

### Running

There is a slight difference when running the docker process with these changes and I didn't find where I could document it.
Previous to these changes we did:
```
docker run -e INFRACOST_API_KEY -v "$PWD":/root --rm infracost/infracost:ci-<version> breakdown --path . --format json --out-file infracost.json
```

With these changes:
```
docker run -e INFRACOST_API_KEY -v "$PWD":/infracost --rm infracost/infracost:ci-<version> breakdown --path . --format json --out-file infracost.json
```

Notice how we bind mount the code directory, we bind mount the code directory to `/infracost` instead of `/root`.

Let me know your thoughts and if there's anything else I could help with.
