### PR TITLE
fix: using unsafe As methods in `go-cty` lib

### DIFF
--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -56,6 +56,34 @@ func (attr *Attribute) IsIterable() bool {
 	return attr.Value().Type().IsCollectionType() || attr.Value().Type().IsObjectType() || attr.Value().Type().IsMapType() || attr.Value().Type().IsListType() || attr.Value().Type().IsSetType() || attr.Value().Type().IsTupleType()
 }
 
+// AsInt returns the Attribute value as a int64. If the cty.Value is not a type
+// that can be converted to integer, this method returns 0.
+func (attr *Attribute) AsInt() int64 {
+	v := attr.Value()
+
+	var i int64
+	err := gocty.FromCtyValue(v, &i)
+	if err != nil {
+		attr.Logger.WithError(err).Debug("could not return attribute value as int64")
+	}
+
+	return i
+}
+
+// AsString returns the Attribute value as a string. If the cty.Value is not a type
+// that can be converted to string, this method returns an empty string.
+func (attr *Attribute) AsString() string {
+	v := attr.Value()
+
+	var s string
+	err := gocty.FromCtyValue(v, &s)
+	if err != nil {
+		attr.Logger.WithError(err).Debug("could not return attribute value as string")
+	}
+
+	return s
+}
+
 // Value returns the Attribute with the underlying hcl.Expression of the hcl.Attribute evaluated with
 // the Attribute Context. This returns a cty.Value with the values filled from any variables or references
 // that the Context carries.

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -60,6 +60,10 @@ func (attr *Attribute) IsIterable() bool {
 // AsInt returns the Attribute value as a int64. If the cty.Value is not a type
 // that can be converted to integer, this method returns 0.
 func (attr *Attribute) AsInt() int64 {
+	if attr == nil {
+		return 0
+	}
+
 	v := attr.Value()
 	if v.Type() == cty.String {
 		s := attr.AsString()
@@ -83,6 +87,10 @@ func (attr *Attribute) AsInt() int64 {
 // AsString returns the Attribute value as a string. If the cty.Value is not a type
 // that can be converted to string, this method returns an empty string.
 func (attr *Attribute) AsString() string {
+	if attr == nil {
+		return ""
+	}
+
 	v := attr.Value()
 	if v.Type() == cty.Number {
 		i := attr.AsInt()
@@ -426,6 +434,7 @@ func (attr *Attribute) Reference() (*Reference, error) {
 	if attr == nil {
 		return nil, fmt.Errorf("attribute is nil")
 	}
+
 	refs := attr.AllReferences()
 	if len(refs) == 0 {
 		return nil, fmt.Errorf("no references for attribute")

--- a/internal/hcl/attribute_test.go
+++ b/internal/hcl/attribute_test.go
@@ -1,0 +1,87 @@
+package hcl
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestAttribute_AsInt(t *testing.T) {
+	tests := []struct {
+		name  string
+		value cty.Value
+		want  int64
+	}{
+		{
+			name:  "cty number to int",
+			value: cty.NumberIntVal(66),
+			want:  66,
+		},
+		{
+			name:  "cty string to int",
+			value: cty.StringVal("66"),
+			want:  66,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr := &Attribute{
+				Ctx: &Context{
+					ctx: &hcl.EvalContext{
+						Variables: map[string]cty.Value{},
+					},
+					logger: newDiscardLogger(),
+				},
+				HCLAttr: &hcl.Attribute{
+					Expr: hcl.StaticExpr(tt.value, hcl.Range{}),
+				},
+				Logger: newDiscardLogger(),
+			}
+
+			actual := attr.AsInt()
+			assert.Equalf(t, tt.want, actual, "AsInt()")
+		})
+	}
+}
+
+func TestAttribute_AsString(t *testing.T) {
+	tests := []struct {
+		name  string
+		value cty.Value
+		want  string
+	}{
+		{
+			name:  "cty string to string",
+			value: cty.StringVal("test"),
+			want:  "test",
+		},
+		{
+			name:  "cty int to string",
+			value: cty.NumberIntVal(1),
+			want:  "1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attr := &Attribute{
+				Ctx: &Context{
+					ctx: &hcl.EvalContext{
+						Variables: map[string]cty.Value{},
+					},
+					logger: newDiscardLogger(),
+				},
+				HCLAttr: &hcl.Attribute{
+					Expr: hcl.StaticExpr(tt.value, hcl.Range{}),
+				},
+				Logger: newDiscardLogger(),
+			}
+
+			actual := attr.AsString()
+			assert.Equalf(t, tt.want, actual, "AsString()")
+		})
+	}
+}

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -569,13 +569,7 @@ func (b *Block) ModuleSource() string {
 		return ""
 	}
 
-	value := attr.Value()
-
-	if value.Type() != cty.String {
-		return ""
-	}
-
-	return value.AsString()
+	return attr.AsString()
 }
 
 // Provider returns the provider by first checking if it is explicitly set as an attribute, if it is not
@@ -588,16 +582,16 @@ func (b *Block) Provider() string {
 
 	attr := b.GetAttribute("provider")
 	if attr != nil {
-		value := attr.Value()
+		value := attr.AsString()
 		r, err := attr.Reference()
 		if err == nil {
 			// An explicit provider is provided so use that
 			return r.String()
 		}
 
-		if value.Type() == cty.String {
+		if value != "" {
 			// An explicit provider is provided so use that
-			return value.AsString()
+			return value
 		}
 	}
 

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -364,10 +364,7 @@ func (e *Evaluator) expandBlockCounts(blocks Blocks) Blocks {
 		count := 1
 		value := countAttr.Value()
 		if !value.IsNull() && value.IsKnown() {
-			if value.Type() == cty.Number {
-				f, _ := value.AsBigFloat().Float64()
-				count = int(f)
-			}
+			count = int(countAttr.AsInt())
 		}
 
 		e.logger.Debugf("expanding block %s because a count attribute of value %d was found", block.LocalName(), count)
@@ -445,7 +442,7 @@ func convertType(val cty.Value, attribute *Attribute) cty.Value {
 	case *hclsyntax.ScopeTraversalExpr:
 		t = v.Traversal.RootName()
 	case *hclsyntax.LiteralValueExpr:
-		t = attribute.Value().AsString()
+		t = attribute.AsString()
 	}
 
 	switch t {
@@ -619,11 +616,8 @@ func (e *Evaluator) loadModule(b *Block) (*ModuleCall, error) {
 	attrs := b.AttributesAsMap()
 	for _, attr := range attrs {
 		if attr.Name() == "source" {
-			sourceVal := attr.Value()
-			if sourceVal.Type() == cty.String {
-				source = sourceVal.AsString()
-				break
-			}
+			source = attr.AsString()
+			break
 		}
 	}
 

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -3,6 +3,7 @@ package hcl
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -364,7 +365,10 @@ func (e *Evaluator) expandBlockCounts(blocks Blocks) Blocks {
 		count := 1
 		value := countAttr.Value()
 		if !value.IsNull() && value.IsKnown() {
-			count = int(countAttr.AsInt())
+			v := countAttr.AsInt()
+			if v <= math.MaxInt32 {
+				count = int(v)
+			}
 		}
 
 		e.logger.Debugf("expanding block %s because a count attribute of value %d was found", block.LocalName(), count)

--- a/internal/hcl/remote_variables_loader.go
+++ b/internal/hcl/remote_variables_loader.go
@@ -317,21 +317,16 @@ func (r *RemoteVariablesLoader) getBackendOrganizationWorkspace(blocks Blocks) (
 }
 
 func getAttribute(block *Block, name string) string {
-	result := ""
-
 	if block == nil {
-		return result
+		return ""
 	}
 
 	attr := block.GetAttribute(name)
 	if attr != nil {
-		val := attr.Value()
-		if !val.IsNull() {
-			result = val.AsString()
-		}
+		return attr.AsString()
 	}
 
-	return result
+	return ""
 }
 
 func getVarValue(variable tfcVar) cty.Value {


### PR DESCRIPTION
fixes https://github.com/infracost/infracost/issues/1846

I've changed code logic to call `Attribute.AsString` and `Attribute.AsInt` respectively. These are panic safe methods and do some naive type conversion for acceptable types.