### PR TITLE
fix(azure): Mark MSSQL database as free when its SKU is ElasticPool

### DIFF
--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -65,6 +65,14 @@ func newAzureRMMSSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schem
 
 	sku := d.GetStringOrDefault("sku_name", "GP_S_Gen5_2")
 
+	if strings.ToLower(sku) == "elasticpool" {
+		return &schema.Resource{
+			Name:      d.Address,
+			NoPrice:   true,
+			IsSkipped: true,
+		}
+	}
+
 	var maxSize *float64
 	if !d.IsEmpty("max_size_gb") {
 		val := d.Get("max_size_gb").Float()

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
@@ -75,9 +75,10 @@
                                                                                                                   
  OVERALL TOTAL                                                                                         $28,383.46 
 ──────────────────────────────────
-15 cloud resources were detected:
+16 cloud resources were detected:
 ∙ 13 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
-∙ 2 were free:
+∙ 3 were free:
+  ∙ 1 x azurerm_mssql_database
   ∙ 1 x azurerm_resource_group
   ∙ 1 x azurerm_sql_server
 Logs:

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
@@ -98,3 +98,9 @@ resource "azurerm_mssql_database" "blank_sku" {
   name      = "acctest-db-e"
   server_id = azurerm_sql_server.example.id
 }
+
+resource "azurerm_mssql_database" "elastic_pool" {
+  name      = "acctest-db-f"
+  server_id = azurerm_sql_server.example.id
+  sku_name  = "ElasticPool"
+}


### PR DESCRIPTION
The costs apply on azure_sql_elastic_pool resource.

From #569:
> If this is ElasticPool then this resource has no cost since it will be handled by the azurerm_sql_elastic_pool resource.

Related to #1259.