### PR TITLE
fix: use terraform workspace for evaluator if provided

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -382,3 +382,18 @@ func TestBreakdownWithPrivateTerraformRegistryModule(t *testing.T) {
 		nil,
 	)
 }
+
+func TestBreakdownWithWorkspace(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path",
+			path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+			"--terraform-workspace",
+			"prod",
+		},
+		nil,
+	)
+}

--- a/cmd/infracost/testdata/breakdown_with_workspace/breakdown_with_workspace.golden
+++ b/cmd/infracost/testdata/breakdown_with_workspace/breakdown_with_workspace.golden
@@ -1,0 +1,20 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_workspace
+Workspace: prod
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.8xlarge)          730  hours     $1,121.28 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ OVERALL TOTAL                                                                 $1,303.28 
+──────────────────────────────────
+1 cloud resource was detected:
+∙ 1 was estimated, it includes usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_workspace/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_workspace/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = terraform.workspace == "prod" ? "m5.8xlarge" : "m5.4xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -118,7 +118,11 @@ func NewHCLProvider(ctx *config.ProjectContext, config *HCLProviderConfig, opts 
 			localWorkspace),
 		)
 	}
-	options = append(options, hcl.OptionWithCredentialsSource(credsSource))
+
+	options = append(options,
+		hcl.OptionWithTerraformWorkspace(localWorkspace),
+		hcl.OptionWithCredentialsSource(credsSource),
+	)
 
 	logger := ctx.Logger().WithFields(log.Fields{"provider": "terraform_dir"})
 	parsers, err := hcl.LoadParsers(ctx.ProjectConfig.Path, ctx.ProjectConfig.ExcludePaths, logger, options...)


### PR DESCRIPTION
fixes: https://github.com/infracost/infracost/issues/1938

This change resolves `--terraform-workspace` flag being ignored for the HCL provider. User provided
workspaces are now set on the `Parser` so they can be used in context evaluation.