### PR TITLE
fix: s3 bucket "No products found for Lifecycle transition" in us-east 2

### DIFF
--- a/internal/resources/aws/s3_storage_class_helpers.go
+++ b/internal/resources/aws/s3_storage_class_helpers.go
@@ -122,7 +122,7 @@ func s3LifecycleTransitionsCostComponent(region string, usageType string, operat
 			Region:     strPtr(region),
 			Service:    strPtr("AmazonS3"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", usageType))},
+				{Key: "usagetype", ValueRegex: strPtr(fmt.Sprintf("/%s$/i", usageType))},
 				{Key: "operation", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", operation))},
 			},
 		},


### PR DESCRIPTION
Relax the usage type regex since the usage type key for regions other than us-east-1 are prefixed by the region code, e.g. "USE2-Requests-Tier4"