### PR TITLE
feat(google): Handle custom compute instances

### DIFF
--- a/internal/providers/terraform/google/compute_instance.go
+++ b/internal/providers/terraform/google/compute_instance.go
@@ -1,8 +1,6 @@
 package google
 
 import (
-	"strings"
-
 	"github.com/infracost/infracost/internal/resources/google"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/tidwall/gjson"
@@ -26,9 +24,6 @@ func getComputeInstanceRegistryItem() *schema.RegistryItem {
 
 func newComputeInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	machineType := d.Get("machine_type").String()
-	if strings.HasPrefix(machineType, "custom-") {
-		return nil
-	}
 
 	region := d.Get("region").String()
 	size := int64(1)

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -123,7 +123,7 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 		Name:                fmt.Sprintf("Custom Instance RAM usage (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
 		Unit:                "gibibyte hour",
 		UnitMultiplier:      decimal.NewFromInt(mbOfRAM / 1024),
-		MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount))),
+		MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount * mbOfRAM / 1024))),
 		MonthlyDiscountPerc: sustainedUseDiscount,
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("gcp"),

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -119,7 +119,6 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 	if monthlyHours != nil {
 		qty = decimal.NewFromFloat(*monthlyHours)
 	}
-
 	cpuCostComponent := &schema.CostComponent{
 		Name:                fmt.Sprintf("Custom instance CPU (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
 		Unit:                "hours",
@@ -152,7 +151,7 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 			Service:       strPtr("Compute Engine"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("^%sCustom%sInstance Ram", instanceType, ext))},
+				{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("^%s%sCustom%sInstance Ram", purchaseOptionPrefix, instanceType, ext))},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -91,9 +91,9 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 			VendorName:    strPtr("gcp"),
 			Region:        strPtr(region),
 			Service:       strPtr("Compute Engine"),
-			ProductFamily: strPtr("Compute Instance"),
+			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "description", ValueRegex: regexPtr("^Custom Instance Core.*$")},
+				{Key: "description", ValueRegex: regexPtr("Custom Instance Core.*")},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{
@@ -111,9 +111,9 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 			VendorName:    strPtr("gcp"),
 			Region:        strPtr(region),
 			Service:       strPtr("Compute Engine"),
-			ProductFamily: strPtr("Compute Instance"),
+			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "description", ValueRegex: regexPtr("^Custom Instance Ram.*$")},
+				{Key: "description", ValueRegex: regexPtr("Custom Instance Ram.*")},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -64,6 +64,44 @@ func computeCostComponent(region, machineType string, purchaseOption string, ins
 	}
 }
 
+// customComputeCostComponent returns a cost component for custom Compute instance usage.
+func customComputeCostComponent(region, machineType string, purchaseOption string, instanceCount int64, monthlyHours *float64) *schema.CostComponent {
+	sustainedUseDiscount := 0.0
+	if strings.ToLower(purchaseOption) == "on_demand" {
+		switch strings.ToLower(strings.Split(machineType, "-")[0]) {
+		case "c2", "n2", "n2d":
+			sustainedUseDiscount = 0.2
+		case "n1", "f1", "g1", "m1":
+			sustainedUseDiscount = 0.3
+		}
+	}
+
+	qty := decimal.NewFromFloat(730)
+	if monthlyHours != nil {
+		qty = decimal.NewFromFloat(*monthlyHours)
+	}
+
+	return &schema.CostComponent{
+		Name:                fmt.Sprintf("Instance usage (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
+		Unit:                "hours",
+		UnitMultiplier:      decimal.NewFromInt(1),
+		MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount))),
+		MonthlyDiscountPerc: sustainedUseDiscount,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("gcp"),
+			Region:        strPtr(region),
+			Service:       strPtr("Compute Engine"),
+			ProductFamily: strPtr("Compute Instance"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "machineType", ValueRegex: regexPtr(fmt.Sprintf("^%s$", machineType))},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption: strPtr(purchaseOption),
+		},
+	}
+}
+
 // bootDiskCostComponent returns a cost component for Boot Disk storage for
 // Compute resources.
 func bootDiskCostComponent(region string, diskSize float64, diskType string) *schema.CostComponent {

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -105,7 +105,7 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 
 	mbOfRAM, err := strconv.ParseInt(strRAMAmount, 10, 64)
 	if err != nil {
-		log.Warnf("Could not parse the custom amount of Ram for %s", machineType)
+		log.Warnf("Could not parse the custom amount of RAM for %s", machineType)
 		return nil
 	}
 

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -126,7 +126,7 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 			Service:       strPtr("Compute Engine"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("%s.*Custom Instance Core.*", instanceType))},
+				{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("^%s Custom Instance Core", instanceType))},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -109,7 +109,7 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 		return nil
 	}
 
