### PR TITLE
feat: add monthly_hrs usage field for aws/azure/gcp VMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,12 @@ test_cmd:
 test_update_cmd:
 	INFRACOST_LOG_LEVEL=warn go test -timeout 30m $(LD_FLAGS) ./cmd/infracost $(or $(ARGS), -update -v -cover)
 
+test_usage:
+	INFRACOST_LOG_LEVEL=warn go test -timeout 30m $(LD_FLAGS) ./internal/usage $(or $(ARGS), -v -cover)
+
+test_update_usage:
+	INFRACOST_LOG_LEVEL=warn go test -timeout 30m $(LD_FLAGS) ./internal/usage $(or $(ARGS), -update -v -cover)
+
 # Run AWS resource tests
 test_aws:
 	INFRACOST_LOG_LEVEL=warn go test -timeout 30m $(LD_FLAGS) ./internal/providers/terraform/aws $(or $(ARGS), -v -cover)

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -648,6 +648,9 @@ resource_usage:
   google_compute_image.my_image:
     storage_gb: 1000 # Total size of image storage in GB.
 
+  google_compute_instance.my_instance:
+    monthly_hours: 450 # Monthly number of hours the instance ran for.
+
   google_compute_machine_image.my_machine_image:
     storage_gb: 1000 # Total size of machine image storage in GB.
 

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -966,6 +966,7 @@ resource_usage:
     monthly_data_processed_gb: 100000 # Monthly data processed by the firewall in GB.
 
   azurerm_linux_virtual_machine.my_linux_vm:
+    monthly_hours: 450 # Monthly number of hours the instance ran for.
     os_disk:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 
@@ -1104,12 +1105,14 @@ resource_usage:
       monthly_disk_operations: 100000 # Monthly number of disk operations (writes, reads, deletes) using a unit size of 256KiB per additional disk.
 
   azurerm_virtual_machine.my_vm:
+    monthly_hours: 450 # Monthly number of hours the instance ran for.
     storage_os_disk:
       monthly_disk_operations: 100000 # Monthly number of main disk operations (writes, reads, deletes) using a unit size of 256KiB.
     storage_data_disk:
       monthly_disk_operations: 100000 # Monthly number of disk operations (writes, reads, deletes) using a unit size of 256KiB per additional disk.
 
   azurerm_windows_virtual_machine.my_windows_vm:
+    monthly_hours: 450 # Monthly number of hours the instance ran for.
     os_disk:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -232,6 +232,7 @@ resource_usage:
     reserved_instance_payment_option: all_upfront # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     monthly_cpu_credit_hrs: 350 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     vcpu_count: 2 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
+    monthly_hours: 450 # Monthly number of hours the instance ran for.
 
   aws_fsx_windows_file_system.my_system:
     backup_storage_gb: 10000 # Total storage used for backups in GB.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -232,7 +232,7 @@ resource_usage:
     reserved_instance_payment_option: all_upfront # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     monthly_cpu_credit_hrs: 350 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     vcpu_count: 2 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    monthly_hours: 450 # Monthly number of hours the instance ran for.
+    monthly_hrs: 450 # Monthly number of hours the instance ran for.
 
   aws_fsx_windows_file_system.my_system:
     backup_storage_gb: 10000 # Total storage used for backups in GB.
@@ -649,7 +649,7 @@ resource_usage:
     storage_gb: 1000 # Total size of image storage in GB.
 
   google_compute_instance.my_instance:
-    monthly_hours: 450 # Monthly number of hours the instance ran for.
+    monthly_hrs: 450 # Monthly number of hours the instance ran for.
 
   google_compute_machine_image.my_machine_image:
     storage_gb: 1000 # Total size of machine image storage in GB.
@@ -969,7 +969,7 @@ resource_usage:
     monthly_data_processed_gb: 100000 # Monthly data processed by the firewall in GB.
 
   azurerm_linux_virtual_machine.my_linux_vm:
-    monthly_hours: 450 # Monthly number of hours the instance ran for.
+    monthly_hrs: 450 # Monthly number of hours the instance ran for.
     os_disk:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 
@@ -1108,14 +1108,14 @@ resource_usage:
       monthly_disk_operations: 100000 # Monthly number of disk operations (writes, reads, deletes) using a unit size of 256KiB per additional disk.
 
   azurerm_virtual_machine.my_vm:
-    monthly_hours: 450 # Monthly number of hours the instance ran for.
+    monthly_hrs: 450 # Monthly number of hours the instance ran for.
     storage_os_disk:
       monthly_disk_operations: 100000 # Monthly number of main disk operations (writes, reads, deletes) using a unit size of 256KiB.
     storage_data_disk:
       monthly_disk_operations: 100000 # Monthly number of disk operations (writes, reads, deletes) using a unit size of 256KiB per additional disk.
 
   azurerm_windows_virtual_machine.my_windows_vm:
-    monthly_hours: 450 # Monthly number of hours the instance ran for.
+    monthly_hrs: 450 # Monthly number of hours the instance ran for.
     os_disk:
       monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
@@ -1,193 +1,183 @@
 
