### PR TITLE
fix: container_cluster setting nil node pool as sub resource

### DIFF
--- a/.github/workflows/create-pr-assets.yml
+++ b/.github/workflows/create-pr-assets.yml
@@ -1,0 +1,26 @@
+name: Create PR assets
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Build project
+        run: |
+          make release
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: "build/*.tar.gz"

--- a/.github/workflows/create-pr-assets.yml
+++ b/.github/workflows/create-pr-assets.yml
@@ -5,22 +5,46 @@ on:
     branches: [ master ]
 
 jobs:
-
   build:
-    name: Build
+    name: Build assets
+    strategy:
+      matrix:
+        include:
+          - target: windows
+          - target: linux
+          - target: darwin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
-
       - name: Build project
-        run: |
-          make release
-
-      - name: Upload artifacts
+        run: make ${{ matrix.target }}
+      - name: Upload amd64 build artifact
         uses: actions/upload-artifact@v3
+        if: ${{ matrix.target != 'windows' }}
         with:
-          path: "build/*.tar.gz"
+          name: ${{ matrix.target }}-amd64
+          path: "build/infracost-${{ matrix.target }}-amd64"
+      - name: Upload windows amd64 build artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.target == 'windows' }}
+        with:
+          name: ${{ matrix.target }}-amd64
+          path: "build/infracost.exe"
+      - name: Upload arm64 build artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.target != 'windows' }}
+        with:
+          name: ${{ matrix.target }}-arm64
+          path: "build/infracost-${{ matrix.target }}-arm64"
+      - name: Upload windows arm64 build artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.target == 'windows' }}
+        with:
+          name: ${{ matrix.target }}-arm64
+          path: "build/infracost-arm64.exe"
+

--- a/internal/providers/terraform/google/container_cluster_test.go
+++ b/internal/providers/terraform/google/container_cluster_test.go
@@ -7,10 +7,9 @@ import (
 )
 
 func TestContainerClusterGoldenFile(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "container_cluster_test")
+	tftest.GoldenFileResourceTestsWithOpts(t, "container_cluster_test", &tftest.GoldenFileOptions{CaptureLogs: true})
 }

--- a/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
+++ b/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
@@ -142,3 +142,6 @@
 ──────────────────────────────────
 16 cloud resources were detected:
 ∙ 16 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+Logs:
+
+level=warning msg="Skipping resource node_pool[0]. Infracost currently does not support E2 custom instances"

--- a/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
+++ b/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
@@ -117,6 +117,15 @@
     ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $467.20 
     └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00 
                                                                                                                       
+ google_container_cluster.with_unsupported_node_pool                                                                  
+ ├─ Cluster management fee                                                      730  hours                     $73.00 
+ ├─ default_pool                                                                                                      
+ │  ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                      6,570  hours                    $220.13 
+ │  └─ Standard provisioned storage (pd-standard)                               900  GB                        $36.00 
+ └─ node_pool[1]                                                                                                      
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $1,401.60 
+    └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00 
+                                                                                                                      
  google_container_cluster.zonal                                                                                       
  ├─ Cluster management fee                                                      730  hours                     $73.00 
  └─ default_pool                                                                                                      
@@ -129,7 +138,7 @@
     ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                      2,920  hours                     $97.84 
     └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00 
                                                                                                                       
- OVERALL TOTAL                                                                                             $26,614.30 
+ OVERALL TOTAL                                                                                             $28,393.03 
 ──────────────────────────────────
-15 cloud resources were detected:
-∙ 15 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+16 cloud resources were detected:
+∙ 16 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.tf
+++ b/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.tf
@@ -183,6 +183,29 @@ resource "google_container_cluster" "with_node_pools_regional_withUsage" {
   }
 }
 
+resource "google_container_cluster" "with_unsupported_node_pool" {
+  name     = "with-node-pools-regional"
+  location = "us-central1"
+
+  node_pool {
+    node_count = 2
+
+    node_config {
+      machine_type = "e2-custom"
+    }
+  }
+
+  node_pool {
+    node_count = 4
+
+    node_config {
+      machine_type = "n1-standard-16"
+      preemptible  = true
+    }
+  }
+}
+
+
 resource "google_container_cluster" "with_node_pools_node_locations_withUsage" {
   name     = "with-node-pools-regional"
   location = "us-central1"

--- a/internal/resources/google/container_cluster.go
+++ b/internal/resources/google/container_cluster.go
@@ -1,9 +1,10 @@
 package google
 
 import (
+	"github.com/shopspring/decimal"
+
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/shopspring/decimal"
 )
 
 // ContainerCluster struct represents Container Cluster resource.
@@ -70,11 +71,17 @@ func (r *ContainerCluster) BuildResource() *schema.Resource {
 	subresources := []*schema.Resource{}
 
 	if r.DefaultNodePool != nil {
-		subresources = append(subresources, r.DefaultNodePool.BuildResource())
+		poolResource := r.DefaultNodePool.BuildResource()
+		if poolResource != nil {
+			subresources = append(subresources, poolResource)
+		}
 	}
 
 	for _, nodePool := range r.NodePools {
-		subresources = append(subresources, nodePool.BuildResource())
+		poolResource := nodePool.BuildResource()
+		if poolResource != nil {
+			subresources = append(subresources, poolResource)
+		}
 	}
 
 	return &schema.Resource{


### PR DESCRIPTION
fixes: https://github.com/infracost/infracost/issues/2180

With the changes in `0.10.15` we have introduced a helper function `computeCostComponents` to help with custom instance types. However this now returns an error and alters `ContainerNodePool` to return nil on unsupported machine types. See https://github.com/infracost/infracost/blob/master/internal/resources/google/container_node_pool.go#L48-L52. The `ContainerCluster` resource was incorrectly setting these nils as valid sub resources which caused a panic.

Adds an additional pipeline step to build and upload release assets to the PR so that we can send these to contributors to review and see if it fixes there issue.