### PR TITLE
feat(installer): Allow installer to download any version

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,9 +19,10 @@ if [ "$arch" = "aarch64" ]; then
   arch="arm64"
 fi
 
-url="https://infracost.io/downloads/latest"
+version=${INFRACOST_VERSION:-latest}
+url="https://infracost.io/downloads/${version}"
 tar="infracost-$os-$arch.tar.gz"
-echo "Downloading latest release of infracost-$os-$arch..."
+echo "Downloading version ${version} of infracost-$os-$arch..."
 curl -sL "$url/$tar" -o "/tmp/$tar"
 echo
 


### PR DESCRIPTION
This PR allows the installer to download a specific version of infracost based on the INFRACOST_VERSION variable. Default to latest