- Name                                                               Monthly Qty  Unit                  Monthly Cost 
-                                                                                                                    
- aws_instance.cnvr_1yr_all_upfront                                                                                  
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $0.00 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.cnvr_1yr_no_upfront                                                                                   
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $21.90 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.cnvr_1yr_partial_upfront                                                                              
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $10.44 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.cnvr_3yr_all_upfront                                                                                  
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $0.00 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.cnvr_3yr_no_upfront                                                                                   
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $15.04 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.cnvr_3yr_partial_upfront                                                                              
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $7.01 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.instance1                                                                                             
- ├─ Instance usage (Linux/UNIX, on-demand, m3.medium)                       730  hours                       $48.91 
- ├─ root_block_device                                                                                               
- │  └─ Storage (general purpose SSD, gp2)                                    10  GB                           $1.00 
- ├─ ebs_block_device[0]                                                                                             
- │  └─ Storage (general purpose SSD, gp2)                                    10  GB                           $1.00 
- ├─ ebs_block_device[1]                                                                                             
- │  ├─ Storage (magnetic)                                                    20  GB                           $1.00 
- │  └─ I/O requests                                            Monthly cost depends on usage: $0.05 per 1M request  
- ├─ ebs_block_device[2]                                                                                             
- │  └─ Storage (cold HDD, sc1)                                               30  GB                           $0.45 
- ├─ ebs_block_device[3]                                                                                             
- │  ├─ Storage (provisioned IOPS SSD, io1)                                   40  GB                           $5.00 
- │  └─ Provisioned IOPS                                                   1,000  IOPS                        $65.00 
- └─ ebs_block_device[4]                                                                                             
-    └─ Storage (general purpose SSD, gp3)                                    20  GB                           $1.60 
-                                                                                                                    
- aws_instance.instance1_detailedMonitoring                                                                          
- ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        730  hours                       $97.09 
- ├─ EC2 detailed monitoring                                                   7  metrics                      $2.10 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.instance1_ebsOptimized                                                                                
- ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        730  hours                       $97.09 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.instance2_ebsOptimized                                                                                
- ├─ Instance usage (Linux/UNIX, on-demand, r3.xlarge)                       730  hours                      $243.09 
- ├─ EBS-optimized usage                                                     730  hours                       $14.60 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.instance_detailedMonitoring_withMonthlyHours                                                          
- ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        100  hours                       $13.30 
- ├─ EC2 detailed monitoring                                                   7  metrics                      $2.10 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.instance_ebsOptimized_withMonthlyHours                                                                
- ├─ Instance usage (Linux/UNIX, on-demand, r3.xlarge)                       100  hours                       $33.30 
- ├─ EBS-optimized usage                                                     100  hours                        $2.00 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.instance_elasticInferenceAccel                                                                        
- ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        730  hours                       $97.09 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.instance_elasticInferenceAccel_withMonthlyHours                                                       
- ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        100  hours                       $13.30 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.instance_withLaunchTemplateById                                                                       
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $32.19 
- ├─ EC2 detailed monitoring                                                   7  metrics                      $2.10 
- ├─ CPU credits                                                           1,460  vCPU-hours                  $73.00 
- ├─ root_block_device                                                                                               
- │  └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
- ├─ ebs_block_device[0]                                                                                             
- │  ├─ Storage (provisioned IOPS SSD, io1)                                   20  GB                           $2.50 
- │  └─ Provisioned IOPS                                                     200  IOPS                        $13.00 
- └─ ebs_block_device[1]                                                                                             
-    ├─ Storage (provisioned IOPS SSD, io1)                                   10  GB                           $1.25 
-    └─ Provisioned IOPS                                                     100  IOPS                         $6.50 
-                                                                                                                    
- aws_instance.instance_withLaunchTemplateByName                                                                     
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $32.19 
- ├─ EC2 detailed monitoring                                                   7  metrics                      $2.10 
- ├─ root_block_device                                                                                               
- │  └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
- └─ ebs_block_device[0]                                                                                             
-    ├─ Storage (provisioned IOPS SSD, io1)                                   10  GB                           $1.25 
-    └─ Provisioned IOPS                                                     100  IOPS                         $6.50 
-                                                                                                                    
- aws_instance.instance_withLaunchTemplateOverride                                                                   
- ├─ Instance usage (Linux/UNIX, on-demand, t3.large)                        730  hours                       $60.74 
- ├─ root_block_device                                                                                               
- │  └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
- └─ ebs_block_device[0]                                                                                             
-    ├─ Storage (provisioned IOPS SSD, io1)                                   20  GB                           $2.50 
-    └─ Provisioned IOPS                                                     100  IOPS                         $6.50 
-                                                                                                                    
- aws_instance.instance_withMonthlyHours                                                                             
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       100  hours                        $4.16 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.std_1yr_all_upfront                                                                                   
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $0.00 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.std_1yr_no_upfront                                                                                    
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $19.05 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.std_1yr_partial_upfront                                                                               
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $9.05 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.std_3yr_all_upfront                                                                                   
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $0.00 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.std_3yr_no_upfront                                                                                    
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $13.14 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.std_3yr_partial_upfront                                                                               
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $6.06 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.t2_default_cpuCredits                                                                                 
- ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                       730  hours                       $33.87 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.t2_standard_cpuCredits                                                                                
- ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                       730  hours                       $33.87 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.t2_unlimited_cpuCredits                                                                               
- ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                       730  hours                       $33.87 
- ├─ CPU credits                                                             600  vCPU-hours                  $30.00 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.t3_default_cpuCredits                                                                                 
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $30.37 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.t3_standard_cpuCredits                                                                                
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $30.37 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- aws_instance.t3_unlimited_cpuCredits                                                                               
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $30.37 
- ├─ CPU credits                                                           1,460  vCPU-hours                  $73.00 
- └─ root_block_device                                                                                               
-    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
-                                                                                                                    
- OVERALL TOTAL                                                                                            $1,406.11 
+ Name                                                            Monthly Qty  Unit                  Monthly Cost 
+                                                                                                                 
+ aws_instance.cnvr_1yr_all_upfront                                                                               
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                        $0.00 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.cnvr_1yr_no_upfront                                                                                
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                       $21.90 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.cnvr_1yr_partial_upfront                                                                           
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                       $10.44 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.cnvr_3yr_all_upfront                                                                               
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                        $0.00 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.cnvr_3yr_no_upfront                                                                                
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                       $15.04 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.cnvr_3yr_partial_upfront                                                                           
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                        $7.01 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.instance1                                                                                          
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.medium)                    730  hours                       $48.91 
+ ├─ root_block_device                                                                                            
+ │  └─ Storage (general purpose SSD, gp2)                                 10  GB                           $1.00 
+ ├─ ebs_block_device[0]                                                                                          
+ │  └─ Storage (general purpose SSD, gp2)                                 10  GB                           $1.00 
+ ├─ ebs_block_device[1]                                                                                          
+ │  ├─ Storage (magnetic)                                                 20  GB                           $1.00 
+ │  └─ I/O requests                                         Monthly cost depends on usage: $0.05 per 1M request  
+ ├─ ebs_block_device[2]                                                                                          
+ │  └─ Storage (cold HDD, sc1)                                            30  GB                           $0.45 
+ ├─ ebs_block_device[3]                                                                                          
+ │  ├─ Storage (provisioned IOPS SSD, io1)                                40  GB                           $5.00 
+ │  └─ Provisioned IOPS                                                1,000  IOPS                        $65.00 
+ └─ ebs_block_device[4]                                                                                          
+    └─ Storage (general purpose SSD, gp3)                                 20  GB                           $1.60 
+                                                                                                                 
+ aws_instance.instance1_detailedMonitoring                                                                       
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                     730  hours                       $97.09 
+ ├─ EC2 detailed monitoring                                                7  metrics                      $2.10 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.instance1_ebsOptimized                                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                     730  hours                       $97.09 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.instance2_ebsOptimized                                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, r3.xlarge)                    730  hours                      $243.09 
+ ├─ EBS-optimized usage                                                  730  hours                       $14.60 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.instance_detailedMonitoring_withMonthlyHours                                                       
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                     100  hours                       $13.30 
+ ├─ EC2 detailed monitoring                                                7  metrics                      $2.10 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.instance_ebsOptimized_withMonthlyHours                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, r3.xlarge)                    100  hours                       $33.30 
+ ├─ EBS-optimized usage                                                  100  hours                        $2.00 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.instance_withLaunchTemplateById                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                    730  hours                       $32.19 
+ ├─ EC2 detailed monitoring                                                7  metrics                      $2.10 
+ ├─ CPU credits                                                        1,460  vCPU-hours                  $73.00 
+ ├─ root_block_device                                                                                            
+ │  └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+ ├─ ebs_block_device[0]                                                                                          
+ │  ├─ Storage (provisioned IOPS SSD, io1)                                20  GB                           $2.50 
+ │  └─ Provisioned IOPS                                                  200  IOPS                        $13.00 
+ └─ ebs_block_device[1]                                                                                          
+    ├─ Storage (provisioned IOPS SSD, io1)                                10  GB                           $1.25 
+    └─ Provisioned IOPS                                                  100  IOPS                         $6.50 
+                                                                                                                 
+ aws_instance.instance_withLaunchTemplateByName                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                    730  hours                       $32.19 
+ ├─ EC2 detailed monitoring                                                7  metrics                      $2.10 
+ ├─ root_block_device                                                                                            
+ │  └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+ └─ ebs_block_device[0]                                                                                          
+    ├─ Storage (provisioned IOPS SSD, io1)                                10  GB                           $1.25 
+    └─ Provisioned IOPS                                                  100  IOPS                         $6.50 
+                                                                                                                 
+ aws_instance.instance_withLaunchTemplateOverride                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.large)                     730  hours                       $60.74 
+ ├─ root_block_device                                                                                            
+ │  └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+ └─ ebs_block_device[0]                                                                                          
+    ├─ Storage (provisioned IOPS SSD, io1)                                20  GB                           $2.50 
+    └─ Provisioned IOPS                                                  100  IOPS                         $6.50 
+                                                                                                                 
+ aws_instance.instance_withMonthlyHours                                                                          
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                    100  hours                        $4.16 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.std_1yr_all_upfront                                                                                
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                        $0.00 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.std_1yr_no_upfront                                                                                 
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                       $19.05 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.std_1yr_partial_upfront                                                                            
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                        $9.05 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.std_3yr_all_upfront                                                                                
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                        $0.00 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.std_3yr_no_upfront                                                                                 
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                       $13.14 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.std_3yr_partial_upfront                                                                            
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                        $6.06 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.t2_default_cpuCredits                                                                              
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                    730  hours                       $33.87 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.t2_standard_cpuCredits                                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                    730  hours                       $33.87 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.t2_unlimited_cpuCredits                                                                            
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                    730  hours                       $33.87 
+ ├─ CPU credits                                                          600  vCPU-hours                  $30.00 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.t3_default_cpuCredits                                                                              
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                    730  hours                       $30.37 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.t3_standard_cpuCredits                                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                    730  hours                       $30.37 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ aws_instance.t3_unlimited_cpuCredits                                                                            
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                    730  hours                       $30.37 
+ ├─ CPU credits                                                        1,460  vCPU-hours                  $73.00 
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
+                                                                                                                 
+ OVERALL TOTAL                                                                                         $1,294.12 
 ──────────────────────────────────
-32 cloud resources were detected:
-∙ 30 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+30 cloud resources were detected:
+∙ 28 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x aws_launch_template
 ∙ 1 is not supported yet, see https://infracost.io/requested-resources:

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
@@ -95,6 +95,11 @@
     ├─ Storage (provisioned IOPS SSD, io1)                           20  GB                           $2.50 
     └─ Provisioned IOPS                                             100  IOPS                         $6.50 
                                                                                                             
+ aws_instance.instance_withMonthlyHours                                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               100  hours                        $4.16 
+ └─ root_block_device                                                                                       
+    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
+                                                                                                            
  aws_instance.std_1yr_all_upfront                                                                           
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
  └─ root_block_device                                                                                       
@@ -157,10 +162,10 @@
  └─ root_block_device                                                                                       
     └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
                                                                                                             
- OVERALL TOTAL                                                                                    $1,236.86 
+ OVERALL TOTAL                                                                                    $1,241.82 
 ──────────────────────────────────
-27 cloud resources were detected:
-∙ 25 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+28 cloud resources were detected:
+∙ 26 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x aws_launch_template
 ∙ 1 is not supported yet, see https://infracost.io/requested-resources:

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
@@ -1,171 +1,193 @@
 
