### PR TITLE
fix: Fix GitHub comment truncation when it's too long

### DIFF
--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -24,7 +24,7 @@ import (
 var (
 	minOutputVersion     = "0.2"
 	maxOutputVersion     = "0.2"
-	GitHubMaxMessageSize = 262144
+	GitHubMaxMessageSize = 262144 // bytes
 )
 
 type ReportInput struct {

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -213,9 +213,12 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 	bufw.Flush()
 	msg := buf.Bytes()
 
-	msgLength := utf8.RuneCount(msg)
-	if markdownOpts.MaxMessageSize > 0 && msgLength > markdownOpts.MaxMessageSize {
-		truncateLength := msgLength - markdownOpts.MaxMessageSize
+	msgByteLength := len(msg)
+	if markdownOpts.MaxMessageSize > 0 && msgByteLength > markdownOpts.MaxMessageSize {
+		msgRuneLength := utf8.RuneCount(msg)
+		// truncation relies on rune length
+		q := float64(msgRuneLength) / float64(msgByteLength)
+		truncateLength := msgRuneLength - int(q * float64(markdownOpts.MaxMessageSize))
 		newLength := utf8.RuneCountInString(diffMsg) - truncateLength - 1000
 
 		opts.diffMsg = truncateMiddle(diffMsg, newLength, "\n\n...(truncated due to message size limit)...\n\n")


### PR DESCRIPTION
GitHub can't accept a comment body larger than 262144 bytes. The previous fix incorrectly used rune length of the message instead of byte length. Rune can be 1-4 bytes, thus the discrepancy between the values. As the truncateMiddle method uses rune length the q value is used to convert the length to rune one based on the message.