### PR TITLE
chore(aws): Add new region mapping for eu-south-2

### DIFF
--- a/internal/resources/aws/util.go
+++ b/internal/resources/aws/util.go
@@ -123,6 +123,7 @@ var RegionMapping = map[string]string{
 	"eu-west-1":       "EU (Ireland)",
 	"eu-west-2":       "EU (London)",
 	"eu-south-1":      "EU (Milan)",
+	"eu-south-2":      "EU (Spain)",
 	"eu-west-3":       "EU (Paris)",
 	"eu-north-1":      "EU (Stockholm)",
 	"ap-east-1":       "Asia Pacific (Hong Kong)",


### PR DESCRIPTION
Currently, CPAPI doesn't have any products with this region or location. However, this will automatically start working when the products are added.

https://aws.amazon.com/blogs/aws/now-open-aws-region-in-spain/