- Name                                                       Monthly Qty  Unit                  Monthly Cost 
-                                                                                                            
- aws_instance.cnvr_1yr_all_upfront                                                                          
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.cnvr_1yr_no_upfront                                                                           
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $21.90 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.cnvr_1yr_partial_upfront                                                                      
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $10.44 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.cnvr_3yr_all_upfront                                                                          
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.cnvr_3yr_no_upfront                                                                           
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $15.04 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.cnvr_3yr_partial_upfront                                                                      
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $7.01 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.instance1                                                                                     
- ├─ Instance usage (Linux/UNIX, on-demand, m3.medium)               730  hours                       $48.91 
- ├─ root_block_device                                                                                       
- │  └─ Storage (general purpose SSD, gp2)                            10  GB                           $1.00 
- ├─ ebs_block_device[0]                                                                                     
- │  └─ Storage (general purpose SSD, gp2)                            10  GB                           $1.00 
- ├─ ebs_block_device[1]                                                                                     
- │  ├─ Storage (magnetic)                                            20  GB                           $1.00 
- │  └─ I/O requests                                    Monthly cost depends on usage: $0.05 per 1M request  
- ├─ ebs_block_device[2]                                                                                     
- │  └─ Storage (cold HDD, sc1)                                       30  GB                           $0.45 
- ├─ ebs_block_device[3]                                                                                     
- │  ├─ Storage (provisioned IOPS SSD, io1)                           40  GB                           $5.00 
- │  └─ Provisioned IOPS                                           1,000  IOPS                        $65.00 
- └─ ebs_block_device[4]                                                                                     
-    └─ Storage (general purpose SSD, gp3)                            20  GB                           $1.60 
-                                                                                                            
- aws_instance.instance1_detailedMonitoring                                                                  
- ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                730  hours                       $97.09 
- ├─ EC2 detailed monitoring                                           7  metrics                      $2.10 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.instance1_ebsOptimized                                                                        
- ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                730  hours                       $97.09 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.instance2_ebsOptimized                                                                        
- ├─ Instance usage (Linux/UNIX, on-demand, r3.xlarge)               730  hours                      $243.09 
- ├─ EBS-optimized usage                                             730  hours                       $14.60 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.instance_withLaunchTemplateById                                                               
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               730  hours                       $32.19 
- ├─ EC2 detailed monitoring                                           7  metrics                      $2.10 
- ├─ CPU credits                                                   1,460  vCPU-hours                  $73.00 
- ├─ root_block_device                                                                                       
- │  └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
- ├─ ebs_block_device[0]                                                                                     
- │  ├─ Storage (provisioned IOPS SSD, io1)                           20  GB                           $2.50 
- │  └─ Provisioned IOPS                                             200  IOPS                        $13.00 
- └─ ebs_block_device[1]                                                                                     
-    ├─ Storage (provisioned IOPS SSD, io1)                           10  GB                           $1.25 
-    └─ Provisioned IOPS                                             100  IOPS                         $6.50 
-                                                                                                            
- aws_instance.instance_withLaunchTemplateByName                                                             
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               730  hours                       $32.19 
- ├─ EC2 detailed monitoring                                           7  metrics                      $2.10 
- ├─ root_block_device                                                                                       
- │  └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
- └─ ebs_block_device[0]                                                                                     
-    ├─ Storage (provisioned IOPS SSD, io1)                           10  GB                           $1.25 
-    └─ Provisioned IOPS                                             100  IOPS                         $6.50 
-                                                                                                            
- aws_instance.instance_withLaunchTemplateOverride                                                           
- ├─ Instance usage (Linux/UNIX, on-demand, t3.large)                730  hours                       $60.74 
- ├─ root_block_device                                                                                       
- │  └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
- └─ ebs_block_device[0]                                                                                     
-    ├─ Storage (provisioned IOPS SSD, io1)                           20  GB                           $2.50 
-    └─ Provisioned IOPS                                             100  IOPS                         $6.50 
-                                                                                                            
- aws_instance.instance_withMonthlyHours                                                                     
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               100  hours                        $4.16 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.std_1yr_all_upfront                                                                           
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.std_1yr_no_upfront                                                                            
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $19.05 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.std_1yr_partial_upfront                                                                       
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $9.05 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.std_3yr_all_upfront                                                                           
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $0.00 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.std_3yr_no_upfront                                                                            
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                       $13.14 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.std_3yr_partial_upfront                                                                       
- ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                730  hours                        $6.06 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.t2_default_cpuCredits                                                                         
- ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)               730  hours                       $33.87 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.t2_standard_cpuCredits                                                                        
- ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)               730  hours                       $33.87 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.t2_unlimited_cpuCredits                                                                       
- ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)               730  hours                       $33.87 
- ├─ CPU credits                                                     600  vCPU-hours                  $30.00 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.t3_default_cpuCredits                                                                         
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               730  hours                       $30.37 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.t3_standard_cpuCredits                                                                        
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               730  hours                       $30.37 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- aws_instance.t3_unlimited_cpuCredits                                                                       
- ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)               730  hours                       $30.37 
- ├─ CPU credits                                                   1,460  vCPU-hours                  $73.00 
- └─ root_block_device                                                                                       
-    └─ Storage (general purpose SSD, gp2)                             8  GB                           $0.80 
-                                                                                                            
- OVERALL TOTAL                                                                                    $1,241.82 
+ Name                                                               Monthly Qty  Unit                  Monthly Cost 
+                                                                                                                    
+ aws_instance.cnvr_1yr_all_upfront                                                                                  
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $0.00 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.cnvr_1yr_no_upfront                                                                                   
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $21.90 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.cnvr_1yr_partial_upfront                                                                              
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $10.44 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.cnvr_3yr_all_upfront                                                                                  
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $0.00 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.cnvr_3yr_no_upfront                                                                                   
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $15.04 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.cnvr_3yr_partial_upfront                                                                              
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $7.01 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.instance1                                                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.medium)                       730  hours                       $48.91 
+ ├─ root_block_device                                                                                               
+ │  └─ Storage (general purpose SSD, gp2)                                    10  GB                           $1.00 
+ ├─ ebs_block_device[0]                                                                                             
+ │  └─ Storage (general purpose SSD, gp2)                                    10  GB                           $1.00 
+ ├─ ebs_block_device[1]                                                                                             
+ │  ├─ Storage (magnetic)                                                    20  GB                           $1.00 
+ │  └─ I/O requests                                            Monthly cost depends on usage: $0.05 per 1M request  
+ ├─ ebs_block_device[2]                                                                                             
+ │  └─ Storage (cold HDD, sc1)                                               30  GB                           $0.45 
+ ├─ ebs_block_device[3]                                                                                             
+ │  ├─ Storage (provisioned IOPS SSD, io1)                                   40  GB                           $5.00 
+ │  └─ Provisioned IOPS                                                   1,000  IOPS                        $65.00 
+ └─ ebs_block_device[4]                                                                                             
+    └─ Storage (general purpose SSD, gp3)                                    20  GB                           $1.60 
+                                                                                                                    
+ aws_instance.instance1_detailedMonitoring                                                                          
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        730  hours                       $97.09 
+ ├─ EC2 detailed monitoring                                                   7  metrics                      $2.10 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.instance1_ebsOptimized                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        730  hours                       $97.09 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.instance2_ebsOptimized                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, r3.xlarge)                       730  hours                      $243.09 
+ ├─ EBS-optimized usage                                                     730  hours                       $14.60 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.instance_detailedMonitoring_withMonthlyHours                                                          
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        100  hours                       $13.30 
+ ├─ EC2 detailed monitoring                                                   7  metrics                      $2.10 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.instance_ebsOptimized_withMonthlyHours                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, r3.xlarge)                       100  hours                       $33.30 
+ ├─ EBS-optimized usage                                                     100  hours                        $2.00 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.instance_elasticInferenceAccel                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        730  hours                       $97.09 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.instance_elasticInferenceAccel_withMonthlyHours                                                       
+ ├─ Instance usage (Linux/UNIX, on-demand, m3.large)                        100  hours                       $13.30 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.instance_withLaunchTemplateById                                                                       
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $32.19 
+ ├─ EC2 detailed monitoring                                                   7  metrics                      $2.10 
+ ├─ CPU credits                                                           1,460  vCPU-hours                  $73.00 
+ ├─ root_block_device                                                                                               
+ │  └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+ ├─ ebs_block_device[0]                                                                                             
+ │  ├─ Storage (provisioned IOPS SSD, io1)                                   20  GB                           $2.50 
+ │  └─ Provisioned IOPS                                                     200  IOPS                        $13.00 
+ └─ ebs_block_device[1]                                                                                             
+    ├─ Storage (provisioned IOPS SSD, io1)                                   10  GB                           $1.25 
+    └─ Provisioned IOPS                                                     100  IOPS                         $6.50 
+                                                                                                                    
+ aws_instance.instance_withLaunchTemplateByName                                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $32.19 
+ ├─ EC2 detailed monitoring                                                   7  metrics                      $2.10 
+ ├─ root_block_device                                                                                               
+ │  └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+ └─ ebs_block_device[0]                                                                                             
+    ├─ Storage (provisioned IOPS SSD, io1)                                   10  GB                           $1.25 
+    └─ Provisioned IOPS                                                     100  IOPS                         $6.50 
+                                                                                                                    
+ aws_instance.instance_withLaunchTemplateOverride                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.large)                        730  hours                       $60.74 
+ ├─ root_block_device                                                                                               
+ │  └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+ └─ ebs_block_device[0]                                                                                             
+    ├─ Storage (provisioned IOPS SSD, io1)                                   20  GB                           $2.50 
+    └─ Provisioned IOPS                                                     100  IOPS                         $6.50 
+                                                                                                                    
+ aws_instance.instance_withMonthlyHours                                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       100  hours                        $4.16 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.std_1yr_all_upfront                                                                                   
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $0.00 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.std_1yr_no_upfront                                                                                    
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $19.05 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.std_1yr_partial_upfront                                                                               
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $9.05 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.std_3yr_all_upfront                                                                                   
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $0.00 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.std_3yr_no_upfront                                                                                    
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                       $13.14 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.std_3yr_partial_upfront                                                                               
+ ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                        730  hours                        $6.06 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.t2_default_cpuCredits                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                       730  hours                       $33.87 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.t2_standard_cpuCredits                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                       730  hours                       $33.87 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.t2_unlimited_cpuCredits                                                                               
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)                       730  hours                       $33.87 
+ ├─ CPU credits                                                             600  vCPU-hours                  $30.00 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.t3_default_cpuCredits                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $30.37 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.t3_standard_cpuCredits                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $30.37 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ aws_instance.t3_unlimited_cpuCredits                                                                               
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                       730  hours                       $30.37 
+ ├─ CPU credits                                                           1,460  vCPU-hours                  $73.00 
+ └─ root_block_device                                                                                               
+    └─ Storage (general purpose SSD, gp2)                                     8  GB                           $0.80 
+                                                                                                                    
+ OVERALL TOTAL                                                                                            $1,406.11 
 ──────────────────────────────────
-28 cloud resources were detected:
-∙ 26 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+32 cloud resources were detected:
+∙ 30 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x aws_launch_template
 ∙ 1 is not supported yet, see https://infracost.io/requested-resources:

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
@@ -253,21 +253,3 @@ resource "aws_instance" "instance_detailedMonitoring_withMonthlyHours" {
   instance_type = "m3.large"
   monitoring    = true
 }
-
-resource "aws_instance" "instance_elasticInferenceAccel_withMonthlyHours" {
-  ami           = "fake_ami"
-  instance_type = "m3.large"
-
-  elastic_inference_accelerator {
-    type = "eia1.medium"
-  }
-}
-
-resource "aws_instance" "instance_elasticInferenceAccel" {
-  ami           = "fake_ami"
-  instance_type = "m3.large"
-
-  elastic_inference_accelerator {
-    type = "eia1.medium"
-  }
-}

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
@@ -236,3 +236,8 @@ resource "aws_instance" "instance_withLaunchTemplateOverride" {
     volume_size = 20
   }
 }
