### PR TITLE
fix: protect cty conversion types against unknown types

### DIFF
--- a/internal/hcl/attribute_test.go
+++ b/internal/hcl/attribute_test.go
@@ -30,6 +30,16 @@ func TestAttribute_AsInt(t *testing.T) {
 			value: cty.StringVal("66"),
 			want:  66,
 		},
+		{
+			name:  "cty null to int",
+			value: cty.NullVal(cty.Number),
+			want:  0,
+		},
+		{
+			name:  "cty nil to int",
+			value: cty.NilVal,
+			want:  0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -68,6 +78,16 @@ func TestAttribute_AsString(t *testing.T) {
 			name:  "cty int to string",
 			value: cty.NumberIntVal(1),
 			want:  "1",
+		},
+		{
+			name:  "cty null to string",
+			value: cty.NullVal(cty.String),
+			want:  "",
+		},
+		{
+			name:  "cty nil to string",
+			value: cty.NilVal,
+			want:  "",
 		},
 	}
 

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -469,19 +468,7 @@ func (p *HCLProvider) countReferences(block *hcl.Block) *countExpression {
 			return &exp
 		}
 
-		v := attribute.Value()
-		ty := v.Type()
-		var i int64
-		switch ty {
-		case cty.Number:
-			i, _ = v.AsBigFloat().Int64()
-		case cty.String:
-			s := v.AsString()
-			i, _ = strconv.ParseInt(s, 10, 64)
-		default:
-			p.logger.Debugf("unsupported go cty type %s expected either Number or String for count expression, using 0", ty)
-		}
-
+		i := attribute.AsInt()
 		exp.ConstantValue = &i
 		return &exp
 	}


### PR DESCRIPTION
fixes #1876

Changes parser and hcl_provider files that were previously using AsString methods behind a
switch statement to use the `gocty.From` function. This handles unknown types and won't
panic if one is provided.

All other instances throughout the codebase (outside of the funcs package, which we don't tend to touch)
use `Attribute.AsString` or `Attribute.AsInt` method which use the `gocty` conversion methods.
I've also added additional `conversion` logic to the native cty functions and added additional null
type checking.

This should resolve most cty panics moving forward.