### PR TITLE
feat: run auto-detected projects in parallel

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"runtime/debug"
 	"sort"
 	"strings"
@@ -259,7 +258,7 @@ func newParallelRunner(cmd *cobra.Command, runCtx *config.RunContext) (*parallel
 		prior = &snapshot
 	}
 
-	parallelism, err := getParallelism(cmd, runCtx)
+	parallelism, err := runCtx.GetParallelism()
 	if err != nil {
 		return nil, err
 	}
@@ -792,33 +791,6 @@ func (r *parallelRunner) generateUsageFile(ctx *config.ProjectContext, provider 
 			pluralized))
 	}
 	return nil
-}
-
-func getParallelism(cmd *cobra.Command, runCtx *config.RunContext) (int, error) {
-	var parallelism int
-
-	if runCtx.Config.Parallelism == nil {
-		parallelism = 4
-		numCPU := runtime.NumCPU()
-		if numCPU*4 > parallelism {
-			parallelism = numCPU * 4
-		}
-		if parallelism > 16 {
-			parallelism = 16
-		}
-	} else {
-		parallelism = *runCtx.Config.Parallelism
-
-		if parallelism < 0 {
-			return parallelism, fmt.Errorf("parallelism must be a positive number")
-		}
-
-		if parallelism > 16 {
-			return parallelism, fmt.Errorf("parallelism must be less than 16")
-		}
-	}
-
-	return parallelism, nil
 }
 
 func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {

--- a/internal/config/run_context.go
+++ b/internal/config/run_context.go
@@ -95,6 +95,36 @@ func (r *RunContext) NewSpinner(msg string) *ui.Spinner {
 	})
 }
 
+func (r *RunContext) GetParallelism() (int, error) {
+	var parallelism int
+
+	if r.Config.Parallelism == nil {
+		parallelism = 4
+		numCPU := runtime.NumCPU()
+		if numCPU*4 > parallelism {
+			parallelism = numCPU * 4
+		}
+
+		if parallelism > 16 {
+			parallelism = 16
+		}
+
+		return parallelism, nil
+	}
+
+	parallelism = *r.Config.Parallelism
+
+	if parallelism < 0 {
+		return parallelism, fmt.Errorf("parallelism must be a positive number")
+	}
+
+	if parallelism > 16 {
+		return parallelism, fmt.Errorf("parallelism must be less than 16")
+	}
+
+	return parallelism, nil
+}
+
 // Context returns the underlying context.
 func (r *RunContext) Context() context.Context {
 	return r.ctx
@@ -105,8 +135,8 @@ func (r *RunContext) UUID() uuid.UUID {
 	return r.uuid
 }
 
-func (c *RunContext) VCSRepositoryURL() string {
-	return c.VCSMetadata.Remote.URL
+func (r *RunContext) VCSRepositoryURL() string {
+	return r.VCSMetadata.Remote.URL
 }
 
 func (r *RunContext) SetContextValue(key string, value interface{}) {

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/hcl"
 	"github.com/infracost/infracost/internal/hcl/modules"
 	"github.com/infracost/infracost/internal/sync"
@@ -204,6 +205,7 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 			p := HCLProvider{
 				parsers: parsers,
 				logger:  entry,
+				ctx:     &config.ProjectContext{RunContext: &config.RunContext{Config: &config.Config{}}},
 			}
 			got, err := p.LoadPlanJSONs()
 			require.NoError(t, err)


### PR DESCRIPTION
Changes the auto-detection functionality to run discovered projects in parallel. This is faster and inline with the `config-file` behaviour.