### PR TITLE
fix: `aws_codebuild_project` with invalid ComputeType causes index panic

### DIFF
--- a/internal/resources/aws/codebuild_project.go
+++ b/internal/resources/aws/codebuild_project.go
@@ -56,30 +56,26 @@ func (r *CodeBuildProject) BuildResource() *schema.Resource {
 }
 
 func (r *CodeBuildProject) nameLabel() string {
-	name := ""
 	switch r.EnvironmentType {
 	case "WINDOWS_SERVER_2019_CONTAINER":
-		name = "Windows ("
-		name += r.computeType()
+		return r.osWithComputeTypeLabel("Windows")
 	case "ARM_CONTAINER":
-		name = "Linux (arm1.large)"
+		return "Linux (arm1.large)"
 	case "LINUX_GPU_CONTAINER":
-		name = "Linux (gpu1.large)"
+		return "Linux (gpu1.large)"
 	default:
-		name = "Linux ("
-		name += r.computeType()
+		return r.osWithComputeTypeLabel("Linux")
 	}
-
-	return name
 }
 
-func (r *CodeBuildProject) computeType() string {
+func (r *CodeBuildProject) osWithComputeTypeLabel(os string) string {
 	pieces := strings.SplitAfter(r.ComputeType, "BUILD_")
 	if len(pieces) < 2 {
-		return ""
+		return os
 	}
 
-	return strings.Replace(strings.ToLower(pieces[1]), "_", ".", 1) + ")"
+	computeType := strings.Replace(strings.ToLower(pieces[1]), "_", ".", 1)
+	return fmt.Sprintf("%s (%s)", os, computeType)
 }
 
 func (r *CodeBuildProject) mapEnvironmentType() string {

--- a/internal/resources/aws/codebuild_project.go
+++ b/internal/resources/aws/codebuild_project.go
@@ -32,8 +32,10 @@ func (r *CodeBuildProject) BuildResource() *schema.Resource {
 		monthlyBuildMinutes = decimalPtr(decimal.NewFromInt(*r.MonthlyBuildMins))
 	}
 
+	computeType := r.mapComputeType()
 	return &schema.Resource{
-		Name: r.Address,
+		Name:      r.Address,
+		IsSkipped: computeType == "",
 		CostComponents: []*schema.CostComponent{
 			{
 				Name:            r.nameLabel(),
@@ -46,7 +48,7 @@ func (r *CodeBuildProject) BuildResource() *schema.Resource {
 					Service:       strPtr("CodeBuild"),
 					ProductFamily: strPtr("Compute"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s:%s/", r.mapEnvironmentType(), r.mapComputeType()))},
+						{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s:%s/", r.mapEnvironmentType(), computeType))},
 					},
 				},
 			},

--- a/internal/resources/aws/codebuild_project.go
+++ b/internal/resources/aws/codebuild_project.go
@@ -2,11 +2,10 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
-
-	"strings"
 
 	"github.com/shopspring/decimal"
 )
@@ -61,17 +60,26 @@ func (r *CodeBuildProject) nameLabel() string {
 	switch r.EnvironmentType {
 	case "WINDOWS_SERVER_2019_CONTAINER":
 		name = "Windows ("
-		name += strings.Replace(strings.ToLower(strings.SplitAfter(r.ComputeType, "BUILD_")[1]), "_", ".", 1) + ")"
+		name += r.computeType()
 	case "ARM_CONTAINER":
 		name = "Linux (arm1.large)"
 	case "LINUX_GPU_CONTAINER":
 		name = "Linux (gpu1.large)"
 	default:
 		name = "Linux ("
-		name += strings.Replace(strings.ToLower(strings.SplitAfter(r.ComputeType, "BUILD_")[1]), "_", ".", 1) + ")"
+		name += r.computeType()
 	}
 
 	return name
+}
+
+func (r *CodeBuildProject) computeType() string {
+	pieces := strings.SplitAfter(r.ComputeType, "BUILD_")
+	if len(pieces) < 2 {
+		return ""
+	}
+
+	return strings.Replace(strings.ToLower(pieces[1]), "_", ".", 1) + ")"
 }
 
 func (r *CodeBuildProject) mapEnvironmentType() string {


### PR DESCRIPTION
Fixes https://github.com/infracost/infracost/issues/1874

Resolves issue where an environment.compute_type having an unexpected format caused a panic.
We now return a blank string for the name label if the compute_type is invalid.