-	qty := decimal.NewFromFloat(730)
+	qty := decimal.NewFromFloat(schema.HourToMonthUnitMultiplier)
 	if monthlyHours != nil {
 		qty = decimal.NewFromFloat(*monthlyHours)
 	}

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -135,7 +135,7 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 	}
 
 	ramCostComponent := &schema.CostComponent{
-		Name:                fmt.Sprintf("Custom Instance RAM usage (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
+		Name:                fmt.Sprintf("Custom Instance RAM (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
 		Unit:                "gibibyte hour",
 		UnitMultiplier:      decimal.NewFromInt(mbOfRAM / 1024),
 		MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount * mbOfRAM / 1024))),

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -56,7 +56,6 @@ func computeCostComponents(region, machineType string, purchaseOption string, in
 	}
 
 	if !strings.Contains(machineType, "custom") {
-
 		return []*schema.CostComponent{
 			{
 				Name:                fmt.Sprintf("Instance usage (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -78,7 +78,7 @@ func computeCostComponents(region, machineType string, purchaseOption string, in
 		}
 	} else {
 		// GCP Custom Instances
-		var re = regexp.MustCompile(`(\D.+)-(\d+)-(\d.+)`)
+		re := regexp.MustCompile(`(\D.+)-(\d+)-(\d.+)`)
 		firstMachineTypeInfo := re.ReplaceAllString(machineType, "$1")
 		strCPUAmount := re.ReplaceAllString(machineType, "$2")
 		strRAMAmount := re.ReplaceAllString(machineType, "$3")

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -109,7 +109,7 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 		return nil
 	}
 
-	qty := decimal.NewFromFloat(schema.HourToMonthUnitMultiplier)
+	qty := decimal.NewFromFloat(schema.HourToMonthUnitMultiplier.InexactFloat64())
 	if monthlyHours != nil {
 		qty = decimal.NewFromFloat(*monthlyHours)
 	}

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -115,7 +115,7 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 	}
 
 	cpuCostComponent := &schema.CostComponent{
-		Name:                fmt.Sprintf("Custom Instance CPU usage (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
+		Name:                fmt.Sprintf("Custom instance CPU (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
 		Unit:                "hours",
 		UnitMultiplier:      decimal.NewFromInt(numberOfCores),
 		MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount * numberOfCores))),

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/shopspring/decimal"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/infracost/infracost/internal/logging"
 	"github.com/infracost/infracost/internal/schema"
@@ -81,13 +82,13 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 	}
 
 	var re = regexp.MustCompile(`(\D.+)-(\d+)-(\d.+)`)
-	firstTypeInfo := re.ReplaceAllString(machineType, "$1")
+	firstMachineTypeInfo := re.ReplaceAllString(machineType, "$1")
 	strCPUAmount := re.ReplaceAllString(machineType, "$2")
 	strRAMAmount := re.ReplaceAllString(machineType, "$3")
 
 	instanceType := ""
