### PR TITLE
fix: loading remote variables

### DIFF
--- a/internal/hcl/remote_variables_loader.go
+++ b/internal/hcl/remote_variables_loader.go
@@ -144,8 +144,8 @@ func (r *RemoteVariablesLoader) Load(blocks Blocks) (map[string]cty.Value, error
 		return vars, nil
 	}
 
-	if workspaceResponse.Data.Attributes.ExecutionMode != "remote" {
-		log.Debugf("Terraform workspace %s does not use remote execution, skipping downloading remote variables", config.workspace)
+	if workspaceResponse.Data.Attributes.ExecutionMode == "local" {
+		log.Debugf("Terraform workspace %s does use local execution, skipping downloading remote variables", config.workspace)
 		return vars, nil
 	}
 


### PR DESCRIPTION
Closes #1786

Remote variables should also be fetched if the TFC workspace is set to `agent` execution mode.
I thought it's just better to flip the if-statement and check if `local` execution mode is set and then skip fetching the remote variables.
