### PR TITLE
fix: use first tier for Lambda duration prices

### DIFF
--- a/internal/resources/aws/lambda_function.go
+++ b/internal/resources/aws/lambda_function.go
@@ -95,6 +95,9 @@ func (a *LambdaFunction) BuildResource() *schema.Resource {
 						{Key: "usagetype", ValueRegex: strPtr("/GB-Second/")},
 					},
 				},
+				PriceFilter: &schema.PriceFilter{
+					StartUsageAmount: strPtr("0"),
+				},
 			},
 		},
 		EstimateUsage: estimate,


### PR DESCRIPTION
This doesn't fix https://github.com/infracost/infracost/issues/1949 yet, but it does make sure that the existing resources consistently uses the first tier pricing for the Duration cost component.

We will want to update to add proper support for tiers but this fixes inconsistent prices and the tests for just now.