### PR TITLE
enhance: format stacktraces so we can match them when reported

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/infracost/infracost/internal/apiclient"
+	"github.com/infracost/infracost/internal/clierror"
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/ui"
 	"github.com/infracost/infracost/internal/update"
@@ -53,7 +54,7 @@ func Run(modifyCtx func(*config.RunContext), args *[]string) {
 
 	defer func() {
 		if appErr != nil {
-			if v, ok := appErr.(*panicError); ok {
+			if v, ok := appErr.(*clierror.PanicError); ok {
 				handleUnexpectedErr(ctx, v)
 			} else {
 				handleCLIError(ctx, appErr)
@@ -62,8 +63,8 @@ func Run(modifyCtx func(*config.RunContext), args *[]string) {
 
 		unexpectedErr := recover()
 		if unexpectedErr != nil {
-			withStack := fmt.Errorf("%s\n%s", unexpectedErr, debug.Stack())
-			handleUnexpectedErr(ctx, withStack)
+			panicErr := clierror.NewPanicError(fmt.Errorf("%s", unexpectedErr), debug.Stack())
+			handleUnexpectedErr(ctx, panicErr)
 		}
 
 		handleUpdateMessage(updateMessageChan)

--- a/go.mod
+++ b/go.mod
@@ -153,6 +153,7 @@ require (
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
 	github.com/lib/pq v1.8.0 // indirect
+	github.com/maruel/panicparse/v2 v2.3.0 // indirect
 	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1083,6 +1083,8 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/maruel/panicparse/v2 v2.3.0 h1:6yirZme0nd29ukOT0BF4sQXj5K2ItJQxbYQBKb9qS/k=
+github.com/maruel/panicparse/v2 v2.3.0/go.mod h1:s3UmQB9Fm/n7n/prcD2xBGDkwXD6y2LeZnhbEXvs9Dg=
 github.com/masterzen/simplexml v0.0.0-20160608183007-4572e39b1ab9/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786/go.mod h1:kCEbxUJlNDEBNbdQMkPSp6yaKcRXVI6f4ddk8Riv4bc=
 github.com/masterzen/winrm v0.0.0-20200615185753-c42b5136ff88/go.mod h1:a2HXwefeat3evJHxFXSayvRHpYEPJYtErl4uIzfaUqY=
@@ -1119,6 +1121,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
+github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.8/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
@@ -1887,6 +1890,7 @@ golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e h1:w36l2Uw3dRan1K3TyXriXvY+6T56GNmlKGcqiQUJDfM=
 golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/clierror/error.go
+++ b/internal/clierror/error.go
@@ -1,22 +1,152 @@
 package clierror
 
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/maruel/panicparse/v2/stack"
+	log "github.com/sirupsen/logrus"
+)
+
 // SanitizedError allows errors to be wrapped with a sanitized message for sending upstream
-type SanitizedError struct {
+type SanitizedError interface {
+	SanitizedError() string
+	SanitizedStack() string
+}
+
+type CLIError struct {
 	sanitizedMsg string
 	err          error
 }
 
-func (e *SanitizedError) Error() string {
-	return e.err.Error()
-}
-
-func (e *SanitizedError) SanitizedError() string {
-	return e.sanitizedMsg
-}
-
-func NewSanitizedError(err error, sanitizedMsg string) *SanitizedError {
-	return &SanitizedError{
+func NewCLIError(err error, sanitizedMsg string) *CLIError {
+	return &CLIError{
 		sanitizedMsg: sanitizedMsg,
 		err:          err,
 	}
+}
+
+func (e *CLIError) Error() string {
+	return e.err.Error()
+}
+
+func (e *CLIError) SanitizedError() string {
+	return e.sanitizedMsg
+}
+
+func (e *CLIError) SanitizedStack() string {
+	return ""
+}
+
+// PanicError is used to collect goroutine panics into an error interface so
+// that we can do type assertion on err checking.
+type PanicError struct {
+	err   error
+	stack []byte
+}
+
+func NewPanicError(err error, stack []byte) *PanicError {
+	return &PanicError{
+		err:   err,
+		stack: stack,
+	}
+}
+
+func (p *PanicError) Error() string {
+	return fmt.Sprintf("%s\n%s", p.err.Error(), p.stack)
+}
+
+func (p *PanicError) SanitizedError() string {
+	return p.err.Error()
+}
+
+func (p *PanicError) SanitizedStack() string {
+	sanitizedStack := p.stack
+	sanitizedStack, err := processStack(sanitizedStack)
+	if err != nil {
+		log.Debugf("Could not sanitize stack: %s", err)
+	}
+
+	return string(sanitizedStack)
+}
+
+// processStack processes the raw stack trace into a format that can be reported upstream.
+// This strips out the absolute path information of the local machine and removes any function args
+// so that the reported value always equals the same string value as an equivalent stack trace.
+// Adapted from: https://pkg.go.dev/github.com/maruel/panicparse/v2/stack#example-package-Text
+func processStack(rawStack []byte) ([]byte, error) {
+	stream := bytes.NewReader(rawStack)
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+
+	s, suffix, err := stack.ScanSnapshot(stream, ioutil.Discard, stack.DefaultOpts())
+	if err != nil && err != io.EOF {
+		return []byte{}, err
+	}
+
+	// Find out similar goroutine traces and group them into buckets.
+	buckets := s.Aggregate(stack.AnyValue).Buckets
+
+	// Calculate padding for alignment.
+	srcLen := 0
+	for _, bucket := range buckets {
+		for _, line := range bucket.Signature.Stack.Calls {
+			if l := len(fmt.Sprintf("%s:%d", line.ImportPath, line.Line)); l > srcLen {
+				srcLen = l
+			}
+		}
+	}
+
+	for _, bucket := range buckets {
+		// Print the goroutine header.
+		extra := ""
+		if s := bucket.SleepString(); s != "" {
+			extra += " [" + s + "]"
+		}
+		if bucket.Locked {
+			extra += " [locked]"
+		}
+
+		if len(bucket.CreatedBy.Calls) != 0 {
+			extra += fmt.Sprintf(" [Created by %s.%s @ %s:%d]", bucket.CreatedBy.Calls[0].Func.DirName, bucket.CreatedBy.Calls[0].Func.Name, bucket.CreatedBy.Calls[0].SrcName, bucket.CreatedBy.Calls[0].Line)
+		}
+		fmt.Fprintf(w, "%d: %s%s\n", len(bucket.IDs), bucket.State, extra)
+
+		// Print the stack lines.
+		for _, line := range bucket.Stack.Calls {
+			_, err := fmt.Fprintf(w,
+				"   %-*s %s()\n",
+				srcLen,
+				fmt.Sprintf("%s:%d", line.ImportPath, line.Line),
+				line.Func.Name)
+			if err != nil {
+				return []byte{}, err
+			}
+		}
+		if bucket.Stack.Elided {
+			_, err := w.WriteString("    (...)\n")
+			if err != nil {
+				return []byte{}, err
+			}
+		}
+	}
+
+	// If there was any remaining data in the pipe, dump it now.
+	if len(suffix) != 0 {
+		_, err := w.Write(suffix)
+		if err != nil {
+			return []byte{}, err
+		}
+	}
+	_, err = io.Copy(w, stream)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	w.Flush()
+
+	return buf.Bytes(), nil
 }

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -93,13 +93,13 @@ func (p *DirProvider) checks() error {
 		msg := fmt.Sprintf("Terraform binary '%s' could not be found. You have two options:\n", binary)
 		msg += "1. Set a custom Terraform binary using the environment variable INFRACOST_TERRAFORM_BINARY.\n\n"
 		msg += fmt.Sprintf("2. Set --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot"))
-		return clierror.NewSanitizedError(errors.Errorf(msg), "Terraform binary could not be found")
+		return clierror.NewCLIError(errors.Errorf(msg), "Terraform binary could not be found")
 	}
 
 	out, err := exec.Command(binary, "-version").Output()
 	if err != nil {
 		msg := fmt.Sprintf("Could not get version of Terraform binary '%s'", binary)
-		return clierror.NewSanitizedError(errors.Errorf(msg), "Could not get version of Terraform binary")
+		return clierror.NewCLIError(errors.Errorf(msg), "Could not get version of Terraform binary")
 	}
 
 	fullVersion := strings.SplitN(string(out), "\n", 2)[0]
@@ -359,7 +359,7 @@ func (p *DirProvider) runPlan(opts *CmdOptions, spinner *ui.Spinner, initOnFail 
 			cmdName = "terragrunt run-all plan"
 		}
 		msg := fmt.Sprintf("%s failed", cmdName)
-		return "", planJSON, clierror.NewSanitizedError(fmt.Errorf("%s: %s", msg, err), msg)
+		return "", planJSON, clierror.NewCLIError(fmt.Errorf("%s: %s", msg, err), msg)
 	}
 
 	spinner.Success()
@@ -376,7 +376,7 @@ func (p *DirProvider) runInit(opts *CmdOptions, spinner *ui.Spinner) error {
 	flags, err := shellquote.Split(p.InitFlags)
 	if err != nil {
 		msg := "parsing terraform-init-flags failed"
-		return clierror.NewSanitizedError(fmt.Errorf("%s: %s", msg, err), msg)
+		return clierror.NewCLIError(fmt.Errorf("%s: %s", msg, err), msg)
 	}
 
 	args = append(args, "init", "-input=false", "-no-color")
@@ -396,7 +396,7 @@ func (p *DirProvider) runInit(opts *CmdOptions, spinner *ui.Spinner) error {
 			cmdName = "terragrunt run-all init"
 		}
 		msg := fmt.Sprintf("%s failed", cmdName)
-		return clierror.NewSanitizedError(fmt.Errorf("%s: %s", msg, err), msg)
+		return clierror.NewCLIError(fmt.Errorf("%s: %s", msg, err), msg)
 	}
 
 	spinner.Success()
@@ -471,7 +471,7 @@ func (p *DirProvider) runShow(opts *CmdOptions, spinner *ui.Spinner, planFile st
 			cmdName = "terragrunt show"
 		}
 		msg := fmt.Sprintf("%s failed", cmdName)
-		return []byte{}, clierror.NewSanitizedError(fmt.Errorf("%s: %s", msg, err), msg)
+		return []byte{}, clierror.NewCLIError(fmt.Errorf("%s: %s", msg, err), msg)
 	}
 	spinner.Success()
 

--- a/internal/providers/terraform/plan_provider.go
+++ b/internal/providers/terraform/plan_provider.go
@@ -98,7 +98,7 @@ func (p *PlanProvider) generatePlanJSON() ([]byte, error) {
 				"and then run Infracost with",
 				ui.PrimaryString("--path=plan.json"),
 			)
-			return []byte{}, clierror.NewSanitizedError(errors.New(m), "Could not detect Terraform directory for plan file")
+			return []byte{}, clierror.NewCLIError(errors.New(m), "Could not detect Terraform directory for plan file")
 		}
 	}
 

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -218,7 +218,7 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 			panic(err)
 		}
 
-		return nil, clierror.NewSanitizedError(
+		return nil, clierror.NewCLIError(
 			errors.Errorf(
 				"%s\n%v%s",
 				"Failed to parse the Terragrunt code using the Terragrunt library:",

--- a/internal/providers/terraform/terragrunt_provider.go
+++ b/internal/providers/terraform/terragrunt_provider.go
@@ -167,7 +167,7 @@ func (p *TerragruntProvider) getProjectDirs() ([]terragruntProjectDirs, error) {
 		err = p.buildTerraformErr(err, false)
 
 		msg := "terragrunt run-all terragrunt-info failed"
-		return []terragruntProjectDirs{}, clierror.NewSanitizedError(fmt.Errorf("%s: %s", msg, err), msg)
+		return []terragruntProjectDirs{}, clierror.NewCLIError(fmt.Errorf("%s: %s", msg, err), msg)
 	}
 
 	var jsons [][]byte


### PR DESCRIPTION
* Make sure stack traces match when reported by not showing abs paths or function args
* Report the stacktrace up as a separate property