### PR TITLE
fix: reference panic caused when block has no valid labels

### DIFF
--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -774,7 +774,14 @@ func (b *Block) Reference() *Reference {
 	}
 
 	parts = append(parts, b.Labels()...)
-	ref, _ := newReference(parts)
+	ref, err := newReference(parts)
+	if err != nil {
+		b.logger.WithError(err).Debugf(
+			"returning empty block reference because we encountered an error generating a new reference",
+		)
+		return &Reference{}
+	}
+
 	return ref
 }
 

--- a/internal/hcl/block_test.go
+++ b/internal/hcl/block_test.go
@@ -1,0 +1,55 @@
+package hcl
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlock_LocalName(t *testing.T) {
+	tests := []struct {
+		name  string
+		block *Block
+		want  string
+	}{
+		{
+			name: "resource Block with empty labels will return empty local name",
+			block: &Block{
+				hclBlock: &hcl.Block{
+					Type:   "resource",
+					Labels: nil,
+				},
+				logger: newDiscardLogger(),
+			},
+			want: "",
+		},
+		{
+			name: "resource Block with valid labels will return reference without resource type",
+			block: &Block{
+				hclBlock: &hcl.Block{
+					Type:   "resource",
+					Labels: []string{"my-resource", "my-name"},
+				},
+				logger: newDiscardLogger(),
+			},
+			want: "my-resource.my-name",
+		},
+		{
+			name: "data Block with valid labels will return reference with Block type",
+			block: &Block{
+				hclBlock: &hcl.Block{
+					Type:   "data",
+					Labels: []string{"my-block", "my-name"},
+				},
+				logger: newDiscardLogger(),
+			},
+			want: "data.my-block.my-name",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, tt.block.LocalName(), "LocalName()")
+		})
+	}
+}


### PR DESCRIPTION
fixes: https://github.com/infracost/infracost/issues/1930

This change resolves a panic when a Block is in an incomplete state and Infracost attempts to build a local
name for the block.

* we now check that the reference returned for the block is valid and did not encounter any errors
* log problems to the debug log so that we can trace errors in future
* added tests to cover specific bug