### PR TITLE
fix: comment is hiding module path when projects are skipped

### DIFF
--- a/cmd/infracost/testdata/comment_git_hub_show_all_projects/comment_git_hub_show_all_projects.golden
+++ b/cmd/infracost/testdata/comment_git_hub_show_all_projects/comment_git_hub_show_all_projects.golden
@@ -9,16 +9,16 @@
   </thead>
   <tbody>
     <tr>
-      <td>infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json</td>
-      <td align="right">$40.56</td>
-      <td align="right">$81.12</td>
-      <td>+$40.56 (+100%)</td>
-    </tr>
-    <tr>
       <td>infracost/infracost/cmd/infraco...aform_v0.14_nochange_plan.json</td>
       <td align="right">$40.56</td>
       <td align="right">$40.56</td>
       <td>$0</td>
+    </tr>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$81.12</td>
+      <td>+$40.56 (+100%)</td>
     </tr>
     <tr>
       <td>All projects</td>

--- a/cmd/infracost/testdata/output_format_bitbucket_comment_with_project_names/output_format_bitbucket_comment_with_project_names.golden
+++ b/cmd/infracost/testdata/output_format_bitbucket_comment_with_project_names/output_format_bitbucket_comment_with_project_names.golden
@@ -1,15 +1,15 @@
 
 ## Infracost estimate: **monthly cost will decrease by $3,364 (-42%) ↓**
 
-| **Project** | **Previous** | **New** | **Diff** |
-| ----------- | -----------: | ------: | -------- |
-| my first project | $1,303 | $743 | -$560.64 (-43%) |
-| my first project again | $1,303 | $743 | -$560.64 (-43%) |
-| my terragrunt multi project | $1,308 | $748 | -$560.64 (-43%) |
-| my terragrunt prod project | $1,308 | $748 | -$560.64 (-43%) |
-| my terragrunt workspace | $1,308 | $748 | -$560.64 (-43%) |
-| my workspace project | $1,303 | $743 | -$560.64 (-43%) |
-| **All projects** | **$7,991** | **$4,627** | **-$3,363.84 (-42%)** |
+| **Project** | **Module path** | **Previous** | **New** | **Diff** |
+| ----------- | ---------- | -----------: | ------: | -------- |
+| my first project |  | $1,303 | $743 | -$560.64 (-43%) |
+| my first project again |  | $1,303 | $743 | -$560.64 (-43%) |
+| my terragrunt multi project | prod | $1,308 | $748 | -$560.64 (-43%) |
+| my terragrunt prod project |  | $1,308 | $748 | -$560.64 (-43%) |
+| my terragrunt workspace | prod | $1,308 | $748 | -$560.64 (-43%) |
+| my workspace project |  | $1,303 | $743 | -$560.64 (-43%) |
+| **All projects** | | **$7,991** | **$4,627** | **-$3,363.84 (-42%)** |
 
 3 projects have no cost estimate changes.
 

--- a/cmd/infracost/testdata/output_format_git_hub_comment_show_all_projects/output_format_git_hub_comment_show_all_projects.golden
+++ b/cmd/infracost/testdata/output_format_git_hub_comment_show_all_projects/output_format_git_hub_comment_show_all_projects.golden
@@ -15,22 +15,22 @@
       <td>+$1,361</td>
     </tr>
     <tr>
+      <td>infracost/infracost/cmd/infraco...aform_v0.14_nochange_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$40.56</td>
+      <td>$0</td>
+    </tr>
+    <tr>
+      <td>infracost/infracost/cmd/infraco...aform_v0.14_nochange_plan.json</td>
+      <td align="right">$40.56</td>
+      <td align="right">$40.56</td>
+      <td>$0</td>
+    </tr>
+    <tr>
       <td>infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json</td>
       <td align="right">$40.56</td>
       <td align="right">$81.12</td>
       <td>+$40.56 (+100%)</td>
-    </tr>
-    <tr>
-      <td>infracost/infracost/cmd/infraco...aform_v0.14_nochange_plan.json</td>
-      <td align="right">$40.56</td>
-      <td align="right">$40.56</td>
-      <td>$0</td>
-    </tr>
-    <tr>
-      <td>infracost/infracost/cmd/infraco...aform_v0.14_nochange_plan.json</td>
-      <td align="right">$40.56</td>
-      <td align="right">$40.56</td>
-      <td>$0</td>
     </tr>
     <tr>
       <td>All projects</td>