-	if firstTypeInfo != "custom" {
-		instanceType = strings.ToUpper(strings.Split(firstTypeInfo, "-")[0])
+	if firstMachineTypeInfo != "custom" {
+		instanceType = strings.ToUpper(strings.Split(firstMachineTypeInfo, "-")[0])
 	}
 
 	ext := ""
@@ -98,12 +99,14 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 
 	numberOfCores, err := strconv.ParseInt(strCPUAmount, 10, 64)
 	if err != nil {
-		return []*schema.CostComponent{}
+		log.Warnf("Could not parse the custom number of Cores for %s", machineType)
+		return nil
 	}
 
 	mbOfRAM, err := strconv.ParseInt(strRAMAmount, 10, 64)
 	if err != nil {
-		return []*schema.CostComponent{}
+		log.Warnf("Could not parse the custom amount of Ram for %s", machineType)
+		return nil
 	}
 
 	qty := decimal.NewFromFloat(730)

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -30,47 +30,10 @@ type ContainerNodeConfig struct {
 }
 
 // computeCostComponent returns a cost component for Compute instance usage.
-func computeCostComponent(region, machineType string, purchaseOption string, instanceCount int64, monthlyHours *float64) *schema.CostComponent {
-	sustainedUseDiscount := 0.0
-	if strings.ToLower(purchaseOption) == "on_demand" {
-		switch strings.ToLower(strings.Split(machineType, "-")[0]) {
-		case "c2", "n2", "n2d":
-			sustainedUseDiscount = 0.2
-		case "n1", "f1", "g1", "m1":
-			sustainedUseDiscount = 0.3
-		}
-	}
-
-	qty := decimal.NewFromFloat(730)
-	if monthlyHours != nil {
-		qty = decimal.NewFromFloat(*monthlyHours)
-	}
-
-	return &schema.CostComponent{
-		Name:                fmt.Sprintf("Instance usage (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
-		Unit:                "hours",
-		UnitMultiplier:      decimal.NewFromInt(1),
-		MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount))),
-		MonthlyDiscountPerc: sustainedUseDiscount,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("gcp"),
-			Region:        strPtr(region),
-			Service:       strPtr("Compute Engine"),
-			ProductFamily: strPtr("Compute Instance"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "machineType", ValueRegex: regexPtr(fmt.Sprintf("^%s$", machineType))},
-			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			PurchaseOption: strPtr(purchaseOption),
-		},
-	}
-}
-
-// customComputeCostComponent returns a cost component for custom Compute instance usage.
-func customComputeCostComponents(region, machineType string, purchaseOption string, instanceCount int64, monthlyHours *float64) []*schema.CostComponent {
+func computeCostComponents(region, machineType string, purchaseOption string, instanceCount int64, monthlyHours *float64) []*schema.CostComponent {
 	sustainedUseDiscount := 0.0
 	fixPurchaseOption := ""
+
 	if strings.ToLower(purchaseOption) == "on_demand" {
 		fixPurchaseOption = "OnDemand"
 		switch strings.ToLower(strings.Split(machineType, "-")[0]) {
@@ -87,82 +50,109 @@ func customComputeCostComponents(region, machineType string, purchaseOption stri
 		fixPurchaseOption = "Preemptible"
 	}
 
-	var re = regexp.MustCompile(`(\D.+)-(\d+)-(\d.+)`)
-	firstMachineTypeInfo := re.ReplaceAllString(machineType, "$1")
-	strCPUAmount := re.ReplaceAllString(machineType, "$2")
-	strRAMAmount := re.ReplaceAllString(machineType, "$3")
-
-	instanceType := ""
-	if firstMachineTypeInfo != "custom" {
-		instanceType = strings.ToUpper(strings.Split(firstMachineTypeInfo, "-")[0]) + " "
-	}
-
-	ext := " "
-	if strings.Contains(strRAMAmount, "ext") {
-		ext = " Extended "
-		strRAMAmount = strings.Split(strRAMAmount, "-")[0]
-	}
-
-	numberOfCores, err := strconv.ParseInt(strCPUAmount, 10, 64)
-	if err != nil {
-		log.Warnf("Could not parse the custom number of Cores for %s", machineType)
-		return nil
-	}
-
-	mbOfRAM, err := strconv.ParseInt(strRAMAmount, 10, 64)
-	if err != nil {
-		log.Warnf("Could not parse the custom amount of RAM for %s", machineType)
-		return nil
-	}
-
 	qty := decimal.NewFromFloat(schema.HourToMonthUnitMultiplier.InexactFloat64())
 	if monthlyHours != nil {
 		qty = decimal.NewFromFloat(*monthlyHours)
 	}
-	cpuCostComponent := &schema.CostComponent{
-		Name:                fmt.Sprintf("Custom instance CPU (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
-		Unit:                "hours",
-		UnitMultiplier:      decimal.NewFromInt(numberOfCores),
-		MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount * numberOfCores))),
-		MonthlyDiscountPerc: sustainedUseDiscount,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("gcp"),
-			Region:        strPtr(region),
-			Service:       strPtr("Compute Engine"),
-			ProductFamily: strPtr("Compute"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("^%s%sCustom Instance Core", purchaseOptionPrefix, instanceType))},
+
+	if !strings.Contains(machineType, "custom") {
+
+		return []*schema.CostComponent{
+			{
+				Name:                fmt.Sprintf("Instance usage (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
+				Unit:                "hours",
+				UnitMultiplier:      decimal.NewFromInt(1),
+				MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount))),
+				MonthlyDiscountPerc: sustainedUseDiscount,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("gcp"),
+					Region:        strPtr(region),
+					Service:       strPtr("Compute Engine"),
+					ProductFamily: strPtr("Compute Instance"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "machineType", ValueRegex: regexPtr(fmt.Sprintf("^%s$", machineType))},
+					},
+				},
+				PriceFilter: &schema.PriceFilter{
+					PurchaseOption: strPtr(purchaseOption),
+				}},
+		}
+	} else {
+		// GCP Custom Instances
+		var re = regexp.MustCompile(`(\D.+)-(\d+)-(\d.+)`)
+		firstMachineTypeInfo := re.ReplaceAllString(machineType, "$1")
+		strCPUAmount := re.ReplaceAllString(machineType, "$2")
+		strRAMAmount := re.ReplaceAllString(machineType, "$3")
+
+		instanceType := ""
+		if firstMachineTypeInfo != "custom" {
+			instanceType = strings.ToUpper(strings.Split(firstMachineTypeInfo, "-")[0]) + " "
+		}
+
+		ext := " "
+		if strings.Contains(strRAMAmount, "ext") {
+			ext = " Extended "
+			strRAMAmount = strings.Split(strRAMAmount, "-")[0]
+		}
+
+		numberOfCores, err := strconv.ParseInt(strCPUAmount, 10, 64)
+		if err != nil {
+			log.Warnf("Could not parse the custom number of Cores for %s", machineType)
+			return nil
+		}
+
+		mbOfRAM, err := strconv.ParseInt(strRAMAmount, 10, 64)
+		if err != nil {
+			log.Warnf("Could not parse the custom amount of RAM for %s", machineType)
+			return nil
+		}
+
+		cpuCostComponent := &schema.CostComponent{
+			Name:                fmt.Sprintf("Custom instance CPU (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
+			Unit:                "hours",
+			UnitMultiplier:      decimal.NewFromInt(numberOfCores),
+			MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount * numberOfCores))),
+			MonthlyDiscountPerc: sustainedUseDiscount,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("gcp"),
+				Region:        strPtr(region),
+				Service:       strPtr("Compute Engine"),
+				ProductFamily: strPtr("Compute"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("^%s%sCustom Instance Core", purchaseOptionPrefix, instanceType))},
+				},
 			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			PurchaseOption: strPtr(fixPurchaseOption),
