### PR TITLE
Fix resources

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -145,7 +145,7 @@ resource_usage:
 
   aws_ebs_volume.my_standard_volume:
     monthly_standard_io_requests: 10000000 # Monthly I/O requests for standard volume (Magnetic storage).
-  
+
   aws_ec2_host.my_host:
     reserved_instance_term: 1_year # Term for Reserved Instances, can be: 1_year, 3_year.
     reserved_instance_payment_option: partial_upfront # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
@@ -189,7 +189,7 @@ resource_usage:
       rule_evaluations: 10000    # Number of rule evaluations on application/network load balancers
     elb:
       monthly_data_processed_gb: 10000 # Monthly data processed on classic loadbalaner
-    
+
   aws_elasticache_cluster.my_redis_snapshot:
     snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB.
     reserved_instance_term: 1_year                          # Term for Reserved Instances, can be: 1_year, 3_year.
@@ -583,11 +583,12 @@ resource_usage:
     monthly_queries_tb: 100 # Monthly number of bytes processed (also referred to as bytes read) in TB.
 
   google_bigquery_table.usage:
-    monthly_active_storage_gb: 1000    # Monthly number of active storage modifications in GB.
-    monthly_long_term_storage_gb: 1000 # Monthly number of long-term storage modifications in GB.
-    monthly_streaming_inserts_mb: 1000 # Monthly number of streaming data inserts in MB.
-    monthly_storage_write_api_gb: 1000 # Monthly number of storage write api in GB.
-    monthly_storage_read_api_tb: 1000  # Monthly number of storage read api in TB.
+    monthly_active_logical storage_gb: 1000    # Monthly number of active logical storage modifications in GB.
+    monthly_active_physical storage_gb: 1000   # Monthly number of active logical storage modifications in GB.
+    monthly_long_term_logical_storage_gb: 1000 # Monthly number of long-term logical storage modifications in GB.
+    monthly_streaming_inserts_mb: 1000         # Monthly number of streaming data inserts in MB.
+    monthly_storage_write_api_gb: 1000         # Monthly number of storage write api in GB.
+    monthly_storage_read_api_tb: 1000          # Monthly number of storage read api in TB.
 
   google_cloudfunctions_function.my_function:
     request_duration_ms: 300               # Average duration of each request in milliseconds.
@@ -1082,7 +1083,7 @@ resource_usage:
     monthly_vcore_hours: 600             # Monthly number of used vCore-hours for serverless compute.
     long_term_retention_storage_gb: 1000 # Number of GBs used by long-term retention backup storage.
     extra_data_storage_gb: 250           # Override number of GBs used by extra data storage.
-  
+
   azurerm_sql_managed_instance.my_database:
     backup_storage_gb: 100            # Backup storage size dedicated for Point In Time Restoration
     long_term_retention_storage_gb: 5 # Number of GBs used by long-term retention backup storage.

--- a/internal/providers/terraform/google/testdata/bigquery_table_test/bigquery_table_test.golden
+++ b/internal/providers/terraform/google/testdata/bigquery_table_test/bigquery_table_test.golden
@@ -5,20 +5,22 @@
  └─ Queries (on-demand)           Monthly cost depends on usage: $5.00 per TB    
                                                                                  
  google_bigquery_table.non_usage                                                 
- ├─ Active storage                Monthly cost depends on usage: $0.023 per GB   
- ├─ Long-term storage             Monthly cost depends on usage: $0.016 per GB   
+ ├─ Active logical storage        Monthly cost depends on usage: $0.023 per GB   
+ ├─ Active physical storage       Monthly cost depends on usage: $0.04 per GB    
+ ├─ Long-term logical storage     Monthly cost depends on usage: $0.016 per GB   
  ├─ Streaming inserts             Monthly cost depends on usage: $0.00005 per MB 
  ├─ Storage write API             Monthly cost depends on usage: $0.025 per GB   
  └─ Storage read API              Monthly cost depends on usage: $1.10 per TB    
                                                                                  
  google_bigquery_table.usage                                                     
- ├─ Active storage                         1,000  GB                      $23.00 
- ├─ Long-term storage                      1,000  GB                      $16.00 
+ ├─ Active logical storage                 1,000  GB                      $23.00 
+ ├─ Active physical storage                1,000  GB                      $40.00 
+ ├─ Long-term logical storage              1,000  GB                      $16.00 
  ├─ Streaming inserts                      1,000  MB                       $0.05 
  ├─ Storage write API                      1,000  GB                      $25.00 
  └─ Storage read API                       1,000  TB                   $1,100.00 
                                                                                  
- OVERALL TOTAL                                                         $1,164.05 
+ OVERALL TOTAL                                                         $1,204.05 
 ──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/bigquery_table_test/bigquery_table_test.usage.yml
+++ b/internal/providers/terraform/google/testdata/bigquery_table_test/bigquery_table_test.usage.yml
@@ -1,8 +1,8 @@
 version: 0.1
-resource_usage: 
+resource_usage:
   google_bigquery_table.usage:
-    monthly_active_storage_gb: 1000  
-    monthly_long_term_storage_gb: 1000 
-    monthly_streaming_inserts_mb: 1000 
-    monthly_storage_write_api_gb: 1000 
+    monthly_active_logical_storage_gb: 1000
+    monthly_long_term_logical_storage_gb: 1000
+    monthly_streaming_inserts_mb: 1000
+    monthly_storage_write_api_gb: 1000
     monthly_storage_read_api_tb: 1000

--- a/internal/resources/aws/cloudwatch_metric_alarm.go
+++ b/internal/resources/aws/cloudwatch_metric_alarm.go
@@ -68,6 +68,7 @@ func (r *CloudwatchMetricAlarm) cloudwatchMetricAlarmCostComponent() *schema.Cos
 			Service:       strPtr("AmazonCloudWatch"),
 			ProductFamily: strPtr("Alarm"),
 			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "group", Value: strPtr("Alarm")},
 				{Key: "alarmType", ValueRegex: regexPtr(alarmType)},
 			},
 		},


### PR DESCRIPTION
This fixes the following uses usage params:
```
monthly_active_storage_gb
monthly_long_term_storage_gb
```

To be what Google now expects:
```
monthly_active_logical_storage_gb
monthly_active_physical_storage_gb
monthly_long_term_logical_storage_gb
```

We will want to add a note to the release notes about this.