### PR TITLE
fix: merge terraform outputs with built naive regexp output mocks

### DIFF
--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/breakdown_terragrunt_hcldeps_output.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/breakdown_terragrunt_hcldeps_output.golden
@@ -63,4 +63,5 @@ Module path: prod2
 ∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 
 Err:
+Warning: Input values were not provided for following Terraform variables: "variable.unspecified_variable". Use --terraform-var-file or --terraform-var to specify them.
 

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
@@ -15,10 +15,35 @@ terraform {
 }
 
 inputs = {
-  instance_type = dependency.test.outputs.aws_instance_type
+  instance_type                 = dependency.test.outputs.aws_instance_type
   root_block_device_volume_size = 50
-  block_device_volume_size = 100
-  block_device_iops = dependency.test2.outputs.block_iops
-  
+  block_device_volume_size      = 100
+  block_device_iops             = dependency.test2.outputs.block_iops
+
+  test_input = {
+    input1 = dependency.test2.outputs.obj.foo
+    input2 = dependency.test2.outputs.obj.bar
+    input3 = dependency.test2.outputs.improper_mock.foo
+    input4 = dependency.test2.outputs.improper_mock.bar
+    input5 = dependency.test2.outputs.list[0].foo
+    input6 = dependency.test2.outputs.list[1].bar
+    input7 = dependency.test2.outputs.improper_mock2[0].foo
+    input8 = dependency.test2.outputs.map["foo"].bar
+    input9 = dependency.test2.outputs.map["baz"].bat
+    input10 = dependency.test2.outputs.improper_mock3["foo"].bar
+    input11 = dependency.test2.outputs.not_exist.foo
+    input12 = dependency.test2.outputs.not_exist_list[0].foo
+    input13 = dependency.test2.outputs.not_exist_map["foo"].bar
+    input14 = dependency.test2.outputs.list_simple[0]
+    input15 = dependency.test2.outputs.list_simple[0]
+    input16 = dependency.test2.outputs.map_simple["foo"]
+    input17 = dependency.test2.outputs.map_simple["bar"]
+    input18 = dependency.test2.outputs.list_not_exist_simple[0]
+    input19 = dependency.test2.outputs.map_not_exist_simple["foo"]
+    input20 = dependency.test2.outputs.list_simple_existing[1]
+    input21 = dependency.test2.outputs.list_existing[1].foo
+    input22 = dependency.test2.outputs.map_existing["bar"]
+  }
+
   hello_world_function_memory_size = 512
 }

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
@@ -43,6 +43,10 @@ inputs = {
     input20 = dependency.test2.outputs.list_simple_existing[1]
     input21 = dependency.test2.outputs.list_existing[1].foo
     input22 = dependency.test2.outputs.map_existing["bar"]
+    input23 = dependency.test2.outputs.bad
+    input24 = dependency.test2.outputs.bad_list[0]
+    input24 = dependency.test2.outputs.good_list_bad_prop[0].id
+    input24 = dependency.test2.outputs.bad_map["test"]
   }
 
   hello_world_function_memory_size = 512

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example/main.tf
@@ -23,6 +23,10 @@ variable "hello_world_function_memory_size" {
   type        = number
 }
 
