### PR TITLE
fix: defer function not returning an empty option func when recovering

### DIFF
--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -110,11 +110,12 @@ func OptionWithInputVars(vars map[string]string) Option {
 
 // OptionWithRawCtyInput sets the input variables for the parser using a cty.Value.
 // OptionWithRawCtyInput expects that this input is a ObjectValue that can be transformed to a map.
-func OptionWithRawCtyInput(input cty.Value) Option {
+func OptionWithRawCtyInput(input cty.Value) (op Option) {
 	defer func() {
 		err := recover()
 		if err != nil {
 			log.Debugf("recovering from panic using raw input cty value %s", err)
+			op = func(p *Parser) {}
 		}
 	}()
 

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -565,6 +565,45 @@ output "mod_result" {
 	assert.Equal(t, "ok", childValAttr.Value().AsString())
 }
 
+func TestOptionWithRawCtyInput(t *testing.T) {
+	type args struct {
+		input cty.Value
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]cty.Value
+	}{
+		{
+			name: "test panic returns empty Option",
+			args: args{
+				input: cty.NilVal,
+			},
+			want: map[string]cty.Value{},
+		},
+		{
+			name: "sets input vars from cty object",
+			args: args{
+				input: cty.ObjectVal(map[string]cty.Value{
+					"test": cty.StringVal("val"),
+				}),
+			},
+			want: map[string]cty.Value{
+				"test": cty.StringVal("val"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Parser{inputVars: map[string]cty.Value{}}
+			option := OptionWithRawCtyInput(tt.args.input)
+			option(&p)
+
+			assert.Equalf(t, tt.want, p.inputVars, "OptionWithRawCtyInput(%v)", tt.args.input)
+		})
+	}
+}
+
 func createTestFile(filename, contents string) string {
 	dir, err := ioutil.TempDir(os.TempDir(), "infracost")
 	if err != nil {


### PR DESCRIPTION
When an invalid `cty.Type` is passed as a raw input type we recover from panic to ignore setting any input vars on the HCL parser. However the defer func does not return a valid option which means that it introduces a runtime error further down the program operation.