### PR TITLE
Feat:(AWS) Adds Lambda provisioned concurrency

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -262,6 +262,13 @@ resource_usage:
   aws_lambda_function.my_function:
     monthly_requests: 100000 # Monthly requests to the Lambda function.
     request_duration_ms: 500 # Average duration of each request in milliseconds.
+  
+  aws_lambda_provisioned_concurrency_config.my_config:
+    monthly_duration_hrs: 100 # Number of hours in a month that provisioned concurrency will be enabled.
+    request_duration_ms: 350 # Average duration of each request in milliseconds during the enabled period.
+    monthly_requests: 10000000 # Number of requests sent to the function during the enabled period.
+    architecture: arm64 # Architecture of the Lambda function.
+    memory_mb: 512 # Memory size of the Lambda function.
 
   aws_alb.my_alb:
     new_connections: 10000    # Number of newly established connections per second on average.

--- a/internal/providers/terraform/aws/lambda_function.go
+++ b/internal/providers/terraform/aws/lambda_function.go
@@ -9,7 +9,6 @@ import (
 func getLambdaFunctionRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:      "aws_lambda_function",
-		Notes:     []string{"Provisioned concurrency is not yet supported."},
 		CoreRFunc: NewLambdaFunction,
 	}
 }

--- a/internal/providers/terraform/aws/lambda_provisioned_concurrency_config.go
+++ b/internal/providers/terraform/aws/lambda_provisioned_concurrency_config.go
@@ -1,8 +1,6 @@
 package aws
 
 import (
-	"fmt"
-
 	"github.com/infracost/infracost/internal/resources/aws"
 	"github.com/infracost/infracost/internal/schema"
 )
@@ -18,8 +16,6 @@ func NewLambdaProvisionedConcurrencyConfig(d *schema.ResourceData, u *schema.Usa
 	region := d.Get("region").String()
 	name := d.Get("function_name").String()
 	provisionedConcurrentExecutions := d.Get("provisioned_concurrent_executions").Int()
-
-	fmt.Println(provisionedConcurrentExecutions)
 
 	r := &aws.LambdaProvisionedConcurrencyConfig{
 		Address:                         d.Address,

--- a/internal/providers/terraform/aws/lambda_provisioned_concurrency_config.go
+++ b/internal/providers/terraform/aws/lambda_provisioned_concurrency_config.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/infracost/infracost/internal/resources/aws"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getLambdaProvisionedConcurrencyConfigRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "aws_lambda_provisioned_concurrency_config",
+		RFunc: NewLambdaProvisionedConcurrencyConfig,
+	}
+}
+
+func NewLambdaProvisionedConcurrencyConfig(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := d.Get("region").String()
+	name := d.Get("function_name").String()
+	provisionedConcurrentExecutions := d.Get("provisioned_concurrent_executions").Int()
+
+	fmt.Println(provisionedConcurrentExecutions)
+
+	r := &aws.LambdaProvisionedConcurrencyConfig{
+		Address:                         d.Address,
+		Region:                          region,
+		Name:                            name,
+		ProvisionedConcurrentExecutions: provisionedConcurrentExecutions,
+	}
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/aws/lambda_provisioned_concurrency_config_test.go
+++ b/internal/providers/terraform/aws/lambda_provisioned_concurrency_config_test.go
@@ -1,0 +1,16 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestLambdaProvisionedConcurrencyConfig(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "lambda_provisioned_concurrency_config_test")
+}

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -108,6 +108,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getGlobalAcceleratorRegistryItem(),
 	getGlobalacceleratorEndpointGroupRegistryItem(),
 	getEC2HostRegistryItem(),
