### PR TITLE
fix: change project locator to find all child modules in files before exiting

### DIFF
--- a/internal/hcl/testdata/project_locator/multi_project_with_module/modules/example2/main.tf
+++ b/internal/hcl/testdata/project_locator/multi_project_with_module/modules/example2/main.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+variable "instance_type" {
+  type = string
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = 50
+  }
+}
+

--- a/internal/hcl/testdata/project_locator/multi_project_with_module/prod/mod.tf
+++ b/internal/hcl/testdata/project_locator/multi_project_with_module/prod/mod.tf
@@ -1,0 +1,5 @@
+module "example2" {
+  source = "../modules/example2"
+
+  instance_type = "m5.4xlarge"
+}


### PR DESCRIPTION
Resolves issue where modules were not excluded from auto-detection if they were spread over multiple files in the root module.