-		},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr(fixPurchaseOption),
+			},
+		}
+
+		ramCostComponent := &schema.CostComponent{
+			Name:                fmt.Sprintf("Custom Instance RAM (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
+			Unit:                "gibibyte hour",
+			UnitMultiplier:      decimal.NewFromInt(mbOfRAM / 1024),
+			MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount * mbOfRAM / 1024))),
+			MonthlyDiscountPerc: sustainedUseDiscount,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("gcp"),
+				Region:        strPtr(region),
+				Service:       strPtr("Compute Engine"),
+				ProductFamily: strPtr("Compute"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("^%s%sCustom%sInstance Ram", purchaseOptionPrefix, instanceType, ext))},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr(fixPurchaseOption),
+			},
+		}
+
+		return []*schema.CostComponent{
+			cpuCostComponent,
+			ramCostComponent,
+		}
 	}
 
-	ramCostComponent := &schema.CostComponent{
-		Name:                fmt.Sprintf("Custom Instance RAM (Linux/UNIX, %s, %s)", purchaseOptionLabel(purchaseOption), machineType),
-		Unit:                "gibibyte hour",
-		UnitMultiplier:      decimal.NewFromInt(mbOfRAM / 1024),
-		MonthlyQuantity:     decimalPtr(qty.Mul(decimal.NewFromInt(instanceCount * mbOfRAM / 1024))),
-		MonthlyDiscountPerc: sustainedUseDiscount,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("gcp"),
-			Region:        strPtr(region),
-			Service:       strPtr("Compute Engine"),
-			ProductFamily: strPtr("Compute"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("^%s%sCustom%sInstance Ram", purchaseOptionPrefix, instanceType, ext))},
-			},
-		},
-		PriceFilter: &schema.PriceFilter{
-			PurchaseOption: strPtr(fixPurchaseOption),
-		},
-	}
-
-	return []*schema.CostComponent{
-		cpuCostComponent,
-		ramCostComponent,
-	}
 }
 
 // bootDiskCostComponent returns a cost component for Boot Disk storage for

