### PR TITLE
enhance: allow an empty list of projects to be run

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -212,6 +212,11 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 
 func checkIfAllProjectsErrored(projects []*schema.Project) error {
 	allError := true
+
+	if len(projects) == 0 {
+		allError = false
+	}
+
 	for _, project := range projects {
 		if !project.Metadata.HasErrors() {
 			allError = false

--- a/cmd/infracost/testdata/config_file_nil_projects_errors/config_file_nil_projects_errors.golden
+++ b/cmd/infracost/testdata/config_file_nil_projects_errors/config_file_nil_projects_errors.golden
@@ -1,3 +1,5 @@
 
+ OVERALL TOTAL-               
+
 Err:
-Error: no projects specified in config file, please specify at least one project, see https://infracost.io/config-file for file specification
+

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -17,10 +17,7 @@ const (
 	maxConfigFileVersion = "0.1"
 )
 
-var (
-	ErrorInvalidConfigFile = errors.New("parsing config file failed check file syntax")
-	ErrorNilProjects       = errors.New("no projects specified in config file, please specify at least one project, see https://infracost.io/config-file for file specification")
-)
+var ErrorInvalidConfigFile = errors.New("parsing config file failed check file syntax")
 
 // YamlError is a custom error type that allows setting multiple
 // error messages under a base message. It is used to decipher
@@ -138,10 +135,6 @@ func (f *fileSpec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		tag := v.Field(i).Tag.Get("yaml")
 		pieces := strings.Split(tag, ",")
 		allowedKeys[strings.TrimSpace(pieces[0])] = struct{}{}
-	}
-
-	if len(r.Projects) == 0 {
-		return &YamlError{raw: ErrorNilProjects}
 	}
 
 	validationError := &YamlError{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,12 +50,12 @@ projects:
 			},
 		},
 		{
-			name: "should return error if no projects given",
+			name: "should not return error if no projects given",
 			contents: []byte(`version: 0.1
 
 projects:
 `),
-			error: &YamlError{raw: ErrorNilProjects},
+			expected: nil,
 		},
 		{
 			name: "should return panic error wrapped with invalid config file error",


### PR DESCRIPTION
I don't think we really need to show an error in this case, and this makes it a lot easier to work with config templates.