### PR TITLE
feat: track git changes in project metadata

### DIFF
--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -43,6 +43,8 @@ func commentCmd(ctx *config.RunContext) *cobra.Command {
 	for _, subCmd := range cmds {
 		subCmd.Flags().StringArray("policy-path", nil, "Path to Infracost policy files, glob patterns need quotes (experimental)")
 		subCmd.Flags().Bool("show-all-projects", false, "Show all projects in the table of the comment output")
+		subCmd.Flags().Bool("show-changed", false, "Show only projects in the table that have code changes")
+		_ = subCmd.Flags().MarkHidden("show-changed")
 	}
 
 	cmd.AddCommand(cmds...)
@@ -96,6 +98,7 @@ func buildCommentBody(cmd *cobra.Command, ctx *config.RunContext, paths []string
 		GuardrailCheck:    guardrailCheck,
 	}
 	opts.ShowAllProjects, _ = cmd.Flags().GetBool("show-all-projects")
+	opts.ShowOnlyChanges, _ = cmd.Flags().GetBool("show-changed")
 
 	b, err := output.ToMarkdown(combined, opts, mdOpts)
 	if err != nil {

--- a/cmd/infracost/comment_github_test.go
+++ b/cmd/infracost/comment_github_test.go
@@ -37,6 +37,12 @@ func TestCommentGitHubShowAllProjects(t *testing.T) {
 		nil)
 }
 
+func TestCommentGitHubShowChangedProjects(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(),
+		[]string{"comment", "github", "--github-token", "abc", "--repo", "test/test", "--commit", "5", "--show-changed", "--path", "./testdata/changes.json", "--dry-run"},
+		nil)
+}
+
 func TestCommentGitHubWithNoGuardrailt(t *testing.T) {
 	ts := guardrailTestEndpoint(guardrailAddRunResponse{
 		GuardrailsChecked: 0,

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -68,8 +68,8 @@ func addRunFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringSlice("exclude-path", nil, "Paths of directories to exclude, glob patterns need quotes")
 	cmd.Flags().Bool("include-all-paths", false, "Set project auto-detection to use all subdirectories in given path")
-	cmd.Flags().String("git-diff", "master", "Show only costs that have git changes compared to the provided branch. Use the name of the current branch to fetch changes from the last two commits")
-	_ = cmd.Flags().MarkHidden("git-diff")
+	cmd.Flags().String("git-diff-target", "master", "Show only costs that have git changes compared to the provided branch. Use the name of the current branch to fetch changes from the last two commits")
+	_ = cmd.Flags().MarkHidden("git-diff-target")
 
 	cmd.Flags().Bool("no-cache", false, "Don't attempt to cache Terraform plans")
 
@@ -93,7 +93,7 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 	}
 
 	repoPath := runCtx.Config.RepoPath()
-	metadata, err := vcs.MetadataFetcher.Get(repoPath, runCtx.Config.ChangeTarget)
+	metadata, err := vcs.MetadataFetcher.Get(repoPath, runCtx.Config.GitDiffTarget)
 	if err != nil {
 		logging.Logger.WithError(err).Debugf("failed to fetch vcs metadata for path %s", repoPath)
 	}
@@ -825,9 +825,9 @@ func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {
 	hasPathFlag := cmd.Flags().Changed("path")
 	hasConfigFile := cmd.Flags().Changed("config-file")
 
-	if cmd.Flags().Changed("git-diff") {
-		s, _ := cmd.Flags().GetString("git-diff")
-		cfg.ChangeTarget = &s
+	if cmd.Flags().Changed("git-diff-target") {
+		s, _ := cmd.Flags().GetString("git-diff-target")
+		cfg.GitDiffTarget = &s
 	}
 
 	cfg.CompareTo, _ = cmd.Flags().GetString("compare-to")

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -68,6 +68,8 @@ func addRunFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringSlice("exclude-path", nil, "Paths of directories to exclude, glob patterns need quotes")
 	cmd.Flags().Bool("include-all-paths", false, "Set project auto-detection to use all subdirectories in given path")
+	cmd.Flags().String("git-diff", "master", "Show only costs that have git changes compared to the provided branch. Use the name of the current branch to fetch changes from the last two commits")
+	_ = cmd.Flags().MarkHidden("git-diff")
 
 	cmd.Flags().Bool("no-cache", false, "Don't attempt to cache Terraform plans")
 
@@ -91,7 +93,7 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 	}
 
 	repoPath := runCtx.Config.RepoPath()
-	metadata, err := vcs.MetadataFetcher.Get(repoPath)
+	metadata, err := vcs.MetadataFetcher.Get(repoPath, runCtx.Config.ChangeTarget)
 	if err != nil {
 		logging.Logger.WithError(err).Debugf("failed to fetch vcs metadata for path %s", repoPath)
 	}
@@ -822,6 +824,13 @@ func getParallelism(cmd *cobra.Command, runCtx *config.RunContext) (int, error) 
 func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {
 	hasPathFlag := cmd.Flags().Changed("path")
 	hasConfigFile := cmd.Flags().Changed("config-file")
+
+	if cmd.Flags().Changed("git-diff") {
+		s, _ := cmd.Flags().GetString("git-diff")
+		cfg.ChangeTarget = &s
+	}
+
+	cfg.CompareTo, _ = cmd.Flags().GetString("compare-to")
 
 	cfg.CompareTo, _ = cmd.Flags().GetString("compare-to")
 

--- a/cmd/infracost/testdata/changes.json
+++ b/cmd/infracost/testdata/changes.json
@@ -1,0 +1,321 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "diff",
+    "vcsBranch": "feat/changes-metadata",
+    "vcsCommitSha": "ddf343cdb15289de461ebc80ab11be05fa4cb390",
+    "vcsCommitAuthorName": "Hugo",
+    "vcsCommitAuthorEmail": "-",
+    "vcsCommitTimestamp": "2022-12-12T10:59:26Z",
+    "vcsCommitMessage": "test change",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost.git"
+  },
+  "runId": "9f8a29a5-2851-4ccf-bd31-6219eda7bc94",
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "infracost/infracost/internal/hcl/testdata/project_locator/multi_project_with_module/dev",
+      "metadata": {
+        "path": "internal/hcl/testdata/project_locator/multi_project_with_module/dev",
+        "type": "terraform_dir",
+        "terraformModulePath": "dev",
+        "vcsSubPath": "internal/hcl/testdata/project_locator/multi_project_with_module/dev",
+        "vcsCodeChanged": true
+      },
+      "pastBreakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "metadata": {},
+            "hourlyCost": "0.77484931506849315",
+            "monthlyCost": "565.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "0.77484931506849315",
+        "totalMonthlyCost": "565.64"
+      },
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "metadata": {},
+            "hourlyCost": "0.77484931506849315",
+            "monthlyCost": "565.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "0.77484931506849315",
+        "totalMonthlyCost": "565.64"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 1,
+        "totalSupportedResources": 1,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 1,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
+      }
+    },
+    {
+      "name": "infracost/infracost/internal/hcl/testdata/project_locator/multi_project_with_module/prod",
+      "metadata": {
+        "path": "internal/hcl/testdata/project_locator/multi_project_with_module/prod",
+        "type": "terraform_dir",
+        "terraformModulePath": "prod",
+        "vcsSubPath": "internal/hcl/testdata/project_locator/multi_project_with_module/prod",
+        "vcsCodeChanged": false
+      },
+      "pastBreakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "metadata": {},
+            "hourlyCost": "0.77484931506849315",
+            "monthlyCost": "565.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "module.example.aws_instance.web_app",
+            "metadata": {},
+            "hourlyCost": "0.77484931506849315",
+            "monthlyCost": "565.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.5496986301369863",
+        "totalMonthlyCost": "1131.28"
+      },
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "metadata": {},
+            "hourlyCost": "0.77484931506849315",
+            "monthlyCost": "565.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "module.example.aws_instance.web_app",
+            "metadata": {},
+            "hourlyCost": "0.77484931506849315",
+            "monthlyCost": "565.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.5496986301369863",
+        "totalMonthlyCost": "1131.28"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 2,
+        "totalSupportedResources": 2,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 2,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
+      }
+    }
+  ],
+  "totalHourlyCost": "2.32454794520547945",
+  "totalMonthlyCost": "1696.92",
+  "pastTotalHourlyCost": "2.32454794520547945",
+  "pastTotalMonthlyCost": "1696.92",
+  "diffTotalHourlyCost": "0",
+  "diffTotalMonthlyCost": "0",
+  "timeGenerated": "2022-12-12T11:19:38.423818Z",
+  "summary": {
+    "totalDetectedResources": 3,
+    "totalSupportedResources": 3,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 3,
+    "totalNoPriceResources": 0,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {}
+  }
+}

