### PR TITLE
feat(Azure): Add support for case insensitive Azure VM sizes

### DIFF
--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -55,9 +55,9 @@ func linuxVirtualMachineCostComponent(region string, instanceType string, monthl
 	purchaseOptionLabel := "pay as you go"
 
 	productNameRe := "/Virtual Machines .* Series$/"
-	if strings.HasPrefix(instanceType, "Basic_") {
+	if strings.HasPrefix(strings.ToLower(instanceType), "basic_") {
 		productNameRe = "/Virtual Machines .* Series Basic$/"
-	} else if !strings.HasPrefix(instanceType, "Standard_") {
+	} else if !strings.HasPrefix(strings.ToLower(instanceType), "standard_") {
 		instanceType = fmt.Sprintf("Standard_%s", instanceType)
 	}
 

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
@@ -13,6 +13,12 @@
     ├─ Storage (S4)                                                         1  months                           $1.54 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
+ azurerm_linux_virtual_machine.basic_b1_lowercase                                                                     
+ ├─ Instance usage (pay as you go, standard_b1s)                          730  hours                            $7.59 
+ └─ os_disk                                                                                                           
+    ├─ Storage (S4)                                                         1  months                           $1.54 
+    └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                      
  azurerm_linux_virtual_machine.basic_b1_withMonthlyHours                                                              
  ├─ Instance usage (pay as you go, Standard_B1s)                          100  hours                            $1.04 
  └─ os_disk                                                                                                           
@@ -32,12 +38,17 @@
     ├─ Storage (E30)                                                        1  months                          $76.80 
     └─ Disk operations                                                      2  10k operations                   $0.00 
                                                                                                                       
+ azurerm_linux_virtual_machine.standard_f2_lowercase                                                                  
+ ├─ Instance usage (pay as you go, standard_f2)                           730  hours                           $72.27 
+ └─ os_disk                                                                                                           
+    └─ Storage (P4)                                                         1  months                           $5.28 
+                                                                                                                      
  azurerm_linux_virtual_machine.standard_f2_premium_disk                                                               
  ├─ Instance usage (pay as you go, Standard_F2)                           730  hours                           $72.27 
  └─ os_disk                                                                                                           
     └─ Storage (P4)                                                         1  months                           $5.28 
                                                                                                                       
- OVERALL TOTAL                                                                                                $360.52 
+ OVERALL TOTAL                                                                                                $447.20 
 ──────────────────────────────────
-6 cloud resources were detected:
-∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+8 cloud resources were detected:
+∙ 8 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.tf
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.tf
@@ -29,6 +29,32 @@ resource "azurerm_linux_virtual_machine" "basic_b1" {
   }
 }
 
+resource "azurerm_linux_virtual_machine" "basic_b1_lowercase" {
+  name                = "basic_b1"
+  resource_group_name = "fake_resource_group"
+  location            = "eastus"
+
+  size           = "standard_b1s"
+  admin_username = "fakeuser"
+  admin_password = "fakepass"
+
+  network_interface_ids = [
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic",
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
 resource "azurerm_linux_virtual_machine" "basic_a2" {
   name                = "basic_a2"
   resource_group_name = "fake_resource_group"
@@ -61,6 +87,32 @@ resource "azurerm_linux_virtual_machine" "standard_f2_premium_disk" {
   location            = "eastus"
 
   size           = "Standard_F2"
+  admin_username = "fakeuser"
+  admin_password = "fakepass"
+
+  network_interface_ids = [
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testrg/providers/Microsoft.Network/networkInterfaces/fakenic",
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "standard_f2_lowercase" {
+  name                = "standard_f2"
+  resource_group_name = "fake_resource_group"
+  location            = "eastus"
+
+  size           = "standard_f2"
   admin_username = "fakeuser"
   admin_password = "fakepass"
 


### PR DESCRIPTION
Regarding [issue 1982](https://github.com/infracost/infracost/issues/1982), VM size in Azure needs to be case insensitive.