### PR TITLE
fix: don't query resources twice if past resources are the same as current resources

### DIFF
--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -310,13 +310,7 @@ func loadResources(t *testing.T, pName string, tfProject TerraformProject, runCt
 	require.NoError(t, err)
 
 	for _, project := range projects {
-		for _, partial := range project.PartialResources {
-			project.Resources = append(project.Resources, schema.BuildResource(partial, nil))
-		}
-
-		for _, partial := range project.PartialPastResources {
-			project.PastResources = append(project.PastResources, schema.BuildResource(partial, nil))
-		}
+		project.BuildResources(map[string]*schema.UsageData{})
 	}
 
 	return projects

--- a/internal/schema/core_resource.go
+++ b/internal/schema/core_resource.go
@@ -76,14 +76,6 @@ func BuildResources(projects []*Project, projectPtrToUsageMap map[*Project]map[s
 	for _, project := range projects {
 		usageMap := projectPtrToUsageMap[project]
 
-		for _, partial := range project.PartialResources {
-			u := usageMap[partial.ResourceData.Address]
-			project.Resources = append(project.Resources, BuildResource(partial, u))
-		}
-
-		for _, partial := range project.PartialPastResources {
-			u := usageMap[partial.ResourceData.Address]
-			project.PastResources = append(project.PastResources, BuildResource(partial, u))
-		}
+		project.BuildResources(usageMap)
 	}
 }

--- a/internal/schema/project.go
+++ b/internal/schema/project.go
@@ -121,18 +121,73 @@ func (p *Project) NameWithWorkspace() string {
 
 // AllResources returns a pointer list of all resources of the state.
 func (p *Project) AllResources() []*Resource {
+	m := make(map[*Resource]bool)
+	for _, r := range p.PastResources {
+		m[r] = true
+	}
+
+	for _, r := range p.Resources {
+		if _, ok := m[r]; !ok {
+			m[r] = true
+		}
+	}
+
 	var resources []*Resource
-	resources = append(resources, p.PastResources...)
-	resources = append(resources, p.Resources...)
+	for r := range m {
+		resources = append(resources, r)
+	}
+
 	return resources
 }
 
 // AllPartialResources returns a pointer list of the current and past partial resources
 func (p *Project) AllPartialResources() []*PartialResource {
+	m := make(map[*PartialResource]bool)
+	for _, r := range p.PartialPastResources {
+		m[r] = true
+	}
+
+	for _, r := range p.PartialResources {
+		if _, ok := m[r]; !ok {
+			m[r] = true
+		}
+	}
+
 	var resources []*PartialResource
-	resources = append(resources, p.PartialPastResources...)
-	resources = append(resources, p.PartialResources...)
+	for r := range m {
+		resources = append(resources, r)
+	}
+
 	return resources
+}
+
+// BuildResources builds the resources from the partial resources
+// and sets the PastResources and Resources fields.
+func (p *Project) BuildResources(usageMap map[string]*UsageData) {
+	pastResources := make([]*Resource, 0, len(p.PartialPastResources))
+	resources := make([]*Resource, 0, len(p.PartialResources))
+
+	seen := make(map[*PartialResource]*Resource)
+
+	for _, p := range p.PartialPastResources {
+		u := usageMap[p.ResourceData.Address]
+		r := BuildResource(p, u)
+		seen[p] = r
+		pastResources = append(pastResources, r)
+	}
+
+	for _, p := range p.PartialResources {
+		r, ok := seen[p]
+		if !ok {
+			u := usageMap[p.ResourceData.Address]
+			r = BuildResource(p, u)
+			seen[p] = r
+		}
+		resources = append(resources, r)
+	}
+
+	p.PastResources = pastResources
+	p.Resources = resources
 }
 
 // CalculateDiff calculates the diff of past and current resources


### PR DESCRIPTION
This prevents the warning logs from being outputted twice.

We could improve this further by checking the existence of each resource individually, but for now this only handles the case where there is no diff.