--- a/cmd/infracost/testdata/comment_git_hub_show_changed_projects/comment_git_hub_show_changed_projects.golden
+++ b/cmd/infracost/testdata/comment_git_hub_show_changed_projects/comment_git_hub_show_changed_projects.golden
@@ -1,0 +1,47 @@
+
+💰 Infracost estimate: **monthly cost will not change**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/internal/hc.../multi_project_with_module/dev</td>
+      <td align="right">$566</td>
+      <td align="right">$566</td>
+      <td>$0</td>
+    </tr>
+    <tr>
+      <td>All projects</td>
+      <td align="right">$1,697</td>
+      <td align="right">$1,697</td>
+      <td>$0</td>
+    </tr>
+  </tbody>
+</table>
+
+1 project has no code changes.
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+──────────────────────────────────
+
+The following projects have no cost estimate changes: infracost/infracost/internal/hcl/testdata/project_locator/multi_project_with_module/dev (Module path: dev), infracost/infracost/internal/hcl/testdata/project_locator/multi_project_with_module/prod (Module path: prod)
+Run the following command to see their breakdown: infracost breakdown --path=/path/to/code
+
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 3 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+```
+</details>
+
+<sub>
+  Is this comment useful? <a href="https://dashboard.infracost.io/feedback/redirect?runId=&value=yes" rel="noopener noreferrer" target="_blank">Yes</a>, <a href="https://dashboard.infracost.io/feedback/redirect?runId=&value=no" rel="noopener noreferrer" target="_blank">No</a>, <a href="https://dashboard.infracost.io/feedback/redirect?runId=&value=other" rel="noopener noreferrer" target="_blank">Other</a>
+</sub>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,7 @@ type Config struct {
 	SyncUsageFile   bool       `yaml:"sync_usage_file,omitempty" ignored:"true"`
 	Fields          []string   `yaml:"fields,omitempty" ignored:"true"`
 	CompareTo       string
+	ChangeTarget    *string
 
 	// Base configuration settings
 	// RootPath defines the raw value of the `--path` flag provided by the user
@@ -148,7 +149,7 @@ func DefaultConfig() *Config {
 // RepoPath returns the filepath to either the config-file location or initial path provided by the user.
 func (c *Config) RepoPath() string {
 	if c.ConfigFilePath != "" {
-		return c.ConfigFilePath
+		return strings.TrimRight(c.ConfigFilePath, filepath.Base(c.ConfigFilePath))
 	}
 
 	return c.RootPath

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,7 @@ type Config struct {
 	SyncUsageFile   bool       `yaml:"sync_usage_file,omitempty" ignored:"true"`
 	Fields          []string   `yaml:"fields,omitempty" ignored:"true"`
 	CompareTo       string
-	ChangeTarget    *string
+	GitDiffTarget   *string
 
 	// Base configuration settings
 	// RootPath defines the raw value of the `--path` flag provided by the user

--- a/internal/hcl/module.go
+++ b/internal/hcl/module.go
@@ -32,6 +32,8 @@ type Module struct {
 	Modules  []*Module
 	Parent   *Module
 	Warnings []Warning
+
+	HasChanges bool
 }
 
 // WarningCode is used to delineate warnings across Infracost.

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -139,7 +139,7 @@ output "loadbalancer"  {
 }
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ output "exp2" {
 }
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -257,7 +257,7 @@ output "instances" {
 }
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -295,7 +295,7 @@ resource "other_resource" "test" {
 
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -339,7 +339,7 @@ output "attr_not_exists" {
 
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -378,7 +378,7 @@ resource "other_resource" "test" {
 
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -429,7 +429,7 @@ output "serviceendpoint_principals" {
 
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -466,7 +466,7 @@ output "val" {
 
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -478,6 +478,16 @@ output "val" {
 	value := attr.Value()
 	require.True(t, value.Type().IsPrimitiveType(), "value is not primitive type but %s", value.Type().GoString())
 	assert.Equal(t, "val-mock", value.AsString())
+}
+
+func Test_SetsHasChangesOnMod(t *testing.T) {
+	path := createTestFile("test.tf", `variable "foo" {}`)
+
+	parser := newParser(RootPath{Path: filepath.Dir(path), HasChanges: true}, newDiscardLogger())
+	module, err := parser.ParseDirectory()
+	require.NoError(t, err)
+
+	assert.True(t, module.HasChanges)
 }
 
 func Test_UnsupportedAttributesMapIndex(t *testing.T) {
@@ -494,7 +504,7 @@ output "val" {
 
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -642,7 +652,7 @@ resource "aws_instance" "my_instance" {
 }
 `)
 
