### PR TITLE
enhance: use relative source path in panics

### DIFF
--- a/internal/clierror/error.go
+++ b/internal/clierror/error.go
@@ -120,7 +120,7 @@ func processStack(rawStack []byte) ([]byte, error) {
 			_, err := fmt.Fprintf(w,
 				"   %-*s %s()\n",
 				srcLen,
-				fmt.Sprintf("%s:%d", line.ImportPath, line.Line),
+				fmt.Sprintf("%s:%d", line.RelSrcPath, line.Line),
 				line.Func.Name)
 			if err != nil {
 				return []byte{}, err


### PR DESCRIPTION
This is more useful than the import path when debugging since it matches the line number