### PR TITLE
fix: add linuxbrew to release path

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -81,6 +81,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Install brew
+        run: |
+          # Add brew to the path. This is required as brew is no longer supported by runner-images.
+          # see: https://github.com/actions/runner-images/issues/6283 for more context
+          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+          # Setup brew environment for coming steps.
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           token: ${{secrets.HOMEBREW_RELEASE_TOKEN}}


### PR DESCRIPTION
GitHub runner-images have removed homebrew from the $PATH on Ubuntu images. See https://github.com/actions/runner-images/issues/6283 for more information.

This changes add linuxbrew to the release path so that prior steps work as intended.