### PR TITLE
fix: mock attribute overriding the default location

### DIFF
--- a/internal/providers/terraform/azure/mssql_database_test.go
+++ b/internal/providers/terraform/azure/mssql_database_test.go
@@ -15,3 +15,14 @@ func TestMSSQLDatabase(t *testing.T) {
 	opts.CaptureLogs = true
 	tftest.GoldenFileResourceTestsWithOpts(t, "mssql_database_test", opts)
 }
+
+func TestMSSQLDatabaseWithBlankLocation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	opts := tftest.DefaultGoldenFileOptions()
+	opts.CaptureLogs = true
+
+	tftest.GoldenFileHCLResourceTestsWithOpts(t, "mssql_database_test_with_blank_location", opts)
+}

--- a/internal/providers/terraform/azure/testdata/mssql_database_test_with_blank_location/mssql_database_test_with_blank_location.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test_with_blank_location/mssql_database_test_with_blank_location.golden
@@ -1,0 +1,17 @@
+
+ Name                                            Monthly Qty  Unit            Monthly Cost 
+                                                                                           
+ azurerm_mssql_database.blank_server_location                                              
+ ├─ Compute (S3)                                          30  days                 $145.16 
+ ├─ Extra data storage                         Monthly cost depends on usage: $0.17 per GB 
+ └─ Long-term retention                        Monthly cost depends on usage: $0.05 per GB 
+                                                                                           
+ OVERALL TOTAL                                                                     $145.16 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 1 was estimated, it includes usage-based costs, see https://infracost.io/usage-file
+∙ 1 is not supported yet, see https://infracost.io/requested-resources:
+  ∙ 1 x azurerm_mssql_server
+Logs:
+
+level=warning msg="Using eastus for resource azurerm_mssql_database.blank_server_location as its 'location' property could not be found."

--- a/internal/providers/terraform/azure/testdata/mssql_database_test_with_blank_location/mssql_database_test_with_blank_location.tf
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test_with_blank_location/mssql_database_test_with_blank_location.tf
@@ -1,0 +1,23 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+data "azurerm_resource_group" "main" {
+  name = "test"
+}
+
+resource "azurerm_mssql_server" "blank_location" {
+  name                         = "blank-location"
+  resource_group_name          = data.azurerm_resource_group.main.name
+  location                     = data.azurerm_resource_group.main.location
+  version                      = "12.0"
+  administrator_login          = "fake"
+  administrator_login_password = "fake"
+}
+
+resource "azurerm_mssql_database" "blank_server_location" {
+  name      = "acctest-db-e"
+  sku_name = "S3"
+  server_id = azurerm_mssql_server.blank_location.id
+}

--- a/internal/providers/terraform/azure/testdata/mssql_database_test_with_blank_location/mssql_database_test_with_blank_location.usage.yml
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test_with_blank_location/mssql_database_test_with_blank_location.usage.yml
@@ -1,0 +1,2 @@
+version: 0.1
+resource_usage:

--- a/internal/providers/terraform/azure/util.go
+++ b/internal/providers/terraform/azure/util.go
@@ -26,16 +26,18 @@ func toAzureCLIName(location string) string {
 
 func lookupRegion(d *schema.ResourceData, parentResourceKeys []string) string {
 	// First check for a location set directly on a resource
-	if d.Get("location").String() != "" {
-		return toAzureCLIName(d.Get("location").String())
+	location := d.Get("location").String()
+	if location != "" && !strings.Contains(location, "mock") {
+		return toAzureCLIName(location)
 	}
 
 	// Then check for any parent resources with a location
 	for _, k := range parentResourceKeys {
 		parents := d.References(k)
 		for _, p := range parents {
-			if p.Get("location").String() != "" {
-				return toAzureCLIName(p.Get("location").String())
+			location := p.Get("location").String()
+			if location != "" && !strings.Contains(location, "mock") {
+				return toAzureCLIName(location)
 			}
 		}
 	}

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -385,6 +385,10 @@ func parseRegion(providerConf gjson.Result, vars gjson.Result, providerKey strin
 		}
 	}
 
+	if strings.Contains(region, "mock") {
+		return ""
+	}
+
 	return region
 }
 

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -208,6 +208,10 @@ func GoldenFileResourceTestsWithOpts(t *testing.T, testName string, options *Gol
 	})
 }
 
+func GoldenFileHCLResourceTestsWithOpts(t *testing.T, testName string, options *GoldenFileOptions) {
+	goldenFileResourceTestWithOpts(t, "hcl", testName, options)
+}
+
 func goldenFileResourceTestWithOpts(t *testing.T, pName string, testName string, options *GoldenFileOptions) {
 	t.Helper()
 


### PR DESCRIPTION
closes https://github.com/infracost/infracost/issues/1824

Solves issues where mock values for cloud attributes were causing the default region not to be used. `e.g.`

```
data "azurerm_resource_group" "main" {
  name = "test"
}

resource "azurerm_mssql_server" "blank_location" {
  location = data.azurerm_resource_group.main.location <== this would evaluate as `location-mock`
  ...
}

resource "azurerm_mssql_database" "blank_server_location" {
  name      = "acctest-db-e"
  sku_name = "S3"
  server_id = azurerm_mssql_server.blank_location.id
}
```

So blank string checks were being skipped as `location-mock` was seen as a valid region. We now check if the returned value is a mock and treat it as a blank value.