### PR TITLE
fix: azure flexible server broken cost component filters and region lookup

### DIFF
--- a/internal/providers/terraform/azure/mysql_flexible_server.go
+++ b/internal/providers/terraform/azure/mysql_flexible_server.go
@@ -4,9 +4,10 @@ import (
 	"regexp"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/infracost/infracost/internal/resources/azure"
 	"github.com/infracost/infracost/internal/schema"
-	log "github.com/sirupsen/logrus"
 )
 
 func getMySQLFlexibleServerRegistryItem() *schema.RegistryItem {
@@ -17,7 +18,7 @@ func getMySQLFlexibleServerRegistryItem() *schema.RegistryItem {
 }
 
 func newMySQLFlexibleServer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := d.Get("location").String()
+	region := lookupRegion(d, []string{})
 	sku := d.Get("sku_name").String()
 	storage := d.GetInt64OrDefault("storage.0.size_gb", 0)
 	iops := d.GetInt64OrDefault("storage.0.iops", 0)

--- a/internal/providers/terraform/azure/postgresql_flexible_server.go
+++ b/internal/providers/terraform/azure/postgresql_flexible_server.go
@@ -4,9 +4,10 @@ import (
 	"regexp"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/infracost/infracost/internal/resources/azure"
 	"github.com/infracost/infracost/internal/schema"
-	log "github.com/sirupsen/logrus"
 )
 
 func getAzureRMPostgreSQLFlexibleServerRegistryItem() *schema.RegistryItem {
@@ -17,7 +18,7 @@ func getAzureRMPostgreSQLFlexibleServerRegistryItem() *schema.RegistryItem {
 }
 
 func newPostgreSQLFlexibleServer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := d.Get("location").String()
+	region := lookupRegion(d, []string{})
 	sku := d.Get("sku_name").String()
 	storage := d.Get("storage_mb").Int()
 

--- a/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
@@ -1,29 +1,34 @@
 
- Name                                                Monthly Qty  Unit              Monthly Cost 
-                                                                                                 
- azurerm_postgresql_flexible_server.burstable                                                    
- ├─ Compute (B_Standard_B1ms)                                730  hours                   $16.06 
- ├─ Storage                                                  128  GB                      $17.66 
- └─ Additional backup storage                              5,000  GB                     $475.00 
-                                                                                                 
- azurerm_postgresql_flexible_server.gp                                                           
- ├─ Compute (GP_Standard_D4s_v3)                             730  hours                  $284.70 
- ├─ Storage                                                   32  GB                       $4.42 
- └─ Additional backup storage                              5,000  GB                     $475.00 
-                                                                                                 
- azurerm_postgresql_flexible_server.mo                                                           
- ├─ Compute (MO_Standard_E4s_v3)                             730  hours                  $382.52 
- ├─ Storage                                                   64  GB                       $8.83 
- └─ Additional backup storage                              5,000  GB                     $475.00 
-                                                                                                 
- azurerm_postgresql_flexible_server.non_usage_gp                                                 
- ├─ Compute (GP_Standard_D16s_v3)                            730  hours                $1,138.80 
- ├─ Storage                                       Monthly cost depends on usage: $0.14 per GB    
- └─ Additional backup storage                     Monthly cost depends on usage: $0.095 per GB   
-                                                                                                 
- OVERALL TOTAL                                                                         $3,277.99 
+ Name                                                         Monthly Qty  Unit              Monthly Cost 
+                                                                                                          
+ azurerm_postgresql_flexible_server.burstable                                                             
+ ├─ Compute (B_Standard_B1ms)                                         730  hours                   $16.06 
+ ├─ Storage                                                           128  GB                      $17.66 
+ └─ Additional backup storage                                       5,000  GB                     $475.00 
+                                                                                                          
+ azurerm_postgresql_flexible_server.gp                                                                    
+ ├─ Compute (GP_Standard_D4s_v3)                                      730  hours                  $284.70 
+ ├─ Storage                                                            32  GB                       $4.42 
+ └─ Additional backup storage                                       5,000  GB                     $475.00 
+                                                                                                          
+ azurerm_postgresql_flexible_server.mo                                                                    
+ ├─ Compute (MO_Standard_E4s_v3)                                      730  hours                  $382.52 
+ ├─ Storage                                                            64  GB                       $8.83 
+ └─ Additional backup storage                                       5,000  GB                     $475.00 
+                                                                                                          
+ azurerm_postgresql_flexible_server.non_usage_gp                                                          
+ ├─ Compute (GP_Standard_D16s_v3)                                     730  hours                $1,138.80 
+ ├─ Storage                                                Monthly cost depends on usage: $0.14 per GB    
+ └─ Additional backup storage                              Monthly cost depends on usage: $0.095 per GB   
+                                                                                                          
+ azurerm_postgresql_flexible_server.readable_location_set                                                 
+ ├─ Compute (B_Standard_B1ms)                                         730  hours                   $12.41 
+ ├─ Storage                                                Monthly cost depends on usage: $0.12 per GB    
+ └─ Additional backup storage                              Monthly cost depends on usage: $0.095 per GB   
+                                                                                                          
+ OVERALL TOTAL                                                                                  $3,290.40 
 ──────────────────────────────────
-5 cloud resources were detected:
-∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 5 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.tf
+++ b/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.tf
@@ -42,3 +42,10 @@ resource "azurerm_postgresql_flexible_server" "non_usage_gp" {
 
   sku_name = "GP_Standard_D16s_v3"
 }
+
+resource "azurerm_postgresql_flexible_server" "readable_location_set" {
+  name                   = "readable-location"
+  resource_group_name    = "anything"
+  location               = "East US"
+  sku_name               = "B_Standard_B1ms"
+}

--- a/internal/resources/azure/mysql_flexible_server.go
+++ b/internal/resources/azure/mysql_flexible_server.go
@@ -109,7 +109,7 @@ func (r *MySQLFlexibleServer) storageCostComponent() *schema.CostComponent {
 			Service:       strPtr("Azure Database for MySQL"),
 			ProductFamily: strPtr("Databases"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr("Azure Database for MySQL Flexible Server Storage")},
+				{Key: "productName", Value: strPtr("Az Database for MySQL Flexible Server Storage")},
 				{Key: "meterName", Value: strPtr("Storage Data Stored")},
 			},
 		},
@@ -145,7 +145,7 @@ func (r *MySQLFlexibleServer) iopsCostComponent() *schema.CostComponent {
 			Service:       strPtr("Azure Database for MySQL"),
 			ProductFamily: strPtr("Databases"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr("Azure Database for MySQL Flexible Server Storage")},
+				{Key: "productName", Value: strPtr("Az Database for MySQL Flexible Server Storage")},
 				{Key: "skuName", Value: strPtr("Additional IOPS")},
 			},
 		},

--- a/internal/resources/azure/postgresql_flexible_server.go
+++ b/internal/resources/azure/postgresql_flexible_server.go
@@ -100,7 +100,7 @@ func (r *PostgreSQLFlexibleServer) storageCostComponent() *schema.CostComponent 
 			Service:       strPtr("Azure Database for PostgreSQL"),
 			ProductFamily: strPtr("Databases"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", Value: strPtr("Azure Database for PostgreSQL Flexible Server Storage")},
+				{Key: "productName", Value: strPtr("Az DB for PostgreSQL Flexible Server Storage")},
 				{Key: "meterName", Value: strPtr("Storage Data Stored")},
 			},
 		},


### PR DESCRIPTION
fixes: https://github.com/infracost/infracost/issues/1884

This change resolves bugs both with PostgreSQL & MySQL Azure flexible server instances.

* changes cost component `productName` filter to match the updated values
* updates flexible server instances to use the `lookupRegion` functionality, which converts commonly used location formats
* adds test case to PostreSQL to account check that cli name conversion works as expected