### PR TITLE
fix: break help text into multiple lines

### DIFF
--- a/cmd/infracost/testdata/upload_help/upload_help.golden
+++ b/cmd/infracost/testdata/upload_help/upload_help.golden
@@ -12,9 +12,9 @@ EXAMPLES
       export INFRACOST_VCS_PULL_REQUEST_URL=http://github.com/myorg...
       export INFRACOST_VCS_PULL_REQUEST_TITLE="My PR title"
       # ... other env vars here
-      
+
       infracost diff --path plan.json --format json --out-file infracost.json
-      
+
       infracost upload --path infracost.json
 
 FLAGS

--- a/cmd/infracost/testdata/upload_help/upload_help.golden
+++ b/cmd/infracost/testdata/upload_help/upload_help.golden
@@ -1,4 +1,8 @@
-Upload an Infracost JSON file to Infracost Cloud. This is useful if you do not use `infracost comment` and instead want to define run metadata, such as pull request URL or title, and upload the results manually.
+Upload an Infracost JSON file to Infracost Cloud. This is useful if you
+do not use 'infracost comment' and instead want to define run metadata,
+such as pull request URL or title, and upload the results manually.
+
+See https://infracost.io/docs/features/cli_commands/#upload-runs
 
 USAGE
   infracost upload [flags]

--- a/cmd/infracost/upload.go
+++ b/cmd/infracost/upload.go
@@ -15,7 +15,11 @@ func uploadCmd(ctx *config.RunContext) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upload",
 		Short: "Upload an Infracost JSON file to Infracost Cloud",
-		Long:  "Upload an Infracost JSON file to Infracost Cloud. This is useful if you do not use `infracost comment` and instead want to define run metadata, such as pull request URL or title, and upload the results manually.",
+		Long: `Upload an Infracost JSON file to Infracost Cloud. This is useful if you
+do not use 'infracost comment' and instead want to define run metadata,
+such as pull request URL or title, and upload the results manually.
+		
+See https://infracost.io/docs/features/cli_commands/#upload-runs`,
 		Example: `  Upload an Infracost JSON file:
       export INFRACOST_VCS_PULL_REQUEST_URL=http://github.com/myorg...
       export INFRACOST_VCS_PULL_REQUEST_TITLE="My PR title"

--- a/cmd/infracost/upload.go
+++ b/cmd/infracost/upload.go
@@ -18,15 +18,15 @@ func uploadCmd(ctx *config.RunContext) *cobra.Command {
 		Long: `Upload an Infracost JSON file to Infracost Cloud. This is useful if you
 do not use 'infracost comment' and instead want to define run metadata,
 such as pull request URL or title, and upload the results manually.
-		
+
 See https://infracost.io/docs/features/cli_commands/#upload-runs`,
 		Example: `  Upload an Infracost JSON file:
       export INFRACOST_VCS_PULL_REQUEST_URL=http://github.com/myorg...
       export INFRACOST_VCS_PULL_REQUEST_TITLE="My PR title"
       # ... other env vars here
-      
+
       infracost diff --path plan.json --format json --out-file infracost.json
-      
+
       infracost upload --path infracost.json`,
 		ValidArgs: []string{"--", "-"},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Also add the docs link