### PR TITLE
fix: fix HCL parsing module regex

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -27,8 +27,11 @@ import (
 )
 
 var (
-	errorNoVarValue     = errors.New("no value found")
-	modReplace          = regexp.MustCompile(`module\.|\[.*\]`)
+	errorNoVarValue = errors.New("no value found")
+	modReplace      = regexp.MustCompile(`^module\.`)
+	// Use a separate regex for nested modules since we want to replace this with '.'
+	nestedModReplace    = regexp.MustCompile(`\.module\.`)
+	modArrayPartReplace = regexp.MustCompile(`\[[^[]*\]`)
 	validBlocksToExpand = map[string]struct{}{
 		"resource": {},
 		"module":   {},
@@ -633,13 +636,20 @@ func (e *Evaluator) loadModule(b *Block) (*ModuleCall, error) {
 
 	if e.moduleMetadata != nil {
 		// if we have module metadata we can parse all the modules as they'll be cached locally!
+
+		// Strip any "module." and "[*]" parts from the module name so it matches the manifest key format
+		key := modReplace.ReplaceAllString(b.FullName(), "")
+		key = nestedModReplace.ReplaceAllString(key, ".")
+		key = modArrayPartReplace.ReplaceAllString(key, "")
+
 		for _, module := range e.moduleMetadata.Modules {
-			key := modReplace.ReplaceAllString(b.FullName(), "")
 			if module.Key == key {
 				modulePath = filepath.Clean(filepath.Join(e.module.RootPath, module.Dir))
 				break
 			}
 		}
+
+		e.logger.Debugf("using path '%s' for module '%s' based on key '%s'", modulePath, b.FullName(), key)
 	}
 
 	if modulePath == "" {


### PR DESCRIPTION
* Fixes for modules that contain the word 'module' by matching only 'module.' at the beginning or '.module.' in the middle of the resource address.
* Fixes for_each and count support for submodules by making sure it only matches non [] characters inside [].