### PR TITLE
fix: panic caused from invalid guest accelerator cost component

### DIFF
--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
@@ -91,6 +91,12 @@
  ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              8,760  hours       $293.51 
  └─ Standard provisioned storage (pd-standard)                     1,200  GB           $48.00 
                                                                                               
+ google_container_node_pool.with_guest_accelerator_a100                                       
+ ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)         2,190  hours     $1,165.07 
+ ├─ SSD provisioned storage (pd-ssd)                                 360  GB           $61.20 
+ ├─ Local SSD provisioned storage                                  1,125  GB           $90.00 
+ └─  NVIDIA Tesla A100 (on-demand)                                 8,760  hours    $17,990.72 
+                                                                                              
  google_container_node_pool.with_node_config_regional                                         
  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)         2,190  hours     $1,165.07 
  ├─ SSD provisioned storage (pd-ssd)                                 360  GB           $61.20 
@@ -101,7 +107,7 @@
  ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              2,920  hours        $97.84 
  └─ Standard provisioned storage (pd-standard)                       400  GB           $16.00 
                                                                                               
- OVERALL TOTAL                                                                      $7,944.86 
+ OVERALL TOTAL                                                                     $27,251.85 
 ──────────────────────────────────
-21 cloud resources were detected:
-∙ 21 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+22 cloud resources were detected:
+∙ 22 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
@@ -95,7 +95,7 @@
  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)         2,190  hours     $1,165.07 
  ├─ SSD provisioned storage (pd-ssd)                                 360  GB           $61.20 
  ├─ Local SSD provisioned storage                                  1,125  GB           $90.00 
- └─  NVIDIA Tesla A100 (on-demand)                                 8,760  hours    $17,990.72 
+ └─ NVIDIA Tesla A100 (on-demand)                                  8,760  hours    $17,990.72 
                                                                                               
  google_container_node_pool.with_node_config_regional                                         
  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)         2,190  hours     $1,165.07 

--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.tf
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.tf
@@ -41,6 +41,24 @@ resource "google_container_node_pool" "with_node_config_regional" {
   }
 }
 
+resource "google_container_node_pool" "with_guest_accelerator_a100" {
+  name       = "with-a100"
+  cluster    = google_container_cluster.default_regional.id
+  node_count = 3
+
+  node_config {
+    machine_type    = "n1-standard-16"
+    disk_size_gb    = 120
+    disk_type       = "pd-ssd"
+    local_ssd_count = 1
+
+    guest_accelerator {
+      type  = "nvidia-tesla-a100"
+      count = 4
+    }
+  }
+}
+
 resource "google_container_node_pool" "cluster_node_locations_regional" {
   name       = "cluster-node-locations"
   cluster    = google_container_cluster.node_locations_regional.id

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -156,7 +156,7 @@ func guestAcceleratorCostComponent(region string, purchaseOption string, guestAc
 		name = "NVIDIA Tesla K80"
 		descPrefix = "Nvidia Tesla K80 GPU"
 	case "nvidia-tesla-a100":
-		name = " NVIDIA Tesla A100"
+		name = "NVIDIA Tesla A100"
 		descPrefix = "Nvidia Tesla A100 GPU"
 	default:
 		logging.Logger.Debugf("skipping cost component because guest_accelerator.type '%s' is not supported", guestAcceleratorType)

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/infracost/infracost/internal/schema"
 	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/logging"
+	"github.com/infracost/infracost/internal/schema"
 )
 
 // ComputeGuestAccelerator defines Guest Accelerator setup for Compute resources.
@@ -129,8 +131,8 @@ func computeDiskCostComponent(region string, diskType string, diskSize float64, 
 	}
 }
 