+	getLambdaProvisionedConcurrencyConfigRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/aws/testdata/lambda_provisioned_concurrency_config_test/lambda_provisioned_concurrency_config_test.golden
+++ b/internal/providers/terraform/aws/testdata/lambda_provisioned_concurrency_config_test/lambda_provisioned_concurrency_config_test.golden
@@ -1,0 +1,11 @@
+
+ Name                                                  Monthly Qty  Unit        Monthly Cost 
+                                                                                             
+ aws_lambda_provisioned_concurrency_config.with_usage                                        
+ ├─ Provisioned Concurrency                              9,000,000  GB-seconds        $30.00 
+ └─ Duration                                             1,750,000  GB-seconds        $13.61 
+                                                                                             
+ OVERALL TOTAL                                                                        $43.61 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/lambda_provisioned_concurrency_config_test/lambda_provisioned_concurrency_config_test.golden
+++ b/internal/providers/terraform/aws/testdata/lambda_provisioned_concurrency_config_test/lambda_provisioned_concurrency_config_test.golden
@@ -1,11 +1,12 @@
 
- Name                                                  Monthly Qty  Unit        Monthly Cost 
-                                                                                             
- aws_lambda_provisioned_concurrency_config.with_usage                                        
- ├─ Provisioned Concurrency                              9,000,000  GB-seconds        $30.00 
- └─ Duration                                             1,750,000  GB-seconds        $13.61 
-                                                                                             
- OVERALL TOTAL                                                                        $43.61 
+ Name                                                  Monthly Qty  Unit         Monthly Cost 
+                                                                                              
+ aws_lambda_provisioned_concurrency_config.with_usage                                         
+ ├─ Requests                                                    10  1M requests         $2.00 
+ ├─ Provisioned Concurrency                              9,000,000  GB-seconds         $30.00 
+ └─ Duration                                             1,750,000  GB-seconds         $13.61 
+                                                                                              
+ OVERALL TOTAL                                                                         $45.61 
 ──────────────────────────────────
 2 cloud resources were detected:
 ∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/lambda_provisioned_concurrency_config_test/lambda_provisioned_concurrency_config_test.tf
