### PR TITLE
fix: pass fresh evaluation lookup map to child module evaluation

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -494,3 +494,16 @@ func TestBreakdownWithNestedForeach(t *testing.T) {
 		nil,
 	)
 }
+
+func TestBreakdownWithDependsUponModule(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path",
+			path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		nil,
+	)
+}

--- a/cmd/infracost/testdata/breakdown_with_depends_upon_module/breakdown_with_depends_upon_module.golden
+++ b/cmd/infracost/testdata/breakdown_with_depends_upon_module/breakdown_with_depends_upon_module.golden
@@ -1,0 +1,17 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_depends_upon_module
+
+ Name                                            Monthly Qty  Unit   Monthly Cost 
+                                                                                  
+ module.database.module.primary.aws_eip.test[0]                                   
+ └─ IP address (if unused)                               730  hours         $3.65 
+                                                                                  
+ module.database.module.replica.aws_eip.test[0]                                   
+ └─ IP address (if unused)                               730  hours         $3.65 
+                                                                                  
+ OVERALL TOTAL                                                              $7.30 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_depends_upon_module/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_depends_upon_module/main.tf
@@ -1,0 +1,9 @@
+module "database" {
+  source = "./tf-rds"
+
+  depends_on = [module.modulePost]
+}
+
+module "modulePost" {
+  source = "./tf-module"
+}

--- a/cmd/infracost/testdata/breakdown_with_depends_upon_module/tf-module/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_depends_upon_module/tf-module/main.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "test" {}

--- a/cmd/infracost/testdata/breakdown_with_depends_upon_module/tf-rds/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_depends_upon_module/tf-rds/main.tf
@@ -1,0 +1,7 @@
+module "primary" {
+  source = "./test"
+}
+
+module "replica" {
+  source = "./test"
+}

--- a/cmd/infracost/testdata/breakdown_with_depends_upon_module/tf-rds/test/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_depends_upon_module/tf-rds/test/main.tf
@@ -1,0 +1,8 @@
+resource "aws_eip" "test" {
+  count = 1
+}
+
+resource "aws_eip" "count_zero" {
+  count = 0
+}
+

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -275,7 +275,7 @@ func (e *Evaluator) evaluateModules() {
 			e.workingDir,
 			vars,
 			e.moduleMetadata,
-			e.visitedModules,
+			map[string]map[string]cty.Value{},
 			e.workspace,
 			e.blockBuilder,
 			nil,
@@ -350,19 +350,19 @@ func (e *Evaluator) expandDynamicBlock(b *Block) {
 //
 // value of:
 //
-//		test.test
-//			id: test
-//			arn: test-arn
+//	test.test
+//		id: test
+//		arn: test-arn
 //
 // that gets expanded should be:
 //
-//	   test.test
-//			a:
-//			  id: test
-//			  arn: test-arn
-//			b:
-//			  id: test
-//			  arn: test-arn
+//	test.test
+//		a:
+//		  id: test
+//		  arn: test-arn
+//		b:
+//		  id: test
+//		  arn: test-arn
 //
 // and not:
 //
@@ -375,10 +375,10 @@ func (e *Evaluator) expandDynamicBlock(b *Block) {
 //
 // which means that blocks written like:
 //
-//		resource "aws_eip" "nat_gateway" {
-//  		for_each   = test.test
+//	resource "aws_eip" "nat_gateway" {
+//		for_each   = test.test
 //			...
-//		}
+//	}
 //
 // will expand correctly to: aws_eip.nat_gateway[a], aws_eip.nat_gateway[b]. Rather than aws_eip.nat_gateway[id], aws_eip.nat_gateway[a] ...
 func (e *Evaluator) expandBlockForEaches(blocks Blocks) Blocks {


### PR DESCRIPTION
fixes: https://github.com/infracost/infracost/issues/1983

Resolves issue where a `depends_upon` block that held a module lower down in the file context was causing the module to re-evaluate. This is because the first evalutation of the file sees that the input for `depends_upon` was a `cty.unkown` value because the context did not contain the evaluation context. When the module has been properly evaluated and exported to outputs, e.g. `module.mymodule` we then reevaluate the module. However, this time the module uses the old module contained in `e.evaluatedModules` cache, meaning it had `Blocks` that were marked as expanded but where not added to the `EvaluationContext`. Therefore they were emitted from the output. We should always pass a fresh `evaluatedModules` cache to a child Evaluator.