### PR TITLE
feat: wildcard support for modules in usage file

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -275,6 +275,21 @@ func TestBreakdownTerraformUsageFile(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "./testdata/example_plan.json", "--usage-file", "./testdata/example_usage.yml"}, nil)
 }
 
+func TestBreakdownTerraformUsageFileWildcardModule(t *testing.T) {
+	name := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())
+	GoldenFileCommandTest(
+		t,
+		name,
+		[]string{
+			"breakdown",
+			"--path", dir,
+			"--usage-file", filepath.Join(dir, "infracost-usage.yml"),
+		},
+		nil,
+	)
+}
+
 func TestBreakdownTerraformUsageFileInvalidKey(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "./testdata/example_plan.json", "--usage-file", "./testdata/infracost-usage-invalid-key.yml"}, nil)
 }

--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -264,7 +264,7 @@ func TestBreakdownTerraformSyncUsageFile(t *testing.T) {
 
 	GoldenFileCommandTest(t, testdataName, []string{"breakdown", "--path", "testdata/breakdown_terraform_sync_usage_file/sync_usage_file.json", "--usage-file", usageFilePath, "--sync-usage-file"}, nil)
 
-	actual, err := ioutil.ReadFile(usageFilePath)
+	actual, err := os.ReadFile(usageFilePath)
 	require.Nil(t, err)
 	actual = stripDynamicValues(actual)
 

--- a/cmd/infracost/scan.go
+++ b/cmd/infracost/scan.go
@@ -91,7 +91,7 @@ func (s scanCmd) run(runCtx *config.RunContext) error {
 	spinner := ui.NewSpinner("Scanning projects for cost optimizations...", spinnerOpts)
 	defer spinner.Fail()
 
-	usageData := make(map[string]*schema.UsageData)
+	usageData := schema.NewUsageMapFromInterface(map[string]interface{}{})
 
 	if s.UsageFile != "" {
 		usageFile, err := usage.LoadUsageFile(s.UsageFile)

--- a/cmd/infracost/testdata/breakdown_terraform_sync_usage_file/breakdown_terraform_sync_usage_file.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_sync_usage_file/breakdown_terraform_sync_usage_file.golden
@@ -8,7 +8,7 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_terraform_sync_usa
  └─ Insights queries data scanned                    Monthly cost depends on usage: $0.005 per GB   
                                                                                                     
  aws_cloudwatch_log_group.production_logs["media"]                                                  
- ├─ Data ingested                                    Monthly cost depends on usage: $0.50 per GB    
+ ├─ Data ingested                                             1,000  GB                     $500.00 
  ├─ Archival Storage                                          1,000  GB                      $30.00 
  └─ Insights queries data scanned                    Monthly cost depends on usage: $0.005 per GB   
                                                                                                     
@@ -28,7 +28,7 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_terraform_sync_usa
  ├─ NAT gateway                                                 730  hours                   $32.85 
  └─ Data processed                                                2  GB                       $0.09 
                                                                                                     
- OVERALL TOTAL                                                                              $251.12 
+ OVERALL TOTAL                                                                              $751.12 
 ──────────────────────────────────
 6 cloud resources were detected:
 ∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/breakdown_terraform_usage_file_wildcard_module.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/breakdown_terraform_usage_file_wildcard_module.golden
@@ -1,39 +1,87 @@
 Project: infracost/infracost/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module
 
- Name                                                 Monthly Qty  Unit         Monthly Cost 
-                                                                                             
- aws_lambda_function.test                                                                    
- ├─ Requests                                                  500  1M requests       $100.00 
- └─ Duration (first 6B)                               275,000,000  GB-seconds      $4,583.34 
-                                                                                             
- module.mod["test"].aws_lambda_function.test2                                                
- ├─ Requests                                                  200  1M requests        $40.00 
- └─ Duration (first 6B)                                70,000,000  GB-seconds      $1,166.67 
-                                                                                             
- module.mod["test"].aws_lambda_function.test["baz"]                                          
- ├─ Requests                                                  100  1M requests        $20.00 
- └─ Duration (first 6B)                                25,000,000  GB-seconds        $416.67 
-                                                                                             
- module.mod["test"].aws_lambda_function.test["foo"]                                          
- ├─ Requests                                                  100  1M requests        $20.00 
- └─ Duration (first 6B)                                25,000,000  GB-seconds        $416.67 
-                                                                                             
- module.mod["test2"].aws_lambda_function.test2                                               
- ├─ Requests                                                  200  1M requests        $40.00 
- └─ Duration (first 6B)                                70,000,000  GB-seconds      $1,166.67 
-                                                                                             
- module.mod["test2"].aws_lambda_function.test["baz"]                                         
- ├─ Requests                                                  700  1M requests       $140.00 
- └─ Duration (first 6B)                               525,000,000  GB-seconds      $8,750.02 
-                                                                                             
- module.mod["test2"].aws_lambda_function.test["foo"]                                         
- ├─ Requests                                                  400  1M requests        $80.00 
- └─ Duration (first 6B)                               180,000,000  GB-seconds      $3,000.01 
-                                                                                             
- OVERALL TOTAL                                                                    $19,940.04 
+ Name                                                          Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                     
+ aws_lambda_function.test                                                                                            
+ ├─ Requests                                                           500  1M requests                      $100.00 
+ └─ Duration (first 6B)                                        275,000,000  GB-seconds                     $4,583.34 
+                                                                                                                     
+ module.mod2["test"].aws_lambda_function.test2                                                                       
+ ├─ Requests                                           Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration (first 6B)                                Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                     
+ module.mod2["test"].aws_lambda_function.test["baz"]                                                                 
+ ├─ Requests                                           Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration (first 6B)                                Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                     
+ module.mod2["test"].aws_lambda_function.test["foo"]                                                                 
+ ├─ Requests                                           Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration (first 6B)                                Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                     
+ module.mod2["test2"].aws_lambda_function.test2                                                                      
+ ├─ Requests                                           Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration (first 6B)                                Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                     
+ module.mod2["test2"].aws_lambda_function.test["baz"]                                                                
+ ├─ Requests                                                           900  1M requests                      $180.00 
+ └─ Duration (first 6B)                                        180,000,000  GB-seconds                     $3,000.01 
+                                                                                                                     
+ module.mod2["test2"].aws_lambda_function.test["foo"]                                                                
+ ├─ Requests                                                           900  1M requests                      $180.00 
+ └─ Duration (first 6B)                                         90,000,000  GB-seconds                     $1,500.00 
+                                                                                                                     
+ module.mod3["test"].aws_lambda_function.test2                                                                       
+ ├─ Requests                                           Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration (first 6B)                                Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                     
+ module.mod3["test"].aws_lambda_function.test["baz"]                                                                 
+ ├─ Requests                                                           200  1M requests                       $40.00 
+ └─ Duration (first 6B)                                         10,000,000  GB-seconds                       $166.67 
+                                                                                                                     
+ module.mod3["test"].aws_lambda_function.test["foo"]                                                                 
+ ├─ Requests                                                           200  1M requests                       $40.00 
+ └─ Duration (first 6B)                                          2,000,000  GB-seconds                        $33.33 
+                                                                                                                     
+ module.mod3["test2"].aws_lambda_function.test2                                                                      
+ ├─ Requests                                           Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration (first 6B)                                Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                     
+ module.mod3["test2"].aws_lambda_function.test["baz"]                                                                
+ ├─ Requests                                                           200  1M requests                       $40.00 
+ └─ Duration (first 6B)                                         10,000,000  GB-seconds                       $166.67 
+                                                                                                                     
+ module.mod3["test2"].aws_lambda_function.test["foo"]                                                                
+ ├─ Requests                                                           200  1M requests                       $40.00 
+ └─ Duration (first 6B)                                          2,000,000  GB-seconds                        $33.33 
+                                                                                                                     
+ module.mod["test"].aws_lambda_function.test2                                                                        
+ ├─ Requests                                                           200  1M requests                       $40.00 
+ └─ Duration (first 6B)                                         70,000,000  GB-seconds                     $1,166.67 
+                                                                                                                     
+ module.mod["test"].aws_lambda_function.test["baz"]                                                                  
+ ├─ Requests                                                           100  1M requests                       $20.00 
+ └─ Duration (first 6B)                                         25,000,000  GB-seconds                       $416.67 
+                                                                                                                     
+ module.mod["test"].aws_lambda_function.test["foo"]                                                                  
+ ├─ Requests                                                           100  1M requests                       $20.00 
+ └─ Duration (first 6B)                                         25,000,000  GB-seconds                       $416.67 
+                                                                                                                     
+ module.mod["test2"].aws_lambda_function.test2                                                                       
+ ├─ Requests                                                           200  1M requests                       $40.00 
+ └─ Duration (first 6B)                                         70,000,000  GB-seconds                     $1,166.67 
+                                                                                                                     
+ module.mod["test2"].aws_lambda_function.test["baz"]                                                                 
+ ├─ Requests                                                           700  1M requests                      $140.00 
+ └─ Duration (first 6B)                                        525,000,000  GB-seconds                     $8,750.02 
+                                                                                                                     
+ module.mod["test2"].aws_lambda_function.test["foo"]                                                                 
+ ├─ Requests                                                           400  1M requests                       $80.00 
+ └─ Duration (first 6B)                                         20,000,000  GB-seconds                       $333.33 
+                                                                                                                     
+ OVERALL TOTAL                                                                                            $22,693.38 
 ──────────────────────────────────
-7 cloud resources were detected:
-∙ 7 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+19 cloud resources were detected:
+∙ 19 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 
 Err:
 

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/breakdown_terraform_usage_file_wildcard_module.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/breakdown_terraform_usage_file_wildcard_module.golden
@@ -1,0 +1,39 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module
+
+ Name                                                 Monthly Qty  Unit         Monthly Cost 
+                                                                                             
+ aws_lambda_function.test                                                                    
+ ├─ Requests                                                  500  1M requests       $100.00 
+ └─ Duration (first 6B)                               275,000,000  GB-seconds      $4,583.34 
+                                                                                             
+ module.mod["test"].aws_lambda_function.test2                                                
+ ├─ Requests                                                  200  1M requests        $40.00 
+ └─ Duration (first 6B)                                70,000,000  GB-seconds      $1,166.67 
+                                                                                             
+ module.mod["test"].aws_lambda_function.test["baz"]                                          
+ ├─ Requests                                                  100  1M requests        $20.00 
+ └─ Duration (first 6B)                                25,000,000  GB-seconds        $416.67 
+                                                                                             
+ module.mod["test"].aws_lambda_function.test["foo"]                                          
+ ├─ Requests                                                  100  1M requests        $20.00 
+ └─ Duration (first 6B)                                25,000,000  GB-seconds        $416.67 
+                                                                                             
+ module.mod["test2"].aws_lambda_function.test2                                               
+ ├─ Requests                                                  200  1M requests        $40.00 
+ └─ Duration (first 6B)                                70,000,000  GB-seconds      $1,166.67 
+                                                                                             
+ module.mod["test2"].aws_lambda_function.test["baz"]                                         
+ ├─ Requests                                                  700  1M requests       $140.00 
+ └─ Duration (first 6B)                               525,000,000  GB-seconds      $8,750.02 
+                                                                                             
+ module.mod["test2"].aws_lambda_function.test["foo"]                                         
+ ├─ Requests                                                  400  1M requests        $80.00 
+ └─ Duration (first 6B)                               180,000,000  GB-seconds      $3,000.01 
+                                                                                             
+ OVERALL TOTAL                                                                    $19,940.04 
+──────────────────────────────────
+7 cloud resources were detected:
+∙ 7 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/infracost-usage.yml
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/infracost-usage.yml
@@ -8,10 +8,22 @@ resource_usage:
     request_duration_ms: 350
   module.mod["test2"].aws_lambda_function.test[*]:
     monthly_requests: 400000000
-    request_duration_ms: 450
+    request_duration_ms: 50
   module.mod["test2"].aws_lambda_function.test["baz"]:
     monthly_requests: 700000000
     request_duration_ms: 750
+  module.mod2["test2"].aws_lambda_function.test[*]:
+    monthly_requests: 900000000
+  module.mod2["test2"].aws_lambda_function.test["baz"]:
+    request_duration_ms: 200
+  module.mod2["test2"].aws_lambda_function.test["foo"]:
+    request_duration_ms: 100
+  module.mod3[*].aws_lambda_function.test[*]:
+    monthly_requests: 200000000
+  module.mod3[*].aws_lambda_function.test["foo"]:
+    request_duration_ms: 10
+  module.mod3[*].aws_lambda_function.test["baz"]:
+    request_duration_ms: 50
   aws_lambda_function.test:
     monthly_requests: 500000000
     request_duration_ms: 550

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/infracost-usage.yml
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/infracost-usage.yml
@@ -1,0 +1,17 @@
+version: 0.1
+resource_usage:
+  module.mod[*].aws_lambda_function.test[*]:
+    monthly_requests: 100000000
+    request_duration_ms: 250
+  module.mod[*].aws_lambda_function.test2:
+    monthly_requests: 200000000
+    request_duration_ms: 350
+  module.mod["test2"].aws_lambda_function.test[*]:
+    monthly_requests: 400000000
+    request_duration_ms: 450
+  module.mod["test2"].aws_lambda_function.test["baz"]:
+    monthly_requests: 700000000
+    request_duration_ms: 750
+  aws_lambda_function.test:
+    monthly_requests: 500000000
+    request_duration_ms: 550

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/main.tf
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+
+module "mod" {
+  for_each = { test = "1", test2 = "2" }
+
+  source = "./modules/test"
+
+  range = { foo = "bar", baz = "bat" }
+}
+
+resource "aws_lambda_function" "test" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  filename      = "function.zip"
+  memory_size   = 1024
+}

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/main.tf
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/main.tf
@@ -15,6 +15,22 @@ module "mod" {
   range = { foo = "bar", baz = "bat" }
 }
 
+module "mod2" {
+  for_each = { test = "1", test2 = "2" }
+
+  source = "./modules/test"
+
+  range = { foo = "bar", baz = "bat" }
+}
+
+module "mod3" {
+  for_each = { test = "1", test2 = "2" }
+
+  source = "./modules/test"
+
+  range = { foo = "bar", baz = "bat" }
+}
+
 resource "aws_lambda_function" "test" {
   function_name = "hello_world"
   role          = "arn:aws:lambda:us-east-1:account-id:resource-id"

--- a/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/modules/test/lambda.tf
+++ b/cmd/infracost/testdata/breakdown_terraform_usage_file_wildcard_module/modules/test/lambda.tf
@@ -1,0 +1,21 @@
+variable "range" {}
+
+resource "aws_lambda_function" "test" {
+  for_each = var.range
+
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  filename      = "function.zip"
+  memory_size   = 1024
+}
+
+resource "aws_lambda_function" "test2" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:account-id:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  filename      = "function.zip"
+  memory_size   = 1024
+}

--- a/internal/prices/usages.go
+++ b/internal/prices/usages.go
@@ -128,7 +128,7 @@ func popResourceActualCosts(ctx *config.RunContext, c *apiclient.UsageAPIClient,
 
 // FetchUsageData fetches usage estimates derived from cloud provider reported usage
 // from the Infracost Cloud Usage API for each supported resource in the project
-func FetchUsageData(ctx *config.RunContext, project *schema.Project) (map[string]*schema.UsageData, error) {
+func FetchUsageData(ctx *config.RunContext, project *schema.Project) (schema.UsageMap, error) {
 	c := apiclient.NewUsageAPIClient(ctx)
 
 	// gather all the CoreResource
@@ -162,7 +162,7 @@ func FetchUsageData(ctx *config.RunContext, project *schema.Project) (map[string
 
 			attributes, err := c.ListUsageQuantities(vars)
 			if err != nil {
-				return nil, err
+				return schema.NewUsageMap(usageMap), err
 			}
 
 			usageMap[address] = &schema.UsageData{
@@ -172,7 +172,7 @@ func FetchUsageData(ctx *config.RunContext, project *schema.Project) (map[string
 		}
 	}
 
-	return usageMap, nil
+	return schema.NewUsageMap(usageMap), nil
 }
 
 // UploadCloudResourceIDs sends the project scoped cloud resource ids to the Usage API, so they can be used

--- a/internal/providers/cloudformation/template_provider.go
+++ b/internal/providers/cloudformation/template_provider.go
@@ -34,7 +34,7 @@ func (p *TemplateProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 	metadata.ConfigSha = p.ctx.ProjectConfig.ConfigSha
 }
 
-func (p *TemplateProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
+func (p *TemplateProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, error) {
 	template, err := goformation.Open(p.Path)
 	if err != nil {
 		return []*schema.Project{}, errors.Wrap(err, "Error reading CloudFormation template file")

--- a/internal/providers/terraform/aws/autoscaling_group_test.go
+++ b/internal/providers/terraform/aws/autoscaling_group_test.go
@@ -119,5 +119,5 @@ func TestAutoscalingGroup_spot(t *testing.T) {
 		},
 	}
 
-	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+	tftest.ResourceTests(t, tf, schema.UsageMap{}, resourceChecks)
 }

--- a/internal/providers/terraform/aws/data_transfer_test.go
+++ b/internal/providers/terraform/aws/data_transfer_test.go
@@ -1,10 +1,12 @@
 package aws_test
 
 import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/infracost/infracost/internal/testutil"
-	"github.com/shopspring/decimal"
-	"testing"
 
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
 )
@@ -27,7 +29,7 @@ func TestChinaDataTransfer(t *testing.T) {
 
 	tf := ``
 
-	usage := schema.NewUsageMap(map[string]interface{}{
+	usage := schema.NewUsageMapFromInterface(map[string]interface{}{
 		"aws_data_transfer.cn-north-1": map[string]interface{}{
 			"region":                            "cn-north-1",
 			"monthly_intra_region_gb":           10,

--- a/internal/providers/terraform/aws/eks_node_group_test.go
+++ b/internal/providers/terraform/aws/eks_node_group_test.go
@@ -1,10 +1,12 @@
 package aws_test
 
 import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/infracost/infracost/internal/testutil"
-	"github.com/shopspring/decimal"
-	"testing"
 
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
 )
@@ -62,5 +64,5 @@ func TestEKSNodeGroup_spot(t *testing.T) {
 		},
 	}
 
-	tftest.ResourceTests(t, tf, schema.NewEmptyUsageMap(), resourceChecks)
+	tftest.ResourceTests(t, tf, schema.UsageMap{}, resourceChecks)
 }

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -142,7 +142,7 @@ func (p *DirProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 	metadata.TerraformWorkspace = terraformWorkspace
 }
 
-func (p *DirProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
+func (p *DirProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, error) {
 	projects := make([]*schema.Project, 0)
 	var out []byte
 	var err error

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -190,7 +190,7 @@ func (p *HCLProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 // LoadResources calls a hcl.Parser to parse the directory config files into hcl.Blocks. It then builds a shallow
 // representation of the terraform plan JSON files from these Blocks, this is passed to the PlanJSONProvider.
 // The PlanJSONProvider uses this shallow representation to actually load Infracost resources.
-func (p *HCLProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
+func (p *HCLProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, error) {
 	jsons := p.LoadPlanJSONs()
 
 	var projects = make([]*schema.Project, len(jsons))
@@ -217,7 +217,7 @@ func (p *HCLProvider) LoadResources(usage map[string]*schema.UsageData) ([]*sche
 	return projects, nil
 }
 
-func (p *HCLProvider) parseResources(parsed HCLProject, usage map[string]*schema.UsageData) *schema.Project {
+func (p *HCLProvider) parseResources(parsed HCLProject, usage schema.UsageMap) *schema.Project {
 	project := p.newProject(parsed)
 
 	partialPastResources, partialResources, err := p.planJSONParser.parseJSON(parsed.JSON, usage)

--- a/internal/providers/terraform/parser_test.go
+++ b/internal/providers/terraform/parser_test.go
@@ -399,7 +399,7 @@ func TestParseJSONResources(t *testing.T) {
 
 	parsed := gjson.Parse(testData)
 
-	usage := schema.NewUsageMap(map[string]interface{}{
+	usage := schema.NewUsageMapFromInterface(map[string]interface{}{
 		"aws_cloudwatch_log_group.array_resource[*]": map[string]interface{}{
 			"monthly_data_ingested_gb": 0,
 		},

--- a/internal/providers/terraform/plan_json_provider.go
+++ b/internal/providers/terraform/plan_json_provider.go
@@ -51,7 +51,7 @@ func (p *PlanJSONProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 	metadata.TerraformWorkspace = p.ctx.ProjectConfig.TerraformWorkspace
 }
 
-func (p *PlanJSONProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
+func (p *PlanJSONProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, error) {
 	spinner := ui.NewSpinner("Extracting only cost-related params from terraform", ui.SpinnerOptions{
 		EnableLogging: p.ctx.RunContext.Config.IsLogging(),
 		NoColor:       p.ctx.RunContext.Config.NoColor,
@@ -72,7 +72,7 @@ func (p *PlanJSONProvider) LoadResources(usage map[string]*schema.UsageData) ([]
 	return []*schema.Project{project}, nil
 }
 
-func (p *PlanJSONProvider) LoadResourcesFromSrc(usage map[string]*schema.UsageData, j []byte, spinner *ui.Spinner) (*schema.Project, error) {
+func (p *PlanJSONProvider) LoadResourcesFromSrc(usage schema.UsageMap, j []byte, spinner *ui.Spinner) (*schema.Project, error) {
 	metadata := config.DetectProjectMetadata(p.ctx.ProjectConfig.Path)
 	metadata.Type = p.Type()
 	p.AddMetadata(metadata)

--- a/internal/providers/terraform/plan_provider.go
+++ b/internal/providers/terraform/plan_provider.go
@@ -39,7 +39,7 @@ func (p *PlanProvider) DisplayType() string {
 	return "Terraform plan binary file"
 }
 
-func (p *PlanProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
+func (p *PlanProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, error) {
 	j, err := p.generatePlanJSON()
 	if err != nil {
 		return []*schema.Project{}, err

--- a/internal/providers/terraform/provider_test.go
+++ b/internal/providers/terraform/provider_test.go
@@ -43,7 +43,7 @@ func TestLoadResources_rootModule(t *testing.T) {
 		},
 	}
 
-	tftest.ResourceTestsForTerraformProject(t, project, schema.NewEmptyUsageMap(), resourceChecks)
+	tftest.ResourceTestsForTerraformProject(t, project, schema.UsageMap{}, resourceChecks)
 }
 
 func TestLoadResources_nestedModule(t *testing.T) {
@@ -98,5 +98,5 @@ func TestLoadResources_nestedModule(t *testing.T) {
 		},
 	}
 
-	tftest.ResourceTestsForTerraformProject(t, project, schema.NewEmptyUsageMap(), resourceChecks)
+	tftest.ResourceTestsForTerraformProject(t, project, schema.UsageMap{}, resourceChecks)
 }

--- a/internal/providers/terraform/state_json_provider.go
+++ b/internal/providers/terraform/state_json_provider.go
@@ -36,7 +36,7 @@ func (p *StateJSONProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 	metadata.ConfigSha = p.ctx.ProjectConfig.ConfigSha
 }
 
-func (p *StateJSONProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
+func (p *StateJSONProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, error) {
 	spinner := ui.NewSpinner("Extracting only cost-related params from terraform", ui.SpinnerOptions{
 		EnableLogging: p.ctx.RunContext.Config.IsLogging(),
 		NoColor:       p.ctx.RunContext.Config.NoColor,

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -129,7 +129,7 @@ type terragruntWorkingDirInfo struct {
 
 // LoadResources finds any Terragrunt projects, prepares them by downloading any required source files, then
 // process each with an HCLProvider.
-func (p *TerragruntHCLProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
+func (p *TerragruntHCLProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, error) {
 	dirs, err := p.prepWorkingDirs()
 	if err != nil {
 		return nil, err

--- a/internal/providers/terraform/terragrunt_provider.go
+++ b/internal/providers/terraform/terragrunt_provider.go
@@ -85,7 +85,7 @@ func (p *TerragruntProvider) AddMetadata(metadata *schema.ProjectMetadata) {
 	metadata.TerraformWorkspace = p.ctx.ProjectConfig.TerraformWorkspace
 }
 
-func (p *TerragruntProvider) LoadResources(usage map[string]*schema.UsageData) ([]*schema.Project, error) {
+func (p *TerragruntProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, error) {
 	// We want to run Terragrunt commands from the config dirs
 	// Terragrunt internally runs Terraform in the working dirs, so we need to be aware of these
 	// so we can handle reading and cleaning up the generated plan files.

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -144,7 +144,7 @@ func installPlugins() error {
 	return nil
 }
 
-func ResourceTests(t *testing.T, tf string, usage map[string]*schema.UsageData, checks []testutil.ResourceCheck) {
+func ResourceTests(t *testing.T, tf string, usage schema.UsageMap, checks []testutil.ResourceCheck) {
 	project := TerraformProject{
 		Files: []File{
 			{
@@ -157,7 +157,7 @@ func ResourceTests(t *testing.T, tf string, usage map[string]*schema.UsageData, 
 	ResourceTestsForTerraformProject(t, project, usage, checks)
 }
 
-func ResourceTestsForTerraformProject(t *testing.T, tfProject TerraformProject, usage map[string]*schema.UsageData, checks []testutil.ResourceCheck) {
+func ResourceTestsForTerraformProject(t *testing.T, tfProject TerraformProject, usage schema.UsageMap, checks []testutil.ResourceCheck) {
 	t.Run("HCL", func(t *testing.T) {
 		resourceTestsForTfProject(t, "hcl", tfProject, usage, checks)
 	})
@@ -167,7 +167,7 @@ func ResourceTestsForTerraformProject(t *testing.T, tfProject TerraformProject, 
 	})
 }
 
-func resourceTestsForTfProject(t *testing.T, pName string, tfProject TerraformProject, usage map[string]*schema.UsageData, checks []testutil.ResourceCheck) {
+func resourceTestsForTfProject(t *testing.T, pName string, tfProject TerraformProject, usage schema.UsageMap, checks []testutil.ResourceCheck) {
 	t.Helper()
 
 	runCtx, err := config.NewRunContextFromEnv(context.Background())
@@ -243,7 +243,7 @@ func goldenFileResourceTestWithOpts(t *testing.T, pName string, testName string,
 	}
 
 	// Load the usage data, if any.
-	var usageData map[string]*schema.UsageData
+	var usageData schema.UsageMap
 	usageFilePath := filepath.Join("testdata", testName, testName+".usage.yml")
 	if _, err := os.Stat(usageFilePath); err == nil || !os.IsNotExist(err) {
 		// usage file exists, load the data
@@ -292,7 +292,7 @@ func goldenFileResourceTestWithOpts(t *testing.T, pName string, testName string,
 	testutil.AssertGoldenFile(t, goldenFilePath, actual)
 }
 
-func loadResources(t *testing.T, pName string, tfProject TerraformProject, runCtx *config.RunContext, usageData map[string]*schema.UsageData) []*schema.Project {
+func loadResources(t *testing.T, pName string, tfProject TerraformProject, runCtx *config.RunContext, usageData schema.UsageMap) []*schema.Project {
 	t.Helper()
 
 	tfdir := createTerraformProject(t, tfProject)
@@ -310,7 +310,7 @@ func loadResources(t *testing.T, pName string, tfProject TerraformProject, runCt
 	require.NoError(t, err)
 
 	for _, project := range projects {
-		project.BuildResources(map[string]*schema.UsageData{})
+		project.BuildResources(schema.UsageMap{})
 	}
 
 	return projects
@@ -357,7 +357,7 @@ func goldenFileSyncTest(t *testing.T, pName, testName string) {
 	projectCtx := config.NewProjectContext(runCtx, &config.Project{}, log.Fields{})
 
 	usageFilePath := filepath.Join("testdata", testName, testName+"_existing_usage.yml")
-	projects := loadResources(t, pName, tfProject, runCtx, map[string]*schema.UsageData{})
+	projects := loadResources(t, pName, tfProject, runCtx, schema.UsageMap{})
 
 	actual := RunSyncUsage(t, projectCtx, projects, usageFilePath)
 	require.NoError(t, err)

--- a/internal/scan/terraform_test.go
+++ b/internal/scan/terraform_test.go
@@ -86,7 +86,7 @@ func TestTerraformPlanScanner_ScanPlan(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	projects, err := hclp.LoadResources(map[string]*schema.UsageData{})
+	projects, err := hclp.LoadResources(schema.UsageMap{})
 	require.NoError(t, err)
 	plans := hclp.LoadPlanJSONs()
 	require.NoError(t, err)

--- a/internal/schema/core_resource.go
+++ b/internal/schema/core_resource.go
@@ -72,7 +72,7 @@ func BuildResource(partial *PartialResource, fetchedUsage *UsageData) *Resource 
 	return res
 }
 
-func BuildResources(projects []*Project, projectPtrToUsageMap map[*Project]map[string]*UsageData) {
+func BuildResources(projects []*Project, projectPtrToUsageMap map[*Project]UsageMap) {
 	for _, project := range projects {
 		usageMap := projectPtrToUsageMap[project]
 

--- a/internal/schema/project.go
+++ b/internal/schema/project.go
@@ -163,14 +163,14 @@ func (p *Project) AllPartialResources() []*PartialResource {
 
 // BuildResources builds the resources from the partial resources
 // and sets the PastResources and Resources fields.
-func (p *Project) BuildResources(usageMap map[string]*UsageData) {
+func (p *Project) BuildResources(usageMap UsageMap) {
 	pastResources := make([]*Resource, 0, len(p.PartialPastResources))
 	resources := make([]*Resource, 0, len(p.PartialResources))
 
 	seen := make(map[*PartialResource]*Resource)
 
 	for _, p := range p.PartialPastResources {
-		u := usageMap[p.ResourceData.Address]
+		u := usageMap.Get(p.ResourceData.Address)
 		r := BuildResource(p, u)
 		seen[p] = r
 		pastResources = append(pastResources, r)
@@ -179,7 +179,7 @@ func (p *Project) BuildResources(usageMap map[string]*UsageData) {
 	for _, p := range p.PartialResources {
 		r, ok := seen[p]
 		if !ok {
-			u := usageMap[p.ResourceData.Address]
+			u := usageMap.Get(p.ResourceData.Address)
 			r = BuildResource(p, u)
 			seen[p] = r
 		}

--- a/internal/schema/provider.go
+++ b/internal/schema/provider.go
@@ -4,5 +4,5 @@ type Provider interface {
 	Type() string
 	DisplayType() string
 	AddMetadata(*ProjectMetadata)
-	LoadResources(map[string]*UsageData) ([]*Project, error)
+	LoadResources(UsageMap) ([]*Project, error)
 }

--- a/internal/schema/usage_data.go
+++ b/internal/schema/usage_data.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"regexp"
+	"sort"
 	"strings"
 
+	addressParser "github.com/hashicorp/go-terraform-address"
 	"github.com/imdario/mergo"
 	jsoniter "github.com/json-iterator/go"
 	log "github.com/sirupsen/logrus"
@@ -149,21 +152,199 @@ func (u *UsageData) CalcEstimationSummary() map[string]bool {
 	return estimationMap
 }
 
-func NewUsageMap(m map[string]interface{}) map[string]*UsageData {
-	usageMap := make(map[string]*UsageData)
+// UsageMap is a map of address to UsageData built from a usage file.
+// UsageMap is a standalone type so that we can do more involved matching functionality.
+type UsageMap struct {
+	data      map[string]*UsageData
+	wildcards wildcards
+}
+
+// NewUsageMapFromInterface returns an initialised UsageMap from interface map.
+func NewUsageMapFromInterface(m map[string]interface{}) UsageMap {
+	data := make(map[string]*UsageData)
 
 	for addr, v := range m {
-		usageMap[addr] = NewUsageData(
+		data[addr] = NewUsageData(
 			addr,
 			ParseAttributes(v),
 		)
 	}
 
-	return usageMap
+	return NewUsageMap(data)
 }
 
-func NewEmptyUsageMap() map[string]*UsageData {
-	return map[string]*UsageData{}
+// NewUsageMap initialises a Usage map with the provided usage key data.
+// It builds a set of wildcard keys if any are found and sorts them ready for searching
+// by Attribute name at a later point.
+func NewUsageMap(data map[string]*UsageData) UsageMap {
+	var keys wildcards
+
+	for key := range data {
+		if strings.Contains(key, "*") {
+			keys = append(keys, wildcard{
+				raw:    key,
+				regexp: usageKeyToRegexp(key),
+			})
+		}
+	}
+
+	sort.Sort(keys)
+
+	return UsageMap{data: data, wildcards: keys}
+}
+
+// Data returns the entire map of usage data stored.
+func (usage UsageMap) Data() map[string]*UsageData {
+	return usage.data
+}
+
+// Get returns UsageData for a given resource address.
+func (usage UsageMap) Get(address string) *UsageData {
+	var data *UsageData
+
+	parsedAddress, err := addressParser.NewAddress(address)
+	if err == nil {
+		val, ok := usage.data[parsedAddress.ResourceSpec.Type]
+		if ok {
+			data = val
+		}
+	}
+
+	if ud := usage.data[address]; ud != nil {
+		if data != nil {
+			mergeAttributes(data, ud)
+		}
+
+		return ud
+	}
+
+	for _, key := range usage.wildcards {
+		d := usage.data[key.raw]
+
+		if key.regexp.MatchString(address) {
+			if data != nil {
+				mergeAttributes(data, d)
+			}
+
+			return d
+		}
+	}
+
+	return data
+}
+
+var wildCardRegxp = regexp.MustCompile(`\[.*?]`)
+
+// wildcard contains information about a wildcard specified usage key.
+type wildcard struct {
+	raw    string
+	regexp *regexp.Regexp
+}
+
+// wildcards implements the Sort.Interface to sort a slice of usage keys with more specific keys first.
+// This means a list with the following:
+//
+//   - module.mod[*].resource.test[*]
+//   - module.mod["foo"].resource.test["baz]
+//   - module.mod["foo].resource.test[*]
+//
+// will be reordered to the following:
+//
+//   - module.mod["foo"].resource.test["baz]
+//   - module.mod["foo].resource.test[*]
+//   - module.mod[*].resource.test[*]
+type wildcards []wildcard
+
+func (w wildcards) Len() int {
+	return len(w)
+}
+
+func (w wildcards) Less(i, j int) bool {
+	a := w[i].raw
+	b := w[j].raw
+
+	aSplit := wildCardRegxp.Split(a, -1)
+	bSplit := wildCardRegxp.Split(b, -1)
+
+	// if these aren't the same resource key then return false.
+	aJoined := strings.Join(aSplit, "")
+	bJoined := strings.Join(bSplit, "")
+	if aJoined != bJoined {
+		return aJoined < bJoined
+	}
+
+	aKeys := wildCardRegxp.FindAllString(a, -1)
+	bKeys := wildCardRegxp.FindAllString(b, -1)
+
+	for index, key := range aKeys {
+		if bKeys[index] == key {
+			continue
+		}
+
+		if key == "[*]" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (w wildcards) Swap(i, j int) {
+	w[i], w[j] = w[j], w[i]
+}
+
+func usageKeyToRegexp(pattern string) *regexp.Regexp {
+	var result strings.Builder
+	for i, literal := range strings.Split(pattern, "*") {
+		if i > 0 {
+			result.WriteString(".*")
+		}
+
+		// QuoteMeta escapes all regular expression metacharacters so that we don't match things like [ or .
+		result.WriteString(regexp.QuoteMeta(literal))
+	}
+
+	return regexp.MustCompile("^" + result.String() + "$")
+}
+
+func mergeAttributes(dst *UsageData, src *UsageData) {
+	for key, srcAttr := range src.Attributes {
+		if _, ok := dst.Attributes[key]; !ok {
+			dst.Attributes[key] = srcAttr
+			continue
+		}
+
+		switch srcAttr.Type {
+		case gjson.String, gjson.Number, gjson.False, gjson.True, gjson.Null:
+			// Should be safe to override
+			dst.Attributes[key] = srcAttr
+		case gjson.JSON:
+			var err error
+			var destJson map[string]interface{}
+			var srcJson map[string]interface{}
+			err = json.Unmarshal([]byte(dst.Attributes[key].Raw), &destJson)
+			if err != nil {
+				log.Errorf("Error merging attribute '%s': %v", key, err)
+				break
+			}
+			err = json.Unmarshal([]byte(srcAttr.Raw), &srcJson)
+			if err != nil {
+				log.Errorf("Error merging attribute '%s': %v", key, err)
+				break
+			}
+			err = mergo.Map(&destJson, srcJson)
+			if err != nil {
+				log.Errorf("Error merging attribute '%s': %v", key, err)
+				break
+			}
+			src, err := json.Marshal(destJson)
+			if err != nil {
+				log.Errorf("Error merging attribute '%s': %v", key, err)
+				break
+			}
+			dst.Attributes[key] = gjson.Parse(string(src))
+		}
+	}
 }
 
 func ParseAttributes(i interface{}) map[string]gjson.Result {
@@ -185,51 +366,4 @@ func ParseAttributes(i interface{}) map[string]gjson.Result {
 	}
 
 	return a
-}
-
-func MergeAttributes(dst *UsageData, src *UsageData) {
-	for key, srcAttr := range src.Attributes {
-		if _, has := dst.Attributes[key]; has {
-			switch srcAttr.Type {
-			case gjson.Null:
-				fallthrough
-			case gjson.True:
-				fallthrough
-			case gjson.False:
-				fallthrough
-			case gjson.Number:
-				fallthrough
-			case gjson.String:
-				// Should be safe to override
-				dst.Attributes[key] = srcAttr
-			case gjson.JSON:
-				var err error
-				var destJson map[string]interface{}
-				var srcJson map[string]interface{}
-				err = json.Unmarshal([]byte(dst.Attributes[key].Raw), &destJson)
-				if err != nil {
-					log.Errorf("Error merging attribute '%s': %v", key, err)
-					break
-				}
-				err = json.Unmarshal([]byte(srcAttr.Raw), &srcJson)
-				if err != nil {
-					log.Errorf("Error merging attribute '%s': %v", key, err)
-					break
-				}
-				err = mergo.Map(&destJson, srcJson)
-				if err != nil {
-					log.Errorf("Error merging attribute '%s': %v", key, err)
-					break
-				}
-				src, err := json.Marshal(destJson)
-				if err != nil {
-					log.Errorf("Error merging attribute '%s': %v", key, err)
-					break
-				}
-				dst.Attributes[key] = gjson.Parse(string(src))
-			}
-		} else {
-			dst.Attributes[key] = srcAttr
-		}
-	}
 }

--- a/internal/usage/usage_file.go
+++ b/internal/usage/usage_file.go
@@ -7,11 +7,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/infracost/infracost/internal/schema"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/mod/semver"
 	yamlv3 "gopkg.in/yaml.v3"
+
+	"github.com/infracost/infracost/internal/schema"
 )
 
 const minUsageFileVersion = "0.1"
@@ -180,18 +181,18 @@ See https://infracost.io/usage-file/ for docs`,
 	return os.WriteFile(path, b, 0600)
 }
 
-func (u *UsageFile) ToUsageDataMap() map[string]*schema.UsageData {
-	m := make(map[string]*schema.UsageData)
+func (u *UsageFile) ToUsageDataMap() schema.UsageMap {
+	m := make(map[string]interface{})
 
 	for _, resourceUsage := range u.ResourceTypeUsages {
-		m[resourceUsage.Name] = schema.NewUsageData(resourceUsage.Name, schema.ParseAttributes(resourceUsage.Map()))
+		m[resourceUsage.Name] = resourceUsage.Map()
 	}
 
 	for _, resourceUsage := range u.ResourceUsages {
-		m[resourceUsage.Name] = schema.NewUsageData(resourceUsage.Name, schema.ParseAttributes(resourceUsage.Map()))
+		m[resourceUsage.Name] = resourceUsage.Map()
 	}
 
-	return m
+	return schema.NewUsageMapFromInterface(m)
 }
 
 func (u *UsageFile) checkVersion() bool {

--- a/internal/usage/usage_file_test.go
+++ b/internal/usage/usage_file_test.go
@@ -1,9 +1,11 @@
 package usage_test
 
 import (
-	"github.com/infracost/infracost/internal/usage"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/infracost/infracost/internal/usage"
 
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
 )
@@ -71,7 +73,7 @@ resource_usage:
 `)
 	assert.NoError(t, err)
 
-	u := usageFile.ToUsageDataMap()["some.resource"]
+	u := usageFile.ToUsageDataMap().Get("some.resource")
 
 	tests := []struct {
 		key  string


### PR DESCRIPTION
This PR adds support for wildcard references in the Infracost usage file.

Users can now specify usage file references such as `module.mod[*].aws_lambda_function.test[*]`.

This functionality is enabled by the introduction of `schema.UsageMap` into the application. This builds a regexp from the usage file name (escaping all regular expression metacharacters apart from *) if a direct match is not made. This means we can support many layers of wildcard references, e.g: `module.mod[*].module.another[*].aws_lambda_function.test[*]`.