-	parser := newParser(filepath.Dir(path), newDiscardLogger())
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, newDiscardLogger())
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -15,10 +15,12 @@ import (
 // ProjectLocator finds Terraform projects for given paths.
 // It naively excludes folders that are imported as modules in other projects.
 type ProjectLocator struct {
-	moduleCalls  map[string]struct{}
-	excludedDirs []string
-	useAllPaths  bool
-	logger       *logrus.Entry
+	modules        map[string]struct{}
+	moduleCalls    map[string][]string
+	excludedDirs   []string
+	changedObjects []string
+	useAllPaths    bool
+	logger         *logrus.Entry
 
 	basePath string
 }
@@ -26,6 +28,7 @@ type ProjectLocator struct {
 // ProjectLocatorConfig provides configuration options on how the locator functions.
 type ProjectLocatorConfig struct {
 	ExcludedSubDirs []string
+	ChangedObjects  []string
 	UseAllPaths     bool
 }
 
@@ -33,27 +36,29 @@ type ProjectLocatorConfig struct {
 func NewProjectLocator(logger *logrus.Entry, config *ProjectLocatorConfig) *ProjectLocator {
 	if config != nil {
 		return &ProjectLocator{
-			moduleCalls:  make(map[string]struct{}),
-			excludedDirs: config.ExcludedSubDirs,
-			logger:       logger,
-			useAllPaths:  config.UseAllPaths,
+			modules:        make(map[string]struct{}),
+			moduleCalls:    make(map[string][]string),
+			excludedDirs:   config.ExcludedSubDirs,
+			changedObjects: config.ChangedObjects,
+			logger:         logger,
+			useAllPaths:    config.UseAllPaths,
 		}
 	}
 
 	return &ProjectLocator{
-		moduleCalls: make(map[string]struct{}),
-		logger:      logger,
+		modules: make(map[string]struct{}),
+		logger:  logger,
 	}
 }
 
-func (p *ProjectLocator) buildMatches(fullPath string) func(string) bool {
-	var matches []string
-	globMatches := make(map[string]struct{})
+func (p *ProjectLocator) buildSkippedMatcher(fullPath string) func(string) bool {
+	var excludedMatches []string
+	excludedGlobs := make(map[string]struct{})
 
 	for _, dir := range p.excludedDirs {
 		var absoluteDir string
 		if dir == filepath.Base(dir) {
-			matches = append(matches, dir)
+			excludedMatches = append(excludedMatches, dir)
 		}
 
 		if filepath.IsAbs(dir) {
@@ -65,18 +70,18 @@ func (p *ProjectLocator) buildMatches(fullPath string) func(string) bool {
 		globs, err := filepath.Glob(absoluteDir)
 		if err == nil {
 			for _, m := range globs {
-				globMatches[m] = struct{}{}
+				excludedGlobs[m] = struct{}{}
 			}
 		}
 	}
 
 	return func(dir string) bool {
-		if _, ok := globMatches[dir]; ok {
+		if _, ok := excludedGlobs[dir]; ok {
 			return true
 		}
 
 		base := filepath.Base(dir)
-		for _, match := range matches {
+		for _, match := range excludedMatches {
 			if match == base {
 				return true
 			}
@@ -86,31 +91,75 @@ func (p *ProjectLocator) buildMatches(fullPath string) func(string) bool {
 	}
 }
 
+func (p ProjectLocator) hasChanges(dir string) bool {
+	if len(p.changedObjects) == 0 {
+		return false
+	}
+
+	for _, change := range p.changedObjects {
+		if inProject(dir, change) {
+			return true
+		}
+
+		// let's check if any of the file changes are within this project's modules.
+		for _, call := range p.moduleCalls[dir] {
+			if inProject(call, change) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func inProject(dir string, change string) bool {
+	rel, err := filepath.Rel(dir, change)
+	if err != nil {
+		return false
+	}
+	return !strings.HasPrefix(rel, "..")
+}
+
+// RootPath holds information about the root directory of a project, this is normally the top level
+// Terraform containing provider blocks.
+type RootPath struct {
+	Path string
+	// HasChanges contains information about whether the project has git changes associated with it.
+	// This will show as true if one or more files/directories have changed in the Path, and also if
+	// and local modules that are used by this project have changes.
+	HasChanges bool
+}
+
 // FindRootModules returns a list of all directories that contain a full Terraform project under the given fullPath.
 // This list excludes any Terraform modules that have been found (if they have been called by a Module source).
-func (p *ProjectLocator) FindRootModules(fullPath string) []string {
+func (p *ProjectLocator) FindRootModules(fullPath string) []RootPath {
 	p.basePath, _ = filepath.Abs(fullPath)
-	p.moduleCalls = make(map[string]struct{})
+	p.modules = make(map[string]struct{})
+	p.moduleCalls = make(map[string][]string)
 
-	isSkipped := p.buildMatches(fullPath)
+	isSkipped := p.buildSkippedMatcher(fullPath)
 	dirs := p.walkPaths(fullPath, 0)
 	p.logger.Debugf("walking directory at %s returned a list of possible Terraform projects: %+v", fullPath, dirs)
 
-	var filtered []string
+	var projects []RootPath
 	for _, dir := range dirs {
 		if isSkipped(dir) {
 			p.logger.Debugf("skipping directory %s as it is marked as exluded by --exclude-path", dir)
 			continue
 		}
 
-		if _, ok := p.moduleCalls[dir]; !ok {
-			filtered = append(filtered, dir)
-		} else {
+		if _, ok := p.modules[dir]; ok && !p.useAllPaths {
 			p.logger.Debugf("skipping directory %s as it has been called as a module", dir)
+			continue
 		}
+
+		projects = append(projects, RootPath{
+			Path:       dir,
+			HasChanges: p.hasChanges(dir),
+		})
 	}
 
-	return filtered
+	return projects
 }
 
 func (p *ProjectLocator) walkPaths(fullPath string, level int) []string {
@@ -157,15 +206,7 @@ func (p *ProjectLocator) walkPaths(fullPath string, level int) []string {
 	}
 
 	files := hclParser.Files()
-
-	// if there are Terraform files at the top level then use this as the root module, no need to search for provider blocks.
-	if level == 0 && len(files) > 0 {
-		return []string{fullPath}
-	}
-
-	if p.useAllPaths && len(files) > 0 {
-		return []string{fullPath}
-	}
+	var providerBlocks bool
 
 	for _, file := range files {
 		body, content, diags := file.Body.PartialContent(justProviderBlocks)
@@ -174,8 +215,9 @@ func (p *ProjectLocator) walkPaths(fullPath string, level int) []string {
 			continue
 		}
 
-		if len(body.Blocks) == 0 {
-			continue
+		// only do this after looping through all files
+		if len(body.Blocks) > 0 {
+			providerBlocks = true
 		}
 
 		moduleBody, _, _ := content.PartialContent(justModuleBlocks)
@@ -200,10 +242,27 @@ func (p *ProjectLocator) walkPaths(fullPath string, level int) []string {
 				}
 
 				mp := filepath.Join(fullPath, realPath)
-				p.moduleCalls[mp] = struct{}{}
+				p.modules[mp] = struct{}{}
+				if v, ok := p.moduleCalls[fullPath]; ok {
+					p.moduleCalls[fullPath] = append(v, mp)
+				} else {
+					p.moduleCalls[fullPath] = []string{mp}
+				}
 			}
 		}
+	}
 
+	// This means we're at the top level and there are Terraform files.
+	// It's safe to assume that this is a Terraform project.
+	if level == 0 && len(files) > 0 {
+		return []string{fullPath}
+	}
+
+	if p.useAllPaths && len(files) > 0 {
+		return []string{fullPath}
+	}
+
+	if providerBlocks {
 		return []string{fullPath}
 	}
 

--- a/internal/hcl/project_locator_test.go
+++ b/internal/hcl/project_locator_test.go
@@ -12,7 +12,7 @@ func TestProjectLocator_FindRootModules_WithSingleProject(t *testing.T) {
 	mods := pl.FindRootModules("./testdata/project_locator/single_project")
 
 	require.Len(t, mods, 1)
-	assert.Contains(t, mods, "./testdata/project_locator/single_project")
+	assert.Contains(t, mods, RootPath{Path: "./testdata/project_locator/single_project", HasChanges: false})
 }
 
 func TestProjectLocator_FindRootModules_WithMultiProject(t *testing.T) {
@@ -20,8 +20,8 @@ func TestProjectLocator_FindRootModules_WithMultiProject(t *testing.T) {
 	mods := pl.FindRootModules("./testdata/project_locator/multi_project_with_module")
 
 	require.Len(t, mods, 2)
-	assert.Contains(t, mods, "testdata/project_locator/multi_project_with_module/dev")
-	assert.Contains(t, mods, "testdata/project_locator/multi_project_with_module/prod")
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_with_module/dev"})
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_with_module/prod"})
 }
 
 func TestProjectLocator_FindRootModules_WithMultiProject_ExcludeDirs(t *testing.T) {
@@ -31,7 +31,33 @@ func TestProjectLocator_FindRootModules_WithMultiProject_ExcludeDirs(t *testing.
 	mods := pl.FindRootModules("./testdata/project_locator/multi_project_with_module")
 
 	require.Len(t, mods, 1)
-	assert.Contains(t, mods, "testdata/project_locator/multi_project_with_module/prod")
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_with_module/prod"})
+}
+
+func TestProjectLocator_FindRootModules_WithMultiProject_WithObjectChanges(t *testing.T) {
+	pl := NewProjectLocator(newDiscardLogger(), &ProjectLocatorConfig{
+		ChangedObjects: []string{
+			"./testdata/project_locator/multi_project_with_module/dev/main.tf",
+		},
+	})
+	mods := pl.FindRootModules("./testdata/project_locator/multi_project_with_module")
+
+	require.Len(t, mods, 2)
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_with_module/dev", HasChanges: true})
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_with_module/prod", HasChanges: false})
+}
+
+func TestProjectLocator_FindRootModules_WithMultiProject_WithModuleObjectChanges(t *testing.T) {
+	pl := NewProjectLocator(newDiscardLogger(), &ProjectLocatorConfig{
+		ChangedObjects: []string{
+			"./testdata/project_locator/multi_project_with_module/modules/example/main.tf",
+		},
+	})
+	mods := pl.FindRootModules("./testdata/project_locator/multi_project_with_module")
+
+	require.Len(t, mods, 2)
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_with_module/dev", HasChanges: false})
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_with_module/prod", HasChanges: true})
 }
 
 func TestProjectLocator_FindRootModules_WithMultiProjectWithoutProviderBlocks(t *testing.T) {
@@ -41,9 +67,9 @@ func TestProjectLocator_FindRootModules_WithMultiProjectWithoutProviderBlocks(t 
 	mods := pl.FindRootModules("./testdata/project_locator/multi_project_without_provider_blocks")
 
 	require.Len(t, mods, 3)
-	assert.Contains(t, mods, "testdata/project_locator/multi_project_without_provider_blocks/dev")
-	assert.Contains(t, mods, "testdata/project_locator/multi_project_without_provider_blocks/prod")
-	assert.Contains(t, mods, "testdata/project_locator/multi_project_without_provider_blocks/modules/example")
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_without_provider_blocks/dev"})
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_without_provider_blocks/prod"})
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_without_provider_blocks/modules/example"})
 }
 
 func TestProjectLocator_FindRootModules_WithMultiProjectWithoutProviderBlocks_ExludePaths(t *testing.T) {
@@ -56,6 +82,6 @@ func TestProjectLocator_FindRootModules_WithMultiProjectWithoutProviderBlocks_Ex
 	mods := pl.FindRootModules("./testdata/project_locator/multi_project_without_provider_blocks")
 
 	require.Len(t, mods, 2)
-	assert.Contains(t, mods, "testdata/project_locator/multi_project_without_provider_blocks/dev")
-	assert.Contains(t, mods, "testdata/project_locator/multi_project_without_provider_blocks/prod")
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_without_provider_blocks/dev"})
+	assert.Contains(t, mods, RootPath{Path: "testdata/project_locator/multi_project_without_provider_blocks/prod"})
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -233,6 +233,7 @@ type Options struct {
 	NoColor           bool
 	ShowSkipped       bool
 	ShowAllProjects   bool
+	ShowOnlyChanges   bool
 	Fields            []string
 	IncludeHTML       bool
 	PolicyChecks      PolicyCheck

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -328,7 +328,13 @@ var CommentMarkdownWithHTMLTemplate = `
   </tbody>
 </table>
 
-  {{- if eq .SkippedProjectCount 1 }}
+  {{- if eq .SkippedUnchangedProjectCount 1 }}
+
+1 project has no code changes.
+  {{- else if gt .SkippedUnchangedProjectCount  0 }}
+
+{{ .SkippedUnchangedProjectCount }} projects have no code changes.
+  {{- else if eq .SkippedProjectCount 1 }}
 
 1 project has no cost estimate changes.
   {{- else if gt .SkippedProjectCount  0 }}

--- a/internal/schema/project.go
+++ b/internal/schema/project.go
@@ -26,6 +26,7 @@ type ProjectMetadata struct {
 	TerraformModulePath string    `json:"terraformModulePath,omitempty"`
 	TerraformWorkspace  string    `json:"terraformWorkspace,omitempty"`
 	VCSSubPath          string    `json:"vcsSubPath,omitempty"`
+	VCSCodeChanged      *bool     `json:"vcsCodeChanged,omitempty"`
 	Warnings            []Warning `json:"warnings,omitempty"`
 	Policies            Policies  `json:"policies,omitempty"`
 }

--- a/internal/vcs/metadata_test.go
+++ b/internal/vcs/metadata_test.go
@@ -122,7 +122,7 @@ func Test_metadataFetcher_GetLocalMetadata(t *testing.T) {
 	}, actual)
 }
 
-func Test_metadataFetcher_GetLocalMetadata_WithChangeBase(t *testing.T) {
+func Test_metadataFetcher_GetLocalMetadata_WithGitDiffTarget(t *testing.T) {
 	tmp := t.TempDir()
 	r, _ := createLocalRepoWithCommits(t, tmp)
 
@@ -167,7 +167,7 @@ func Test_metadataFetcher_GetLocalMetadata_WithChangeBase(t *testing.T) {
 			ChangedObjects: []string{
 				filepath.Join(tmp, "branch-file"),
 			},
-			ChangeBase: &base,
+			GitDiffTarget: &base,
 		},
 		PullRequest: nil,
 		Pipeline:    nil,

--- a/schema/infracost.schema.json
+++ b/schema/infracost.schema.json
@@ -257,6 +257,9 @@
         "vcsSubPath": {
           "type": "string"
         },
+        "vcsCodeChanged": {
+          "type": "boolean"
+        },
         "warnings": {
           "items": {
             "$schema": "http://json-schema.org/draft-04/schema#",


### PR DESCRIPTION
Adds support to track git changes for HCL projects. If changes can be detected, we set the `vcsCodeChanged` project metadata field on any projects that have been modified. This behaviour is works with the `show-changed` flag that `infracost comment` supports.