### PR TITLE
fix: fix HCL parsing values within local objects

### DIFF
--- a/cmd/infracost/hcl_test.go
+++ b/cmd/infracost/hcl_test.go
@@ -114,3 +114,15 @@ func TestHCLModuleForEach(t *testing.T) {
 		nil,
 	)
 }
+
+func TestHCLLocalObjectMock(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		nil,
+	)
+}

--- a/cmd/infracost/testdata/hcllocal_object_mock/hcllocal_object_mock.golden
+++ b/cmd/infracost/testdata/hcllocal_object_mock/hcllocal_object_mock.golden
@@ -1,0 +1,16 @@
+Project: infracost/infracost/cmd/infracost/testdata/hcllocal_object_mock
+
+ Name                                                 Monthly Qty  Unit   Monthly Cost 
+                                                                                       
+ aws_instance.workers_launch_template                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, m4.large)          730  hours        $73.00 
+ └─ root_block_device                                                                  
+    └─ Storage (general purpose SSD, gp2)                       8  GB            $0.80 
+                                                                                       
+ OVERALL TOTAL                                                                  $73.80 
+──────────────────────────────────
+1 cloud resource was detected:
+∙ 1 was estimated, it includes usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/hcllocal_object_mock/main.tf
+++ b/cmd/infracost/testdata/hcllocal_object_mock/main.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+data "aws_ami" "my_ami" {
+  count       = 1
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+  owners = ["099720109477"]
+}
+
+locals {
+  defaults = {
+    instance_type = "m4.large"
+    ami           = data.aws_ami.my_ami.*.name[0]
+  }
+}
+
+resource "aws_instance" "workers_launch_template" {
+  instance_type = local.defaults["instance_type"]
+  ami           = local.defaults.ami
+}

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -647,6 +647,13 @@ func (attr *Attribute) findBadVariablesFromExpression(expression hcl.Expression)
 				return badVars
 			}
 		}
+	case *hclsyntax.ObjectConsExpr:
+		for _, item := range t.Items {
+			badVars = append(badVars, attr.findBadVariablesFromExpression(item.KeyExpr)...)
+			badVars = append(badVars, attr.findBadVariablesFromExpression(item.ValueExpr)...)
+		}
+
+		return badVars
 	}
 
 	return attr.findBadVariables(expression.Variables())

--- a/internal/hcl/context.go
+++ b/internal/hcl/context.go
@@ -122,7 +122,7 @@ func mergeObjects(a cty.Value, b cty.Value) cty.Value {
 		old, exists := output[key]
 
 		if exists && isValidCtyObject(val) && isValidCtyObject(old) {
-			output[key] = mergeObjects(val, old)
+			output[key] = mergeObjects(old, val)
 			continue
 		}
 


### PR DESCRIPTION
This is a potential fix for https://github.com/infracost/infracost/issues/1760.

This fixes 2 underlying issues:
1. When evaluating local objects with mocks, bad variables from objects weren't supported, which meant the whole object is mocked instead of specififc values
2. When merging object variables the arg order was incorrect, which meant a mocked value was overritten as an unknown type