--- a/cmd/infracost/testdata/output_format_git_hub_comment_with_project_names_with_metadata/output_format_git_hub_comment_with_project_names_with_metadata.golden
+++ b/cmd/infracost/testdata/output_format_git_hub_comment_with_project_names_with_metadata/output_format_git_hub_comment_with_project_names_with_metadata.golden
@@ -20,19 +20,19 @@
     </tr>
     <tr>
       <td>my terragrunt project</td>
-      <td>prod</td>
-      <td></td>
-      <td align="right">$1,308</td>
-      <td align="right">$748</td>
-      <td>-$560.64 (-43%)</td>
-    </tr>
-    <tr>
-      <td>my terragrunt project</td>
       <td>dev</td>
       <td>ws2</td>
       <td align="right">$51.09</td>
       <td align="right">$51.97</td>
       <td>+$0.88 (+2%)</td>
+    </tr>
+    <tr>
+      <td>my terragrunt project</td>
+      <td>prod</td>
+      <td></td>
+      <td align="right">$1,308</td>
+      <td align="right">$748</td>
+      <td>-$560.64 (-43%)</td>
     </tr>
     <tr>
       <td>my terragrunt project</td>

--- a/cmd/infracost/testdata/output_format_git_hub_comment_without_module_path/infracost.json
+++ b/cmd/infracost/testdata/output_format_git_hub_comment_without_module_path/infracost.json
@@ -658,7 +658,7 @@
       }
     },
     {
-      "name": "same_name_plan",
+      "name": "different_name_plan",
       "metadata": {
         "path": "./cmd/infracost/testdata/terraform_v0.14_plan.json",
         "type": "terraform_plan_json",

--- a/cmd/infracost/testdata/output_format_git_hub_comment_without_module_path/output_format_git_hub_comment_without_module_path.golden
+++ b/cmd/infracost/testdata/output_format_git_hub_comment_without_module_path/output_format_git_hub_comment_without_module_path.golden
@@ -9,7 +9,7 @@
   </thead>
   <tbody>
     <tr>
-      <td>same_name_plan</td>
+      <td>different_name_plan</td>
       <td align="right">$40.56</td>
       <td align="right">$40.56</td>
       <td>$0</td>
@@ -30,7 +30,7 @@
 
 ```
 ──────────────────────────────────
-Project: same_name_plan
+Project: different_name_plan
 
 + aws_instance.instance_2
   Monthly cost depends on usage
@@ -49,7 +49,7 @@ Project: same_name_plan
           Monthly cost depends on usage
             +$0.10 per GB
 
-Monthly cost change for same_name_plan
+Monthly cost change for different_name_plan
 Amount:  $0.00 ($40.56 → $40.56)
 Percent: 0%
 

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -69,32 +69,22 @@ func formatCostChangeSentence(currency string, pastCost, cost *decimal.Decimal, 
 }
 
 func calculateMetadataToDisplay(projects []Project) (hasModulePath bool, hasWorkspace bool) {
-	// we only want to show metadata fields if they can help distinguish projects with the same name
-
-	sprojects := make([]Project, 0)
-	for _, p := range projects {
-		if p.Diff == nil || len(p.Diff.Resources) == 0 { // ignore the projects that are skipped
-			continue
-		}
-		sprojects = append(sprojects, p)
-	}
-
-	sort.Slice(sprojects, func(i, j int) bool {
-		if sprojects[i].Name != sprojects[j].Name {
-			return sprojects[i].Name < sprojects[j].Name
+	sort.Slice(projects, func(i, j int) bool {
+		if projects[i].Name != projects[j].Name {
+			return projects[i].Name < projects[j].Name
 		}
 
-		if sprojects[i].Metadata.TerraformModulePath != sprojects[j].Metadata.TerraformModulePath {
-			return sprojects[i].Metadata.TerraformModulePath < sprojects[j].Metadata.TerraformModulePath
+		if projects[i].Metadata.TerraformModulePath != projects[j].Metadata.TerraformModulePath {
+			return projects[i].Metadata.TerraformModulePath < projects[j].Metadata.TerraformModulePath
 		}
 
-		return sprojects[i].Metadata.WorkspaceLabel() < sprojects[j].Metadata.WorkspaceLabel()
+		return projects[i].Metadata.WorkspaceLabel() < projects[j].Metadata.WorkspaceLabel()
 	})
 
 	// check if any projects that have the same name have different path or workspace
-	for i, p := range sprojects {
+	for i, p := range projects {
 		if i > 0 { // we compare vs the previous item, so skip index 0
-			prev := sprojects[i-1]
+			prev := projects[i-1]
 			if p.Name == prev.Name {
 				if p.Metadata.TerraformModulePath != prev.Metadata.TerraformModulePath {
 					hasModulePath = true


### PR DESCRIPTION
We should still take into account skipped projects when showing the comment summary so users can still identify which project changed.