### PR TITLE
fix: change project paths to absolute path if initial --config-file path is abs

### DIFF
--- a/cmd/infracost/hcl_test.go
+++ b/cmd/infracost/hcl_test.go
@@ -2,15 +2,35 @@ package main_test
 
 import (
 	"path"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/infracost/infracost/internal/testutil"
 )
 
 func TestHCLMultiProjectInfra(t *testing.T) {
-	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(),
-		[]string{"breakdown", "--config-file", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName(), "infracost.config.yml")},
-		nil)
+	name := testutil.CalcGoldenFileTestdataDirName()
+
+	t.Run("rel path", func(t *testing.T) {
+		GoldenFileCommandTest(t, name,
+			[]string{"breakdown", "--config-file", path.Join("./testdata", name, "infracost.config.yml")},
+			nil)
+	})
+
+	t.Run("abs path", func(t *testing.T) {
+		abs, err := filepath.Abs(path.Join("./testdata", name, "infracost.config.yml"))
+		require.NoError(t, err)
+
+		GoldenFileCommandTest(t, name,
+			[]string{
+				"breakdown",
+				"--config-file",
+				abs,
+			},
+			nil)
+	})
 }
 
 func TestHCLMultiWorkspace(t *testing.T) {

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -131,10 +131,20 @@ func NewHCLProvider(ctx *config.ProjectContext, config *HCLProviderConfig, opts 
 	runCtx := ctx.RunContext
 	locatorConfig := &hcl.ProjectLocatorConfig{ExcludedSubDirs: ctx.ProjectConfig.ExcludePaths, ChangedObjects: runCtx.VCSMetadata.Commit.ChangedObjects, UseAllPaths: ctx.ProjectConfig.IncludeAllPaths}
 
-	path := ctx.RunContext.Config.RepoPath()
-	loader := modules.NewModuleLoader(path, credsSource, logger, ctx.RunContext.ModuleMutex)
+	wd := ctx.RunContext.Config.RepoPath()
+	initialPath := ctx.ProjectConfig.Path
+	if filepath.IsAbs(wd) {
+		abs, err := filepath.Abs(initialPath)
+		if err != nil {
+			logger.WithError(err).Warnf("could not make project path absolute to match provided --config-file/--path path absolute, this will result in module loading failures")
+		} else {
+			initialPath = abs
+		}
+	}
+
+	loader := modules.NewModuleLoader(wd, credsSource, logger, ctx.RunContext.ModuleMutex)
 	parsers, err := hcl.LoadParsers(
-		ctx.ProjectConfig.Path,
+		initialPath,
 		loader,
 		locatorConfig,
 		logger,


### PR DESCRIPTION

fixes #2231

With the change to the top-level .infracost folder, if an absolute path is used for config-file or path resolution then we fail to build the correct paths for modules. This PR changes the project path passed to the `Parser` to be abs if the initial path (--config-file/--path) is absolute.