### PR TITLE
feat: Upload cloud resource ids when usage api is enabled

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -482,6 +482,8 @@ func (r *parallelRunner) runProjectConfig(ctx *config.ProjectContext) (*projectO
 		return nil, err
 	}
 
+	_ = r.uploadCloudResourceIDs(projects)
+
 	r.buildResources(projects)
 
 	spinnerOpts := ui.SpinnerOptions{
@@ -533,7 +535,8 @@ func (r *parallelRunner) runProjectConfig(ctx *config.ProjectContext) (*projectO
 
 	spinner.Success()
 
-	r.populateActualCosts(projects)
+	// Disabled for now
+	// r.populateActualCosts(projects)
 
 	out.projects = projects
 
@@ -542,6 +545,42 @@ func (r *parallelRunner) runProjectConfig(ctx *config.ProjectContext) (*projectO
 	}
 
 	return out, nil
+}
+
+func (r *parallelRunner) uploadCloudResourceIDs(projects []*schema.Project) error {
+	if r.runCtx.Config.UsageAPIEndpoint == "" || !r.hasCloudResourceIDToUpload(projects) {
+		return nil
+	}
+
+	spinnerOpts := ui.SpinnerOptions{
+		EnableLogging: r.runCtx.Config.IsLogging(),
+		NoColor:       r.runCtx.Config.NoColor,
+		Indent:        "  ",
+	}
+	spinner := ui.NewSpinner("Sending resource IDs to Infracost Cloud for usage estimates", spinnerOpts)
+	defer spinner.Fail()
+
+	for _, project := range projects {
+		if err := prices.UploadCloudResourceIDs(r.runCtx, project); err != nil {
+			logging.Logger.WithError(err).Debugf("failed to upload resource IDs for project %s", project.Name)
+			return err
+		}
+	}
+
+	spinner.Success()
+	return nil
+}
+
+func (r *parallelRunner) hasCloudResourceIDToUpload(projects []*schema.Project) bool {
+	for _, project := range projects {
+		for _, partial := range project.AllPartialResources() {
+			if len(partial.CloudResourceIds) > 0 {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (r *parallelRunner) buildResources(projects []*schema.Project) {
@@ -609,26 +648,26 @@ func (r *parallelRunner) fetchProjectUsage(projects []*schema.Project) map[*sche
 	return projectPtrToUsageMap
 }
 
-func (r *parallelRunner) populateActualCosts(projects []*schema.Project) {
-	if r.runCtx.Config.UsageAPIEndpoint != "" {
-		spinnerOpts := ui.SpinnerOptions{
-			EnableLogging: r.runCtx.Config.IsLogging(),
-			NoColor:       r.runCtx.Config.NoColor,
-			Indent:        "  ",
-		}
-		spinner := ui.NewSpinner("Retrieving actual costs from Infracost Cloud", spinnerOpts)
-		defer spinner.Fail()
-
-		for _, project := range projects {
-			if err := prices.PopulateActualCosts(r.runCtx, project); err != nil {
-				logging.Logger.WithError(err).Debugf("failed to retrieve actual costs for project %s", project.Name)
-				return
-			}
-		}
-
-		spinner.Success()
-	}
-}
+// func (r *parallelRunner) populateActualCosts(projects []*schema.Project) {
+//	if r.runCtx.Config.UsageAPIEndpoint != "" {
+//		spinnerOpts := ui.SpinnerOptions{
+//			EnableLogging: r.runCtx.Config.IsLogging(),
+//			NoColor:       r.runCtx.Config.NoColor,
+//			Indent:        "  ",
+//		}
+//		spinner := ui.NewSpinner("Retrieving actual costs from Infracost Cloud", spinnerOpts)
+//		defer spinner.Fail()
+//
+//		for _, project := range projects {
+//			if err := prices.PopulateActualCosts(r.runCtx, project); err != nil {
+//				logging.Logger.WithError(err).Debugf("failed to retrieve actual costs for project %s", project.Name)
+//				return
+//			}
+//		}
+//
+//		spinner.Success()
+//	}
+// }
 
 func (r *parallelRunner) runHCLProvider(wg *sync.WaitGroup, ctx *config.ProjectContext, usageFile *usage.UsageFile, out *projectOutput) {
 	defer func() {

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -576,7 +576,7 @@ func (r *parallelRunner) uploadCloudResourceIDs(projects []*schema.Project) erro
 func (r *parallelRunner) hasCloudResourceIDToUpload(projects []*schema.Project) bool {
 	for _, project := range projects {
 		for _, partial := range project.AllPartialResources() {
-			if len(partial.CloudResourceIds) > 0 {
+			if len(partial.CloudResourceIDs) > 0 {
 				return true
 			}
 		}

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -552,6 +552,8 @@ func (r *parallelRunner) uploadCloudResourceIDs(projects []*schema.Project) erro
 		return nil
 	}
 
+	r.runCtx.SetContextValue("uploadedResourceIds", true)
+
 	spinnerOpts := ui.SpinnerOptions{
 		EnableLogging: r.runCtx.Config.IsLogging(),
 		NoColor:       r.runCtx.Config.NoColor,
@@ -639,7 +641,7 @@ func (r *parallelRunner) fetchProjectUsage(projects []*schema.Project) map[*sche
 			logging.Logger.WithError(err).Debugf("failed to retrieve usage data for project %s", project.Name)
 			return nil
 		}
-
+		r.runCtx.SetContextValue("fetchedUsageData", true)
 		projectPtrToUsageMap[project] = usageMap
 	}
 

--- a/cmd/infracost/testdata/breakdown_with_actual_costs/breakdown_with_actual_costs.golden
+++ b/cmd/infracost/testdata/breakdown_with_actual_costs/breakdown_with_actual_costs.golden
@@ -10,9 +10,6 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_actual_costs
  ├─ On-demand backup storage                          100,004  GB       $10,000.40 
  ├─ Table data restored                               100,005  GB       $15,000.75 
  └─ Streams read request unit (sRRU)                  100,006  sRRUs         $0.02 
- └─ Actual costs (arn:aws_dynamodb_table)                                          
-    ├─ $0.005123 per some aws thing                     1,000  GB            $5.12 
-    └─ $0.045 per some other aws thing                  1,000  GB           $45.00 
                                                                                    
  OVERALL TOTAL                                                          $70,002.42 
 ──────────────────────────────────

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -419,12 +419,13 @@ func SetUUIDAttributes(moduleBlock *Block, block *hcl.Block) {
 }
 
 func newUniqueAttribute(name string, withCount bool) *hclsyntax.Attribute {
+	// prefix ids with hcl- so they can be identified as fake
 	var exp hclsyntax.Expression = &hclsyntax.LiteralValueExpr{
-		Val: cty.StringVal(uuid.NewString()),
+		Val: cty.StringVal("hcl-" + uuid.NewString()),
 	}
 
 	if withCount {
-		e, diags := hclsyntax.ParseExpression([]byte(`"`+uuid.NewString()+`-${count.index}"`), name, hcl.Pos{})
+		e, diags := hclsyntax.ParseExpression([]byte(`"hcl-`+uuid.NewString()+`-${count.index}"`), name, hcl.Pos{})
 		if !diags.HasErrors() {
 			exp = e
 		}

--- a/internal/prices/usages.go
+++ b/internal/prices/usages.go
@@ -179,7 +179,7 @@ func UploadCloudResourceIDs(ctx *config.RunContext, project *schema.Project) err
 
 	var resourceIDs []apiclient.ResourceIDAddress
 	for _, partial := range project.AllPartialResources() {
-		for _, resourceID := range partial.CloudResourceIds {
+		for _, resourceID := range partial.CloudResourceIDs {
 			resourceIDs = append(resourceIDs, apiclient.ResourceIDAddress{
 				Address:    partial.ResourceData.Address,
 				ResourceID: resourceID},

--- a/internal/providers/terraform/aws/aws.go
+++ b/internal/providers/terraform/aws/aws.go
@@ -38,6 +38,19 @@ func GetDefaultRefIDFunc(d *schema.ResourceData) []string {
 	return defaultRefs
 }
 
+func DefaultCloudResourceIDFunc(d *schema.ResourceData) []string {
+	arnAttr, ok := arnAttributeMap[d.Type]
+	if !ok {
+		arnAttr = "arn"
+	}
+
+	arn := d.Get(arnAttr).String()
+	if strings.HasPrefix(arn, "arn:aws:") && !strings.HasPrefix(arn, "arn:aws:hcl") {
+		return []string{arn}
+	}
+	return []string{}
+}
+
 func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {
 
 	specialContexts := make(map[string]interface{})

--- a/internal/providers/terraform/aws/aws.go
+++ b/internal/providers/terraform/aws/aws.go
@@ -39,6 +39,13 @@ func GetDefaultRefIDFunc(d *schema.ResourceData) []string {
 }
 
 func DefaultCloudResourceIDFunc(d *schema.ResourceData) []string {
+	var ids []string
+
+	id := d.Get("id").String()
+	if id != "" && id != "none" && !strings.HasPrefix(id, "hcl-") {
+		ids = append(ids, id)
+	}
+
 	arnAttr, ok := arnAttributeMap[d.Type]
 	if !ok {
 		arnAttr = "arn"
@@ -46,9 +53,10 @@ func DefaultCloudResourceIDFunc(d *schema.ResourceData) []string {
 
 	arn := d.Get(arnAttr).String()
 	if strings.HasPrefix(arn, "arn:aws:") && !strings.HasPrefix(arn, "arn:aws:hcl") {
-		return []string{arn}
+		ids = append(ids, arn)
 	}
-	return []string{}
+
+	return ids
 }
 
 func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {

--- a/internal/providers/terraform/azure/azure.go
+++ b/internal/providers/terraform/azure/azure.go
@@ -11,6 +11,10 @@ func GetDefaultRefIDFunc(d *schema.ResourceData) []string {
 	return []string{d.Get("id").String()}
 }
 
+func DefaultCloudResourceIDFunc(d *schema.ResourceData) []string {
+	return []string{}
+}
+
 func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{}
 }

--- a/internal/providers/terraform/google/google.go
+++ b/internal/providers/terraform/google/google.go
@@ -18,6 +18,10 @@ func GetDefaultRefIDFunc(d *schema.ResourceData) []string {
 	return defaultRefs
 }
 
+func DefaultCloudResourceIDFunc(d *schema.ResourceData) []string {
+	return []string{}
+}
+
 func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{}
 }

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -52,6 +52,7 @@ func (p *Parser) createPartialResource(d *schema.ResourceData, u *schema.UsageDa
 					NoPrice:     true,
 					SkipMessage: "Free resource.",
 				},
+				CloudResourceIds: registryItem.CloudResourceIDFunc(d),
 			}
 		}
 
@@ -62,7 +63,7 @@ func (p *Parser) createPartialResource(d *schema.ResourceData, u *schema.UsageDa
 		if registryItem.CoreRFunc != nil {
 			coreRes := registryItem.CoreRFunc(d)
 			if coreRes != nil {
-				return &schema.PartialResource{ResourceData: d, CoreResource: coreRes}
+				return &schema.PartialResource{ResourceData: d, CoreResource: coreRes, CloudResourceIds: registryItem.CloudResourceIDFunc(d)}
 			}
 		} else {
 			res := registryItem.RFunc(d, u)
@@ -71,7 +72,7 @@ func (p *Parser) createPartialResource(d *schema.ResourceData, u *schema.UsageDa
 					res.EstimationSummary = u.CalcEstimationSummary()
 				}
 
-				return &schema.PartialResource{ResourceData: d, Resource: res}
+				return &schema.PartialResource{ResourceData: d, Resource: res, CloudResourceIds: registryItem.CloudResourceIDFunc(d)}
 			}
 		}
 	}

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -52,7 +52,7 @@ func (p *Parser) createPartialResource(d *schema.ResourceData, u *schema.UsageDa
 					NoPrice:     true,
 					SkipMessage: "Free resource.",
 				},
-				CloudResourceIds: registryItem.CloudResourceIDFunc(d),
+				CloudResourceIDs: registryItem.CloudResourceIDFunc(d),
 			}
 		}
 
@@ -63,7 +63,7 @@ func (p *Parser) createPartialResource(d *schema.ResourceData, u *schema.UsageDa
 		if registryItem.CoreRFunc != nil {
 			coreRes := registryItem.CoreRFunc(d)
 			if coreRes != nil {
-				return &schema.PartialResource{ResourceData: d, CoreResource: coreRes, CloudResourceIds: registryItem.CloudResourceIDFunc(d)}
+				return &schema.PartialResource{ResourceData: d, CoreResource: coreRes, CloudResourceIDs: registryItem.CloudResourceIDFunc(d)}
 			}
 		} else {
 			res := registryItem.RFunc(d, u)
@@ -72,7 +72,7 @@ func (p *Parser) createPartialResource(d *schema.ResourceData, u *schema.UsageDa
 					res.EstimationSummary = u.CalcEstimationSummary()
 				}
 
-				return &schema.PartialResource{ResourceData: d, Resource: res, CloudResourceIds: registryItem.CloudResourceIDFunc(d)}
+				return &schema.PartialResource{ResourceData: d, Resource: res, CloudResourceIDs: registryItem.CloudResourceIDFunc(d)}
 			}
 		}
 	}

--- a/internal/providers/terraform/registry.go
+++ b/internal/providers/terraform/registry.go
@@ -24,26 +24,35 @@ func GetResourceRegistryMap() *ResourceRegistryMap {
 
 		// Merge all resource registries
 		for _, registryItem := range aws.ResourceRegistry {
+			if registryItem.CloudResourceIDFunc == nil {
+				registryItem.CloudResourceIDFunc = aws.DefaultCloudResourceIDFunc
+			}
 			resourceRegistryMap[registryItem.Name] = registryItem
 			resourceRegistryMap[registryItem.Name].DefaultRefIDFunc = aws.GetDefaultRefIDFunc
 		}
-		for _, registryItem := range createFreeResources(aws.FreeResources, aws.GetDefaultRefIDFunc) {
+		for _, registryItem := range createFreeResources(aws.FreeResources, aws.GetDefaultRefIDFunc, aws.DefaultCloudResourceIDFunc) {
 			resourceRegistryMap[registryItem.Name] = registryItem
 		}
 
 		for _, registryItem := range azure.ResourceRegistry {
+			if registryItem.CloudResourceIDFunc == nil {
+				registryItem.CloudResourceIDFunc = azure.DefaultCloudResourceIDFunc
+			}
 			resourceRegistryMap[registryItem.Name] = registryItem
 			resourceRegistryMap[registryItem.Name].DefaultRefIDFunc = azure.GetDefaultRefIDFunc
 		}
-		for _, registryItem := range createFreeResources(azure.FreeResources, azure.GetDefaultRefIDFunc) {
+		for _, registryItem := range createFreeResources(azure.FreeResources, azure.GetDefaultRefIDFunc, azure.DefaultCloudResourceIDFunc) {
 			resourceRegistryMap[registryItem.Name] = registryItem
 		}
 
 		for _, registryItem := range google.ResourceRegistry {
+			if registryItem.CloudResourceIDFunc == nil {
+				registryItem.CloudResourceIDFunc = google.DefaultCloudResourceIDFunc
+			}
 			resourceRegistryMap[registryItem.Name] = registryItem
 			resourceRegistryMap[registryItem.Name].DefaultRefIDFunc = google.GetDefaultRefIDFunc
 		}
-		for _, registryItem := range createFreeResources(google.FreeResources, google.GetDefaultRefIDFunc) {
+		for _, registryItem := range createFreeResources(google.FreeResources, google.GetDefaultRefIDFunc, google.DefaultCloudResourceIDFunc) {
 			resourceRegistryMap[registryItem.Name] = registryItem
 		}
 	})
@@ -88,14 +97,15 @@ func HasSupportedProvider(rType string) bool {
 	return strings.HasPrefix(rType, "aws_") || strings.HasPrefix(rType, "google_") || strings.HasPrefix(rType, "azurerm_")
 }
 
-func createFreeResources(l []string, defaultRefsFunc schema.ReferenceIDFunc) []*schema.RegistryItem {
+func createFreeResources(l []string, defaultRefsFunc schema.ReferenceIDFunc, resourceIdFunc schema.CloudResourceIDFunc) []*schema.RegistryItem {
 	freeResources := make([]*schema.RegistryItem, 0)
 	for _, resourceName := range l {
 		freeResources = append(freeResources, &schema.RegistryItem{
-			Name:             resourceName,
-			NoPrice:          true,
-			Notes:            []string{"Free resource."},
-			DefaultRefIDFunc: defaultRefsFunc,
+			Name:                resourceName,
+			NoPrice:             true,
+			Notes:               []string{"Free resource."},
+			DefaultRefIDFunc:    defaultRefsFunc,
+			CloudResourceIDFunc: resourceIdFunc,
 		})
 	}
 	return freeResources

--- a/internal/schema/core_resource.go
+++ b/internal/schema/core_resource.go
@@ -26,9 +26,13 @@ type PartialResource struct {
 	// Resource field is provided for backward compatibility with provider resource builders
 	// that have not yet been converted to build CoreResource's
 	Resource *Resource
+
+	// CloudResourceIds are collected during parsing in case they need to be uploaded to the
+	// Cloud Usage API to be used in the usage estimate calculations.
+	CloudResourceIds []string
 }
 
-// Build create a new Resource from the CoreResource, or (for backward compatibility) returns
+// BuildResource create a new Resource from the CoreResource, or (for backward compatibility) returns
 // a previously built Resource
 func BuildResource(partial *PartialResource, fetchedUsage *UsageData) *Resource {
 	var res *Resource

--- a/internal/schema/core_resource.go
+++ b/internal/schema/core_resource.go
@@ -27,9 +27,9 @@ type PartialResource struct {
 	// that have not yet been converted to build CoreResource's
 	Resource *Resource
 
-	// CloudResourceIds are collected during parsing in case they need to be uploaded to the
+	// CloudResourceIDs are collected during parsing in case they need to be uploaded to the
 	// Cloud Usage API to be used in the usage estimate calculations.
-	CloudResourceIds []string
+	CloudResourceIDs []string
 }
 
 // BuildResource create a new Resource from the CoreResource, or (for backward compatibility) returns

--- a/internal/schema/project.go
+++ b/internal/schema/project.go
@@ -99,6 +99,14 @@ func (p *Project) AllResources() []*Resource {
 	return resources
 }
 
+// AllPartialResources returns a pointer list of the current and past partial resources
+func (p *Project) AllPartialResources() []*PartialResource {
+	var resources []*PartialResource
+	resources = append(resources, p.PartialPastResources...)
+	resources = append(resources, p.PartialResources...)
+	return resources
+}
+
 // CalculateDiff calculates the diff of past and current resources
 func (p *Project) CalculateDiff() {
 	if p.HasDiff {

--- a/internal/schema/registry_item.go
+++ b/internal/schema/registry_item.go
@@ -3,6 +3,9 @@ package schema
 // ReferenceIDFunc is used to let references be built using non-standard IDs (anything other than d.Get("id").string)
 type ReferenceIDFunc func(d *ResourceData) []string
 
+// CloudResourceIDFunc is used to calculate the cloud resource ids (AWS ARN, Google HREF, etc...) associated with the resource
+type CloudResourceIDFunc func(d *ResourceData) []string
+
 type RegistryItem struct {
 	Name                string
 	Notes               []string
@@ -11,5 +14,6 @@ type RegistryItem struct {
 	ReferenceAttributes []string
 	CustomRefIDFunc     ReferenceIDFunc
 	DefaultRefIDFunc    ReferenceIDFunc
+	CloudResourceIDFunc CloudResourceIDFunc
 	NoPrice             bool
 }


### PR DESCRIPTION
This collects and uploads aws arns to the usage API when it is enabled.  There is additional work needed to collect non-arn aws ids and (eventually) google and azure ids.