### PR TITLE
fix: module source path

### DIFF
--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -671,7 +671,8 @@ func (p *projectLocator) walkPaths(fullPath string, level int) []string {
 							continue
 						}
 
-						p.moduleCalls[realPath] = struct{}{}
+						mp := filepath.Join(fullPath, realPath)
+						p.moduleCalls[mp] = struct{}{}
 					}
 				}
 			}


### PR DESCRIPTION
fixes issue where module exclusion was not working as the path was not relative to the working directory. This meant that modules like `module/t` was being marked as `../module/t`. We now join the path to the working directory evaluating `..module/t` under the `./dev` path would result in `module/t`