### PR TITLE
fix: filter `repoMetadata` from telemetry

### DIFF
--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -13,6 +13,12 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+var (
+	excludedEnv = map[string]struct{}{
+		"repoMetadata": {},
+	}
+)
+
 type PricingAPIClient struct {
 	APIClient
 	Currency       string
@@ -80,9 +86,18 @@ func (c *PricingAPIClient) AddEvent(name string, env map[string]interface{}) err
 		return nil
 	}
 
+	filtered := make(map[string]interface{})
+	for k, v := range env {
+		if _, ok := excludedEnv[k]; ok {
+			continue
+		}
+
+		filtered[k] = v
+	}
+
 	d := map[string]interface{}{
 		"event": name,
-		"env":   env,
+		"env":   filtered,
 	}
 
 	_, err := c.doRequest("POST", "/event", d)


### PR DESCRIPTION
removes `repoMetadata` key from `env` sent to `/events`