### PR TITLE
fix: reload ModuleCall when `each.value` changes

### DIFF
--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -44,7 +44,8 @@ type Attribute struct {
 	Verbose bool
 	Logger  *logrus.Entry
 	// newMock generates a mock value for the attribute if it's value is missing.
-	newMock func(attr *Attribute) cty.Value
+	newMock       func(attr *Attribute) cty.Value
+	previousValue cty.Value
 }
 
 // IsIterable returns if the attribute can be ranged over.
@@ -125,7 +126,29 @@ func (attr *Attribute) Value() cty.Value {
 	}
 
 	attr.Logger.Debug("fetching attribute value")
-	return attr.value(0)
+	val := attr.value(0)
+	attr.previousValue = val
+
+	return val
+}
+
+// HasChanged returns if the Attribute Value has changed since Value was last called.
+func (attr *Attribute) HasChanged() (change bool) {
+	if attr == nil {
+		return false
+	}
+
+	defer func() {
+		e := recover()
+		if e != nil {
+			attr.Logger.Debugf("HasChanged panicked with cty.Value comparison %s", e)
+			change = true
+		}
+	}()
+
+	previous := attr.previousValue
+	current := attr.value(0)
+	return !previous.RawEquals(current)
 }
 
 func (attr *Attribute) value(retry int) (ctyVal cty.Value) {

--- a/internal/providers/terraform/registry.go
+++ b/internal/providers/terraform/registry.go
@@ -81,7 +81,9 @@ func (r *ResourceRegistryMap) GetDefaultRefIDFunc(resourceDataType string) schem
 	if ok {
 		return item.DefaultRefIDFunc
 	}
-	return nil
+	return func(d *schema.ResourceData) []string {
+		return []string{d.Get("id").String()}
+	}
 }
 
 func GetUsageOnlyResources() []string {

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -504,7 +504,7 @@ func (p *TerragruntHCLProvider) runTerragrunt(opts *tgoptions.TerragruntOptions)
 				path = mod.Module.RootPath
 			}
 
-			p.logger.Debugf("Terragrunt config path %s returned module %s with error: %s", opts.TerragruntConfigPath, path, mod.Error)
+			p.logger.Warnf("Terragrunt config path %s returned module %s with error: %s", opts.TerragruntConfigPath, path, mod.Error)
 		}
 		evaluatedOutputs := mod.Module.Blocks.Outputs(true)
 		p.outputs[opts.TerragruntConfigPath] = evaluatedOutputs


### PR DESCRIPTION
When expanding a module we pass the `each.value` to it's definition block to set as initial vars in the child `Evaluator`. If the module `for_each` depends on a value that is yet to be known in the evaluation `Context` then the `each.value` will be incomplete.

This PR fixes this issue by:
1. Checking if `Blocks` in the evaluation loop `HaveChanged` to their `for_each` attribute. If they do then we expand these blocks again, setting the lower level `each.value` to the correct value.
3. We now keep track of `ModuleCalls` as a map, which allows us to lookup if the changed `Blocks` correspond to a loaded `ModuleCall`. If they do we reset the `Definition` block to the newly expanded one with the correct value.
4. This means that in `evaluateModules` call in the `Evaluator` that we see that the input vars have changed and reload the module

It also changes the `Registry` `GetDefaultRefIDFunc` behaviour to fallback to generating a reference from `id` this means unsupported resources can still be indexed as references.
