### PR TITLE
fix: use pr URL for local git metadata if provided

### DIFF
--- a/internal/vcs/metadata.go
+++ b/internal/vcs/metadata.go
@@ -338,10 +338,16 @@ func (f *metadataFetcher) getLocalGitMetadata(path string) (Metadata, error) {
 		remote = repoOverrideURL
 	}
 
+	var pullRequest *PullRequest
+	if prOverrideURL != "" {
+		pullRequest = &PullRequest{URL: prOverrideURL}
+	}
+
 	return Metadata{
-		Remote: urlStringToRemote(remote),
-		Branch: Branch{Name: branch},
-		Commit: commitToMetadata(commit),
+		Remote:      urlStringToRemote(remote),
+		Branch:      Branch{Name: branch},
+		Commit:      commitToMetadata(commit),
+		PullRequest: pullRequest,
 	}, nil
 }
 


### PR DESCRIPTION
Resolves issue where providing Infracost PR env variable `INFRACOST_VCS_PULL_REQUEST_URL` for a VCS provider that doesn't have specific metadata logic (e.g. Jenkins) will send a blank pr url to the dashboard.
See this slack thread for more info: https://infracost-community.slack.com/archives/C01G63Q4HS7/p1660511891023239