### PR TITLE
feat: support absolute filepaths for terraform var files

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -150,6 +150,7 @@ func TestBreakdownTerraformDirectoryWithDefaultVarFiles(t *testing.T) {
 	})
 
 	t.Run("with hcl var flags", func(t *testing.T) {
+		abs, _ := filepath.Abs(path.Join(dir, "abs.tfvars"))
 		GoldenFileCommandTest(
 			t,
 			testName,
@@ -157,6 +158,7 @@ func TestBreakdownTerraformDirectoryWithDefaultVarFiles(t *testing.T) {
 				"breakdown",
 				"--path", dir,
 				"--terraform-var-file", "hcl.tfvars",
+				"--terraform-var-file", abs,
 				"--terraform-var-file", "hcl.tfvars.json",
 				"--terraform-var", "block2_ebs_volume_size=2000",
 				"--terraform-var", "block2_volume_type=io1",

--- a/cmd/infracost/testdata/breakdown_terraform_directory_with_default_var_files/abs.tfvars
+++ b/cmd/infracost/testdata/breakdown_terraform_directory_with_default_var_files/abs.tfvars
@@ -1,0 +1,1 @@
+block1_ebs_iops = 1000

--- a/cmd/infracost/testdata/breakdown_terraform_directory_with_default_var_files/hcl.tfvars
+++ b/cmd/infracost/testdata/breakdown_terraform_directory_with_default_var_files/hcl.tfvars
@@ -1,2 +1,1 @@
 instance_type   = "m5.2xlarge"
-block1_ebs_iops = 1000

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -31,12 +31,18 @@ type Option func(p *Parser)
 // to the Parser initialPath. Paths that don't exist will be ignored.
 func OptionWithTFVarsPaths(paths []string) Option {
 	return func(p *Parser) {
-		var relative []string
+		var filenames []string
 		for _, name := range paths {
-			tfvp := path.Join(p.initialPath, name)
-			relative = append(relative, tfvp)
+			if path.IsAbs(name) {
+				filenames = append(filenames, name)
+				continue
+			}
+
+			relToProject := path.Join(p.initialPath, name)
+			filenames = append(filenames, relToProject)
 		}
-		p.tfvarsPaths = relative
+
+		p.tfvarsPaths = filenames
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/infracost/infracost/issues/2166

This change enables users to pass absolute paths to the `--terraform-var-file` flag. This allows for greater composability of projects, and helps users who have a top level global var file directory.