### PR TITLE
fix: VCS project name issues

### DIFF
--- a/internal/config/project_context_test.go
+++ b/internal/config/project_context_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-git/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectProjectMetadataVCSSubPath(t *testing.T) {
+	type args struct {
+		wdir     string
+		expected string
+	}
+
+	type test struct {
+		name          string
+		createProject func(t *testing.T) (input args, cleanup func())
+	}
+
+	tests := []test{
+		{
+			name: "sub path detected correctly",
+			createProject: func(t *testing.T) (input args, cleanup func()) {
+				t.Setenv("INFRACOST_VCS_REPOSITORY_URL", "test")
+				// set the TMPDDIR variable to the non testing directory so that we can accurately replicate
+				// known bugs which set /private prefix in Darwin for /tmp
+				t.Setenv("TMPDIR", "")
+
+				tmp, clean := tmpDir(t, os.TempDir())
+				_, err := git.PlainInit(tmp, false)
+				assert.NoError(t, err)
+
+				sub, _ := tmpDir(t, tmp)
+				child, err := filepath.Rel(tmp, sub)
+				assert.NoError(t, err)
+
+				return args{
+					wdir:     sub,
+					expected: child,
+				}, clean
+			},
+		},
+		{
+			name: "root github project returns empty string",
+			createProject: func(t *testing.T) (input args, cleanup func()) {
+				t.Setenv("INFRACOST_VCS_REPOSITORY_URL", "test")
+				// set the TMPDDIR variable to the non testing directory so that we can accurately replicate
+				// known bugs which set /private prefix in Darwin for /tmp
+				t.Setenv("TMPDIR", "")
+
+				tmp, clean := tmpDir(t, os.TempDir())
+				_, err := git.PlainInit(tmp, false)
+				assert.NoError(t, err)
+
+				return args{
+					wdir:     tmp,
+					expected: "",
+				}, clean
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, cleanup := tt.createProject(t)
+			defer cleanup()
+
+			meta := DetectProjectMetadata(input.wdir)
+			assert.Equal(t, input.expected, meta.VCSSubPath)
+		})
+	}
+
+}
+
+func tmpDir(t *testing.T, path string) (string, func()) {
+	t.Helper()
+
+	fs := osfs.New(path)
+	path, err := util.TempDir(fs, "", "")
+	require.NoError(t, err)
+
+	return fs.Join(fs.Root(), path), func() {
+		t.Helper()
+
+		err := util.RemoveAll(fs, path)
+		assert.NoError(t, err)
+	}
+}

--- a/internal/schema/project_test.go
+++ b/internal/schema/project_test.go
@@ -26,3 +26,85 @@ func TestNameFromRepoURL(t *testing.T) {
 		assert.Equal(t, test.name, actual)
 	}
 }
+
+func TestGenerateProjectName(t *testing.T) {
+	type args struct {
+		metadata         *ProjectMetadata
+		projectName      string
+		dashboardEnabled bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "azure repo url should show org/project/repo with spaces",
+			args: args{
+				metadata: &ProjectMetadata{
+					VCSRepoURL: "https://SG-GDI-CTO-PublicCloud@dev.azure.com/SG-GDI-CTO-PublicCloud/CloudSolutions%20Playground/_git/CloudSolutions%20Playground",
+				},
+			},
+			want: "SG-GDI-CTO-PublicCloud/CloudSolutions Playground/CloudSolutions Playground",
+		},
+		{
+			name: "github repo https url",
+			args: args{
+				metadata: &ProjectMetadata{
+					VCSRepoURL: "https://github.com/infracost/infracost.git",
+				},
+			},
+			want: "infracost/infracost",
+		},
+		{
+			name: "github repo ssh url",
+			args: args{
+				metadata: &ProjectMetadata{
+					VCSRepoURL: "git@github.com:infracost/infracost.git",
+				},
+			},
+			want: "infracost/infracost",
+		},
+		{
+			name: "gitlab repo https url",
+			args: args{
+				metadata: &ProjectMetadata{
+					VCSRepoURL: "https://gitlab.com/infracost/infracost-gitlab-ci.git",
+				},
+			},
+			want: "infracost/infracost-gitlab-ci",
+		},
+		{
+			name: "gitlab repo ssh url",
+			args: args{
+				metadata: &ProjectMetadata{
+					VCSRepoURL: "git@gitlab.com:infracost/infracost-gitlab-ci.git",
+				},
+			},
+			want: "infracost/infracost-gitlab-ci",
+		},
+		{
+			name: "bitbucket repo https url",
+			args: args{
+				metadata: &ProjectMetadata{
+					VCSRepoURL: "https://hugorutinfracost@bitbucket.org/infracost/infracost-bitbucket-pipeline.git",
+				},
+			},
+			want: "infracost/infracost-bitbucket-pipeline",
+		},
+		{
+			name: "bitbucket repo ssh url",
+			args: args{
+				metadata: &ProjectMetadata{
+					VCSRepoURL: "git@bitbucket.org:infracost/infracost-bitbucket-pipeline.git",
+				},
+			},
+			want: "infracost/infracost-bitbucket-pipeline",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, GenerateProjectName(tt.args.metadata, tt.args.projectName, tt.args.dashboardEnabled), "GenerateProjectName(%v, %v, %v)", tt.args.metadata, tt.args.projectName, tt.args.dashboardEnabled)
+		})
+	}
+}


### PR DESCRIPTION
* Fixes issue where `git rev-parse --show-toplevel` was showing the /private
dir in its output. This means that the relative vcs subpath was showing an invalid
path. I've changed the get top-level functionality to use go git, which does not
have this problem and reduces our dependence on the git binary.
* It also changes functionality to return an empty string if the working directory is the top
level git project. This means that `/.` is no longer appended to the project name in
output.
* resolves problems with azure repos URL and escaped names

