### PR TITLE
fix: Azure Repos url with a space returns 404

### DIFF
--- a/internal/comment/azure_repos_test.go
+++ b/internal/comment/azure_repos_test.go
@@ -12,8 +12,8 @@ func Test_buildAzureAPIURL(t *testing.T) {
 		want    string
 	}{
 		{
-			repoURL: "https://SG-GDI-CTO-PublicCloud@dev.azure.com/SG-GDI-CTO-PublicCloud/CloudSolutions%20Playground/_git/CloudSolutions%20Playground",
-			want:    "https://dev.azure.com/SG-GDI-CTO-PublicCloud/CloudSolutions%20Playground/_apis/git/repositories/CloudSolutions%20Playground/",
+			repoURL: "https://infracost-user@dev.azure.com/infracost/my%20project/_git/my%20repo",
+			want:    "https://dev.azure.com/infracost/my%20project/_apis/git/repositories/my%20repo/",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/comment/azure_repos_test.go
+++ b/internal/comment/azure_repos_test.go
@@ -1,0 +1,26 @@
+package comment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_buildAzureAPIURL(t *testing.T) {
+	tests := []struct {
+		repoURL string
+		want    string
+	}{
+		{
+			repoURL: "https://SG-GDI-CTO-PublicCloud@dev.azure.com/SG-GDI-CTO-PublicCloud/CloudSolutions%20Playground/_git/CloudSolutions%20Playground",
+			want:    "https://dev.azure.com/SG-GDI-CTO-PublicCloud/CloudSolutions%20Playground/_apis/git/repositories/CloudSolutions%20Playground/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.repoURL, func(t *testing.T) {
+			got, err := buildAzureAPIURL(tt.repoURL)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/schema/project_test.go
+++ b/internal/schema/project_test.go
@@ -42,10 +42,10 @@ func TestGenerateProjectName(t *testing.T) {
 			name: "azure repo url should show org/project/repo with spaces",
 			args: args{
 				metadata: &ProjectMetadata{
-					VCSRepoURL: "https://SG-GDI-CTO-PublicCloud@dev.azure.com/SG-GDI-CTO-PublicCloud/CloudSolutions%20Playground/_git/CloudSolutions%20Playground",
+					VCSRepoURL: "https://infracost-user@dev.azure.com/infracost/my%20project/_git/my%20repo",
 				},
 			},
-			want: "SG-GDI-CTO-PublicCloud/CloudSolutions Playground/CloudSolutions Playground",
+			want: "infracost/my project/my repo",
 		},
 		{
 			name: "github repo https url",


### PR DESCRIPTION
Resolves https://github.com/infracost/infracost/issues/1857

Solves an issue where an encoded space was getting encoded twice, resulting in `%2520`.
We now parse the URL before splitting it by `_git` and then rebuilding the path.