### PR TITLE
fix: resolve private Terraform registry modules

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           INFRACOST_API_KEY: "00000000000000000000000000000000"
           INFRACOST_LOG_LEVEL: info
+          INFRACOST_TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
 
       - name: Test example works ok from CLI
         run: |

--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -363,3 +363,16 @@ func TestBreakdownInitFlagsError(t *testing.T) {
 		nil,
 	)
 }
+
+func TestBreakdownWithPrivateTerraformRegistryModule(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path",
+			path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		nil,
+	)
+}

--- a/cmd/infracost/hcl_test.go
+++ b/cmd/infracost/hcl_test.go
@@ -10,13 +10,13 @@ import (
 func TestHCLMultiProjectInfra(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(),
 		[]string{"breakdown", "--config-file", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName(), "infracost.config.yml")},
-		&GoldenFileOptions{RunTerraformCLI: true})
+		nil)
 }
 
 func TestHCLMultiWorkspace(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(),
 		[]string{"breakdown", "--config-file", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName(), "infracost.config.yml")},
-		&GoldenFileOptions{RunTerraformCLI: true})
+		nil)
 }
 
 func TestHCLMultiVarFiles(t *testing.T) {

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	stdLog "log"
 	"os"
 	"runtime/debug"
 
@@ -19,6 +20,12 @@ import (
 	"github.com/infracost/infracost/internal/update"
 	"github.com/infracost/infracost/internal/version"
 )
+
+func init() {
+	// set the stdlib default logger to flush to discard, this is done as a number of
+	// Terraform libs use the std logger directly, which impacts Infracost output.
+	stdLog.SetOutput(ioutil.Discard)
+}
 
 func main() {
 	Run(nil, nil)

--- a/cmd/infracost/testdata/breakdown_with_private_terraform_registry_module/breakdown_with_private_terraform_registry_module.golden
+++ b/cmd/infracost/testdata/breakdown_with_private_terraform_registry_module/breakdown_with_private_terraform_registry_module.golden
@@ -1,0 +1,41 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_private_terraform_registry_module
+
+ Name                                                 Monthly Qty  Unit     Monthly Cost 
+                                                                                         
+ module.ec2_cluster.aws_instance.this[0]                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours           $8.47 
+ ├─ EC2 detailed monitoring                                     7  metrics         $2.10 
+ └─ root_block_device                                                                    
+    └─ Storage (general purpose SSD, gp2)                       8  GB              $0.80 
+                                                                                         
+ module.ec2_cluster.aws_instance.this[1]                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours           $8.47 
+ ├─ EC2 detailed monitoring                                     7  metrics         $2.10 
+ └─ root_block_device                                                                    
+    └─ Storage (general purpose SSD, gp2)                       8  GB              $0.80 
+                                                                                         
+ module.ec2_cluster.aws_instance.this[2]                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours           $8.47 
+ ├─ EC2 detailed monitoring                                     7  metrics         $2.10 
+ └─ root_block_device                                                                    
+    └─ Storage (general purpose SSD, gp2)                       8  GB              $0.80 
+                                                                                         
+ module.ec2_cluster.aws_instance.this[3]                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours           $8.47 
+ ├─ EC2 detailed monitoring                                     7  metrics         $2.10 
+ └─ root_block_device                                                                    
+    └─ Storage (general purpose SSD, gp2)                       8  GB              $0.80 
+                                                                                         
+ module.ec2_cluster.aws_instance.this[4]                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours           $8.47 
+ ├─ EC2 detailed monitoring                                     7  metrics         $2.10 
+ └─ root_block_device                                                                    
+    └─ Storage (general purpose SSD, gp2)                       8  GB              $0.80 
+                                                                                         
+ OVERALL TOTAL                                                                    $56.84 
+──────────────────────────────────
+5 cloud resources were detected:
+∙ 5 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_private_terraform_registry_module/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_private_terraform_registry_module/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+module "ec2_cluster" {
+  source  = "app.terraform.io/infracost/ec2-instance/aws"
+  version = "~> 2.0"
+
+  name           = "my-cluster"
+  instance_count = 5
+
+  ami                    = "ami-ebd02392"
+  instance_type          = "t2.micro"
+  key_name               = "user1"
+  monitoring             = true
+  vpc_security_group_ids = ["sg-12345678"]
+  subnet_id              = "subnet-eddcdzz4"
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
+  }
+}

--- a/examples/terraform/main.tf
+++ b/examples/terraform/main.tf
@@ -6,24 +6,28 @@ provider "aws" {
   secret_key                  = "mock_secret_key"
 }
 
-module "ec2_cluster" {
-  source  = "app.terraform.io/infracost/ec2-instance/aws"
-  version = "~> 2.0"
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge" # <<<<< Try changing this to m5.8xlarge to compare the costs
 
-  name           = "my-cluster"
-  instance_count = 5
-
-  ami                    = "ami-ebd02392"
-  instance_type          = "t2.micro"
-  key_name               = "user1"
-  monitoring             = true
-  vpc_security_group_ids = ["sg-12345678"]
-  subnet_id              = "subnet-eddcdzz4"
-
-  tags = {
-    Terraform   = "true"
-    Environment = "dev"
+  root_block_device {
+    volume_size = 50
   }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1" # <<<<< Try changing this to gp2 to compare costs
+    volume_size = 1000
+    iops        = 800
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  memory_size   = 1024 # <<<<< Try changing this to 512 to compare costs
 }
 
 output "aws_instance_type" {

--- a/examples/terraform/main.tf
+++ b/examples/terraform/main.tf
@@ -6,28 +6,24 @@ provider "aws" {
   secret_key                  = "mock_secret_key"
 }
 
-resource "aws_instance" "web_app" {
-  ami           = "ami-674cbc1e"
-  instance_type = "m5.4xlarge" # <<<<< Try changing this to m5.8xlarge to compare the costs
+module "ec2_cluster" {
+  source  = "app.terraform.io/infracost/ec2-instance/aws"
+  version = "~> 2.0"
 
-  root_block_device {
-    volume_size = 50
+  name           = "my-cluster"
+  instance_count = 5
+
+  ami                    = "ami-ebd02392"
+  instance_type          = "t2.micro"
+  key_name               = "user1"
+  monitoring             = true
+  vpc_security_group_ids = ["sg-12345678"]
+  subnet_id              = "subnet-eddcdzz4"
+
+  tags = {
+    Terraform   = "true"
+    Environment = "dev"
   }
-
-  ebs_block_device {
-    device_name = "my_data"
-    volume_type = "io1" # <<<<< Try changing this to gp2 to compare costs
-    volume_size = 1000
-    iops        = 800
-  }
-}
-
-resource "aws_lambda_function" "hello_world" {
-  function_name = "hello_world"
-  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
-  handler       = "exports.test"
-  runtime       = "nodejs12.x"
-  memory_size   = 1024 # <<<<< Try changing this to 512 to compare costs
 }
 
 output "aws_instance_type" {

--- a/go.mod
+++ b/go.mod
@@ -214,3 +214,5 @@ require (
 replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1.1-0.20210226104003-408905a61c8e
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
+
+replace github.com/gruntwork-io/terragrunt => /Users/ali/code/terragrunt

--- a/go.mod
+++ b/go.mod
@@ -100,8 +100,10 @@ require (
 
 require (
 	github.com/alecthomas/jsonschema v0.0.0-20211209230136-e2b41affa5c1
+	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/go-github/v41 v41.0.0
 	github.com/gruntwork-io/terragrunt v0.36.9
+	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734
 	github.com/pkg/browser v0.0.0-20201207095918-0426ae3fba23
 	github.com/shurcooL/githubv4 v0.0.0-20220115235240-a14260e6f8a2
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a
@@ -135,7 +137,6 @@ require (
 	github.com/go-errors/errors v1.0.2-0.20180813162953-d98b870cc4e0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect
@@ -147,7 +148,6 @@ require (
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/terraform v0.15.3 // indirect
-	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/vault/api v1.0.5-0.20210210214158-405eced08457 // indirect
 	github.com/hashicorp/vault/sdk v0.1.14-0.20210322210658-b52b8b8c1264 // indirect
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect
@@ -214,5 +214,3 @@ require (
 replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1.1-0.20210226104003-408905a61c8e
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
-
-replace github.com/gruntwork-io/terragrunt => /Users/ali/code/terragrunt

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
-	github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.2.1
 	github.com/joho/godotenv v1.4.0
@@ -56,7 +55,6 @@ require (
 
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/apparentlymart/go-textseg v1.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,7 @@ github.com/aliscott/go-pretty/v6 v6.1.1-0.20210226104003-408905a61c8e/go.mod h1:
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190329064014-6e358769c32a/go.mod h1:T9M45xf79ahXVelWoOBmH0y4aC1t5kXO5BxwyakgIGA=
 github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20190103054945-8205d1f41e70/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/aliyun/aliyun-tablestore-go-sdk v4.1.2+incompatible/go.mod h1:LDQHRZylxvcg8H7wBIDfvO5g/cy4/sz1iucBlc2l3Jw=
+github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antchfx/xpath v0.0.0-20190129040759-c8489ed3251e/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0/go.mod h1:LzD22aAzDP8/dyiCKFp31He4m2GPjl0AFyzDtZzUu9M=
@@ -236,6 +237,7 @@ github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD
 github.com/armon/go-metrics v0.3.3/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
@@ -619,6 +621,7 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
@@ -629,6 +632,7 @@ github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4u
 github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Aiu34=
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2SubfXjIWgci8=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
 github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
 github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
@@ -850,6 +854,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
+github.com/gruntwork-io/terragrunt v0.36.9 h1:N5935Zog4DcnNctDFpabxCs+pEGhqdxqCDXN10btD+g=
+github.com/gruntwork-io/terragrunt v0.36.9/go.mod h1:rO4Y+T5tY0qZBpVpnq9JRcMubEMByMcZ9RTHPxUyx84=
 github.com/gruntwork-io/terratest v0.32.6 h1:OEA11ZqEwKRowEdxusDnAPnMUN0w/jzeNcziuQsqkYk=
 github.com/gruntwork-io/terratest v0.32.6/go.mod h1:0iy7d56CziX3R4ZUn570HMElr4WgBKoKNa8Hzex7bvo=
 github.com/hashicorp/aws-sdk-go-base v0.6.0/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=
@@ -1074,6 +1080,7 @@ github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHef
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/winrm v0.0.0-20200615185753-c42b5136ff88/go.mod h1:a2HXwefeat3evJHxFXSayvRHpYEPJYtErl4uIzfaUqY=
+github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -850,8 +850,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/gruntwork-io/gruntwork-cli v0.7.0/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
-github.com/gruntwork-io/terragrunt v0.36.9 h1:N5935Zog4DcnNctDFpabxCs+pEGhqdxqCDXN10btD+g=
-github.com/gruntwork-io/terragrunt v0.36.9/go.mod h1:rO4Y+T5tY0qZBpVpnq9JRcMubEMByMcZ9RTHPxUyx84=
 github.com/gruntwork-io/terratest v0.32.6 h1:OEA11ZqEwKRowEdxusDnAPnMUN0w/jzeNcziuQsqkYk=
 github.com/gruntwork-io/terratest v0.32.6/go.mod h1:0iy7d56CziX3R4ZUn570HMElr4WgBKoKNa8Hzex7bvo=
 github.com/hashicorp/aws-sdk-go-base v0.6.0/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=

--- a/go.sum
+++ b/go.sum
@@ -225,7 +225,6 @@ github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:o
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-shquot v0.0.1/go.mod h1:lw58XsE5IgUXZ9h0cxnypdx31p9mPFIVEQ9P3c7MlrU=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
@@ -330,7 +329,6 @@ github.com/briandowns/spinner v1.15.0 h1:L0jR0MYN7OAeMwpTzDZWIeqyDLXtTeJFxqoq+sL
 github.com/briandowns/spinner v1.15.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
-github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
@@ -861,7 +859,6 @@ github.com/gruntwork-io/terratest v0.32.6/go.mod h1:0iy7d56CziX3R4ZUn570HMElr4Wg
 github.com/hashicorp/aws-sdk-go-base v0.6.0/go.mod h1:2fRjWDv3jJBeN6mVWFHV6hFTNeFBx2gpDLQaZNxUVAY=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -889,7 +886,6 @@ github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-kms-wrapping/entropy v0.1.0/go.mod h1:d1g9WGtAunDNpek8jUIEJnBlbgKS1N2Q61QkHiZyR1g=
 github.com/hashicorp/go-msgpack v0.5.4/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
-github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
@@ -937,8 +933,6 @@ github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV
 github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.12.0 h1:PsYxySWpMD4KPaoJLnsHwtK5Qptvj/4Q6s0t4sUxZf4=
 github.com/hashicorp/hcl/v2 v2.12.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
-github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80 h1:PFfGModn55JA0oBsvFghhj0v93me+Ctr3uHC/UmFAls=
-github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80/go.mod h1:Cxv+IJLuBiEhQ7pBYGEuORa0nr4U994pE8mYLuFd7v0=
 github.com/hashicorp/jsonapi v0.0.0-20210420151930-edf82c9774bf/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
@@ -985,7 +979,6 @@ github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6t
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a/go.mod h1:yL958EeXv8Ylng6IfnvG4oflryUi3vgA3xPs9hmII1s=
@@ -1656,7 +1649,6 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
@@ -2219,7 +2211,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/api v0.0.0-20190620084959-7cf5895f2711/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E4v2+5ZY8r8sAMnyFC5A=
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/api v0.19.3/go.mod h1:VF+5FT1B74Pw3KxMdKyinLo+zynBaMBiAfGMuldcNDs=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -109,6 +109,19 @@ projects:
 			err := os.WriteFile(path, tt.contents, os.ModePerm)
 			require.NoError(t, err)
 
+			// we need to remove INFRACOST_TERRAFORM_CLOUD_TOKEN value for these tests.
+			// as CI uses INFRACOST_TERRAFORM_CLOUD_TOKEN for private registry tests. This means the expected value
+			// will be inconsistent and show "***".
+			key := "INFRACOST_TERRAFORM_CLOUD_TOKEN"
+			v := os.Getenv(key)
+			os.Unsetenv(key)
+
+			if v != "" {
+				defer func() {
+					os.Setenv(key, v)
+				}()
+			}
+
 			err = c.LoadFromConfigFile(path)
 
 			require.Equal(t, tt.error, err)

--- a/internal/credentials/terraform.go
+++ b/internal/credentials/terraform.go
@@ -1,0 +1,147 @@
+package credentials
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	ErrMissingCloudToken = errors.New("no Terraform Cloud token is set")
+	ErrInvalidCloudToken = errors.New("invalid Terraform Cloud Token")
+)
+
+// FindTerraformCloudToken returns a TFC Bearer token for the given host.
+func FindTerraformCloudToken(host string) string {
+	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
+		log.Debugf("TF_CLI_CONFIG_FILE is set, checking %s for Terraform Cloud credentials", os.Getenv("TF_CLI_CONFIG_FILE"))
+		token, err := credFromHCL(os.Getenv("TF_CLI_CONFIG_FILE"), host)
+		if err != nil {
+			log.Debugf("Error reading Terraform config file %s: %v", os.Getenv("TF_CLI_CONFIG_FILE"), err)
+		}
+		if token != "" {
+			return token
+		}
+	}
+
+	credFile := defaultCredFile()
+	if _, err := os.Stat(credFile); err == nil {
+		log.Debugf("Checking %s for Terraform Cloud credentials", credFile)
+		token, err := credFromJSON(credFile, host)
+		if err != nil {
+			log.Debugf("Error reading Terraform credentials file %s: %v", credFile, err)
+		}
+		if token != "" {
+			return token
+		}
+	}
+
+	confFile := defaultConfFile()
+	if _, err := os.Stat(confFile); err == nil {
+		log.Debugf("Checking %s for Terraform Cloud credentials", confFile)
+		token, err := credFromHCL(confFile, host)
+		if err != nil {
+			log.Debugf("Error reading Terraform config file %s: %v", confFile, err)
+		}
+		if token != "" {
+			return token
+		}
+	}
+
+	return ""
+}
+
+func credFromHCL(filename string, host string) (string, error) {
+	parser := hclparse.NewParser()
+	f, parseDiags := parser.ParseHCLFile(filename)
+	if parseDiags.HasErrors() {
+		return "", parseDiags
+	}
+
+	var conf struct {
+		Credentials []struct {
+			Name  string `hcl:"name,label"`
+			Token string `hcl:"token"`
+		} `hcl:"credentials,block"`
+	}
+
+	decodeDiags := gohcl.DecodeBody(f.Body, nil, &conf)
+	if decodeDiags.HasErrors() {
+		return "", parseDiags
+	}
+
+	for _, c := range conf.Credentials {
+		if c.Name == host {
+			return c.Token, nil
+		}
+	}
+
+	return "", nil
+}
+
+func credFromJSON(filename, host string) (string, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+
+	var conf struct {
+		Credentials map[string]struct {
+			Token string `json:"token"`
+		} `json:"credentials"`
+	}
+	err = json.Unmarshal(data, &conf)
+	if err != nil {
+		return "", err
+	}
+
+	if hostCred, ok := conf.Credentials[host]; ok {
+		return hostCred.Token, nil
+	}
+
+	return "", nil
+}
+
+// CheckCloudConfigSet returns if there is valid configuration for Terraform Cloud available on the system.
+func CheckCloudConfigSet() bool {
+	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
+		return true
+	}
+
+	if _, err := os.Stat(defaultConfFile()); err == nil {
+		return true
+	}
+
+	if _, err := os.Stat(defaultCredFile()); err == nil {
+		return true
+	}
+
+	return false
+}
+
+func defaultConfFile() string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("APPDATA"), "terraform.rc")
+	}
+
+	p, _ := homedir.Expand("~/.terraformrc")
+	return p
+}
+
+func defaultCredFile() string {
+	var dir string
+	if runtime.GOOS == "windows" {
+		dir = filepath.Join(os.Getenv("APPDATA"), "terraform.d")
+	} else {
+		dir, _ = homedir.Expand("~/.terraform.d")
+	}
+	return path.Join(dir, "credentials.tfrc.json")
+}

--- a/internal/hcl/modules/cache_test.go
+++ b/internal/hcl/modules/cache_test.go
@@ -20,6 +20,11 @@ func TestLookupModule(t *testing.T) {
 			Source: "git::https://github.com/namespace/module-b.git?v=0.5.0",
 			Dir:    ".infracost/module-b",
 		},
+		"module-d": {
+			Key:    "module-c",
+			Source: "app.terraform.io/infracost/ec2-instance/aws",
+			Dir:    ".infracost/module-c",
+		},
 		"submodule-a": {
 			Key:     "submodule-a",
 			Source:  "registry.terraform.io/namespace/module-a/aws//submodule/path",
@@ -34,6 +39,7 @@ func TestLookupModule(t *testing.T) {
 	}
 	cache := &Cache{
 		keyMap: keyMap,
+		disco:  NewDisco(nil),
 	}
 
 	tests := []struct {
@@ -49,6 +55,7 @@ func TestLookupModule(t *testing.T) {
 		{"module-b", &tfconfig.ModuleCall{Source: "git::https://github.com/namespace/module-b.git?v=0.5.0"}, keyMap["module-b"], ""},
 		{"module-b", &tfconfig.ModuleCall{Source: "git::https://github.com/namespace/module-b.git?v=0.6.0"}, nil, "source has changed"},
 		{"module-c", &tfconfig.ModuleCall{Source: "git::https://github.com/namespace/module-c.git?v=0.6.0"}, nil, "not in cache"},
+		{"module-d", &tfconfig.ModuleCall{Source: "app.terraform.io/infracost/ec2-instance/aws"}, keyMap["module-d"], ""},
 		{"submodule-a", &tfconfig.ModuleCall{Source: "registry.terraform.io/namespace/module-a/aws//submodule/path", Version: ">=1.0"}, keyMap["submodule-a"], ""},
 		{"submodule-a", &tfconfig.ModuleCall{Source: "namespace/module-a/aws//submodule/path", Version: ">=1.0"}, keyMap["submodule-a"], ""},
 		{"submodule-a", &tfconfig.ModuleCall{Source: "registry.terraform.io/namespace/module-a/aws//submodule/path", Version: ">=2.0"}, nil, "version constraint doesn't match"},
@@ -58,13 +65,15 @@ func TestLookupModule(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual, err := cache.lookupModule(test.key, test.moduleCall)
+		t.Run(test.key, func(t *testing.T) {
+			actual, err := cache.lookupModule(test.key, test.moduleCall)
 
-		actualErr := ""
-		if err != nil {
-			actualErr = err.Error()
-		}
-		assert.Equal(t, test.expectedError, actualErr)
-		assert.Equal(t, test.expected, actual)
+			actualErr := ""
+			if err != nil {
+				actualErr = err.Error()
+			}
+			assert.Equal(t, test.expectedError, actualErr)
+			assert.Equal(t, test.expected, actual)
+		})
 	}
 }

--- a/internal/hcl/modules/credentials_source.go
+++ b/internal/hcl/modules/credentials_source.go
@@ -1,0 +1,55 @@
+package modules
+
+import (
+	"net/http"
+
+	svchost "github.com/hashicorp/terraform-svchost"
+	"github.com/hashicorp/terraform-svchost/auth"
+)
+
+type FindTokenForHost func(host string) (string, error)
+
+type HostCredentials struct {
+	token string
+}
+
+func NewHostCredentials(token string) *HostCredentials {
+	return &HostCredentials{
+		token: token,
+	}
+}
+
+func (c *HostCredentials) Token() string {
+	return c.token
+}
+
+func (c *HostCredentials) PrepareRequest(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.Token())
+}
+
+type CredentialsSource struct {
+	findTokenForHost FindTokenForHost
+}
+
+func NewCredentialsSource(findTokenForHost FindTokenForHost) *CredentialsSource {
+	return &CredentialsSource{
+		findTokenForHost: findTokenForHost,
+	}
+}
+
+func (s *CredentialsSource) ForHost(host svchost.Hostname) (auth.HostCredentials, error) {
+	token, err := s.findTokenForHost(host.ForDisplay())
+	if err != nil {
+		return nil, err
+	}
+
+	return NewHostCredentials(token), nil
+}
+
+func (s *CredentialsSource) StoreForHost(host svchost.Hostname, credentials auth.HostCredentialsWritable) error {
+	return nil
+}
+
+func (s *CredentialsSource) ForgetForHost(host svchost.Hostname) error {
+	return nil
+}

--- a/internal/hcl/modules/credentials_source.go
+++ b/internal/hcl/modules/credentials_source.go
@@ -1,10 +1,25 @@
 package modules
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
 
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclparse"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/auth"
+	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	ErrMissingCloudToken = errors.New("no Terraform Cloud token is set")
+	ErrInvalidCloudToken = errors.New("invalid Terraform Cloud Token")
 )
 
 type HostCredentials struct {
@@ -21,22 +36,53 @@ func (c HostCredentials) PrepareRequest(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+c.Token())
 }
 
-type FindTokenForHost func(host string) string
-
+// CredentialsSource is an object that may be able to provide credentials
+// for a given module source.
 type CredentialsSource struct {
-	findTokenForHost FindTokenForHost
+	BaseCredentialSet BaseCredentialSet
 }
 
-func NewCredentialsSource(findTokenForHost FindTokenForHost) *CredentialsSource {
-	return &CredentialsSource{
-		findTokenForHost: findTokenForHost,
+// BaseCredentialSet are the underlying credentials that CredentialsSource will use if no other credentials can be
+// found for a given host.
+type BaseCredentialSet struct {
+	TerraformCloudToken string
+	TerraformCloudHost  string
+}
+
+// NewCredentialsSource returns a CredentialsSource attempting to set the BaseCredentialSet as the base.
+// If creds doesn't contain static details, NewCredentialsSource will attempt to fill the credential set from
+// the environment, returning an error if it cannot.
+func NewCredentialsSource(creds BaseCredentialSet) (*CredentialsSource, error) {
+	if creds.TerraformCloudHost == "" {
+		creds.TerraformCloudHost = "app.terraform.io"
 	}
+
+	if creds.TerraformCloudToken == "" && !CheckCloudConfigSet() {
+		return &CredentialsSource{}, ErrMissingCloudToken
+	}
+
+	if creds.TerraformCloudToken == "" {
+		creds.TerraformCloudToken = FindTerraformCloudToken(creds.TerraformCloudHost)
+	}
+
+	if creds.TerraformCloudToken == "" {
+		return &CredentialsSource{}, ErrMissingCloudToken
+	}
+
+	return &CredentialsSource{
+		BaseCredentialSet: creds,
+	}, nil
 }
 
 // ForHost returns a non-nil HostCredentials if the source has credentials
 // available for the host, and a nil HostCredentials if it does not.
 func (s *CredentialsSource) ForHost(host svchost.Hostname) (auth.HostCredentials, error) {
-	return HostCredentials{token: s.findTokenForHost(host.ForDisplay())}, nil
+	display := host.ForDisplay()
+	if s.BaseCredentialSet.TerraformCloudHost == display {
+		return HostCredentials{token: s.BaseCredentialSet.TerraformCloudToken}, nil
+	}
+
+	return HostCredentials{token: FindTerraformCloudToken(display)}, nil
 }
 
 // StoreForHost is unimplemented but is required for the auth.CredentialsSource interface.
@@ -47,4 +93,131 @@ func (s *CredentialsSource) StoreForHost(host svchost.Hostname, credentials auth
 // ForgetForHost is unimplemented but is required for the auth.CredentialsSource interface.
 func (s *CredentialsSource) ForgetForHost(host svchost.Hostname) error {
 	return nil
+}
+
+// FindTerraformCloudToken returns a TFC Bearer token for the given host.
+func FindTerraformCloudToken(host string) string {
+	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
+		log.Debugf("TF_CLI_CONFIG_FILE is set, checking %s for Terraform Cloud credentials", os.Getenv("TF_CLI_CONFIG_FILE"))
+		token, err := credFromHCL(os.Getenv("TF_CLI_CONFIG_FILE"), host)
+		if err != nil {
+			log.Debugf("Error reading Terraform config file %s: %v", os.Getenv("TF_CLI_CONFIG_FILE"), err)
+		}
+		if token != "" {
+			return token
+		}
+	}
+
+	credFile := defaultCredFile()
+	if _, err := os.Stat(credFile); err == nil {
+		log.Debugf("Checking %s for Terraform Cloud credentials", credFile)
+		token, err := credFromJSON(credFile, host)
+		if err != nil {
+			log.Debugf("Error reading Terraform credentials file %s: %v", credFile, err)
+		}
+		if token != "" {
+			return token
+		}
+	}
+
+	confFile := defaultConfFile()
+	if _, err := os.Stat(confFile); err == nil {
+		log.Debugf("Checking %s for Terraform Cloud credentials", confFile)
+		token, err := credFromHCL(confFile, host)
+		if err != nil {
+			log.Debugf("Error reading Terraform config file %s: %v", confFile, err)
+		}
+		if token != "" {
+			return token
+		}
+	}
+
+	return ""
+}
+
+func credFromHCL(filename string, host string) (string, error) {
+	parser := hclparse.NewParser()
+	f, parseDiags := parser.ParseHCLFile(filename)
+	if parseDiags.HasErrors() {
+		return "", parseDiags
+	}
+
+	var conf struct {
+		Credentials []struct {
+			Name  string `hcl:"name,label"`
+			Token string `hcl:"token"`
+		} `hcl:"credentials,block"`
+	}
+
+	decodeDiags := gohcl.DecodeBody(f.Body, nil, &conf)
+	if decodeDiags.HasErrors() {
+		return "", parseDiags
+	}
+
+	for _, c := range conf.Credentials {
+		if c.Name == host {
+			return c.Token, nil
+		}
+	}
+
+	return "", nil
+}
+
+func credFromJSON(filename, host string) (string, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+
+	var conf struct {
+		Credentials map[string]struct {
+			Token string `json:"token"`
+		} `json:"credentials"`
+	}
+	err = json.Unmarshal(data, &conf)
+	if err != nil {
+		return "", err
+	}
+
+	if hostCred, ok := conf.Credentials[host]; ok {
+		return hostCred.Token, nil
+	}
+
+	return "", nil
+}
+
+// CheckCloudConfigSet returns if there is valid configuration for Terraform Cloud available on the system.
+func CheckCloudConfigSet() bool {
+	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
+		return true
+	}
+
+	if _, err := os.Stat(defaultConfFile()); err == nil {
+		return true
+	}
+
+	if _, err := os.Stat(defaultCredFile()); err == nil {
+		return true
+	}
+
+	return false
+}
+
+func defaultConfFile() string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(os.Getenv("APPDATA"), "terraform.rc")
+	}
+
+	p, _ := homedir.Expand("~/.terraformrc")
+	return p
+}
+
+func defaultCredFile() string {
+	var dir string
+	if runtime.GOOS == "windows" {
+		dir = filepath.Join(os.Getenv("APPDATA"), "terraform.d")
+	} else {
+		dir, _ = homedir.Expand("~/.terraform.d")
+	}
+	return path.Join(dir, "credentials.tfrc.json")
 }

--- a/internal/hcl/modules/credentials_source.go
+++ b/internal/hcl/modules/credentials_source.go
@@ -7,25 +7,21 @@ import (
 	"github.com/hashicorp/terraform-svchost/auth"
 )
 
-type FindTokenForHost func(host string) (string, error)
-
 type HostCredentials struct {
 	token string
 }
 
-func NewHostCredentials(token string) *HostCredentials {
-	return &HostCredentials{
-		token: token,
+func (c HostCredentials) Token() string { return c.token }
+
+func (c HostCredentials) PrepareRequest(req *http.Request) {
+	if c.token == "" {
+		return
 	}
-}
 
-func (c *HostCredentials) Token() string {
-	return c.token
-}
-
-func (c *HostCredentials) PrepareRequest(req *http.Request) {
 	req.Header.Set("Authorization", "Bearer "+c.Token())
 }
+
+type FindTokenForHost func(host string) string
 
 type CredentialsSource struct {
 	findTokenForHost FindTokenForHost
@@ -37,19 +33,18 @@ func NewCredentialsSource(findTokenForHost FindTokenForHost) *CredentialsSource 
 	}
 }
 
+// ForHost returns a non-nil HostCredentials if the source has credentials
+// available for the host, and a nil HostCredentials if it does not.
 func (s *CredentialsSource) ForHost(host svchost.Hostname) (auth.HostCredentials, error) {
-	token, err := s.findTokenForHost(host.ForDisplay())
-	if err != nil {
-		return nil, err
-	}
-
-	return NewHostCredentials(token), nil
+	return HostCredentials{token: s.findTokenForHost(host.ForDisplay())}, nil
 }
 
+// StoreForHost is unimplemented but is required for the auth.CredentialsSource interface.
 func (s *CredentialsSource) StoreForHost(host svchost.Hostname, credentials auth.HostCredentialsWritable) error {
 	return nil
 }
 
+// ForgetForHost is unimplemented but is required for the auth.CredentialsSource interface.
 func (s *CredentialsSource) ForgetForHost(host svchost.Hostname) error {
 	return nil
 }

--- a/internal/hcl/modules/credentials_source.go
+++ b/internal/hcl/modules/credentials_source.go
@@ -1,25 +1,12 @@
 package modules
 
 import (
-	"encoding/json"
-	"errors"
 	"net/http"
-	"os"
-	"path"
-	"path/filepath"
-	"runtime"
 
-	"github.com/hashicorp/hcl/v2/gohcl"
-	"github.com/hashicorp/hcl/v2/hclparse"
 	svchost "github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/auth"
-	"github.com/mitchellh/go-homedir"
-	log "github.com/sirupsen/logrus"
-)
 
-var (
-	ErrMissingCloudToken = errors.New("no Terraform Cloud token is set")
-	ErrInvalidCloudToken = errors.New("invalid Terraform Cloud Token")
+	"github.com/infracost/infracost/internal/credentials"
 )
 
 type HostCredentials struct {
@@ -40,37 +27,46 @@ func (c HostCredentials) PrepareRequest(req *http.Request) {
 // for a given module source.
 type CredentialsSource struct {
 	BaseCredentialSet BaseCredentialSet
+	FetchToken        FetchTokenFunc
 }
+
+// FetchTokenFunc defines a function that returns a token for a given key.
+// This can be an environment key, a header key, whatever the CredentialsSource requires.
+type FetchTokenFunc func(key string) string
 
 // BaseCredentialSet are the underlying credentials that CredentialsSource will use if no other credentials can be
 // found for a given host.
 type BaseCredentialSet struct {
-	TerraformCloudToken string
-	TerraformCloudHost  string
+	Token string
+	Host  string
 }
 
-// NewCredentialsSource returns a CredentialsSource attempting to set the BaseCredentialSet as the base.
-// If creds doesn't contain static details, NewCredentialsSource will attempt to fill the credential set from
+// NewTerraformCredentialsSource returns a CredentialsSource attempting to set the BaseCredentialSet as the base.
+// If creds doesn't contain static details, NewTerraformCredentialsSource will attempt to fill the credential set from
 // the environment, returning an error if it cannot.
-func NewCredentialsSource(creds BaseCredentialSet) (*CredentialsSource, error) {
-	if creds.TerraformCloudHost == "" {
-		creds.TerraformCloudHost = "app.terraform.io"
+func NewTerraformCredentialsSource(creds BaseCredentialSet) (*CredentialsSource, error) {
+	if creds.Host == "" {
+		creds.Host = "app.terraform.io"
 	}
 
-	if creds.TerraformCloudToken == "" && !CheckCloudConfigSet() {
-		return &CredentialsSource{}, ErrMissingCloudToken
+	f := credentials.FindTerraformCloudToken
+	c := &CredentialsSource{FetchToken: f}
+
+	if creds.Token == "" && !credentials.CheckCloudConfigSet() {
+		return c, credentials.ErrMissingCloudToken
 	}
 
-	if creds.TerraformCloudToken == "" {
-		creds.TerraformCloudToken = FindTerraformCloudToken(creds.TerraformCloudHost)
+	if creds.Token == "" {
+		creds.Token = f(creds.Host)
 	}
 
-	if creds.TerraformCloudToken == "" {
-		return &CredentialsSource{}, ErrMissingCloudToken
+	if creds.Token == "" {
+		return c, credentials.ErrMissingCloudToken
 	}
 
 	return &CredentialsSource{
 		BaseCredentialSet: creds,
+		FetchToken:        f,
 	}, nil
 }
 
@@ -78,11 +74,11 @@ func NewCredentialsSource(creds BaseCredentialSet) (*CredentialsSource, error) {
 // available for the host, and a nil HostCredentials if it does not.
 func (s *CredentialsSource) ForHost(host svchost.Hostname) (auth.HostCredentials, error) {
 	display := host.ForDisplay()
-	if s.BaseCredentialSet.TerraformCloudHost == display {
-		return HostCredentials{token: s.BaseCredentialSet.TerraformCloudToken}, nil
+	if s.BaseCredentialSet.Host == display {
+		return HostCredentials{token: s.BaseCredentialSet.Token}, nil
 	}
 
-	return HostCredentials{token: FindTerraformCloudToken(display)}, nil
+	return HostCredentials{token: s.FetchToken(display)}, nil
 }
 
 // StoreForHost is unimplemented but is required for the auth.CredentialsSource interface.
@@ -93,131 +89,4 @@ func (s *CredentialsSource) StoreForHost(host svchost.Hostname, credentials auth
 // ForgetForHost is unimplemented but is required for the auth.CredentialsSource interface.
 func (s *CredentialsSource) ForgetForHost(host svchost.Hostname) error {
 	return nil
-}
-
-// FindTerraformCloudToken returns a TFC Bearer token for the given host.
-func FindTerraformCloudToken(host string) string {
-	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
-		log.Debugf("TF_CLI_CONFIG_FILE is set, checking %s for Terraform Cloud credentials", os.Getenv("TF_CLI_CONFIG_FILE"))
-		token, err := credFromHCL(os.Getenv("TF_CLI_CONFIG_FILE"), host)
-		if err != nil {
-			log.Debugf("Error reading Terraform config file %s: %v", os.Getenv("TF_CLI_CONFIG_FILE"), err)
-		}
-		if token != "" {
-			return token
-		}
-	}
-
-	credFile := defaultCredFile()
-	if _, err := os.Stat(credFile); err == nil {
-		log.Debugf("Checking %s for Terraform Cloud credentials", credFile)
-		token, err := credFromJSON(credFile, host)
-		if err != nil {
-			log.Debugf("Error reading Terraform credentials file %s: %v", credFile, err)
-		}
-		if token != "" {
-			return token
-		}
-	}
-
-	confFile := defaultConfFile()
-	if _, err := os.Stat(confFile); err == nil {
-		log.Debugf("Checking %s for Terraform Cloud credentials", confFile)
-		token, err := credFromHCL(confFile, host)
-		if err != nil {
-			log.Debugf("Error reading Terraform config file %s: %v", confFile, err)
-		}
-		if token != "" {
-			return token
-		}
-	}
-
-	return ""
-}
-
-func credFromHCL(filename string, host string) (string, error) {
-	parser := hclparse.NewParser()
-	f, parseDiags := parser.ParseHCLFile(filename)
-	if parseDiags.HasErrors() {
-		return "", parseDiags
-	}
-
-	var conf struct {
-		Credentials []struct {
-			Name  string `hcl:"name,label"`
-			Token string `hcl:"token"`
-		} `hcl:"credentials,block"`
-	}
-
-	decodeDiags := gohcl.DecodeBody(f.Body, nil, &conf)
-	if decodeDiags.HasErrors() {
-		return "", parseDiags
-	}
-
-	for _, c := range conf.Credentials {
-		if c.Name == host {
-			return c.Token, nil
-		}
-	}
-
-	return "", nil
-}
-
-func credFromJSON(filename, host string) (string, error) {
-	data, err := os.ReadFile(filename)
-	if err != nil {
-		return "", err
-	}
-
-	var conf struct {
-		Credentials map[string]struct {
-			Token string `json:"token"`
-		} `json:"credentials"`
-	}
-	err = json.Unmarshal(data, &conf)
-	if err != nil {
-		return "", err
-	}
-
-	if hostCred, ok := conf.Credentials[host]; ok {
-		return hostCred.Token, nil
-	}
-
-	return "", nil
-}
-
-// CheckCloudConfigSet returns if there is valid configuration for Terraform Cloud available on the system.
-func CheckCloudConfigSet() bool {
-	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
-		return true
-	}
-
-	if _, err := os.Stat(defaultConfFile()); err == nil {
-		return true
-	}
-
-	if _, err := os.Stat(defaultCredFile()); err == nil {
-		return true
-	}
-
-	return false
-}
-
-func defaultConfFile() string {
-	if runtime.GOOS == "windows" {
-		return filepath.Join(os.Getenv("APPDATA"), "terraform.rc")
-	}
-
-	p, _ := homedir.Expand("~/.terraformrc")
-	return p
-}
-
-func defaultCredFile() string {
-	var dir string
-	if runtime.GOOS == "windows" {
-		dir = filepath.Join(os.Getenv("APPDATA"), "terraform.d")
-	} else {
-		dir, _ = homedir.Expand("~/.terraform.d")
-	}
-	return path.Join(dir, "credentials.tfrc.json")
 }

--- a/internal/hcl/modules/fetch.go
+++ b/internal/hcl/modules/fetch.go
@@ -27,13 +27,13 @@ func NewPackageFetcher() *PackageFetcher {
 // fetch downloads the remote module using the go-getter library
 // See: https://github.com/hashicorp/go-getter
 func (r *PackageFetcher) fetch(moduleAddr string, dest string) error {
+	err := os.MkdirAll(dest, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("Failed to create directory '%s': %w", dest, err)
+	}
+
 	if prevDest, ok := r.cache[moduleAddr]; ok {
 		log.Debugf("Module %s already downloaded, copying from '%s' to '%s'", moduleAddr, prevDest, dest)
-
-		err := os.Mkdir(dest, os.ModePerm)
-		if err != nil {
-			return fmt.Errorf("Failed to create directory '%s': %w", dest, err)
-		}
 
 		// Skip dotfiles and create new symlinks to be consistent with what Terraform init does
 		opt := copy.Options{

--- a/internal/hcl/modules/fetch.go
+++ b/internal/hcl/modules/fetch.go
@@ -27,13 +27,13 @@ func NewPackageFetcher() *PackageFetcher {
 // fetch downloads the remote module using the go-getter library
 // See: https://github.com/hashicorp/go-getter
 func (r *PackageFetcher) fetch(moduleAddr string, dest string) error {
-	err := os.MkdirAll(dest, os.ModePerm)
-	if err != nil {
-		return fmt.Errorf("Failed to create directory '%s': %w", dest, err)
-	}
-
 	if prevDest, ok := r.cache[moduleAddr]; ok {
 		log.Debugf("Module %s already downloaded, copying from '%s' to '%s'", moduleAddr, prevDest, dest)
+
+		err := os.Mkdir(dest, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("Failed to create directory '%s': %w", dest, err)
+		}
 
 		// Skip dotfiles and create new symlinks to be consistent with what Terraform init does
 		opt := copy.Options{

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -243,9 +243,6 @@ func (m *ModuleLoader) loadModule(moduleCall *tfconfig.ModuleCall, parentPath st
 	log.Debugf("Module %s not recognized as registry module, treating as remote module: %s", key, err.Error())
 	log.Debugf("Downloading module %s from remote %s", key, moduleCall.Source)
 
-	fmt.Println("DEBUG")
-	fmt.Println(m.Path)
-	fmt.Println(m.downloadDir())
 	err = m.packageFetcher.fetch(moduleAddr, dest)
 	if err != nil {
 		return nil, err

--- a/internal/hcl/modules/loader_test.go
+++ b/internal/hcl/modules/loader_test.go
@@ -15,7 +15,7 @@ func testLoaderE2E(t *testing.T, path string, expectedModules []*ManifestModule,
 		assert.NoError(t, err)
 	}
 
-	moduleLoader := NewModuleLoader(path)
+	moduleLoader := NewModuleLoader(path, &CredentialsSource{})
 
 	manifest, err := moduleLoader.Load()
 	if !assert.NoError(t, err) {

--- a/internal/hcl/modules/loader_test.go
+++ b/internal/hcl/modules/loader_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/infracost/infracost/internal/credentials"
 )
 
 func testLoaderE2E(t *testing.T, path string, expectedModules []*ManifestModule, cleanup bool) {
@@ -15,7 +17,7 @@ func testLoaderE2E(t *testing.T, path string, expectedModules []*ManifestModule,
 		assert.NoError(t, err)
 	}
 
-	moduleLoader := NewModuleLoader(path, &CredentialsSource{})
+	moduleLoader := NewModuleLoader(path, &CredentialsSource{FetchToken: credentials.FindTerraformCloudToken})
 
 	manifest, err := moduleLoader.Load()
 	if !assert.NoError(t, err) {

--- a/internal/hcl/modules/registry.go
+++ b/internal/hcl/modules/registry.go
@@ -69,7 +69,7 @@ func (d Disco) ModuleLocation(source string) (RegistryURL, error) {
 
 	r := RegistryURL{
 		Location:  fmt.Sprintf("%s%s/%s/%s", serviceURL.String(), namespace, moduleName, target),
-		RawSource: fmt.Sprintf("%s/%s/%s/%s", host, namespace, moduleName, target),
+		RawSource: source,
 	}
 
 	c, err := d.disco.CredentialsForHost(svchost.Hostname(host))

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/sirupsen/logrus"
@@ -150,9 +151,9 @@ func OptionWithRemoteVarLoader(host, token, localWorkspace string) Option {
 	}
 }
 
-func OptionWithCredentialsSource(findTokenForHost modules.FindTokenForHost) Option {
+func OptionWithCredentialsSource(source *modules.CredentialsSource) Option {
 	return func(p *Parser) {
-		p.credentialsSource = modules.NewCredentialsSource(findTokenForHost)
+		p.credentialsSource = source
 	}
 }
 
@@ -252,9 +253,8 @@ func newParser(initialPath string, options ...Option) *Parser {
 	if p.newSpinner != nil {
 		loaderOpts = append(loaderOpts, modules.LoaderWithSpinner(p.newSpinner))
 	}
-	loaderOpts = append(loaderOpts, modules.LoaderWithCredentialsSource(p.credentialsSource))
 
-	p.moduleLoader = modules.NewModuleLoader(initialPath, loaderOpts...)
+	p.moduleLoader = modules.NewModuleLoader(initialPath, p.credentialsSource, loaderOpts...)
 
 	return p
 }

--- a/internal/providers/terraform/cloud.go
+++ b/internal/providers/terraform/cloud.go
@@ -1,24 +1,15 @@
 package terraform
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"path"
-	"path/filepath"
-	"runtime"
 
-	"github.com/hashicorp/hcl2/gohcl"
-	"github.com/hashicorp/hcl2/hclparse"
-	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-)
 
-var ErrMissingCloudToken = errors.New("no Terraform Cloud token is set")
-var ErrInvalidCloudToken = errors.New("invalid Terraform Cloud Token")
+	"github.com/infracost/infracost/internal/hcl/modules"
+)
 
 func cloudAPI(host string, path string, token string) ([]byte, error) {
 	client := &http.Client{}
@@ -38,135 +29,10 @@ func cloudAPI(host string, path string, token string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 401 {
-		return []byte{}, ErrInvalidCloudToken
+		return []byte{}, modules.ErrInvalidCloudToken
 	} else if resp.StatusCode != 200 {
 		return []byte{}, errors.Errorf("invalid response from Terraform remote: %s", resp.Status)
 	}
 
 	return io.ReadAll(resp.Body)
-}
-
-func findCloudToken(host string) string {
-	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
-		log.Debugf("TF_CLI_CONFIG_FILE is set, checking %s for Terraform Cloud credentials", os.Getenv("TF_CLI_CONFIG_FILE"))
-		token, err := credFromHCL(os.Getenv("TF_CLI_CONFIG_FILE"), host)
-		if err != nil {
-			log.Debugf("Error reading Terraform config file %s: %v", os.Getenv("TF_CLI_CONFIG_FILE"), err)
-		}
-		if token != "" {
-			return token
-		}
-	}
-
-	credFile := defaultCredFile()
-	if _, err := os.Stat(credFile); err == nil {
-		log.Debugf("Checking %s for Terraform Cloud credentials", credFile)
-		token, err := credFromJSON(credFile, host)
-		if err != nil {
-			log.Debugf("Error reading Terraform credentials file %s: %v", credFile, err)
-		}
-		if token != "" {
-			return token
-		}
-	}
-
-	confFile := defaultConfFile()
-	if _, err := os.Stat(confFile); err == nil {
-		log.Debugf("Checking %s for Terraform Cloud credentials", confFile)
-		token, err := credFromHCL(confFile, host)
-		if err != nil {
-			log.Debugf("Error reading Terraform config file %s: %v", confFile, err)
-		}
-		if token != "" {
-			return token
-		}
-	}
-
-	return ""
-}
-
-func credFromHCL(filename string, host string) (string, error) {
-	parser := hclparse.NewParser()
-	f, parseDiags := parser.ParseHCLFile(filename)
-	if parseDiags.HasErrors() {
-		return "", parseDiags
-	}
-
-	var conf struct {
-		Credentials []struct {
-			Name  string `hcl:"name,label"`
-			Token string `hcl:"token"`
-		} `hcl:"credentials,block"`
-	}
-
-	decodeDiags := gohcl.DecodeBody(f.Body, nil, &conf)
-	if decodeDiags.HasErrors() {
-		return "", parseDiags
-	}
-
-	for _, c := range conf.Credentials {
-		if c.Name == host {
-			return c.Token, nil
-		}
-	}
-
-	return "", nil
-}
-
-func credFromJSON(filename, host string) (string, error) {
-	data, err := os.ReadFile(filename)
-	if err != nil {
-		return "", err
-	}
-
-	var conf struct {
-		Credentials map[string]struct {
-			Token string `json:"token"`
-		} `json:"credentials"`
-	}
-	err = json.Unmarshal(data, &conf)
-	if err != nil {
-		return "", err
-	}
-
-	if hostCred, ok := conf.Credentials[host]; ok {
-		return hostCred.Token, nil
-	}
-
-	return "", nil
-}
-
-func checkCloudConfigSet() bool {
-	if os.Getenv("TF_CLI_CONFIG_FILE") != "" {
-		return true
-	}
-
-	if _, err := os.Stat(defaultConfFile()); err == nil {
-		return true
-	}
-
-	if _, err := os.Stat(defaultCredFile()); err == nil {
-		return true
-	}
-
-	return false
-}
-
-func defaultConfFile() string {
-	if runtime.GOOS == "windows" {
-		return filepath.Join(os.Getenv("APPDATA"), "terraform.rc")
-	}
-
-	p, _ := homedir.Expand("~/.terraformrc")
-	return p
-}
-
-func defaultCredFile() string {
-	var dir string
-	if runtime.GOOS == "windows" {
-		dir = filepath.Join(os.Getenv("APPDATA"), "terraform.d")
-	} else {
-		dir, _ = homedir.Expand("~/.terraform.d")
-	}
-	return path.Join(dir, "credentials.tfrc.json")
 }

--- a/internal/providers/terraform/cloud.go
+++ b/internal/providers/terraform/cloud.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/infracost/infracost/internal/hcl/modules"
+	"github.com/infracost/infracost/internal/credentials"
 )
 
 func cloudAPI(host string, path string, token string) ([]byte, error) {
@@ -29,7 +29,7 @@ func cloudAPI(host string, path string, token string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 401 {
-		return []byte{}, modules.ErrInvalidCloudToken
+		return []byte{}, credentials.ErrInvalidCloudToken
 	} else if resp.StatusCode != 200 {
 		return []byte{}, errors.Errorf("invalid response from Terraform remote: %s", resp.Status)
 	}

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/infracost/infracost/internal/clierror"
 	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/hcl/modules"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/infracost/infracost/internal/ui"
 
@@ -403,8 +404,8 @@ func (p *DirProvider) runInit(opts *CmdOptions, spinner *ui.Spinner) error {
 }
 
 func (p *DirProvider) runRemotePlan(opts *CmdOptions, args []string) ([]byte, error) {
-	if p.TerraformCloudToken == "" && !checkCloudConfigSet() {
-		return []byte{}, ErrMissingCloudToken
+	if p.TerraformCloudToken == "" && !modules.CheckCloudConfigSet() {
+		return []byte{}, modules.ErrMissingCloudToken
 	}
 
 	stdout, err := Cmd(opts, args...)
@@ -428,10 +429,10 @@ func (p *DirProvider) runRemotePlan(opts *CmdOptions, args []string) ([]byte, er
 
 	token := p.TerraformCloudToken
 	if token == "" {
-		token = findCloudToken(host)
+		token = modules.FindTerraformCloudToken(host)
 	}
 	if token == "" {
-		return []byte{}, ErrMissingCloudToken
+		return []byte{}, modules.ErrMissingCloudToken
 	}
 
 	body, err := cloudAPI(host, fmt.Sprintf("/api/v2/runs/%s/plan", runID), token)
@@ -532,7 +533,7 @@ func (p *DirProvider) buildTerraformErr(err error, isInit bool) error {
 		msg += "\n\nYou have two options:\n"
 		msg += "1. Run `terraform workspace select your_workspace` first or set the TF_WORKSPACE environment variable.\n\n"
 		msg += fmt.Sprintf("2. Set --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot"))
-	} else if errors.Is(err, ErrMissingCloudToken) || errors.Is(err, ErrInvalidCloudToken) || strings.HasPrefix(stderr, "Error: Required token could not be found") {
+	} else if errors.Is(err, modules.ErrMissingCloudToken) || errors.Is(err, modules.ErrInvalidCloudToken) || strings.HasPrefix(stderr, "Error: Required token could not be found") {
 		msg += "\n\nYou have two options:\n"
 		msg += "1. Run `terraform login` or set the INFRACOST_TERRAFORM_CLOUD_TOKEN environment variable.'\n\n"
 		msg += fmt.Sprintf("2. Set --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot"))

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/infracost/infracost/internal/clierror"
 	"github.com/infracost/infracost/internal/config"
-	"github.com/infracost/infracost/internal/hcl/modules"
+	"github.com/infracost/infracost/internal/credentials"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/infracost/infracost/internal/ui"
 
@@ -404,8 +404,8 @@ func (p *DirProvider) runInit(opts *CmdOptions, spinner *ui.Spinner) error {
 }
 
 func (p *DirProvider) runRemotePlan(opts *CmdOptions, args []string) ([]byte, error) {
-	if p.TerraformCloudToken == "" && !modules.CheckCloudConfigSet() {
-		return []byte{}, modules.ErrMissingCloudToken
+	if p.TerraformCloudToken == "" && !credentials.CheckCloudConfigSet() {
+		return []byte{}, credentials.ErrMissingCloudToken
 	}
 
 	stdout, err := Cmd(opts, args...)
@@ -429,10 +429,10 @@ func (p *DirProvider) runRemotePlan(opts *CmdOptions, args []string) ([]byte, er
 
 	token := p.TerraformCloudToken
 	if token == "" {
-		token = modules.FindTerraformCloudToken(host)
+		token = credentials.FindTerraformCloudToken(host)
 	}
 	if token == "" {
-		return []byte{}, modules.ErrMissingCloudToken
+		return []byte{}, credentials.ErrMissingCloudToken
 	}
 
 	body, err := cloudAPI(host, fmt.Sprintf("/api/v2/runs/%s/plan", runID), token)
@@ -533,7 +533,7 @@ func (p *DirProvider) buildTerraformErr(err error, isInit bool) error {
 		msg += "\n\nYou have two options:\n"
 		msg += "1. Run `terraform workspace select your_workspace` first or set the TF_WORKSPACE environment variable.\n\n"
 		msg += fmt.Sprintf("2. Set --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot"))
-	} else if errors.Is(err, modules.ErrMissingCloudToken) || errors.Is(err, modules.ErrInvalidCloudToken) || strings.HasPrefix(stderr, "Error: Required token could not be found") {
+	} else if errors.Is(err, credentials.ErrMissingCloudToken) || errors.Is(err, credentials.ErrInvalidCloudToken) || strings.HasPrefix(stderr, "Error: Required token could not be found") {
 		msg += "\n\nYou have two options:\n"
 		msg += "1. Run `terraform login` or set the INFRACOST_TERRAFORM_CLOUD_TOKEN environment variable.'\n\n"
 		msg += fmt.Sprintf("2. Set --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot"))

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -104,15 +104,15 @@ func NewHCLProvider(ctx *config.ProjectContext, config *HCLProviderConfig, opts 
 
 	options = append(options, opts...)
 
-	credsSource, err := modules.NewCredentialsSource(modules.BaseCredentialSet{
-		TerraformCloudToken: ctx.ProjectConfig.TerraformCloudToken,
-		TerraformCloudHost:  ctx.ProjectConfig.TerraformCloudHost,
+	credsSource, err := modules.NewTerraformCredentialsSource(modules.BaseCredentialSet{
+		Token: ctx.ProjectConfig.TerraformCloudToken,
+		Host:  ctx.ProjectConfig.TerraformCloudHost,
 	})
 	localWorkspace := ctx.ProjectConfig.TerraformWorkspace
 	if err == nil {
 		options = append(options, hcl.OptionWithRemoteVarLoader(
-			credsSource.BaseCredentialSet.TerraformCloudHost,
-			credsSource.BaseCredentialSet.TerraformCloudToken,
+			credsSource.BaseCredentialSet.Host,
+			credsSource.BaseCredentialSet.Token,
 			localWorkspace),
 		)
 	}


### PR DESCRIPTION
Closes https://github.com/infracost/infracost/issues/1667

* Uses https://github.com/hashicorp/terraform-svchost discovery mechanism to try and resolve the real location for the module
* Adds credential support based off of `disco` mechanism
* Adds private module tests and reworks CI pipeline to include Terraform Cloud tokens for test