### PR TITLE
fix: array notation causing issues with mocking terragrunt deps

### DIFF
--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/breakdown_terragrunt_hcldeps_output.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/breakdown_terragrunt_hcldeps_output.golden
@@ -57,7 +57,15 @@ Module path: prod2
                                                                                                                       
  Project total                                                                                                $747.64 
 
- OVERALL TOTAL                                                                                              $1,560.25 
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/stag
+Module path: stag
+
+ Name           Monthly Qty  Unit  Monthly Cost 
+                                                
+ Project total                            $0.00 
+
+ OVERALL TOTAL                        $1,560.25 
 ──────────────────────────────────
 6 cloud resources were detected:
 ∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
@@ -48,6 +48,7 @@ inputs = {
     input24 = dependency.test2.outputs.good_list_bad_prop[0].id
     input24 = dependency.test2.outputs.bad_map["test"]
     input25 = dependency.test2.outputs.bad_map["test"]["bar"].id
+    input26 = [dependency.test2.outputs.map_existing["test"]["bar"].id]
   }
 
   hello_world_function_memory_size = 512

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
@@ -10,6 +10,10 @@ dependency "test2" {
   config_path = "../prod2"
 }
 
+dependency "stag-dep" {
+  config_path = "../stag"
+}
+
 terraform {
   source = "..//modules/example"
 }
@@ -21,15 +25,15 @@ inputs = {
   block_device_iops             = dependency.test2.outputs.block_iops
 
   test_input = {
-    input1 = dependency.test2.outputs.obj.foo
-    input2 = dependency.test2.outputs.obj.bar
-    input3 = dependency.test2.outputs.improper_mock.foo
-    input4 = dependency.test2.outputs.improper_mock.bar
-    input5 = dependency.test2.outputs.list[0].foo
-    input6 = dependency.test2.outputs.list[1].bar
-    input7 = dependency.test2.outputs.improper_mock2[0].foo
-    input8 = dependency.test2.outputs.map["foo"].bar
-    input9 = dependency.test2.outputs.map["baz"].bat
+    input1  = dependency.test2.outputs.obj.foo
+    input2  = dependency.test2.outputs.obj.bar
+    input3  = dependency.test2.outputs.improper_mock.foo
+    input4  = dependency.test2.outputs.improper_mock.bar
+    input5  = dependency.test2.outputs.list[0].foo
+    input6  = dependency.test2.outputs.list[1].bar
+    input7  = dependency.test2.outputs.improper_mock2[0].foo
+    input8  = dependency.test2.outputs.map["foo"].bar
+    input9  = dependency.test2.outputs.map["baz"].bat
     input10 = dependency.test2.outputs.improper_mock3["foo"].bar
     input11 = dependency.test2.outputs.not_exist.foo
     input12 = dependency.test2.outputs.not_exist_list[0].foo
@@ -49,6 +53,12 @@ inputs = {
     input24 = dependency.test2.outputs.bad_map["test"]
     input25 = dependency.test2.outputs.bad_map["test"]["bar"].id
     input26 = [dependency.test2.outputs.map_existing["test"]["bar"].id]
+    input27 = <<EOF
+    {
+      "key": "${dependency.stag-dep.outputs.retrieved_secrets.0}",
+      "key2": "${dependency.stag-dep.outputs.retrieved_secrets.1}"
+    }
+EOF
   }
 
   hello_world_function_memory_size = 512

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example3/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/modules/example3/main.tf
@@ -1,0 +1,8 @@
+data "aws_secretsmanager_secret" "bad" {
+  name = "example"
+}
+
+output "retrieved_secrets" {
+  value     = values(data.aws_secretsmanager_secret.bad)[*].value
+  sensitive = true
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/stag/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/stag/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example3"
+}
+
+inputs = {
+  test = "test"
+}

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -516,6 +516,8 @@ func mergeObjectWithDependencyMap(valueMap map[string]cty.Value, pieces []string
 		split := strings.Split(key, "[")
 		key = split[0]
 		pieces = append(keys, pieces[1:]...)
+	} else {
+		key = strings.TrimSuffix(key, "]")
 	}
 
 	if len(pieces) == 1 {

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -433,7 +433,7 @@ func convertToCtyWithJson(val interface{}) (cty.Value, error) {
 }
 
 var (
-	depRegexp   = regexp.MustCompile(`dependency\.[\w.\[\]"]+`)
+	depRegexp   = regexp.MustCompile(`dependency\.[\w\-.\[\]"]+`)
 	indexRegexp = regexp.MustCompile(`(\w+)\[(\d+)]`)
 	mapRegexp   = regexp.MustCompile(`\["([\w\d]+)"]`)
 )
@@ -531,6 +531,12 @@ func mergeObjectWithDependencyMap(valueMap map[string]cty.Value, pieces []string
 
 	if v, ok := valueMap[key]; ok {
 		if v.CanIterateElements() {
+			if isList(v) {
+				index, _ := strconv.Atoi(pieces[1])
+
+				return mergeListWithDependencyMap(valueMap, pieces[1:], key, index)
+			}
+
 			valueMap[key] = cty.ObjectVal(mergeObjectWithDependencyMap(v.AsValueMap(), pieces[1:]))
 			return valueMap
 		}
@@ -543,11 +549,15 @@ func mergeObjectWithDependencyMap(valueMap map[string]cty.Value, pieces []string
 	return valueMap
 }
 
+func isList(v cty.Value) bool {
+	return v.Type().IsTupleType() || v.Type().IsListType()
+}
+
 func mergeListWithDependencyMap(valueMap map[string]cty.Value, pieces []string, key string, index int) map[string]cty.Value {
 	indexVal := cty.NumberIntVal(int64(index))
 
 	if len(pieces) == 1 {
-		if v, ok := valueMap[key]; ok && (v.Type().IsListType() || v.Type().IsTupleType()) {
+		if v, ok := valueMap[key]; ok && isList(v) {
 			// if we have the index already in the dependency output, and it is known use the existing value.
 			// If the value is unknown we need to override it wil a mock as Terragrunt will explode when they
 			// try and marshal the cty values to JSON.
@@ -585,7 +595,7 @@ func mergeListWithDependencyMap(valueMap map[string]cty.Value, pieces []string, 
 
 	mockValue := cty.ObjectVal(mergeObjectWithDependencyMap(map[string]cty.Value{}, pieces[1:]))
 
-	if v, ok := valueMap[key]; ok && (v.Type().IsListType() || v.Type().IsTupleType()) {
+	if v, ok := valueMap[key]; ok && isList(v) {
 		// if we have the index already in the dependency output, and it is known use the existing value.
 		// If the value is unknown we need to override it wil a mock as Terragrunt will explode when they
 		// try and marshal the cty values to JSON.


### PR DESCRIPTION
Resolves issue where the object attribute to mock had a trailing `]` appended to the key if the dependency was within a array.