### PR TITLE
fix: use correct metric to display skipped unchanged project

### DIFF
--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -208,9 +208,11 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 	}
 
 	skippedUnchangedProjectCount := 0
-	for _, p := range out.Projects {
-		if hasCodeChanges(opts, p) {
-			skippedUnchangedProjectCount++
+	if opts.ShowOnlyChanges {
+		for _, p := range out.Projects {
+			if !hasCodeChanges(opts, p) {
+				skippedUnchangedProjectCount++
+			}
 		}
 	}
 


### PR DESCRIPTION
Increment the skipped code changes projects if the flag has been set and there are **no** code changes