### PR TITLE
fix: support modules with `for_each` or `count`

### DIFF
--- a/cmd/infracost/hcl_test.go
+++ b/cmd/infracost/hcl_test.go
@@ -90,3 +90,27 @@ func TestHCLModuleRelativeFilesets(t *testing.T) {
 		},
 	)
 }
+
+func TestHCLModuleCount(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		nil,
+	)
+}
+
+func TestHCLModuleForEach(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		nil,
+	)
+}

--- a/cmd/infracost/testdata/hclmodule_count/hclmodule_count.golden
+++ b/cmd/infracost/testdata/hclmodule_count/hclmodule_count.golden
@@ -1,0 +1,27 @@
+Project: infracost/infracost/cmd/infracost/testdata/hclmodule_count
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ module.this[0].aws_instance.web_app                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours       $560.64 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ module.this[1].aws_instance.web_app                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)            730  hours         $8.47 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ OVERALL TOTAL                                                                   $933.11 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/hclmodule_count/main.tf
+++ b/cmd/infracost/testdata/hclmodule_count/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+module "this" {
+  count         = 2
+  source        = "./modules/test"
+  instance_type = count.index == 0 ? "m5.4xlarge" : "t2.micro"
+}

--- a/cmd/infracost/testdata/hclmodule_count/modules/test/main.tf
+++ b/cmd/infracost/testdata/hclmodule_count/modules/test/main.tf
@@ -1,0 +1,19 @@
+variable "instance_type" {
+  type = string
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/cmd/infracost/testdata/hclmodule_for_each/hclmodule_for_each.golden
+++ b/cmd/infracost/testdata/hclmodule_for_each/hclmodule_for_each.golden
@@ -1,0 +1,27 @@
+Project: infracost/infracost/cmd/infracost/testdata/hclmodule_for_each
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ module.this[0].aws_instance.web_app                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours       $560.64 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ module.this[1].aws_instance.web_app                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)            730  hours         $8.47 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ OVERALL TOTAL                                                                   $933.11 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/hclmodule_for_each/main.tf
+++ b/cmd/infracost/testdata/hclmodule_for_each/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+module "this" {
+  for_each      = [1, 2]
+  source        = "./modules/test"
+  instance_type = each.value == 1 ? "m5.4xlarge" : "t2.micro"
+}

--- a/cmd/infracost/testdata/hclmodule_for_each/modules/test/main.tf
+++ b/cmd/infracost/testdata/hclmodule_for_each/modules/test/main.tf
@@ -1,0 +1,19 @@
+variable "instance_type" {
+  type = string
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	errorNoVarValue     = errors.New("no value found")
-	modReplace          = regexp.MustCompile(`module\.`)
+	modReplace          = regexp.MustCompile(`module\.|\[.*\]`)
 	validBlocksToExpand = map[string]struct{}{
 		"resource": {},
 		"module":   {},


### PR DESCRIPTION
This updates the module key matching to ignore anything inside square brackets so we can match what is stored in the manifest