### PR TITLE
enhance: Truncate GitHub comment if it's too large

### DIFF
--- a/cmd/infracost/comment_github.go
+++ b/cmd/infracost/comment_github.go
@@ -81,6 +81,7 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 				WillUpdate:          prNumber != 0 && behavior == "update",
 				WillReplace:         prNumber != 0 && behavior == "delete-and-new",
 				IncludeFeedbackLink: true,
+				MaxMessageSize:      output.GitHubMaxMessageSize,
 			})
 			var policyFailure output.PolicyCheckFailures
 			if err != nil {

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -18,8 +18,9 @@ import (
 )
 
 var (
-	minOutputVersion = "0.2"
-	maxOutputVersion = "0.2"
+	minOutputVersion     = "0.2"
+	maxOutputVersion     = "0.2"
+	GitHubMaxMessageSize = 262144
 )
 
 type ReportInput struct {
@@ -271,7 +272,9 @@ func FormatOutput(format string, r Root, opts Options) ([]byte, error) {
 		b, err = ToHTML(r, opts)
 	case "diff":
 		b, err = ToDiff(r, opts)
-	case "github-comment", "gitlab-comment", "azure-repos-comment":
+	case "github-comment":
+		b, err = ToMarkdown(r, opts, MarkdownOptions{MaxMessageSize: GitHubMaxMessageSize})
+	case "gitlab-comment", "azure-repos-comment":
 		b, err = ToMarkdown(r, opts, MarkdownOptions{})
 	case "bitbucket-comment":
 		b, err = ToMarkdown(r, opts, MarkdownOptions{BasicSyntax: true})

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"sort"
 	"text/template"
+	"unicode/utf8"
 
 	"github.com/infracost/infracost/internal/ui"
 	"github.com/pkg/errors"
@@ -102,9 +103,17 @@ func calculateMetadataToDisplay(projects []Project) (hasModulePath bool, hasWork
 }
 
 func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, error) {
-	diff, err := ToDiff(out, opts)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to generate diff")
+	var diffMsg string
+
+	if opts.diffMsg != "" {
+		diffMsg = opts.diffMsg
+	} else {
+		diff, err := ToDiff(out, opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to generate diff")
+		}
+
+		diffMsg = ui.StripColor(string(diff))
 	}
 
 	hasModulePath, hasWorkspace := calculateMetadataToDisplay(out.Projects)
@@ -168,7 +177,7 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 	if markdownOpts.BasicSyntax {
 		t = CommentMarkdownTemplate
 	}
-	tmpl, err = tmpl.Parse(t)
+	tmpl, err := tmpl.Parse(t)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -189,7 +198,7 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 	}{
 		out,
 		skippedProjectCount,
-		ui.StripColor(string(diff)),
+		diffMsg,
 		opts,
 		markdownOpts})
 	if err != nil {
@@ -197,5 +206,16 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 	}
 
 	bufw.Flush()
-	return buf.Bytes(), nil
+	msg := buf.Bytes()
+
+	msgLength := utf8.RuneCount(msg)
+	if markdownOpts.MaxMessageSize > 0 && msgLength > markdownOpts.MaxMessageSize {
+		truncateLength := msgLength - markdownOpts.MaxMessageSize
+		newLength := utf8.RuneCountInString(diffMsg) - truncateLength - 1000
+
+		opts.diffMsg = truncateMiddle(diffMsg, newLength, "\n\n...(truncated due to message size limit)...\n\n")
+		return ToMarkdown(out, opts, markdownOpts)
+	}
+
+	return msg, nil
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -213,6 +213,7 @@ type Options struct {
 	Fields            []string
 	IncludeHTML       bool
 	PolicyChecks      PolicyCheck
+	diffMsg           string
 }
 
 // PolicyCheck holds information if a given run has any policy checks enabled.
@@ -252,6 +253,7 @@ type MarkdownOptions struct {
 	IncludeFeedbackLink bool
 	OmitDetails         bool
 	BasicSyntax         bool
+	MaxMessageSize      int
 }
 
 func outputBreakdown(resources []*schema.Resource) *Breakdown {

--- a/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.tf
+++ b/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.tf
@@ -44,8 +44,8 @@ resource "azurerm_postgresql_flexible_server" "non_usage_gp" {
 }
 
 resource "azurerm_postgresql_flexible_server" "readable_location_set" {
-  name                   = "readable-location"
-  resource_group_name    = "anything"
-  location               = "East US"
-  sku_name               = "B_Standard_B1ms"
+  name                = "readable-location"
+  resource_group_name = "anything"
+  location            = "East US"
+  sku_name            = "B_Standard_B1ms"
 }


### PR DESCRIPTION
GitHub has a limit of 262,144 characters per comment body.
https://github.com/orgs/community/discussions/27190#discussioncomment-3254953