### PR TITLE
chore: add debug line on client requests

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 
+	"github.com/infracost/infracost/internal/logging"
 	"github.com/infracost/infracost/internal/version"
 )
 
@@ -54,6 +55,8 @@ func (c *APIClient) doQueries(queries []GraphQLQuery) ([]gjson.Result, error) {
 }
 
 func (c *APIClient) doRequest(method string, path string, d interface{}) ([]byte, error) {
+	logging.Logger.Debugf("'%s' request to '%s' using trace_id: '%s'", method, path, c.uuid.String())
+
 	reqBody, err := json.Marshal(d)
 	if err != nil {
 		return []byte{}, errors.Wrap(err, "Error generating request body")


### PR DESCRIPTION
adds debug line to log similar to following:

```
'POST' request to '/graphql' using trace_id: '4af66d3e-38a7-4ef6-85ee-0b327125eca2'
```

which means we can trace the cli run through the graphql server.