### PR TITLE
fix: detect vcs provider from remote if not provided

### DIFF
--- a/internal/vcs/metadata.go
+++ b/internal/vcs/metadata.go
@@ -108,6 +108,10 @@ func mergeEnvProvidedMetadata(m Metadata) Metadata {
 		}
 	}
 
+	if m.PullRequest != nil && m.PullRequest.VCSProvider == "" {
+		m.PullRequest.VCSProvider = vcsProviderFromHost(m.Remote.Host)
+	}
+
 	if envMeta.Pipeline.ID != "" {
 		m.Pipeline = &Pipeline{
 			ID: envMeta.Pipeline.ID,

--- a/internal/vcs/metadata_test.go
+++ b/internal/vcs/metadata_test.go
@@ -134,7 +134,7 @@ func Test_metadataFetcher_GetLocalMetadataMergesWithEnv(t *testing.T) {
 			Time:        obj.Author.When,
 			Message:     obj.Message,
 		},
-		PullRequest: &PullRequest{ID: pullID},
+		PullRequest: &PullRequest{ID: pullID, VCSProvider: "github"},
 		Pipeline:    nil,
 	}, actual)
 }


### PR DESCRIPTION
Changes the metadata fetcher to set a vcs provider from the host if it has not been provided already. This is useful for deployment platforms like atlantis.