### PR TITLE
fix(aws): fix DB instance cost component lookup

### DIFF
--- a/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
+++ b/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
@@ -26,3 +26,7 @@
 ∙ 2 were free:
   ∙ 1 x aws_waf_ipset
   ∙ 1 x aws_waf_rule
+Logs:
+
+level=warning msg="Multiple prices found for aws_waf_web_acl.my_waf Requests, using the first price"
+level=warning msg="Multiple prices found for aws_waf_web_acl.withoutUsage Requests, using the first price"

--- a/internal/providers/terraform/aws/waf_web_acl_test.go
+++ b/internal/providers/terraform/aws/waf_web_acl_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func TestWAFWebACLGoldenFile(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "waf_web_acl_test")
+	opts := tftest.DefaultGoldenFileOptions()
+	opts.CaptureLogs = true
+	tftest.GoldenFileResourceTestsWithOpts(t, "waf_web_acl_test", opts)
 }

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -222,6 +222,7 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 				ProductFamily: strPtr("Provisioned IOPS"),
 				AttributeFilters: []*schema.AttributeFilter{
 					{Key: "deploymentOption", Value: strPtr(deploymentOption)},
+					{Key: "groupDescription", Value: strPtr("RDS Provisioned IOPS")},
 					{Key: "databaseEngine", Value: strPtr("Any")},
 				},
 			},


### PR DESCRIPTION
This fixes the AWS DB instance so it uses the price for the io1 IOPs instead of the new gp3 IOPs.

We should add support for gp3 for RDS after https://github.com/hashicorp/terraform-provider-aws/pull/27670 is finalized. I had a quick look, but it's not clear yet what the attribute for throughput will be called.