### PR TITLE
fix: passing `cty.NilVal` to hcl expressions when in a partial evaluation state

### DIFF
--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -183,10 +183,6 @@ func (attr *Attribute) value(retry int) (ctyVal cty.Value) {
 		}
 	}
 
-	if !ctyVal.IsKnown() {
-		return cty.NilVal
-	}
-
 	return ctyVal
 }
 

--- a/internal/hcl/attribute_test.go
+++ b/internal/hcl/attribute_test.go
@@ -1,10 +1,16 @@
 package hcl
 
 import (
+	"bytes"
+	"fmt"
+	"io"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -84,4 +90,79 @@ func TestAttribute_AsString(t *testing.T) {
 			assert.Equalf(t, tt.want, actual, "AsString()")
 		})
 	}
+}
+
+func TestAttributeValueWithIncompleteContextAndConditionalShouldNotPanic(t *testing.T) {
+	p := hclparse.NewParser()
+	f, diags := p.ParseHCL([]byte(`
+locals {
+  original_tags    = "test"
+  transformed_tags = local.original_tags
+  id = var.enabled ? local.transformed_tags : "test3"
+}
+`), "test")
+
+	require.False(t, diags.HasErrors(), fmt.Sprintf("diags has unexpected error %s from parsing input string", diags.Error()))
+
+	c, _, diags := f.Body.PartialContent(terraformSchemaV012)
+	require.False(t, diags.HasErrors(), "diags has unexpected error %s from parsing body content", diags.Error())
+
+	var block *hcl.Block
+	for _, b := range c.Blocks {
+		if b.Type == "locals" {
+			block = b
+		}
+	}
+
+	require.NotNil(t, block, "could not find required test block")
+
+	attrs, diags := block.Body.JustAttributes()
+	require.False(t, diags.HasErrors(), "diags has unexpected error %s fetching attributes", diags.Error())
+
+	buf := bytes.NewBuffer([]byte{})
+	l := logrus.New()
+	l.SetFormatter(&logrus.TextFormatter{DisableTimestamp: true})
+	l.SetOutput(buf)
+	l.SetLevel(logrus.DebugLevel)
+	logger := logrus.NewEntry(l)
+
+	l2 := logrus.New()
+	l2.SetOutput(io.Discard)
+	discard := logrus.NewEntry(l2)
+
+	tag := Attribute{
+		HCLAttr: attrs["transformed_tags"],
+		Ctx: &Context{ctx: &hcl.EvalContext{
+			Variables: map[string]cty.Value{},
+		}},
+		Logger: discard,
+	}
+
+	attr := Attribute{
+		HCLAttr: attrs["id"],
+		Ctx: &Context{
+			ctx: &hcl.EvalContext{
+				Variables: map[string]cty.Value{
+					"local": cty.ObjectVal(map[string]cty.Value{
+						"original_tags":    cty.StringVal("test"),
+						"transformed_tags": tag.Value(),
+					}),
+					"var": cty.ObjectVal(map[string]cty.Value{
+						"enabled": cty.BoolVal(true),
+					}),
+				},
+			},
+			logger: logger,
+		},
+		Verbose: false,
+		Logger:  logger,
+	}
+
+	v := attr.Value()
+	assert.Equal(t, cty.DynamicVal, v)
+
+	b, err := io.ReadAll(buf)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(b), "invalid memory address")
 }


### PR DESCRIPTION
Resolves https://github.com/infracost/infracost/issues/1789 

The hcl libs don't expect `cty.NilVal` to be used in expression evaluation They instead favour types like `cty.DynamicVal` to express unknown or invalid variables. The steps that produced a panic were as such:

1. The user provides the following block:
    ```
    locals {
      original_tags    = "test"
      transformed_tags = local.original_tags
      id = var.enabled ? local.transformed_tags : "test3"
    }
    ```
2. On the initial first pass of the module the `Evaluator` builds an `EvaluationContext` with the local attributes.
3. In this case `transformed_tags` attribute returns an error as the `EvaluationContext` does not mention locals (this is the first pass of the context, so there are no Variables outside of things like `terraform.cwd` and other constants). Therefore the `attr.Expr.Value` call returns an error and `cty.DynamicVal` to say we can't evaluate the expression.
4. This would mean that the `Attribute` would reach [the following code gate](https://github.com/infracost/infracost/pull/1867/files#diff-c16545ee8d29ccb3c08c2c8fdc2a4469df0f981dc1c7d00515c88300144e50e6L136-L139) (prior to this change):
    ```
    if !ctyVal.IsKnown() {
        return cty.NilVal
    }
    ```	 
    and `cty.NilVal` would return
5.  When evaluating the `id` attribute, the `EvaluationContext` has  the `Variable` `local.transformed_tags` set as a `cty.NilVal`
6. The `ConditionalExpression` in the hcl lib panics when trying to get a `FriendlyName` for the nil type.


This change removes the `isKnown` check from the `Attribute.Value` method and instead passes the returned `cty.Value` from `Expr.Value` method call. This means that in the above example, `cty.DynamicVal` is used within the `ConditionalExpression` which won't panic.