+
+resource "aws_instance" "instance_withMonthlyHours" {
+  ami           = "fake_ami"
+  instance_type = "t3.medium"
+}

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
@@ -241,3 +241,33 @@ resource "aws_instance" "instance_withMonthlyHours" {
   ami           = "fake_ami"
   instance_type = "t3.medium"
 }
+
+resource "aws_instance" "instance_ebsOptimized_withMonthlyHours" {
+  ami           = "fake_ami"
+  instance_type = "r3.xlarge"
+  ebs_optimized = true
+}
+
+resource "aws_instance" "instance_detailedMonitoring_withMonthlyHours" {
+  ami           = "fake_ami"
+  instance_type = "m3.large"
+  monitoring    = true
+}
+
+resource "aws_instance" "instance_elasticInferenceAccel_withMonthlyHours" {
+  ami           = "fake_ami"
+  instance_type = "m3.large"
+
+  elastic_inference_accelerator {
+    type = "eia1.medium"
+  }
+}
+
+resource "aws_instance" "instance_elasticInferenceAccel" {
+  ami           = "fake_ami"
+  instance_type = "m3.large"
+
+  elastic_inference_accelerator {
+    type = "eia1.medium"
+  }
+}

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
@@ -88,6 +88,3 @@ resource_usage:
 
   aws_instance.instance_detailedMonitoring_withMonthlyHours:
     monthly_hours: 100
-
-  aws_instance.instance_elasticInferenceAccel_withMonthlyHours:
-    monthly_hours: 100

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
@@ -81,10 +81,10 @@ resource_usage:
     vcpu_count: 2
 
   aws_instance.instance_withMonthlyHours:
-    monthly_hours: 100
+    monthly_hrs: 100
 
   aws_instance.instance_ebsOptimized_withMonthlyHours:
-    monthly_hours: 100
+    monthly_hrs: 100
 
   aws_instance.instance_detailedMonitoring_withMonthlyHours:
-    monthly_hours: 100
+    monthly_hrs: 100

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
@@ -79,3 +79,6 @@ resource_usage:
   aws_instance.instance_withLaunchTemplateOverride:
     monthly_cpu_credit_hrs: 730
     vcpu_count: 2
+
+  aws_instance.instance_withMonthlyHours:
+    monthly_hours: 100

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.usage.yml
@@ -82,3 +82,12 @@ resource_usage:
 
   aws_instance.instance_withMonthlyHours:
     monthly_hours: 100
+
+  aws_instance.instance_ebsOptimized_withMonthlyHours:
+    monthly_hours: 100
+
+  aws_instance.instance_detailedMonitoring_withMonthlyHours:
+    monthly_hours: 100
+
+  aws_instance.instance_elasticInferenceAccel_withMonthlyHours:
+    monthly_hours: 100

--- a/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
+++ b/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
@@ -42,7 +42,7 @@ func aksClusterNodePool(name, region string, n gjson.Result, nodeCount decimal.D
 		Name: name,
 	}
 	instanceType := n.Get("vm_size").String()
-	costComponents = append(costComponents, linuxVirtualMachineCostComponent(region, instanceType))
+	costComponents = append(costComponents, linuxVirtualMachineCostComponent(region, instanceType, nil))
 	mainResource.CostComponents = costComponents
 	schema.MultiplyQuantities(mainResource, nodeCount)
 

--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -27,7 +27,7 @@ func NewAzureRMLinuxVirtualMachine(d *schema.ResourceData, u *schema.UsageData) 
 
 	var monthlyHours *int64 = nil
 	if u != nil {
-		monthlyHours = u.GetInt("monthly_hours")
+		monthlyHours = u.GetInt("monthly_hrs")
 	}
 
 	costComponents := []*schema.CostComponent{linuxVirtualMachineCostComponent(region, instanceType, monthlyHours)}

--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -25,9 +25,9 @@ func NewAzureRMLinuxVirtualMachine(d *schema.ResourceData, u *schema.UsageData) 
 
 	instanceType := d.Get("size").String()
 
-	var monthlyHours *int64 = nil
+	var monthlyHours *float64 = nil
 	if u != nil {
-		monthlyHours = u.GetInt("monthly_hrs")
+		monthlyHours = u.GetFloat("monthly_hrs")
 	}
 
 	costComponents := []*schema.CostComponent{linuxVirtualMachineCostComponent(region, instanceType, monthlyHours)}
@@ -50,7 +50,7 @@ func NewAzureRMLinuxVirtualMachine(d *schema.ResourceData, u *schema.UsageData) 
 	}
 }
 
