### PR TITLE
fix: use context method for cloud enabled telemetry value

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -323,9 +323,7 @@ func loadGlobalFlags(ctx *config.RunContext, cmd *cobra.Command) error {
 	}
 
 	ctx.SetContextValue("dashboardEnabled", ctx.Config.EnableDashboard)
-	if ctx.Config.EnableCloud != nil {
-		ctx.SetContextValue("cloudEnabled", ctx.Config.EnableCloud)
-	}
+	ctx.SetContextValue("cloudEnabled", ctx.IsCloudEnabled())
 	ctx.SetContextValue("isDefaultPricingAPIEndpoint", ctx.Config.PricingAPIEndpoint == ctx.Config.DefaultPricingAPIEndpoint)
 
 	flagNames := make([]string, 0)


### PR DESCRIPTION
Uses the correct IsCloudEnabled method to set `cloudEnabled` telemetry.