### PR TITLE
Add support for Oracle CDB engine in AWS RDS

### DIFF
--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
@@ -106,6 +106,10 @@
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
  └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
                                                                                                                     
+ aws_db_instance.oracle-ee-cdb                                                                                      
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
+ └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
+                                                                                                                    
  aws_db_instance.oracle-se                                                                                          
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
  ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
@@ -121,6 +125,11 @@
  └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
                                                                                                                     
  aws_db_instance.oracle-se2                                                                                         
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                        $219.00 
+ ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
+ └─ Additional backup storage                                           1,000  GB                            $95.00 
+                                                                                                                    
+ aws_db_instance.oracle-se2-cdb                                                                                     
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                        $219.00 
  ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
  └─ Additional backup storage                                           1,000  GB                            $95.00 
@@ -164,7 +173,7 @@
  ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
  └─ Additional backup storage                                           1,000  GB                            $95.00 
                                                                                                                     
- OVERALL TOTAL                                                                                            $7,123.35 
+ OVERALL TOTAL                                                                                            $7,541.23 
 ──────────────────────────────────
-35 cloud resources were detected:
-∙ 35 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+37 cloud resources were detected:
+∙ 37 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.tf
@@ -101,8 +101,16 @@ resource "aws_db_instance" "oracle-se2" {
   engine         = "oracle-se2"
   instance_class = "db.t3.large"
 }
+resource "aws_db_instance" "oracle-se2-cdb" {
+  engine         = "oracle-se2-cdb"
+  instance_class = "db.t3.large"
+}
 resource "aws_db_instance" "oracle-ee" {
   engine         = "oracle-ee"
+  instance_class = "db.t3.large"
+}
+resource "aws_db_instance" "oracle-ee-cdb" {
+  engine         = "oracle-ee-cdb"
   instance_class = "db.t3.large"
 }
 resource "aws_db_instance" "sqlserver-ex" {

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.usage.yml
@@ -20,6 +20,8 @@ resource_usage:
     additional_backup_storage_gb: 1000
   aws_db_instance.oracle-se2:
     additional_backup_storage_gb: 1000
+  aws_db_instance.oracle-se2-cdb:
+    additional_backup_storage_gb: 1000
   aws_db_instance.sqlserver-ex:
     additional_backup_storage_gb: 1000
   aws_db_instance.sqlserver-web:

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -66,7 +66,7 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 		databaseEngine = "Aurora MySQL"
 	case "aurora-postgresql":
 		databaseEngine = "Aurora PostgreSQL"
-	case "oracle-se", "oracle-se1", "oracle-se2", "oracle-ee":
+	case "oracle-se", "oracle-se1", "oracle-se2", "oracle-se2-cdb", "oracle-ee", "oracle-ee-cdb":
 		databaseEngine = "Oracle"
 	case "sqlserver-ex", "sqlserver-web", "sqlserver-se", "sqlserver-ee":
 		databaseEngine = "SQL Server"
@@ -78,9 +78,9 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 		databaseEdition = "Standard"
 	case "oracle-se1":
 		databaseEdition = "Standard One"
-	case "oracle-se2":
+	case "oracle-se2", "oracle-se2-cdb":
 		databaseEdition = "Standard Two"
-	case "oracle-ee", "sqlserver-ee":
+	case "oracle-ee", "oracle-ee-cdb", "sqlserver-ee":
 		databaseEdition = "Enterprise"
 	case "sqlserver-ex":
 		databaseEdition = "Express"
@@ -90,7 +90,7 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 
 	var licenseModel string
 	engineVal := strings.ToLower(r.Engine)
-	if engineVal == "oracle-se1" || engineVal == "oracle-se2" || strings.HasPrefix(engineVal, "sqlserver-") {
+	if engineVal == "oracle-se1" || engineVal == "oracle-se2" || engineVal == "oracle-se2-cdb" || strings.HasPrefix(engineVal, "sqlserver-") {
 		licenseModel = "License included"
 	}
 	if strings.ToLower(r.LicenseModel) == "bring-your-own-license" {


### PR DESCRIPTION
## Objective:

Add support for `oracle-se2-cdb` and `oracle-ee-cdb` RDS engine types. Fixes #1792 

## Pricing details:

`oracle-se2-cdb` and `oracle-ee-cdb` should use the same prices as the existing `oracle-se2` and `oracle-ee` respectively.

## Status:

- [x] Generated the resource files
- [x] Updated the internal/resources file
- [x] Updated the internal/provider/terraform/.../resources file
- [ ] Added usage parameters to infracost-usage-example.yml
- [ ] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [ ] Created a PR to update "Supported Resources" in the [docs](<LINK TO DOCS PULL REQUEST>)

## Issues:

None