### PR TITLE
refactor: ignore sensitive vars from warnings

### DIFF
--- a/internal/providers/terraform/testdata/hcl_provider_test/populates_warnings_on_missing_vars/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/populates_warnings_on_missing_vars/main.tf
@@ -10,6 +10,51 @@ variable "missing_var" {
   type = bool
 }
 
+variable "test_token" {
+  type = bool
+}
+
+variable "token_test" {
+  type = bool
+}
+
+variable "test_secret" {
+  type = bool
+}
+
+variable "secret_test" {
+  type = bool
+}
+
+variable "test_password" {
+  type = bool
+}
+
+variable "password_test" {
+  type = bool
+}
+
+variable "test_username" {
+  type = bool
+}
+
+variable "username_test" {
+  type = bool
+}
+
+variable "test_api_key_test" {
+  type = bool
+}
+
+variable "test_expiration_date_test" {
+  type = bool
+}
+
+variable "sensitive_test" {
+  type      = bool
+  sensitive = true
+}
+
 resource "aws_eip" "eip" {
   network_interface = "test"
 }


### PR DESCRIPTION
Removes sensitive variables from warnings output. Variables are omitted if they are:

* marked as `sensitive`
* contain a substring from a predetermined list of strings