-// guestAcceleratorCostComponent returns a cost component for Guest Accelerator
-// usage for Compute resources.
+// guestAcceleratorCostComponent returns a cost component for Guest Accelerator usage for Compute resources.
+// Callers should be aware guestAcceleratorCostComponent returns nil if the provided guestAcceleratorType is not supported.
 func guestAcceleratorCostComponent(region string, purchaseOption string, guestAcceleratorType string, guestAcceleratorCount int64, instanceCount int64, monthlyHours *float64) *schema.CostComponent {
 	var (
 		name       string
@@ -153,7 +155,11 @@ func guestAcceleratorCostComponent(region string, purchaseOption string, guestAc
 	case "nvidia-tesla-k80":
 		name = "NVIDIA Tesla K80"
 		descPrefix = "Nvidia Tesla K80 GPU"
+	case "nvidia-tesla-a100":
+		name = " NVIDIA Tesla A100"
+		descPrefix = "Nvidia Tesla A100 GPU"
 	default:
+		logging.Logger.Debugf("skipping cost component because guest_accelerator.type '%s' is not supported", guestAcceleratorType)
 		return nil
 	}
 

--- a/internal/resources/google/compute_instance.go
+++ b/internal/resources/google/compute_instance.go
@@ -50,7 +50,9 @@ func (r *ComputeInstance) BuildResource() *schema.Resource {
 	}
 
 	for _, guestAccel := range r.GuestAccelerators {
-		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.Size, r.MonthlyHours))
+		if component := guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.Size, r.MonthlyHours); component != nil {
+			costComponents = append(costComponents, component)
+		}
 	}
 
 	return &schema.Resource{

--- a/internal/resources/google/compute_instance_group_manager.go
+++ b/internal/resources/google/compute_instance_group_manager.go
@@ -45,7 +45,9 @@ func (r *ComputeInstanceGroupManager) BuildResource() *schema.Resource {
 	}
 
 	for _, guestAccel := range r.GuestAccelerators {
-		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.TargetSize, nil))
+		if component := guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.TargetSize, nil); component != nil {
+			costComponents = append(costComponents, component)
+		}
 	}
 
 	return &schema.Resource{

--- a/internal/resources/google/compute_region_instance_group_manager.go
+++ b/internal/resources/google/compute_region_instance_group_manager.go
@@ -45,7 +45,9 @@ func (r *ComputeRegionInstanceGroupManager) BuildResource() *schema.Resource {
 	}
 
 	for _, guestAccel := range r.GuestAccelerators {
-		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.TargetSize, nil))
+		if component := guestAcceleratorCostComponent(r.Region, r.PurchaseOption, guestAccel.Type, guestAccel.Count, r.TargetSize, nil); component != nil {
+			costComponents = append(costComponents, component)
+		}
 	}
 
 	return &schema.Resource{

--- a/internal/resources/google/container_node_pool.go
+++ b/internal/resources/google/container_node_pool.go
@@ -1,9 +1,10 @@
 package google
 
 import (
+	"github.com/shopspring/decimal"
+
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/shopspring/decimal"
 )
 
 // ContainerNodePool struct represents Container Cluster's Node Pool resource.
@@ -53,7 +54,9 @@ func (r *ContainerNodePool) BuildResource() *schema.Resource {
 	}
 
 	for _, guestAccel := range r.NodeConfig.GuestAccelerators {
-		costComponents = append(costComponents, guestAcceleratorCostComponent(r.Region, r.NodeConfig.PurchaseOption, guestAccel.Type, guestAccel.Count, poolSize, nil))
+		if component := guestAcceleratorCostComponent(r.Region, r.NodeConfig.PurchaseOption, guestAccel.Type, guestAccel.Count, poolSize, nil); component != nil {
+			costComponents = append(costComponents, component)
+		}
 	}
 
 	resource := &schema.Resource{


### PR DESCRIPTION
fixes: https://github.com/infracost/infracost/issues/1932

This change resolves a panic where a nil `CostComponent` was being attributed to a `Resource` if a
`guest_accelerator.type` was an unexpected string. Fixes include:

* Altered all callers to expect that `guestAcceleratorCostComponent` could return nil if the `type` is invalid.
* Added unhandled `nvidia-tesla-a100` type to list of supported valid guest accelerator types