### PR TITLE
fix: use min_count for node pool size if node_count not specified

### DIFF
--- a/internal/providers/terraform/azure/kubernetes_cluster.go
+++ b/internal/providers/terraform/azure/kubernetes_cluster.go
@@ -51,6 +51,12 @@ func NewAzureRMKubernetesCluster(d *schema.ResourceData, u *schema.UsageData) *s
 	if d.Get("default_node_pool.0.node_count").Type != gjson.Null {
 		nodeCount = decimal.NewFromInt(d.Get("default_node_pool.0.node_count").Int())
 	}
+
+	// if the node count is not set explicitly let's take the min_count.
+	if d.Get("default_node_pool.0.min_count").Type != gjson.Null && nodeCount.Equal(decimal.NewFromInt(1)) {
+		nodeCount = decimal.NewFromInt(d.Get("default_node_pool.0.min_count").Int())
+	}
+
 	if u != nil {
 		if v, ok := u.Get("default_node_pool").Map()["nodes"]; ok {
 			nodeCount = decimal.NewFromInt(v.Int())

--- a/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
+++ b/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
@@ -27,6 +27,12 @@ func NewAzureRMKubernetesClusterNodePool(d *schema.ResourceData, u *schema.Usage
 	if d.Get("node_count").Type != gjson.Null {
 		nodeCount = decimal.NewFromInt(d.Get("node_count").Int())
 	}
+
+	// if the node count is not set explicitly let's take the min_count.
+	if d.Get("min_count").Type != gjson.Null && nodeCount.Equal(decimal.NewFromInt(1)) {
+		nodeCount = decimal.NewFromInt(d.Get("min_count").Int())
+	}
+
 	if u != nil && u.Get("nodes").Exists() {
 		nodeCount = decimal.NewFromInt(u.Get("nodes").Int())
 	}

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
@@ -25,9 +25,12 @@
  └─ os_disk                                                                              
     └─ Storage (P10)                                             2  months        $39.42 
                                                                                          
- OVERALL TOTAL                                                                   $697.88 
+ azurerm_kubernetes_cluster_node_pool.with_min_count                                     
+ └─ Instance usage (pay as you go, Standard_DS2_v2)          1,460  hours        $213.16 
+                                                                                         
+ OVERALL TOTAL                                                                   $911.04 
 ──────────────────────────────────
-6 cloud resources were detected:
-∙ 5 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+7 cloud resources were detected:
+∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
@@ -49,3 +49,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "usage_basic_A2" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
   vm_size               = "Basic_A2"
 }
+
+resource "azurerm_kubernetes_cluster_node_pool" "with_min_count" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
+  vm_size               = "Standard_DS2_v2"
+  min_count             = 2
+  os_disk_type          = "Ephemeral"
+}

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
@@ -7,6 +7,13 @@
     └─ os_disk                                                                            
        └─ Storage (P10)                                           1  months        $19.71 
                                                                                           
+ azurerm_kubernetes_cluster.min_count                                                     
+ ├─ Uptime SLA                                                  730  hours         $73.00 
+ └─ default_node_pool                                                                     
+    ├─ Instance usage (pay as you go, Standard_DS2_v2)        2,190  hours        $319.74 
+    └─ os_disk                                                                            
+       └─ Storage (P10)                                           3  months        $59.13 
+                                                                                          
  azurerm_kubernetes_cluster.paid_5nc_32gb                                                 
  ├─ Uptime SLA                                                  730  hours         $73.00 
  └─ default_node_pool                                                                     
@@ -30,9 +37,9 @@
  └─ DNS                                                                                   
     └─ Hosted zone                                                1  months         $0.50 
                                                                                           
- OVERALL TOTAL                                                                  $1,497.62 
+ OVERALL TOTAL                                                                  $1,949.49 
 ──────────────────────────────────
-5 cloud resources were detected:
-∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+6 cloud resources were detected:
+∙ 5 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.tf
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.tf
@@ -44,6 +44,25 @@ resource "azurerm_kubernetes_cluster" "paid_D2SV2_3nc_128gb" {
   }
 }
 
+resource "azurerm_kubernetes_cluster" "min_count" {
+  name                = "example-aks1"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.example.name
+  dns_prefix          = "exampleaks1"
+  sku_tier            = "Paid"
+
+  default_node_pool {
+    name            = "default"
+    min_count       = 3
+    vm_size         = "Standard_DS2_v2"
+    os_disk_size_gb = 128
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
 resource "azurerm_kubernetes_cluster" "paid_5nc_32gb" {
   name                = "example-aks1"
   location            = "eastus"


### PR DESCRIPTION
Resolves issue where users specifying only `min_count` for node pools were receiving count = 1;