### PR TITLE
enhance(aws): Skip compute cost component when AWS instance has an EC2 host

### DIFF
--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -21,6 +21,7 @@ func getInstanceRegistryItem() *schema.RegistryItem {
 		RFunc: NewInstance,
 		ReferenceAttributes: []string{
 			"ebs_block_device.#.volume_id",
+			"host_id",
 			"launch_template.#.id",
 			"launch_template.#.name",
 		},
@@ -76,6 +77,7 @@ func NewInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	monitoring = d.GetBoolOrDefault("monitoring", monitoring)
 	cpuCredits = d.GetStringOrDefault("credit_specification.0.cpu_credits", cpuCredits)
 	tenancy = d.GetStringOrDefault("tenancy", tenancy)
+	hasHost := len(d.References("host_id")) > 0
 
 	a := &aws.Instance{
 		Address:          d.Address,
@@ -87,6 +89,7 @@ func NewInstance(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 		EBSOptimized:     ebsOptimized,
 		EnableMonitoring: monitoring,
 		CPUCredits:       cpuCredits,
+		HasHost:          hasHost,
 	}
 
 	a.RootBlockDevice = &aws.EBSVolume{

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.golden
@@ -1,6 +1,9 @@
 
  Name                                                            Monthly Qty  Unit                  Monthly Cost 
                                                                                                                  
+ aws_ec2_host.mac                                                                                                
+ └─ EC2 Dedicated Host (on-demand, mac1)                                 730  hours                      $790.59 
+                                                                                                                 
  aws_instance.cnvr_1yr_all_upfront                                                                               
  ├─ Instance usage (Linux/UNIX, reserved, t3.medium)                     730  hours                        $0.00 
  └─ root_block_device                                                                                            
@@ -174,14 +177,18 @@
  └─ root_block_device                                                                                            
     └─ Storage (general purpose SSD, gp2)                                  8  GB                           $0.80 
                                                                                                                  
- OVERALL TOTAL                                                                                         $1,294.12 
+ aws_instance.with_host                                                                                          
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                 50  GB                           $5.00 
+                                                                                                                 
+ OVERALL TOTAL                                                                                         $2,089.71 
 ──────────────────────────────────
-30 cloud resources were detected:
-∙ 28 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+32 cloud resources were detected:
+∙ 30 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x aws_launch_template
 ∙ 1 is not supported yet, see https://infracost.io/requested-resources:
   ∙ 1 x aws_instance
 Logs:
 
-level=warning msg="Skipping resource aws_instance.instance1_hostTenancy. Infracost currently does not support host tenancy for AWS EC2 instances"
+level=warning msg="Skipping resource aws_instance.instance1_hostTenancy. Infracost currently does not support host tenancy for AWS EC2 instances without Host ID set up"

--- a/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/instance_test/instance_test.tf
@@ -253,3 +253,18 @@ resource "aws_instance" "instance_detailedMonitoring_withMonthlyHours" {
   instance_type = "m3.large"
   monitoring    = true
 }
+
+resource "aws_ec2_host" "mac" {
+  instance_type     = "mac1.metal"
+  availability_zone = "us-east-2a"
+}
+
+resource "aws_instance" "with_host" {
+  ami           = "fake_ami"
+  instance_type = "fake" # TF requires it
+  host_id       = aws_ec2_host.mac.id
+
+  root_block_device {
+    volume_size = 50
+  }
+}


### PR DESCRIPTION
Fixes #2103.