+++ b/internal/providers/terraform/aws/testdata/lambda_provisioned_concurrency_config_test/lambda_provisioned_concurrency_config_test.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+# Add example resources for LambdaProvisionedConcurrencyConfig below
+resource "aws_lambda_provisioned_concurrency_config" "with_usage" {
+  function_name                     = "lambda_function_name"
+  provisioned_concurrent_executions = 50
+  qualifier                         = 1
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "without_usage" {
+  function_name                     = "lambda_function_name"
+  provisioned_concurrent_executions = 100
+  qualifier                         = 1
+}

--- a/internal/providers/terraform/aws/testdata/lambda_provisioned_concurrency_config_test/lambda_provisioned_concurrency_config_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/lambda_provisioned_concurrency_config_test/lambda_provisioned_concurrency_config_test.usage.yml
@@ -1,0 +1,8 @@
+version: 0.1
+resource_usage:
+  aws_lambda_provisioned_concurrency_config.with_usage:
+    monthly_duration_hrs: 100
+    request_duration_ms: 350
+    monthly_requests: 10000000
+    architecture: arm64
+    memory_mb: 512

--- a/internal/resources/aws/lambda_provisioned_concurrency_config.go
+++ b/internal/resources/aws/lambda_provisioned_concurrency_config.go
@@ -1,0 +1,116 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// LambdaProvisionedConcurrencyConfig initializes a requested number of execution environments so that
+// they are prepared to respond immediatley to your functions invocations. Configuring provisioned
+// concurrency incurs charges to your AWS Account.
+//
+// Resource information: https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html
+// Pricing information: https://aws.amazon.com/lambda/pricing/#Provisioned_Concurrency_Pricing
+type LambdaProvisionedConcurrencyConfig struct {
+	Address                         string
+	Region                          string
+	Name                            string
+	ProvisionedConcurrentExecutions int64
+
+	MonthlyDurationHours *int64  `infracost_usage:"monthly_duration_hrs"`
+	MonthlyRequests      *int64  `infracost_usage:"monthly_requests"`
+	RequestDurationMS    *int64  `infracost_usage:"request_duration_ms"`
+	Architecture         *string `infracost_usage:"architecture"`
+	MemoryMB             *int64  `infracost_usage:"memory_mb"`
+}
+
+var LambdaProvisionedConcurrencyConfigUsageSchema = []*schema.UsageItem{
+	{Key: "memory_mb", ValueType: schema.Int64, DefaultValue: 512},
+	{Key: "architecture", ValueType: schema.String, DefaultValue: "x86_64"},
+	{Key: "monthly_duration_hrs", ValueType: schema.Int64, DefaultValue: 0},
+	{Key: "monthly_requests", ValueType: schema.Int64, DefaultValue: 0},
+	{Key: "request_duration_ms", ValueType: schema.Int64, DefaultValue: 0},
+}
+
+func (r *LambdaProvisionedConcurrencyConfig) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+func (r *LambdaProvisionedConcurrencyConfig) BuildResource() *schema.Resource {
+	monthlyDurationHours := decimal.NewFromInt(0)
+	memorySize := decimal.NewFromInt(512)
+	monthlyRequests := decimal.NewFromInt(0)
+
+	concurrentExecutions := decimal.NewFromInt(r.ProvisionedConcurrentExecutions)
+
+	if r.MonthlyRequests != nil {
+		monthlyRequests = decimal.NewFromInt(*r.MonthlyRequests)
+	}
+
+	if r.MonthlyDurationHours != nil {
+		monthlyDurationHours = decimal.NewFromInt(*r.MonthlyDurationHours)
+	}
+
+	averageRequestDuration := decimal.NewFromInt(1)
+	if r.RequestDurationMS != nil {
+		averageRequestDuration = decimal.NewFromInt(*r.RequestDurationMS)
+	}
+
+	if r.MemoryMB != nil {
+		memorySize = decimal.NewFromInt(*r.MemoryMB)
+	}
+
+	totalSeconds := monthlyDurationHours.Mul(decimal.NewFromInt(3600))
+	totalConcurrencyConfigured := concurrentExecutions.Mul(memorySize.Div(decimal.NewFromInt(1024)))
+	totalConcurrency := totalConcurrencyConfigured.Mul(totalSeconds)
+
+	concurrencyType := "AWS-Lambda-Provisioned-Concurrency"
+	durationType := "AWS-Lambda-Duration-Provisioned"
+
+	if strVal(r.Architecture) == "arm64" {
+		concurrencyType = "AWS-Lambda-Provisioned-Concurrency-ARM"
+		durationType = "AWS-Lambda-Duration-Provisioned-ARM"
+	}
+
+	provisionDuration := calculateGBSeconds(memorySize, averageRequestDuration, monthlyRequests)
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name:            "Provisioned Concurrency",
+			Unit:            "GB-seconds",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: &totalConcurrency,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("AWSLambda"),
+				ProductFamily: strPtr("Serverless"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "group", Value: strPtr(concurrencyType)},
+				},
+			},
+		},
+		{
+			Name:            "Duration",
+			Unit:            "GB-seconds",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: &provisionDuration,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("aws"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("AWSLambda"),
+				ProductFamily: strPtr("Serverless"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "group", Value: strPtr(durationType)},
+				},
+			},
+		},
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    LambdaProvisionedConcurrencyConfigUsageSchema,
+		CostComponents: costComponents,
+	}
+}

--- a/internal/resources/aws/lambda_provisioned_concurrency_config.go
+++ b/internal/resources/aws/lambda_provisioned_concurrency_config.go
@@ -7,7 +7,7 @@ import (
 )
 
 // LambdaProvisionedConcurrencyConfig initializes a requested number of execution environments so that
-// they are prepared to respond immediatley to your functions invocations. Configuring provisioned
+// they are prepared to respond immediately to your functions invocations. Configuring provisioned
 // concurrency incurs charges to your AWS Account.
 //
 // Resource information: https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html


### PR DESCRIPTION
Adds new resource `aws_lambda_provisioned_concurrency_config` to support provisioned concurrency in lambda. I think there's potentially more that can be done to merge with `aws_lambda_function`. I did try to use the references logic within the code but couldn't get it to work. This resource provides 2 cost components, duration & concurrency. 

Closes more of #2138 