### PR TITLE
chore: skip sending error reports to self hosted cloud pricing API

### DIFF
--- a/internal/apiclient/errors.go
+++ b/internal/apiclient/errors.go
@@ -14,6 +14,10 @@ import (
 var pathRegex = regexp.MustCompile(`(\w+:)?[\.~\w]*[\/\\]+([^\s:'\"\]]+)|([\w+-]\.\w{2,})`)
 
 func ReportCLIError(ctx *config.RunContext, cliErr error, replacePath bool) error {
+	if ctx.Config.IsSelfHosted() {
+		return nil
+	}
+
 	errMsg := ui.StripColor(cliErr.Error())
 	stacktrace := ""
 


### PR DESCRIPTION
This change skips sending error traces to any self-hosted cloud pricing instance. These
reports are already skipped server side: https://github.com/infracost/cloud-pricing-api/blob/master/src/events/events.ts#L15-L17.
So ignoring them in the CLI avoids confusion for self-hosted users.