### PR TITLE
fix: halts panic when attribute has been redeclared as a child block

### DIFF
--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -547,7 +547,7 @@ func (p *HCLProvider) marshalBlock(block *hcl.Block, jsonValues map[string]inter
 				p.logger.WithFields(log.Fields{
 					"parent_block": block.LocalName(),
 					"child_block":  b.LocalName(),
-				}).Debugf("skipping attribute: %s that has also been declared as a child block", key)
+				}).Debugf("skipping attribute '%s' that has also been declared as a child block", key)
 
 				continue
 			}

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -375,7 +375,7 @@ func (p *HCLProvider) getResourceOutput(block *hcl.Block) ResourceOutput {
 	}
 
 	jsonValues := marshalAttributeValues(block.Type(), block.Values())
-	marshalBlock(block, jsonValues)
+	p.marshalBlock(block, jsonValues)
 
 	changes.Change.After = jsonValues
 	planned.Values = jsonValues
@@ -530,7 +530,7 @@ func blockToReferences(block *hcl.Block) map[string]interface{} {
 	return expressionValues
 }
 
-func marshalBlock(block *hcl.Block, jsonValues map[string]interface{}) {
+func (p *HCLProvider) marshalBlock(block *hcl.Block, jsonValues map[string]interface{}) {
 	for _, b := range block.Children() {
 		key := b.Type()
 		if key == "dynamic" || key == "depends_on" {
@@ -539,10 +539,19 @@ func marshalBlock(block *hcl.Block, jsonValues map[string]interface{}) {
 
 		childValues := marshalAttributeValues(key, b.Values())
 		if len(b.Children()) > 0 {
-			marshalBlock(b, childValues)
+			p.marshalBlock(b, childValues)
 		}
 
 		if v, ok := jsonValues[key]; ok {
+			if _, ok := v.(json.RawMessage); ok {
+				p.logger.WithFields(log.Fields{
+					"parent_block": block.LocalName(),
+					"child_block":  b.LocalName(),
+				}).Debugf("skipping attribute: %s that has also been declared as a child block", key)
+
+				continue
+			}
+
 			jsonValues[key] = append(v.([]interface{}), childValues)
 			continue
 		}

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -153,6 +153,15 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "does not panic on double attribute definition",
+			attrs: map[string]map[string]string{
+				"aws_eip.invalid_eip": {
+					"id":  "eip",
+					"arn": "eip-arn",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/providers/terraform/testdata/hcl_provider_test/does_not_panic_on_double_attribute_definition/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/does_not_panic_on_double_attribute_definition/expected.json
@@ -1,0 +1,74 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.1.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_eip.invalid_eip",
+          "mode": "managed",
+          "type": "aws_eip",
+          "name": "invalid_eip",
+          "schema_version": 0,
+          "values": {
+            "arn": "eip-arn",
+            "id": "eip",
+            "network_interface": "test"
+          },
+          "infracost_metadata": {
+            "calls": [
+              {
+                "filename": "testdata/hcl_provider_test/does_not_panic_on_double_attribute_definition/main.tf",
+                "blockName": "aws_eip.invalid_eip"
+              }
+            ],
+            "filename": "testdata/hcl_provider_test/does_not_panic_on_double_attribute_definition/main.tf"
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_eip.invalid_eip",
+      "mode": "managed",
+      "type": "aws_eip",
+      "name": "invalid_eip",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "arn": "eip-arn",
+          "id": "eip",
+          "network_interface": "test"
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_eip.invalid_eip",
+          "mode": "managed",
+          "type": "aws_eip",
+          "name": "invalid_eip",
+          "provider_config_key": "aws",
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/does_not_panic_on_double_attribute_definition/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/does_not_panic_on_double_attribute_definition/main.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_eip" "invalid_eip" {
+  network_interface = "test"
+
+  network_interface {
+    this_is_wrong = "test"
+  }
+}


### PR DESCRIPTION
Fixes #1871

Resolves interface conversion panic when an block has an attribute which has been redeclared as a child block.
This is an invalid state and would be incorrect Terraform, hence why we haven't encountered this problem before.
We now handle this case by ignoring the child block definition and putting an entry into the debug log.