### PR TITLE
fix: panic arising from cty conversion of cty.NilVal

### DIFF
--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -173,7 +173,7 @@ func (attr *Attribute) value(retry int) (ctyVal cty.Value) {
 					// let's first try and find the actual value for this bad variable.
 					// If it has an actual value let's use that to pass into the list.
 					val, _ := traversal.TraverseAbs(ctx)
-					if val == cty.NilVal {
+					if val.IsNull() {
 						val = mockedVal
 					}
 

--- a/internal/hcl/remote_variables_loader.go
+++ b/internal/hcl/remote_variables_loader.go
@@ -217,7 +217,7 @@ func (r *RemoteVariablesLoader) Load(blocks Blocks) (map[string]cty.Value, error
 			vv, ok := varsMap[v.ID]
 			if ok {
 				val := getVarValue(vv)
-				if !val.IsNull() {
+				if !val.IsNull() && val.IsKnown() {
 					vars[vv.Key] = val
 				}
 			}
@@ -331,7 +331,7 @@ func getAttribute(block *Block, name string) string {
 
 func getVarValue(variable tfcVar) cty.Value {
 	if variable.Sensitive || variable.Category != "terraform" || variable.Value == "" {
-		return cty.NilVal
+		return cty.DynamicVal
 	}
 
 	return cty.StringVal(variable.Value)

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -661,7 +661,7 @@ func (p *HCLProvider) marshalBlock(block *hcl.Block, jsonValues map[string]inter
 }
 
 func marshalAttributeValues(blockType string, value cty.Value) map[string]interface{} {
-	if value == cty.NilVal || value.IsNull() {
+	if value.IsNull() {
 		return nil
 	}
 	ret := make(map[string]interface{})


### PR DESCRIPTION
gocty.ToCtyValue panics if any type provided to it is nil. This can happen if we use NilVal at any point in the context evaluation. I've removed all references of NilVal for attributes/variable evaluation in favour of DynamicVal which is an Unknown type, and should be conversion safe. I've also wrapped the problem function in a recover statement to catch any panics that might arise due to unforseen evaluation problems. This means that the terragrunt inputs would use a safe default of mocked values rather than just exiting.