-func linuxVirtualMachineCostComponent(region string, instanceType string, monthlyHours *int64) *schema.CostComponent {
+func linuxVirtualMachineCostComponent(region string, instanceType string, monthlyHours *float64) *schema.CostComponent {
 	purchaseOption := "Consumption"
 	purchaseOptionLabel := "pay as you go"
 
@@ -61,9 +61,9 @@ func linuxVirtualMachineCostComponent(region string, instanceType string, monthl
 		instanceType = fmt.Sprintf("Standard_%s", instanceType)
 	}
 
-	qty := decimal.NewFromInt(730)
+	qty := decimal.NewFromFloat(730)
 	if monthlyHours != nil {
-		qty = decimal.NewFromInt(*monthlyHours)
+		qty = decimal.NewFromFloat(*monthlyHours)
 	}
 
 	return &schema.CostComponent{

--- a/internal/providers/terraform/azure/linux_virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine_scale_set.go
@@ -18,7 +18,7 @@ func NewAzureRMLinuxVirtualMachineScaleSet(d *schema.ResourceData, u *schema.Usa
 
 	instanceType := d.Get("sku").String()
 
-	costComponents := []*schema.CostComponent{linuxVirtualMachineCostComponent(region, instanceType)}
+	costComponents := []*schema.CostComponent{linuxVirtualMachineCostComponent(region, instanceType, nil)}
 	subResources := make([]*schema.Resource, 0)
 
 	if d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool() {

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
@@ -13,6 +13,12 @@
     ├─ Storage (S4)                                                         1  months                           $1.54 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
+ azurerm_linux_virtual_machine.basic_b1_withMonthlyHours                                                              
+ ├─ Instance usage (pay as you go, Standard_B1s)                          100  hours                            $1.04 
+ └─ os_disk                                                                                                           
+    ├─ Storage (S4)                                                         1  months                           $1.54 
+    └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                      
  azurerm_linux_virtual_machine.standard_a2_ultra_enabled                                                              
  ├─ Instance usage (pay as you go, Standard_A2_v2)                        730  hours                           $66.43 
  ├─ Ultra disk reservation (if unattached)                 Monthly cost depends on usage: $4.38 per vCPU              
@@ -31,7 +37,7 @@
  └─ os_disk                                                                                                           
     └─ Storage (P4)                                                         1  months                           $5.28 
                                                                                                                       
- OVERALL TOTAL                                                                                                $357.95 
+ OVERALL TOTAL                                                                                                $360.52 
 ──────────────────────────────────
-5 cloud resources were detected:
-∙ 5 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.tf
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.tf
@@ -137,3 +137,29 @@ resource "azurerm_linux_virtual_machine" "standard_a2_ultra_enabled" {
     version   = "latest"
   }
 }
+
+resource "azurerm_linux_virtual_machine" "basic_b1_withMonthlyHours" {
+  name                = "basic_b1"
+  resource_group_name = "fake_resource_group"
+  location            = "eastus"
+
+  size           = "Standard_B1s"
+  admin_username = "fakeuser"
+  admin_password = "fakepass"
+
+  network_interface_ids = [
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic",
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.usage.yml
@@ -4,4 +4,4 @@ resource_usage:
     os_disk:
       monthly_disk_operations: 20000
   azurerm_linux_virtual_machine.basic_b1_withMonthlyHours:
-    monthly_hours: 100
+    monthly_hrs: 100

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.usage.yml
@@ -3,3 +3,5 @@ resource_usage:
   azurerm_linux_virtual_machine.standard_a2_v2_custom_disk:
     os_disk:
       monthly_disk_operations: 20000
+  azurerm_linux_virtual_machine.basic_b1_withMonthlyHours:
+    monthly_hours: 100

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
@@ -8,6 +8,13 @@
     ├─ Storage (S4)                                                   1  months                           $1.54 
     └─ Disk operations                               Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                 
+ azurerm_virtual_machine.linux_withMonthlyHours                                                                 
+ ├─ Instance usage (pay as you go, Standard_DS1_v2)                 100  hours                            $7.30 
+ ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $4.38 per vCPU              
+ └─ storage_os_disk                                                                                             
+    ├─ Storage (S4)                                                   1  months                           $1.54 
+    └─ Disk operations                               Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                
  azurerm_virtual_machine.windows                                                                                
  ├─ Instance usage (pay as you go, Standard_DS1_v2)                 730  hours                           $91.98 
  ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $4.38 per vCPU              
@@ -27,10 +34,17 @@
     ├─ Provisioned IOPS                                           2,048  IOPS                           $101.66 
     └─ Throughput                                                     8  MB/s                             $2.80 
                                                                                                                 
- OVERALL TOTAL                                                                                          $385.16 
+ azurerm_virtual_machine.windows_withMonthlyHours                                                               
+ ├─ Instance usage (pay as you go, Standard_DS1_v2)                 100  hours                           $12.60 
+ ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $4.38 per vCPU              
+ └─ storage_os_disk                                                                                             
+    ├─ Storage (S4)                                                   1  months                           $1.54 
+    └─ Disk operations                               Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                
+ OVERALL TOTAL                                                                                          $408.13 
 ──────────────────────────────────
-6 cloud resources were detected:
-∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+8 cloud resources were detected:
+∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 4 were free:
   ∙ 1 x azurerm_network_interface
   ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.tf
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.tf
@@ -61,8 +61,35 @@ resource "azurerm_virtual_machine" "linux" {
   os_profile_linux_config {
     disable_password_authentication = false
   }
+}
 
+resource "azurerm_virtual_machine" "linux_withMonthlyHours" {
+  name                  = "vm"
+  location              = azurerm_resource_group.main.location
+  resource_group_name   = azurerm_resource_group.main.name
+  network_interface_ids = [azurerm_network_interface.main.id]
+  vm_size               = "Standard_DS1_v2"
 
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+  storage_os_disk {
+    name              = "myosdisk1"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+  os_profile {
+    computer_name  = "hostname"
+    admin_username = "testadmin"
+    admin_password = "Password1234!"
+  }
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
 }
 
 resource "azurerm_virtual_machine" "windows" {
@@ -111,5 +138,26 @@ resource "azurerm_virtual_machine" "windows" {
     create_option     = "FromImage"
     managed_disk_type = "UltraSSD_LRS"
     lun               = 4
+  }
+}
+
+resource "azurerm_virtual_machine" "windows_withMonthlyHours" {
+  name                  = "vm"
+  location              = azurerm_resource_group.main.location
+  resource_group_name   = azurerm_resource_group.main.name
+  network_interface_ids = [azurerm_network_interface.main.id]
+  vm_size               = "Standard_DS1_v2"
+
+  storage_os_disk {
+    name              = "myosdisk1"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+    os_type           = "Windows"
+  }
+  os_profile {
+    computer_name  = "hostname"
+    admin_username = "testadmin"
+    admin_password = "Password1234!"
   }
 }

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.usage.yml
@@ -5,3 +5,7 @@ resource_usage:
       monthly_disk_operations: 1000000
     storage_data_disk:
       monthly_disk_operations: 2000000
+  azurerm_virtual_machine.linux_withMonthlyHours:
+    monthly_hours: 100
+  azurerm_virtual_machine.windows_withMonthlyHours:
+    monthly_hours: 100

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.usage.yml
@@ -6,6 +6,6 @@ resource_usage:
     storage_data_disk:
       monthly_disk_operations: 2000000
   azurerm_virtual_machine.linux_withMonthlyHours:
-    monthly_hours: 100
+    monthly_hrs: 100
   azurerm_virtual_machine.windows_withMonthlyHours:
-    monthly_hours: 100
+    monthly_hrs: 100

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
@@ -13,6 +13,12 @@
     ├─ Storage (S4)                                                              1  months                           $1.54 
     └─ Disk operations                                          Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                            
+ azurerm_windows_virtual_machine.basic_a2_withMonthlyHours                                                                 
+ ├─ Instance usage (pay as you go, Basic_A2)                                   100  hours                           $13.30 
+ └─ os_disk                                                                                                                
+    ├─ Storage (S4)                                                              1  months                           $1.54 
+    └─ Disk operations                                          Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                           
  azurerm_windows_virtual_machine.standard_a2_ultra_enabled                                                                 
  ├─ Instance usage (pay as you go, Standard_A2_v2)                             730  hours                           $99.28 
  ├─ Ultra disk reservation (if unattached)                      Monthly cost depends on usage: $4.38 per vCPU              
@@ -37,7 +43,7 @@
  └─ os_disk                                                                                                                
     └─ Storage (P4)                                                              1  months                           $5.28 
                                                                                                                            
- OVERALL TOTAL                                                                                                   $1,943.37 
+ OVERALL TOTAL                                                                                                   $1,958.20 
 ──────────────────────────────────
-6 cloud resources were detected:
-∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+7 cloud resources were detected:
+∙ 7 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.tf
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.tf
@@ -167,3 +167,29 @@ resource "azurerm_windows_virtual_machine" "Standard_E16-8as_v4" {
     version   = "fake"
   }
 }
+
+resource "azurerm_windows_virtual_machine" "basic_a2_withMonthlyHours" {
+  name                = "basic_a2"
+  resource_group_name = "fake_resource_group"
+  location            = "eastus"
+
+  size           = "Basic_A2"
+  admin_username = "fakeuser"
+  admin_password = "fakepass"
+
+  network_interface_ids = [
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic",
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.usage.yml
@@ -4,4 +4,4 @@ resource_usage:
     os_disk:
       monthly_disk_operations: 20000
   azurerm_windows_virtual_machine.basic_a2_withMonthlyHours:
-    monthly_hours: 100
+    monthly_hrs: 100

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.usage.yml
@@ -3,3 +3,5 @@ resource_usage:
   azurerm_windows_virtual_machine.standard_a2_v2_custom_disk:
     os_disk:
       monthly_disk_operations: 20000
+  azurerm_windows_virtual_machine.basic_a2_withMonthlyHours:
+    monthly_hours: 100

--- a/internal/providers/terraform/azure/virtual_machine.go
+++ b/internal/providers/terraform/azure/virtual_machine.go
@@ -34,7 +34,7 @@ func NewAzureRMVirtualMachine(d *schema.ResourceData, u *schema.UsageData) *sche
 
 	var monthlyHours *int64 = nil
 	if u != nil {
-		monthlyHours = u.GetInt("monthly_hours")
+		monthlyHours = u.GetInt("monthly_hrs")
 	}
 
 	if strings.ToLower(os) == "windows" {

--- a/internal/providers/terraform/azure/virtual_machine.go
+++ b/internal/providers/terraform/azure/virtual_machine.go
@@ -32,9 +32,9 @@ func NewAzureRMVirtualMachine(d *schema.ResourceData, u *schema.UsageData) *sche
 		os = "Windows"
 	}
 
-	var monthlyHours *int64 = nil
+	var monthlyHours *float64 = nil
 	if u != nil {
-		monthlyHours = u.GetInt("monthly_hrs")
+		monthlyHours = u.GetFloat("monthly_hrs")
 	}
 
 	if strings.ToLower(os) == "windows" {

--- a/internal/providers/terraform/azure/virtual_machine.go
+++ b/internal/providers/terraform/azure/virtual_machine.go
@@ -32,13 +32,19 @@ func NewAzureRMVirtualMachine(d *schema.ResourceData, u *schema.UsageData) *sche
 		os = "Windows"
 	}
 
-	if strings.ToLower(os) == "windows" {
-		licenseType := d.Get("license_type").String()
-		costComponents = append(costComponents, windowsVirtualMachineCostComponent(region, instanceType, licenseType))
-	} else {
-		costComponents = append(costComponents, linuxVirtualMachineCostComponent(region, instanceType))
+	var monthlyHours *int64 = nil
+	if u != nil {
+		monthlyHours = u.GetInt("monthly_hours")
 	}
 
+	if strings.ToLower(os) == "windows" {
+		licenseType := d.Get("license_type").String()
+		costComponents = append(costComponents, windowsVirtualMachineCostComponent(region, instanceType, licenseType, monthlyHours))
+	} else {
+		costComponents = append(costComponents, linuxVirtualMachineCostComponent(region, instanceType, monthlyHours))
+	}
+
+	// TODO: is this always assuming ultrassdreservation cost?
 	costComponents = append(costComponents, ultraSSDReservationCostComponent(region))
 
 	var storageOperations *decimal.Decimal

--- a/internal/providers/terraform/azure/virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/virtual_machine_scale_set.go
@@ -45,7 +45,7 @@ func NewAzureRMVirtualMachineScaleSet(d *schema.ResourceData, u *schema.UsageDat
 	}
 
 	if strings.ToLower(os) == "linux" {
-		costComponents = append(costComponents, linuxVirtualMachineCostComponent(region, instanceType))
+		costComponents = append(costComponents, linuxVirtualMachineCostComponent(region, instanceType, nil))
 	}
 
 	if strings.ToLower(os) == "windows" {
@@ -53,7 +53,7 @@ func NewAzureRMVirtualMachineScaleSet(d *schema.ResourceData, u *schema.UsageDat
 		if d.Get("license_type").Type != gjson.Null {
 			licenseType = d.Get("license_type").String()
 		}
-		costComponents = append(costComponents, windowsVirtualMachineCostComponent(region, instanceType, licenseType))
+		costComponents = append(costComponents, windowsVirtualMachineCostComponent(region, instanceType, licenseType, nil))
 	}
 
 	r := &schema.Resource{

--- a/internal/providers/terraform/azure/windows_virtual_machine.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine.go
@@ -26,7 +26,7 @@ func NewAzureRMWindowsVirtualMachine(d *schema.ResourceData, u *schema.UsageData
 
 	var monthlyHours *int64 = nil
 	if u != nil {
-		monthlyHours = u.GetInt("monthly_hours")
+		monthlyHours = u.GetInt("monthly_hrs")
 	}
 
 	costComponents := []*schema.CostComponent{windowsVirtualMachineCostComponent(region, instanceType, licenseType, monthlyHours)}

--- a/internal/providers/terraform/azure/windows_virtual_machine.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine.go
@@ -24,9 +24,9 @@ func NewAzureRMWindowsVirtualMachine(d *schema.ResourceData, u *schema.UsageData
 	instanceType := d.Get("size").String()
 	licenseType := d.Get("license_type").String()
 
-	var monthlyHours *int64 = nil
+	var monthlyHours *float64 = nil
 	if u != nil {
-		monthlyHours = u.GetInt("monthly_hrs")
+		monthlyHours = u.GetFloat("monthly_hrs")
 	}
 
 	costComponents := []*schema.CostComponent{windowsVirtualMachineCostComponent(region, instanceType, licenseType, monthlyHours)}
@@ -49,7 +49,7 @@ func NewAzureRMWindowsVirtualMachine(d *schema.ResourceData, u *schema.UsageData
 	}
 }
 
-func windowsVirtualMachineCostComponent(region string, instanceType string, licenseType string, monthlyHours *int64) *schema.CostComponent {
+func windowsVirtualMachineCostComponent(region string, instanceType string, licenseType string, monthlyHours *float64) *schema.CostComponent {
 	purchaseOption := "Consumption"
 	purchaseOptionLabel := "pay as you go"
 
@@ -66,9 +66,9 @@ func windowsVirtualMachineCostComponent(region string, instanceType string, lice
 		purchaseOptionLabel = "hybrid benefit"
 	}
 
-	qty := decimal.NewFromInt(730)
+	qty := decimal.NewFromFloat(730)
 	if monthlyHours != nil {
-		qty = decimal.NewFromInt(*monthlyHours)
+		qty = decimal.NewFromFloat(*monthlyHours)
 	}
 
 	return &schema.CostComponent{

--- a/internal/providers/terraform/azure/windows_virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine_scale_set.go
@@ -19,7 +19,7 @@ func NewAzureRMWindowsVirtualMachineScaleSet(d *schema.ResourceData, u *schema.U
 	instanceType := d.Get("sku").String()
 	licenseType := d.Get("license_type").String()
 
-	costComponents := []*schema.CostComponent{windowsVirtualMachineCostComponent(region, instanceType, licenseType)}
+	costComponents := []*schema.CostComponent{windowsVirtualMachineCostComponent(region, instanceType, licenseType, nil)}
 
 	if d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool() {
 		costComponents = append(costComponents, ultraSSDReservationCostComponent(region))

--- a/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
@@ -31,6 +31,6 @@
  OVERALL TOTAL                                                                        $37.80 
 ──────────────────────────────────
 11 cloud resources were detected:
-∙ 8 were estimated
+∙ 8 were estimated, 3 of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free:
   ∙ 3 x google_compute_address

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
@@ -6,6 +6,11 @@
  ├─ Standard provisioned storage (pd-standard)                         10  GB            $0.40 
  └─ NVIDIA Tesla K80 (on-demand)                                    2,920  hours       $919.80 
                                                                                                
+ google_compute_instance.gpu_with_hours                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)            100  hours        $53.20 
+ ├─ Standard provisioned storage (pd-standard)                         10  GB            $0.40 
+ └─ NVIDIA Tesla K80 (on-demand)                                      400  hours       $126.00 
+                                                                                               
  google_compute_instance.local_ssd                                                             
  ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)                  730  hours         $3.88 
  ├─ Standard provisioned storage (pd-standard)                         10  GB            $0.40 
@@ -33,7 +38,11 @@
  ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)                  730  hours         $3.88 
  └─ Standard provisioned storage (pd-standard)                         10  GB            $0.40 
                                                                                                
- OVERALL TOTAL                                                                       $1,638.42 
+ google_compute_instance.with_hours                                                            
+ ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)                  100  hours         $0.53 
+ └─ Standard provisioned storage (pd-standard)                         10  GB            $0.40 
+                                                                                               
+ OVERALL TOTAL                                                                       $1,818.95 
 ──────────────────────────────────
-7 cloud resources were detected:
-∙ 7 were estimated
+9 cloud resources were detected:
+∙ 9 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.tf
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.tf
@@ -105,7 +105,6 @@ resource "google_compute_instance" "preemptible_local_ssd" {
   }
 }
 
-
 resource "google_compute_instance" "gpu" {
   name         = "gpu"
   machine_type = "n1-standard-16"
@@ -145,6 +144,43 @@ resource "google_compute_instance" "preemptible_gpu" {
 
   scheduling {
     preemptible = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_instance" "with_hours" {
+  name         = "standard"
+  machine_type = "f1-micro"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "centos-cloud/centos-7"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_instance" "gpu_with_hours" {
+  name         = "gpu"
+  machine_type = "n1-standard-16"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "centos-cloud/centos-7"
+    }
+  }
+
+  guest_accelerator {
+    type  = "nvidia-tesla-k80"
+    count = 4
   }
 
   network_interface {

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.usage.yml
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.usage.yml
@@ -1,0 +1,6 @@
+version: 0.1
+resource_usage:
+  google_compute_instance.with_hours:
+    monthly_hours: 100
+  google_compute_instance.gpu_with_hours:
+    monthly_hours: 100

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.usage.yml
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.usage.yml
@@ -1,6 +1,6 @@
 version: 0.1
 resource_usage:
   google_compute_instance.with_hours:
-    monthly_hours: 100
+    monthly_hrs: 100
   google_compute_instance.gpu_with_hours:
-    monthly_hours: 100
+    monthly_hrs: 100

--- a/internal/providers/terraform/google/testdata/compute_machine_image_test/compute_machine_image_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_machine_image_test/compute_machine_image_test.golden
@@ -14,4 +14,4 @@
  OVERALL TOTAL                                                                             $274.86 
 ──────────────────────────────────
 3 cloud resources were detected:
-∙ 3 were estimated, 2 of which include usage-based costs, see https://infracost.io/usage-file
+∙ 3 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/resources/aws/instance.go
+++ b/internal/resources/aws/instance.go
@@ -39,7 +39,7 @@ type Instance struct {
 	ReservedInstancePaymentOption *string `infracost_usage:"reserved_instance_payment_option"`
 	MonthlyCPUCreditHours         *int64  `infracost_usage:"monthly_cpu_credit_hrs"`
 	VCPUCount                     *int64  `infracost_usage:"vcpu_count"`
-	MonthlyHours                  *int64  `infracost_usage:"monthly_hours"`
+	MonthlyHours                  *int64  `infracost_usage:"monthly_hrs"`
 }
 
 var InstanceUsageSchema = []*schema.UsageItem{
@@ -49,7 +49,7 @@ var InstanceUsageSchema = []*schema.UsageItem{
 	{Key: "reserved_instance_payment_option", DefaultValue: "", ValueType: schema.String},
 	{Key: "monthly_cpu_credit_hrs", DefaultValue: 0, ValueType: schema.Int64},
 	{Key: "vcpu_count", DefaultValue: 0, ValueType: schema.Int64},
-	{Key: "monthly_hours", DefaultValue: 730, ValueType: schema.Int64},
+	{Key: "monthly_hrs", DefaultValue: 730, ValueType: schema.Int64},
 }
 
 func (a *Instance) PopulateUsage(u *schema.UsageData) {

--- a/internal/resources/aws/instance.go
+++ b/internal/resources/aws/instance.go
@@ -33,13 +33,13 @@ type Instance struct {
 	EBSBlockDevices                 []*EBSVolume
 
 	// "usage" args
-	OperatingSystem               *string `infracost_usage:"operating_system"`
-	ReservedInstanceType          *string `infracost_usage:"reserved_instance_type"`
-	ReservedInstanceTerm          *string `infracost_usage:"reserved_instance_term"`
-	ReservedInstancePaymentOption *string `infracost_usage:"reserved_instance_payment_option"`
-	MonthlyCPUCreditHours         *int64  `infracost_usage:"monthly_cpu_credit_hrs"`
-	VCPUCount                     *int64  `infracost_usage:"vcpu_count"`
-	MonthlyHours                  *int64  `infracost_usage:"monthly_hrs"`
+	OperatingSystem               *string  `infracost_usage:"operating_system"`
+	ReservedInstanceType          *string  `infracost_usage:"reserved_instance_type"`
+	ReservedInstanceTerm          *string  `infracost_usage:"reserved_instance_term"`
+	ReservedInstancePaymentOption *string  `infracost_usage:"reserved_instance_payment_option"`
+	MonthlyCPUCreditHours         *int64   `infracost_usage:"monthly_cpu_credit_hrs"`
+	VCPUCount                     *int64   `infracost_usage:"vcpu_count"`
+	MonthlyHours                  *float64 `infracost_usage:"monthly_hrs"`
 }
 
 var InstanceUsageSchema = []*schema.UsageItem{
@@ -49,7 +49,7 @@ var InstanceUsageSchema = []*schema.UsageItem{
 	{Key: "reserved_instance_payment_option", DefaultValue: "", ValueType: schema.String},
 	{Key: "monthly_cpu_credit_hrs", DefaultValue: 0, ValueType: schema.Int64},
 	{Key: "vcpu_count", DefaultValue: 0, ValueType: schema.Int64},
-	{Key: "monthly_hrs", DefaultValue: 730, ValueType: schema.Int64},
+	{Key: "monthly_hrs", DefaultValue: 730, ValueType: schema.Float64},
 }
 
 func (a *Instance) PopulateUsage(u *schema.UsageData) {
@@ -175,9 +175,9 @@ func (a *Instance) computeCostComponent() *schema.CostComponent {
 		purchaseOptionLabel = "reserved"
 	}
 
-	qty := decimal.NewFromInt(730)
+	qty := decimal.NewFromFloat(730)
 	if a.MonthlyHours != nil {
-		qty = decimal.NewFromInt(*a.MonthlyHours)
+		qty = decimal.NewFromFloat(*a.MonthlyHours)
 	}
 
 	return &schema.CostComponent{
@@ -215,9 +215,9 @@ func (a *Instance) ebsOptimizedCostComponent() *schema.CostComponent {
 	 *    > The hourly price for EBS-optimized instances is in addition to the hourly usage fee
 	 *    > for supported instance types.
 	 */
-	qty := decimal.NewFromInt(730)
+	qty := decimal.NewFromFloat(730)
 	if a.MonthlyHours != nil {
-		qty = decimal.NewFromInt(*a.MonthlyHours)
+		qty = decimal.NewFromFloat(*a.MonthlyHours)
 	}
 
 	return &schema.CostComponent{
@@ -266,9 +266,9 @@ func (a *Instance) elasticInferenceAcceleratorCostComponent() *schema.CostCompon
 	 *    > With Amazon Elastic Inference, you pay only for the accelerator hours you use.
 	 *    > There are no upfront costs or minimum fees.
 	 */
-	qty := decimal.NewFromInt(730)
+	qty := decimal.NewFromFloat(730)
 	if a.MonthlyHours != nil {
-		qty = decimal.NewFromInt(*a.MonthlyHours)
+		qty = decimal.NewFromFloat(*a.MonthlyHours)
 	}
 
 	return &schema.CostComponent{

--- a/internal/resources/aws/instance.go
+++ b/internal/resources/aws/instance.go
@@ -240,24 +240,10 @@ func (a *Instance) ebsOptimizedCostComponent() *schema.CostComponent {
 }
 
 func (a *Instance) detailedMonitoringCostComponent() *schema.CostComponent {
-	/**
-	 * Detailed monitoring is billed hourly whenever the attached instance is live.
-	 *
-	 * From the detailed monitoring docs:
-	 *    > As with all custom metrics, EC2 Detailed Monitoring is prorated by the hour and
-	 *    > metered only when the instance sends metrics to CloudWatch.
-	 */
-	maxQty := decimal.NewFromInt(730)
-	qty := maxQty.Copy()
-	if a.MonthlyHours != nil {
-		qty = decimal.NewFromInt(*a.MonthlyHours)
-	}
-	monthlyMultiplier := maxQty.Div(qty)
-
 	return &schema.CostComponent{
 		Name:                 "EC2 detailed monitoring",
 		Unit:                 "metrics",
-		UnitMultiplier:       monthlyMultiplier,
+		UnitMultiplier:       decimal.NewFromInt(1),
 		MonthlyQuantity:      decimalPtr(decimal.NewFromInt(int64(defaultEC2InstanceMetricCount))),
 		IgnoreIfMissingPrice: true,
 		ProductFilter: &schema.ProductFilter{

--- a/internal/resources/aws/launch_template.go
+++ b/internal/resources/aws/launch_template.go
@@ -103,14 +103,14 @@ func (a *LaunchTemplate) BuildResource() *schema.Resource {
 	if spotCount > 0 {
 		instance.PurchaseOption = "spot"
 		c := instance.computeCostComponent()
-		c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(decimal.NewFromInt(spotCount)))
+		c.MonthlyQuantity = decimalPtr(c.MonthlyQuantity.Mul(decimal.NewFromInt(spotCount)))
 		r.CostComponents = append([]*schema.CostComponent{c}, r.CostComponents...)
 	}
 
 	if onDemandCount > 0 {
 		instance.PurchaseOption = "on_demand"
 		c := instance.computeCostComponent()
-		c.HourlyQuantity = decimalPtr(c.HourlyQuantity.Mul(decimal.NewFromInt(onDemandCount)))
+		c.MonthlyQuantity = decimalPtr(c.MonthlyQuantity.Mul(decimal.NewFromInt(onDemandCount)))
 		r.CostComponents = append([]*schema.CostComponent{c}, r.CostComponents...)
 	}
 

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -180,7 +180,7 @@ func guestAcceleratorCostComponent(region string, purchaseOption string, guestAc
 		Name:                fmt.Sprintf("%s (%s)", name, purchaseOptionLabel(purchaseOption)),
 		Unit:                "hours",
 		UnitMultiplier:      decimal.NewFromInt(1),
-		MonthlyQuantity:      decimalPtr(qty),
+		MonthlyQuantity:     decimalPtr(qty),
 		MonthlyDiscountPerc: sustainedUseDiscount,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("gcp"),

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -25,7 +25,7 @@ type ContainerNodeConfig struct {
 }
 
 // computeCostComponent returns a cost component for Compute instance usage.
-func computeCostComponent(region, machineType string, purchaseOption string, instanceCount int64) *schema.CostComponent {
+func computeCostComponent(region, machineType string, purchaseOption string, instanceCount int64, monthlyHours *int64) *schema.CostComponent {
 	sustainedUseDiscount := 0.0
 	if strings.ToLower(purchaseOption) == "on_demand" {
 		switch strings.ToLower(strings.Split(machineType, "-")[0]) {
@@ -36,11 +36,16 @@ func computeCostComponent(region, machineType string, purchaseOption string, ins
 		}
 	}
 
+	qty := decimal.NewFromInt(730)
+	if monthlyHours != nil {
+		qty = decimal.NewFromInt(*monthlyHours)
+	}
+
 	return &schema.CostComponent{
 		Name:                fmt.Sprintf("Instance usage (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
 		Unit:                "hours",
 		UnitMultiplier:      decimal.NewFromInt(1),
-		HourlyQuantity:      decimalPtr(decimal.NewFromInt(instanceCount)),
+		MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount))),
 		MonthlyDiscountPerc: sustainedUseDiscount,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("gcp"),
@@ -126,7 +131,7 @@ func computeDiskCostComponent(region string, diskType string, diskSize float64, 
 
 // guestAcceleratorCostComponent returns a cost component for Guest Accelerator
 // usage for Compute resources.
-func guestAcceleratorCostComponent(region string, purchaseOption string, guestAcceleratorType string, guestAcceleratorCount int64, instanceCount int64) *schema.CostComponent {
+func guestAcceleratorCostComponent(region string, purchaseOption string, guestAcceleratorType string, guestAcceleratorCount int64, instanceCount int64, monthlyHours *int64) *schema.CostComponent {
 	var (
 		name       string
 		descPrefix string
@@ -165,11 +170,17 @@ func guestAcceleratorCostComponent(region string, purchaseOption string, guestAc
 		sustainedUseDiscount = 0.3
 	}
 
+	qty := decimal.NewFromInt(730)
+	if monthlyHours != nil {
+		qty = decimal.NewFromInt(*monthlyHours)
+	}
+	qty = qty.Mul(count)
+
 	return &schema.CostComponent{
 		Name:                fmt.Sprintf("%s (%s)", name, purchaseOptionLabel(purchaseOption)),
 		Unit:                "hours",
 		UnitMultiplier:      decimal.NewFromInt(1),
-		HourlyQuantity:      decimalPtr(count),
+		MonthlyQuantity:      decimalPtr(qty),
 		MonthlyDiscountPerc: sustainedUseDiscount,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("gcp"),

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -25,7 +25,7 @@ type ContainerNodeConfig struct {
 }
 
 // computeCostComponent returns a cost component for Compute instance usage.
-func computeCostComponent(region, machineType string, purchaseOption string, instanceCount int64, monthlyHours *int64) *schema.CostComponent {
+func computeCostComponent(region, machineType string, purchaseOption string, instanceCount int64, monthlyHours *float64) *schema.CostComponent {
 	sustainedUseDiscount := 0.0
 	if strings.ToLower(purchaseOption) == "on_demand" {
 		switch strings.ToLower(strings.Split(machineType, "-")[0]) {
@@ -36,9 +36,9 @@ func computeCostComponent(region, machineType string, purchaseOption string, ins
 		}
 	}
 
-	qty := decimal.NewFromInt(730)
+	qty := decimal.NewFromFloat(730)
 	if monthlyHours != nil {
-		qty = decimal.NewFromInt(*monthlyHours)
+		qty = decimal.NewFromFloat(*monthlyHours)
 	}
 
 	return &schema.CostComponent{
@@ -131,7 +131,7 @@ func computeDiskCostComponent(region string, diskType string, diskSize float64, 
 
 // guestAcceleratorCostComponent returns a cost component for Guest Accelerator
 // usage for Compute resources.
-func guestAcceleratorCostComponent(region string, purchaseOption string, guestAcceleratorType string, guestAcceleratorCount int64, instanceCount int64, monthlyHours *int64) *schema.CostComponent {
+func guestAcceleratorCostComponent(region string, purchaseOption string, guestAcceleratorType string, guestAcceleratorCount int64, instanceCount int64, monthlyHours *float64) *schema.CostComponent {
 	var (
 		name       string
 		descPrefix string
@@ -170,9 +170,9 @@ func guestAcceleratorCostComponent(region string, purchaseOption string, guestAc
 		sustainedUseDiscount = 0.3
 	}
 
-	qty := decimal.NewFromInt(730)
+	qty := decimal.NewFromFloat(730)
 	if monthlyHours != nil {
-		qty = decimal.NewFromInt(*monthlyHours)
+		qty = decimal.NewFromFloat(*monthlyHours)
 	}
 	qty = qty.Mul(count)
 

--- a/internal/resources/google/compute_instance.go
+++ b/internal/resources/google/compute_instance.go
@@ -19,12 +19,12 @@ type ComputeInstance struct {
 	ScratchDisks      int
 	GuestAccelerators []*ComputeGuestAccelerator
 
-	MonthlyHours *int64 `infracost_usage:"monthly_hrs"`
+	MonthlyHours *float64 `infracost_usage:"monthly_hrs"`
 }
 
 // ComputeInstanceUsageSchema defines a list which represents the usage schema of ComputeInstance.
 var ComputeInstanceUsageSchema = []*schema.UsageItem{
-	{Key: "monthly_hrs", DefaultValue: 730, ValueType: schema.Int64},
+	{Key: "monthly_hrs", DefaultValue: 730, ValueType: schema.Float64},
 }
 
 // PopulateUsage parses the u schema.UsageData into the ComputeInstance.

--- a/internal/resources/google/compute_instance.go
+++ b/internal/resources/google/compute_instance.go
@@ -19,12 +19,12 @@ type ComputeInstance struct {
 	ScratchDisks      int
 	GuestAccelerators []*ComputeGuestAccelerator
 
-	MonthlyHours *int64 `infracost_usage:"monthly_hours"`
+	MonthlyHours *int64 `infracost_usage:"monthly_hrs"`
 }
 
 // ComputeInstanceUsageSchema defines a list which represents the usage schema of ComputeInstance.
 var ComputeInstanceUsageSchema = []*schema.UsageItem{
-	{Key: "monthly_hours", DefaultValue: 730, ValueType: schema.Int64},
+	{Key: "monthly_hrs", DefaultValue: 730, ValueType: schema.Int64},
 }
 
 // PopulateUsage parses the u schema.UsageData into the ComputeInstance.

--- a/internal/resources/google/compute_instance.go
+++ b/internal/resources/google/compute_instance.go
@@ -18,10 +18,14 @@ type ComputeInstance struct {
 	BootDiskType      string
 	ScratchDisks      int
 	GuestAccelerators []*ComputeGuestAccelerator
+
+	MonthlyHours *int64 `infracost_usage:"monthly_hours"`
 }
 
 // ComputeInstanceUsageSchema defines a list which represents the usage schema of ComputeInstance.
-var ComputeInstanceUsageSchema = []*schema.UsageItem{}
+var ComputeInstanceUsageSchema = []*schema.UsageItem{
+	{Key: "monthly_hours", DefaultValue: 730, ValueType: schema.Int64},
+}
 
 // PopulateUsage parses the u schema.UsageData into the ComputeInstance.
 // It uses the `infracost_usage` struct tags to populate data into the ComputeInstance.
@@ -34,7 +38,7 @@ func (r *ComputeInstance) PopulateUsage(u *schema.UsageData) {
 // See providers folder for more information.
 func (r *ComputeInstance) BuildResource() *schema.Resource {
 	costComponents := []*schema.CostComponent{
-		computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.Size),
+		computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours),
 	}
 
 	if r.HasBootDisk {
@@ -46,7 +50,7 @@ func (r *ComputeInstance) BuildResource() *schema.Resource {
 	}
 
 	for _, guestAccel := range r.GuestAccelerators {
-		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.Size))
+		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.Size, r.MonthlyHours))
 	}
 
 	return &schema.Resource{

--- a/internal/resources/google/compute_instance_group_manager.go
+++ b/internal/resources/google/compute_instance_group_manager.go
@@ -33,7 +33,7 @@ func (r *ComputeInstanceGroupManager) PopulateUsage(u *schema.UsageData) {
 // See providers folder for more information.
 func (r *ComputeInstanceGroupManager) BuildResource() *schema.Resource {
 	costComponents := []*schema.CostComponent{
-		computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.TargetSize),
+		computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.TargetSize, nil),
 	}
 
 	for _, disk := range r.Disks {
@@ -45,7 +45,7 @@ func (r *ComputeInstanceGroupManager) BuildResource() *schema.Resource {
 	}
 
 	for _, guestAccel := range r.GuestAccelerators {
-		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.TargetSize))
+		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.TargetSize, nil))
 	}
 
 	return &schema.Resource{

--- a/internal/resources/google/compute_region_instance_group_manager.go
+++ b/internal/resources/google/compute_region_instance_group_manager.go
@@ -33,7 +33,7 @@ func (r *ComputeRegionInstanceGroupManager) PopulateUsage(u *schema.UsageData) {
 // See providers folder for more information.
 func (r *ComputeRegionInstanceGroupManager) BuildResource() *schema.Resource {
 	costComponents := []*schema.CostComponent{
-		computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.TargetSize),
+		computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.TargetSize, nil),
 	}
 
 	for _, disk := range r.Disks {
@@ -45,7 +45,7 @@ func (r *ComputeRegionInstanceGroupManager) BuildResource() *schema.Resource {
 	}
 
 	for _, guestAccel := range r.GuestAccelerators {
-		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.TargetSize))
+		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.TargetSize, nil))
 	}
 
 	return &schema.Resource{

--- a/internal/resources/google/container_node_pool.go
+++ b/internal/resources/google/container_node_pool.go
@@ -44,7 +44,7 @@ func (r *ContainerNodePool) BuildResource() *schema.Resource {
 	poolSize := int64(1)
 
 	costComponents := []*schema.CostComponent{
-		computeCostComponent(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize),
+		computeCostComponent(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil),
 		computeDiskCostComponent(r.Region, r.NodeConfig.DiskType, r.NodeConfig.DiskSize, poolSize),
 	}
 
@@ -53,7 +53,7 @@ func (r *ContainerNodePool) BuildResource() *schema.Resource {
 	}
 
 	for _, guestAccel := range r.NodeConfig.GuestAccelerators {
-		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.NodeConfig.PurchaseOption, guestAccel.Type, guestAccel.Count, poolSize))
+		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.NodeConfig.PurchaseOption, guestAccel.Type, guestAccel.Count, poolSize, nil))
 	}
 
 	resource := &schema.Resource{

--- a/internal/usage/testdata/usage_file/usage_file.golden
+++ b/internal/usage/testdata/usage_file/usage_file.golden
@@ -11,7 +11,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730.0 # Monthly number of hours the instance ran for.
   aws_instance.instance_counted[0]:
     operating_system: linux # Override the operating system of the instance, can be: linux, windows, suse, rhel.
     # reserved_instance_type: "" # Offering class for Reserved Instances, can be: convertible, standard.
@@ -19,7 +19,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730.0 # Monthly number of hours the instance ran for.
   ##
   ## The following usage values are all commented-out, you can uncomment resources and customize as needed.
   ##
@@ -30,7 +30,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730.0 # Monthly number of hours the instance ran for.
   aws_instance.with_usage:
     operating_system: windows # Override the operating system of the instance, can be: linux, windows, suse, rhel.
     reserved_instance_type: standard # Offering class for Reserved Instances, can be: convertible, standard.
@@ -38,7 +38,7 @@ resource_usage:
     reserved_instance_payment_option: all_upfront # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730.0 # Monthly number of hours the instance ran for.
   aws_s3_bucket.with_usage:
     object_tags: 10000000 # This comment shouldn't be overwritten
     # standard:
@@ -208,7 +208,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730.0 # Monthly number of hours the instance ran for.
   # aws_s3_bucket.no_usage:
     # object_tags: 0 # Total object tags. Only for AWS provider V3.
     # standard:

--- a/internal/usage/testdata/usage_file/usage_file.golden
+++ b/internal/usage/testdata/usage_file/usage_file.golden
@@ -11,6 +11,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
+    # monthly_hours: 730 # Monthly number of hours the instance ran for.
   aws_instance.instance_counted[0]:
     operating_system: linux # Override the operating system of the instance, can be: linux, windows, suse, rhel.
     # reserved_instance_type: "" # Offering class for Reserved Instances, can be: convertible, standard.
@@ -18,6 +19,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
+    # monthly_hours: 730 # Monthly number of hours the instance ran for.
   ##
   ## The following usage values are all commented-out, you can uncomment resources and customize as needed.
   ##
@@ -28,6 +30,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
+    # monthly_hours: 730 # Monthly number of hours the instance ran for.
   aws_instance.with_usage:
     operating_system: windows # Override the operating system of the instance, can be: linux, windows, suse, rhel.
     reserved_instance_type: standard # Offering class for Reserved Instances, can be: convertible, standard.
@@ -35,6 +38,7 @@ resource_usage:
     reserved_instance_payment_option: all_upfront # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
+    # monthly_hours: 730 # Monthly number of hours the instance ran for.
   aws_s3_bucket.with_usage:
     object_tags: 10000000 # This comment shouldn't be overwritten
     # standard:
@@ -204,6 +208,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
+    # monthly_hours: 730 # Monthly number of hours the instance ran for.
   # aws_s3_bucket.no_usage:
     # object_tags: 0 # Total object tags. Only for AWS provider V3.
     # standard:

--- a/internal/usage/testdata/usage_file/usage_file.golden
+++ b/internal/usage/testdata/usage_file/usage_file.golden
@@ -11,7 +11,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hours: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
   aws_instance.instance_counted[0]:
     operating_system: linux # Override the operating system of the instance, can be: linux, windows, suse, rhel.
     # reserved_instance_type: "" # Offering class for Reserved Instances, can be: convertible, standard.
@@ -19,7 +19,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hours: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
   ##
   ## The following usage values are all commented-out, you can uncomment resources and customize as needed.
   ##
@@ -30,7 +30,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hours: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
   aws_instance.with_usage:
     operating_system: windows # Override the operating system of the instance, can be: linux, windows, suse, rhel.
     reserved_instance_type: standard # Offering class for Reserved Instances, can be: convertible, standard.
@@ -38,7 +38,7 @@ resource_usage:
     reserved_instance_payment_option: all_upfront # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hours: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
   aws_s3_bucket.with_usage:
     object_tags: 10000000 # This comment shouldn't be overwritten
     # standard:
@@ -208,7 +208,7 @@ resource_usage:
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hours: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
   # aws_s3_bucket.no_usage:
     # object_tags: 0 # Total object tags. Only for AWS provider V3.
     # standard:

--- a/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
+++ b/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
@@ -64,7 +64,7 @@ version: 0.1
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730.0 # Monthly number of hours the instance ran for.
   # aws_s3_bucket.no_usage:
     # object_tags: 0 # Total object tags. Only for AWS provider V3.
     # standard:

--- a/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
+++ b/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
@@ -64,6 +64,7 @@ version: 0.1
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
+    # monthly_hours: 730 # Monthly number of hours the instance ran for.
   # aws_s3_bucket.no_usage:
     # object_tags: 0 # Total object tags. Only for AWS provider V3.
     # standard:

--- a/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
+++ b/internal/usage/testdata/usage_file_no_usage/usage_file_no_usage.golden
@@ -64,7 +64,7 @@ version: 0.1
     # reserved_instance_payment_option: "" # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
     # monthly_cpu_credit_hrs: 0 # Number of hours in the month where the instance is expected to burst. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
     # vcpu_count: 0 # Number of the vCPUs for the instance type. Only applicable with t2, t3 & t4 Instance types. T2 requires credit_specification to be unlimited.
-    # monthly_hours: 730 # Monthly number of hours the instance ran for.
+    # monthly_hrs: 730 # Monthly number of hours the instance ran for.
   # aws_s3_bucket.no_usage:
     # object_tags: 0 # Total object tags. Only for AWS provider V3.
     # standard:


### PR DESCRIPTION
Updates the following resource types to support a `monthly_hrs` usage flag:

- `aws_instance`
- `azurerm_virtual_machine`
- `azurerm_linux_virtual_machine`
- `azurerm_windows_virtual_machine`
- `google_compute_instance`

This addresses #1556.