--- a/internal/resources/google/compute_instance.go
+++ b/internal/resources/google/compute_instance.go
@@ -42,7 +42,7 @@ func (r *ComputeInstance) BuildResource() *schema.Resource {
 	costComponents := []*schema.CostComponent{}
 
 	if strings.Contains(r.MachineType, "custom") {
-		costComponents = append(costComponents, customComputeCostComponents(r.Region, r.MachineType, r.PurchaseOption, r.Size, nil)...)
+		costComponents = append(costComponents, customComputeCostComponents(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours)...)
 	} else {
 		costComponents = append(costComponents, computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours))
 	}

--- a/internal/resources/google/compute_instance.go
+++ b/internal/resources/google/compute_instance.go
@@ -37,9 +37,7 @@ func (r *ComputeInstance) PopulateUsage(u *schema.UsageData) {
 // This method is called after the resource is initialised by an IaC provider.
 // See providers folder for more information.
 func (r *ComputeInstance) BuildResource() *schema.Resource {
-	costComponents := []*schema.CostComponent{}
-
-	costComponents = append(costComponents, computeCostComponents(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours)...)
+	costComponents := computeCostComponents(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours)
 
 	if r.HasBootDisk {
 		costComponents = append(costComponents, bootDiskCostComponent(r.Region, r.BootDiskSize, r.BootDiskType))

--- a/internal/resources/google/compute_instance.go
+++ b/internal/resources/google/compute_instance.go
@@ -1,8 +1,6 @@
 package google
 
 import (
-	"strings"
-
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
 )
@@ -41,11 +39,7 @@ func (r *ComputeInstance) PopulateUsage(u *schema.UsageData) {
 func (r *ComputeInstance) BuildResource() *schema.Resource {
 	costComponents := []*schema.CostComponent{}
 
-	if strings.Contains(r.MachineType, "custom") {
-		costComponents = append(costComponents, customComputeCostComponents(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours)...)
-	} else {
-		costComponents = append(costComponents, computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours))
-	}
+	costComponents = append(costComponents, computeCostComponents(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours)...)
 
 	if r.HasBootDisk {
 		costComponents = append(costComponents, bootDiskCostComponent(r.Region, r.BootDiskSize, r.BootDiskType))

--- a/internal/resources/google/compute_instance.go
+++ b/internal/resources/google/compute_instance.go
@@ -1,6 +1,8 @@
 package google
 
 import (
+	"strings"
+
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
 )
@@ -37,8 +39,12 @@ func (r *ComputeInstance) PopulateUsage(u *schema.UsageData) {
 // This method is called after the resource is initialised by an IaC provider.
 // See providers folder for more information.
 func (r *ComputeInstance) BuildResource() *schema.Resource {
-	costComponents := []*schema.CostComponent{
-		computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours),
+	costComponents := []*schema.CostComponent{}
+
+	if strings.Contains(r.MachineType, "custom") {
+		costComponents = append(costComponents, customComputeCostComponents(r.Region, r.MachineType, r.PurchaseOption, r.Size, nil)...)
+	} else {
+		costComponents = append(costComponents, computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.Size, r.MonthlyHours))
 	}
 
 	if r.HasBootDisk {

--- a/internal/resources/google/compute_instance_group_manager.go
+++ b/internal/resources/google/compute_instance_group_manager.go
@@ -32,10 +32,7 @@ func (r *ComputeInstanceGroupManager) PopulateUsage(u *schema.UsageData) {
 // This method is called after the resource is initialised by an IaC provider.
 // See providers folder for more information.
 func (r *ComputeInstanceGroupManager) BuildResource() *schema.Resource {
-	costComponents := []*schema.CostComponent{
-		computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.TargetSize, nil),
-	}
-
+	costComponents := computeCostComponents(r.Region, r.MachineType, r.PurchaseOption, r.TargetSize, nil)
 	for _, disk := range r.Disks {
 		costComponents = append(costComponents, computeDiskCostComponent(r.Region, disk.Type, disk.Size, r.TargetSize))
 	}

--- a/internal/resources/google/compute_region_instance_group_manager.go
+++ b/internal/resources/google/compute_region_instance_group_manager.go
@@ -32,9 +32,7 @@ func (r *ComputeRegionInstanceGroupManager) PopulateUsage(u *schema.UsageData) {
 // This method is called after the resource is initialised by an IaC provider.
 // See providers folder for more information.
 func (r *ComputeRegionInstanceGroupManager) BuildResource() *schema.Resource {
-	costComponents := []*schema.CostComponent{
-		computeCostComponent(r.Region, r.MachineType, r.PurchaseOption, r.TargetSize, nil),
-	}
+	costComponents := computeCostComponents(r.Region, r.MachineType, r.PurchaseOption, r.TargetSize, nil)
 
 	for _, disk := range r.Disks {
 		costComponents = append(costComponents, computeDiskCostComponent(r.Region, disk.Type, disk.Size, r.TargetSize))

--- a/internal/resources/google/container_node_pool.go
+++ b/internal/resources/google/container_node_pool.go
@@ -1,6 +1,8 @@
 package google
 
 import (
+	"strings"
+
 	"github.com/shopspring/decimal"
 
 	"github.com/infracost/infracost/internal/resources"
@@ -44,8 +46,15 @@ func (r *ContainerNodePool) BuildResource() *schema.Resource {
 
 	poolSize := int64(1)
 
+	var costComponent *schema.CostComponent
+	if strings.Contains(r.NodeConfig.MachineType, "custom") {
+		costComponent = customComputeCostComponent(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil)
+	} else {
+		costComponent = computeCostComponent(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil)
+	}
+
 	costComponents := []*schema.CostComponent{
-		computeCostComponent(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil),
+		costComponent,
 		computeDiskCostComponent(r.Region, r.NodeConfig.DiskType, r.NodeConfig.DiskSize, poolSize),
 	}
 

--- a/internal/resources/google/container_node_pool.go
+++ b/internal/resources/google/container_node_pool.go
@@ -1,8 +1,6 @@
 package google
 
 import (
-	"strings"
-
 	"github.com/shopspring/decimal"
 
 	"github.com/infracost/infracost/internal/resources"
@@ -50,11 +48,7 @@ func (r *ContainerNodePool) BuildResource() *schema.Resource {
 		computeDiskCostComponent(r.Region, r.NodeConfig.DiskType, r.NodeConfig.DiskSize, poolSize),
 	}
 
-	if strings.Contains(r.NodeConfig.MachineType, "custom") {
-		costComponents = append(costComponents, customComputeCostComponents(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil)...)
-	} else {
-		costComponents = append(costComponents, computeCostComponent(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil))
-	}
+	costComponents = append(costComponents, computeCostComponents(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil)...)
 
 	if r.NodeConfig.LocalSSDCount > 0 {
 		costComponents = append(costComponents, scratchDiskCostComponent(r.Region, r.NodeConfig.PurchaseOption, int(r.NodeConfig.LocalSSDCount)))

--- a/internal/resources/google/container_node_pool.go
+++ b/internal/resources/google/container_node_pool.go
@@ -46,16 +46,14 @@ func (r *ContainerNodePool) BuildResource() *schema.Resource {
 
 	poolSize := int64(1)
 
-	var costComponent *schema.CostComponent
-	if strings.Contains(r.NodeConfig.MachineType, "custom") {
-		costComponent = customComputeCostComponent(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil)
-	} else {
-		costComponent = computeCostComponent(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil)
+	costComponents := []*schema.CostComponent{
+		computeDiskCostComponent(r.Region, r.NodeConfig.DiskType, r.NodeConfig.DiskSize, poolSize),
 	}
 
-	costComponents := []*schema.CostComponent{
-		costComponent,
-		computeDiskCostComponent(r.Region, r.NodeConfig.DiskType, r.NodeConfig.DiskSize, poolSize),
+	if strings.Contains(r.NodeConfig.MachineType, "custom") {
+		costComponents = append(costComponents, customComputeCostComponents(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil)...)
+	} else {
+		costComponents = append(costComponents, computeCostComponent(r.Region, r.NodeConfig.MachineType, r.NodeConfig.PurchaseOption, poolSize, nil))
 	}
 
 	if r.NodeConfig.LocalSSDCount > 0 {


### PR DESCRIPTION
**Why is this PR necessary**?
In order to provide the pricing for GCP custom instances (e.g custom-20-20480),, we need to adapt the attribute filters not to search by machine type but by the amount of CPU and RAM specified.

**What does it do**?
This PR creates a new function `customComputeCostComponent` similar to `computeCostComponent`. 
Also, it adds conditionals for verifying whether the node pool or the VM are using a custom machine type or not.

**References**:
https://github.com/infracost/infracost/issues/1447
https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#create
