### PR TITLE
fix: don't assume role when parsing Terragrunt

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -319,6 +319,10 @@ func TestBreakdownTerragruntNested(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../../examples"}, nil)
 }
 
+func TestBreakdownTerragruntIAMRoles(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())}, nil)
+}
+
 func TestInstanceWithAttachmentBeforeDeploy(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "./testdata/instance_with_attachment_before_deploy.json"}, nil)
 }

--- a/cmd/infracost/testdata/breakdown_terragrunt_iamroles/breakdown_terragrunt_iamroles.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_iamroles/breakdown_terragrunt_iamroles.golden
@@ -1,0 +1,23 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_iamroles
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+ ├─ root_block_device                                                                                                 
+ │  └─ Storage (general purpose SSD, gp2)                                50  GB                                 $5.00 
+ └─ ebs_block_device[0]                                                                                               
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration                                            Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ OVERALL TOTAL                                                                                                $742.64 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terragrunt_iamroles/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_iamroles/main.tf
@@ -1,0 +1,27 @@
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  memory_size   = 1024
+}
+
+output "aws_instance_type" {
+  value = aws_instance.web_app.instance_type
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_iamroles/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_iamroles/terragrunt.hcl
@@ -1,0 +1,20 @@
+locals {
+  aws_region = "us-east-1"
+}
+
+iam_role = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region                      = "${local.aws_region}"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+EOF
+}

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gruntwork-io/terragrunt/aws_helper"
 	tgcli "github.com/gruntwork-io/terragrunt/cli"
 	"github.com/gruntwork-io/terragrunt/cli/tfsource"
 	tgconfig "github.com/gruntwork-io/terragrunt/config"
@@ -273,17 +272,6 @@ func (p *TerragruntHCLProvider) runTerragrunt(opts *tgoptions.TerragruntOptions)
 			opts.TerragruntConfigPath,
 		)
 		return nil, nil
-	}
-
-	// We merge the OriginalIAMRoleOptions into the one from the config, because the CLI passed IAMRoleOptions has
-	// precedence.
-	opts.IAMRoleOptions = tgoptions.MergeIAMRoleOptions(
-		terragruntConfig.GetIAMRoleOptions(),
-		opts.OriginalIAMRoleOptions,
-	)
-
-	if err := aws_helper.AssumeRoleAndUpdateEnvIfNecessary(opts); err != nil {
-		return nil, err
 	}
 
 	// get the default download dir


### PR DESCRIPTION
Previously if the user had `iam_role` set in their Terragrunt config we were assuming the role like Terragrunt does. This was failing in cases where the AWS credentials were not availability in the environment. Since we're parsing the HCL we don't make any calls to the AWS APIs so don't need to assume the role.