### PR TITLE
fix: module for_each attributes not expanding correctly

### DIFF
--- a/internal/hcl/module.go
+++ b/internal/hcl/module.go
@@ -2,6 +2,7 @@ package hcl
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -34,6 +35,32 @@ type Module struct {
 	Warnings []Warning
 
 	HasChanges bool
+}
+
+// Index returns the count index of the Module using the name.
+// Index returns nil if the Module has no count.
+func (m *Module) Index() *int64 {
+	matches := countRegex.FindStringSubmatch(m.Name)
+
+	if len(matches) > 0 {
+		i, _ := strconv.ParseInt(matches[1], 10, 64)
+
+		return &i
+	}
+
+	return nil
+}
+
+// Key returns the foreach key of the Module using the name.
+// Key returns nil if the Module has no each key.
+func (m *Module) Key() *string {
+	matches := foreachRegex.FindStringSubmatch(m.Name)
+
+	if len(matches) > 0 {
+		return &matches[1]
+	}
+
+	return nil
 }
 
 // WarningCode is used to delineate warnings across Infracost.


### PR DESCRIPTION
Resolves various issue within the Evaluator which was causing module for_each attributes to not be expanded correctly.

* Solves issue where for_each that references a Block that doesn't need to be expanded was never getting expanded as we were always checking if Block.expanded was true even if the Block had no count/for_each
* When modules are expanded we now set the EvaluationContext to have the correct Variables. Prior to this change expanded modules were being set with their expansion key in the name. e.g:
  ```
  module "foo" {
    source = "../foo"
  
    for_each = {
       "one" = {
           "bar" = "bat"
       }
       "two" = {
          ...
       }
    }
    bar      = each.value.bar
  }
  ```
  would have been set in the context to:
  ```
  module
     foo
     foo[one]
       bar: bat
     foo[two]
       ...
  ```
  instead of of the correct format:
  
  ```
  module
     foo
       one
         bar: bat
       two
         ...
  ```
* Removes logic that duplicates expansion of modules. We expand modules before the `loadModules` call in Evaluator, but fail to override the `Module.Blocks` with these expanded Blocks. This means that we expand these module outputs twice which can lead to incorrect EvaluationContext, e.g:

  ```
  module
     foo
       one
         bar: bat
         # after duplicate expansion
         one
            bar: bat
         two
            ...
       two
         ...
  ```