+variable "test_input" {
+  type        = object({})
+}
+
 resource "aws_instance" "web_app" {
   ami           = "ami-674cbc1e"
   instance_type = var.instance_type

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example2/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example2/main.tf
@@ -23,6 +23,9 @@ variable "hello_world_function_memory_size" {
   type        = number
 }
 
+variable "unspecified_variable" {
+}
+
 resource "aws_instance" "web_app" {
   ami           = "ami-674cbc1e"
   instance_type = var.instance_type
@@ -47,6 +50,33 @@ resource "aws_lambda_function" "hello_world" {
   memory_size   = var.hello_world_function_memory_size
 }
 
+locals {
+  bad  = format("%s", var.unspecified_variable.id[0])
+  bad2 = format("%s", var.unspecified_variable.id[0])
+}
+
+output "bad" {
+  value = local.bad
+}
+
+output "bad_list" {
+  value = [local.bad2]
+}
+
+output "good_list_bad_prop" {
+  value = [
+    {
+      id : local.bad
+    }
+  ]
+}
+
+output "bad_map" {
+  value = tomap({
+    "test" : local.bad
+  })
+}
+
 output "block_iops" {
   value = 600
 }
@@ -64,7 +94,7 @@ output "list_simple" {
 }
 
 output "list_existing" {
-  value = [{"foo": "bar"}]
+  value = [{ "foo" : "bar" }]
 }
 
 output "list_simple_existing" {

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example2/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example2/main.tf
@@ -51,6 +51,50 @@ output "block_iops" {
   value = 600
 }
 
+output "obj" {
+  value = {}
+}
+
+output "list" {
+  value = []
+}
+
+output "list_simple" {
+  value = []
+}
+
+output "list_existing" {
+  value = [{"foo": "bar"}]
+}
+
+output "list_simple_existing" {
+  value = ["foo"]
+}
+
+output "map" {
+  value = tomap({})
+}
+
+output "map_existing" {
+  value = tomap({ "foo" : "bar" })
+}
+
+output "map_simple" {
+  value = tomap({})
+}
+
+output "improper_mock" {
+  value = "invalid-mock-of-a-complex-type"
+}
+
+output "improper_mock2" {
+  value = "invalid-mock-of-a-complex-type"
+}
+
+output "improper_mock3" {
+  value = "invalid-mock-of-a-complex-type"
+}
+
 output "test_object_type" {
   value = aws_instance.web_app
 }

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/prod/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/prod/terragrunt.hcl
@@ -7,10 +7,11 @@ terraform {
 }
 
 inputs = {
-  instance_type = "m5.4xlarge"
+  instance_type                 = "m5.4xlarge"
   root_block_device_volume_size = 100
-  block_device_volume_size = 1000
-  block_device_iops = 800
-  
+  block_device_volume_size      = 1000
+  block_device_iops             = 800
+  test_input                    = {}
+
   hello_world_function_memory_size = 1024
 }

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -274,8 +274,12 @@ func buildObject(traversal hcl.Traversal, value cty.Value, mock cty.Value, i int
 			return cty.ObjectVal(valueMap)
 		}
 
-		val := buildObject(traversal, cty.ObjectVal(make(map[string]cty.Value)), mock, i+1)
-		valueMap[k] = val
+		if len(traversal)-1 == i {
+			valueMap[k] = mock
+		} else {
+			valueMap[k] = buildObject(traversal, cty.ObjectVal(make(map[string]cty.Value)), mock, i+1)
+		}
+
 		return cty.ObjectVal(valueMap)
 	}
 

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -121,7 +121,7 @@ func (attr *Attribute) AsString() string {
 // that the Context carries.
 func (attr *Attribute) Value() cty.Value {
 	if attr == nil {
-		return cty.NilVal
+		return cty.DynamicVal
 	}
 
 	attr.Logger.Debug("fetching attribute value")
@@ -132,7 +132,6 @@ func (attr *Attribute) value(retry int) (ctyVal cty.Value) {
 	defer func() {
 		if err := recover(); err != nil {
 			attr.Logger.Debugf("could not evaluate value for attr: %s. This is most likely an issue in the underlying hcl/go-cty libraries and can be ignored, but we log the stacktrace for debugging purposes. Err: %s\n%s", attr.Name(), err, debug.Stack())
-			ctyVal = cty.NilVal
 		}
 	}()
 
@@ -240,6 +239,10 @@ func traverseVarAndSetCtx(ctx *hcl.EvalContext, traversal hcl.Traversal, mock ct
 func buildObject(traversal hcl.Traversal, ob map[string]cty.Value, mock cty.Value, i int) map[string]cty.Value {
 	if i > len(traversal)-1 {
 		return ob
+	}
+
+	if ob == nil {
+		ob = make(map[string]cty.Value)
 	}
 
 	traverser := traversal[i]

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -131,7 +131,8 @@ func (attr *Attribute) Value() cty.Value {
 func (attr *Attribute) value(retry int) (ctyVal cty.Value) {
 	defer func() {
 		if err := recover(); err != nil {
-			attr.Logger.Debugf("could not evaluate value for attr: %s. This is most likely an issue in the underlying hcl/go-cty libraries and can be ignored, but we log the stacktrace for debugging purposes. Err: %s\n%s", attr.Name(), err, debug.Stack())
+			trace := debug.Stack()
+			attr.Logger.Debugf("could not evaluate value for attr: %s. This is most likely an issue in the underlying hcl/go-cty libraries and can be ignored, but we log the stacktrace for debugging purposes. Err: %s\n%s", attr.Name(), err, trace)
 		}
 	}()
 
@@ -225,41 +226,39 @@ func traverseVarAndSetCtx(ctx *hcl.EvalContext, traversal hcl.Traversal, mock ct
 		return
 	}
 
-	ob := ctx.Variables[rootName].AsValueMap()
-	if ob == nil {
-		ob = make(map[string]cty.Value)
+	ob := ctx.Variables[rootName]
+	if ob.IsNull() || !ob.IsKnown() {
+		ob = cty.ObjectVal(make(map[string]cty.Value))
 	}
 
-	ob = buildObject(traversal, ob, mock, 0)
-	ctx.Variables[rootName] = cty.ObjectVal(ob)
+	ctx.Variables[rootName] = buildObject(traversal, ob, mock, 0)
 }
 
 // buildObject builds an attribute map from the traversal. It fills any missing attributes that are
 // defined by the traversal.
-func buildObject(traversal hcl.Traversal, ob map[string]cty.Value, mock cty.Value, i int) map[string]cty.Value {
+func buildObject(traversal hcl.Traversal, value cty.Value, mock cty.Value, i int) cty.Value {
 	if i > len(traversal)-1 {
-		return ob
-	}
-
-	if ob == nil {
-		ob = make(map[string]cty.Value)
+		return value
 	}
 
 	traverser := traversal[i]
+	valueMap := value.AsValueMap()
+	if valueMap == nil {
+		valueMap = make(map[string]cty.Value)
+	}
 
 	// traverse splat is a special holding type which means we want to traverse all the attributes on the map.
 	if _, ok := traverser.(hcl.TraverseSplat); ok {
-		for k, v := range ob {
+		for k, v := range valueMap {
 			if v.Type().IsObjectType() {
-				valueMap := v.AsValueMap()
-				ob[k] = cty.ObjectVal(buildObject(traversal, valueMap, mock, i+1))
+				valueMap[k] = buildObject(traversal, v, mock, i+1)
 				continue
 			}
 
-			ob[k] = v
+			valueMap[k] = v
 		}
 
-		return ob
+		return cty.ObjectVal(valueMap)
 	}
 
 	if index, ok := traverser.(hcl.TraverseIndex); ok {
@@ -270,15 +269,14 @@ func buildObject(traversal hcl.Traversal, ob map[string]cty.Value, mock cty.Valu
 
 		k := kc.AsString()
 
-		if vv, exists := ob[k]; exists {
-			val := buildObject(traversal, vv.AsValueMap(), mock, i+1)
-			ob[k] = cty.ObjectVal(val)
-			return ob
+		if vv, exists := valueMap[k]; exists {
+			valueMap[k] = buildObject(traversal, vv, mock, i+1)
+			return cty.ObjectVal(valueMap)
 		}
 
-		val := buildObject(traversal, make(map[string]cty.Value), mock, i+1)
-		ob[k] = cty.ObjectVal(val)
-		return ob
+		val := buildObject(traversal, cty.ObjectVal(make(map[string]cty.Value)), mock, i+1)
+		valueMap[k] = val
+		return cty.ObjectVal(valueMap)
 	}
 
 	if v, ok := traverser.(hcl.TraverseAttr); ok {
@@ -287,26 +285,26 @@ func buildObject(traversal hcl.Traversal, ob map[string]cty.Value, mock cty.Valu
 			// then we should return here. It's most likely that we weren't able to
 			// get the full variable calls for the context, so resetting the value could
 			// be harmful.
-			if _, exists := ob[v.Name]; exists && mock.Type() == cty.String {
-				return ob
+			if _, exists := valueMap[v.Name]; exists && mock.Type() == cty.String {
+				return value
 			}
 
-			ob[v.Name] = mock
-			return ob
+			valueMap[v.Name] = mock
+			return cty.ObjectVal(valueMap)
 		}
 
-		if vv, exists := ob[v.Name]; exists {
+		if vv, exists := valueMap[v.Name]; exists {
 			if isList(vv) {
 				items := make([]cty.Value, vv.LengthInt())
 				it := vv.ElementIterator()
 				for it.Next() {
 					key, sourceItem := it.Element()
-					val := buildObject(traversal, sourceItem.AsValueMap(), mock, i+1)
+					val := buildObject(traversal, sourceItem, mock, i+1)
 					i, _ := key.AsBigFloat().Int64()
-					items[i] = cty.ObjectVal(val)
+					items[i] = val
 				}
-				ob[v.Name] = cty.TupleVal(items)
-				return ob
+				valueMap[v.Name] = cty.TupleVal(items)
+				return cty.ObjectVal(valueMap)
 			}
 
 			next := traversal[i+1]
@@ -316,17 +314,15 @@ func buildObject(traversal hcl.Traversal, ob map[string]cty.Value, mock cty.Valu
 				}
 			}
 
-			val := buildObject(traversal, vv.AsValueMap(), mock, i+1)
-			ob[v.Name] = cty.ObjectVal(val)
-			return ob
+			valueMap[v.Name] = buildObject(traversal, vv, mock, i+1)
+			return cty.ObjectVal(valueMap)
 		}
 
-		val := buildObject(traversal, make(map[string]cty.Value), mock, i+1)
-		ob[v.Name] = cty.ObjectVal(val)
-		return ob
+		valueMap[v.Name] = buildObject(traversal, cty.ObjectVal(make(map[string]cty.Value)), mock, i+1)
+		return cty.ObjectVal(valueMap)
 	}
 
-	return buildObject(traversal, ob, mock, i+1)
+	return buildObject(traversal, value, mock, i+1)
 }
 
 // findCorrectCtx uses name to find the correct context to target. findCorrectCtx returns the first

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -1,12 +1,15 @@
 package terraform
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime/debug"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -253,10 +256,7 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 //  3. we then evaluate the Terraform project built by Terragrunt storing any outputs so that we can use
 //     these for further runTerragrunt calls that use the dependency outputs.
 func (p *TerragruntHCLProvider) runTerragrunt(opts *tgoptions.TerragruntOptions) (*terragruntWorkingDirInfo, error) {
-	outputs, err := p.fetchDependencyOutputs(opts)
-	if err != nil {
-		return nil, err
-	}
+	outputs := p.fetchDependencyOutputs(opts)
 
 	terragruntConfig, err := tgconfig.ParseConfigFile(opts.TerragruntConfigPath, opts, nil, &outputs)
 	if err != nil {
@@ -368,8 +368,167 @@ func convertToCtyWithJson(val interface{}) (cty.Value, error) {
 	return ctyJsonVal.Value, nil
 }
 
-// fetchDependencyOutputs returns the Terraform outputs from the dependencies of Terragrunt file provided in the opts input.
-func (p *TerragruntHCLProvider) fetchDependencyOutputs(opts *tgoptions.TerragruntOptions) (cty.Value, error) {
+var (
+	depRegexp   = regexp.MustCompile(`dependency\.[\w.\[\]"]+`)
+	indexRegexp = regexp.MustCompile(`(\w+)\[(\d+)]`)
+	mapRegexp   = regexp.MustCompile(`(\w+)\["([\w\d]+)"]`)
+)
+
+func (p *TerragruntHCLProvider) fetchDependencyOutputs(opts *tgoptions.TerragruntOptions) cty.Value {
+	moduleOutputs, err := p.fetchModuleOutputs(opts)
+	if err != nil {
+		p.logger.WithError(err).Debug("failed to fetch real module outputs, defaulting to mocked outputs from file regexp")
+	}
+
+	file, err := os.Open(opts.TerragruntConfigPath)
+	if err != nil {
+		p.logger.WithError(err).Debug("could not open Terragrunt file for dependency regexps")
+		return moduleOutputs
+	}
+
+	var matches []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// skip any commented out lines
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		match := depRegexp.FindString(line)
+		if match != "" {
+			matches = append(matches, match)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		p.logger.WithError(err).Debug("error scanning Terragrunt file lines matching whole file with regexp")
+
+		b, err := os.ReadFile(opts.TerragruntConfigPath)
+		if err != nil {
+			p.logger.WithError(err).Debug("could not read Terragrunt file for dependency regxps")
+		}
+
+		matches = depRegexp.FindAllString(string(b), -1)
+	}
+
+	if len(matches) == 0 {
+		return moduleOutputs
+	}
+
+	valueMap := moduleOutputs.AsValueMap()
+
+	for _, match := range matches {
+		pieces := strings.Split(match, ".")
+		valueMap = mergeObjectWithDependencyMap(valueMap, pieces[1:])
+	}
+
+	return cty.ObjectVal(valueMap)
+}
+
+func mergeObjectWithDependencyMap(valueMap map[string]cty.Value, pieces []string) map[string]cty.Value {
+	if valueMap == nil {
+		valueMap = make(map[string]cty.Value)
+	}
+
+	if len(pieces) == 0 {
+		return valueMap
+	}
+
+	key := pieces[0]
+	indexKeys := indexRegexp.FindStringSubmatch(key)
+	if len(indexKeys) != 0 {
+		index, _ := strconv.Atoi(indexKeys[2])
+		return mergeListWithDependencyMap(valueMap, pieces, indexKeys[1], index)
+	}
+
+	mapKeys := mapRegexp.FindStringSubmatch(key)
+	if len(mapKeys) != 0 {
+		key = mapKeys[1]
+		pieces = append([]string{pieces[0], mapKeys[2]}, pieces[1:]...)
+	}
+
+	if len(pieces) == 1 {
+		if _, ok := valueMap[key]; ok {
+			return valueMap
+		}
+
+		valueMap[key] = cty.StringVal(fmt.Sprintf("%s-mock", key))
+		return valueMap
+	}
+
+	if v, ok := valueMap[key]; ok {
+		if v.CanIterateElements() {
+			valueMap[key] = cty.ObjectVal(mergeObjectWithDependencyMap(v.AsValueMap(), pieces[1:]))
+			return valueMap
+		}
+
+		valueMap[key] = cty.ObjectVal(mergeObjectWithDependencyMap(make(map[string]cty.Value), pieces[1:]))
+		return valueMap
+	}
+
+	valueMap[key] = cty.ObjectVal(mergeObjectWithDependencyMap(make(map[string]cty.Value), pieces[1:]))
+	return valueMap
+}
+
+func mergeListWithDependencyMap(valueMap map[string]cty.Value, pieces []string, key string, index int) map[string]cty.Value {
+	if len(pieces) == 1 {
+		if v, ok := valueMap[key]; ok && (v.Type().IsListType() || v.Type().IsTupleType()) {
+			m := v.Type().GoString()
+			log.Println(m)
+			if v.HasIndex(cty.NumberIntVal(int64(index))).True() {
+				return valueMap
+			}
+
+			existing := v.AsValueSlice()
+			vals := make([]cty.Value, index+1)
+			copy(vals, existing)
+
+			for i := len(existing); i <= index; i++ {
+				vals[i] = cty.StringVal(fmt.Sprintf("%s-%d-mock", key, i))
+			}
+
+			valueMap[key] = cty.TupleVal(vals)
+			return valueMap
+		}
+
+		vals := make([]cty.Value, index+1)
+		for i := 0; i <= index; i++ {
+			vals[i] = cty.StringVal(fmt.Sprintf("%s-%d-mock", key, i))
+		}
+
+		valueMap[key] = cty.ListVal(vals)
+		return valueMap
+	}
+
+	if v, ok := valueMap[key]; ok && (v.Type().IsListType() || v.Type().IsTupleType()) {
+		if v.HasIndex(cty.NumberIntVal(int64(index))).True() {
+			return valueMap
+		}
+
+		existing := v.AsValueSlice()
+		vals := make([]cty.Value, index+1)
+		copy(vals, existing)
+
+		for i := len(existing); i <= index; i++ {
+			vals[i] = cty.ObjectVal(mergeObjectWithDependencyMap(map[string]cty.Value{}, pieces[1:]))
+		}
+
+		valueMap[key] = cty.TupleVal(vals)
+		return valueMap
+	}
+
+	vals := make([]cty.Value, index+1)
+	for i := 0; i <= index; i++ {
+		vals[i] = cty.ObjectVal(mergeObjectWithDependencyMap(map[string]cty.Value{}, pieces[1:]))
+	}
+
+	valueMap[key] = cty.ListVal(vals)
+	return valueMap
+}
+
+// fetchModuleOutputs returns the Terraform outputs from the dependencies of Terragrunt file provided in the opts input.
+func (p *TerragruntHCLProvider) fetchModuleOutputs(opts *tgoptions.TerragruntOptions) (cty.Value, error) {
 	outputs := cty.MapVal(map[string]cty.Value{
 		"outputs": cty.ObjectVal(map[string]cty.Value{
 			"mock": cty.StringVal("val"),


### PR DESCRIPTION
* Resolves issues where Terragrunt cannot parse an input file because the dependency outputs are not available. This can happen if outputs are mocked and a complex object or list is unavailable. This PR fixes this by merging actual Terraform outputs with missing outputs identified using regular expressions.
* Resolves an issue where mocked values which used index entries were returning an incorrect value type of an empty object. This meant that we were passing an unknown type into the Terragrunt inputs. 