### PR TITLE
Add support for case insensitive Azure VM sizes

### DIFF
--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -55,9 +55,9 @@ func linuxVirtualMachineCostComponent(region string, instanceType string, monthl
 	purchaseOptionLabel := "pay as you go"
 
 	productNameRe := "/Virtual Machines .* Series$/"
-	if strings.HasPrefix(instanceType, "Basic_") {
+	if strings.HasPrefix(strings.ToLower(instanceType), "basic_") {
 		productNameRe = "/Virtual Machines .* Series Basic$/"
-	} else if !strings.HasPrefix(instanceType, "Standard_") {
+	} else if !strings.HasPrefix(strings.ToLower(instanceType), "standard_") {
 		instanceType = fmt.Sprintf("Standard_%s", instanceType)
 	}
 

--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -53,8 +53,8 @@ func NewAzureRMLinuxVirtualMachine(d *schema.ResourceData, u *schema.UsageData) 
 func linuxVirtualMachineCostComponent(region string, instanceType string, monthlyHours *float64) *schema.CostComponent {
 	purchaseOption := "Consumption"
 	purchaseOptionLabel := "pay as you go"
-
 	productNameRe := "/Virtual Machines .* Series$/"
+	
 	if strings.HasPrefix(strings.ToLower(instanceType), "basic_") {
 		productNameRe = "/Virtual Machines .* Series Basic$/"
 	} else if !strings.HasPrefix(strings.ToLower(instanceType), "standard_") {

--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -54,10 +54,10 @@ func linuxVirtualMachineCostComponent(region string, instanceType string, monthl
 	purchaseOption := "Consumption"
 	purchaseOptionLabel := "pay as you go"
 	productNameRe := "/Virtual Machines .* Series$/"
-	
-	if strings.HasPrefix(strings.ToLower(instanceType), "basic_") {
+
+	if strings.HasPrefix(instanceType, "Basic_") {
 		productNameRe = "/Virtual Machines .* Series Basic$/"
-	} else if !strings.HasPrefix(strings.ToLower(instanceType), "standard_") {
+	} else if !strings.HasPrefix(instanceType, "Standard_") {
 		instanceType = fmt.Sprintf("Standard_%s", instanceType)
 	}
 


### PR DESCRIPTION
Regarding [Issue 1982](https://github.com/infracost/infracost/issues/1982), VM size in Azure needs to be case insensitive.
