### PR TITLE
feat: show all errored project

### DIFF
--- a/cmd/infracost/output_test.go
+++ b/cmd/infracost/output_test.go
@@ -43,6 +43,14 @@ func TestOutputFormatGitHubComment(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "github-comment", "--path", "./testdata/example_out.json", "--path", "./testdata/terraform_v0.14_breakdown.json", "--path", "./testdata/terraform_v0.14_nochange_breakdown.json"}, nil)
 }
 
+func TestOutputFormatGitHubCommentWithAllError(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "github-comment", "--path", "./testdata/errors.json"}, nil)
+}
+
+func TestOutputFormatGitHubCommentNoProject(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "github-comment", "--path", "./testdata/no_project.json"}, nil)
+}
+
 func TestOutputFormatGitHubCommentWithProjectNames(t *testing.T) {
 	testName := testutil.CalcGoldenFileTestdataDirName()
 	GoldenFileCommandTest(t, testName,

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/Rhymond/go-money"
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -112,11 +111,6 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 		}
 	}
 
-	err = checkIfAllProjectsErrored(projects)
-	if err != nil {
-		return err
-	}
-
 	r, err := output.ToOutputFormat(projects)
 	if err != nil {
 		return err
@@ -186,46 +180,6 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 			cmd.PrintErrln()
 		}
 		cmd.Println(string(b))
-	}
-
-	return nil
-}
-
-func checkIfAllProjectsErrored(projects []*schema.Project) error {
-	allError := true
-
-	if len(projects) == 0 {
-		allError = false
-	}
-
-	if len(projects) == 1 && len(projects[0].Metadata.Errors) == 1 {
-		return errors.New(projects[0].Metadata.Errors[0].Message)
-	}
-
-	for _, project := range projects {
-		if !project.Metadata.HasErrors() {
-			allError = false
-			break
-		}
-	}
-
-	if allError {
-		multi := &multierror.Error{}
-		for _, project := range projects {
-			msg := fmt.Sprintf("project %s errored: \n", project.Name)
-			for i, diag := range project.Metadata.Errors {
-				msg += "\t\t\t" + diag.Message
-
-				if i != len(project.Metadata.Errors)-1 {
-					msg += "\n"
-				}
-
-			}
-
-			multi.Errors = append(multi.Errors, errors.New(msg))
-		}
-
-		return multi
 	}
 
 	return nil

--- a/cmd/infracost/testdata/breakdown_init_flags_error/breakdown_init_flags_error.hcl.golden
+++ b/cmd/infracost/testdata/breakdown_init_flags_error/breakdown_init_flags_error.hcl.golden
@@ -1,3 +1,24 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_init_flags_error
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+ ├─ root_block_device                                                                                                 
+ │  └─ Storage (general purpose SSD, gp2)                                50  GB                                 $5.00 
+ └─ ebs_block_device[0]                                                                                               
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ └─ Duration (first 6B)                                 Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ OVERALL TOTAL                                                                                                $742.64 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 
 Err:
-Error: Flag terraform-init-flags is deprecated and only compatible with --terraform-force-cli.
+Warning: Flag terraform-init-flags is deprecated and only compatible with --terraform-force-cli.
+

--- a/cmd/infracost/testdata/breakdown_invalid_path/breakdown_invalid_path.golden
+++ b/cmd/infracost/testdata/breakdown_invalid_path/breakdown_invalid_path.golden
@@ -1,5 +1,13 @@
+Project: infracost/infracost/cmd/infracost/invalid
 
-Err:
-Error: No such file or directory invalid
+Errors:
+  No such file or directory invalid
 
 Try setting --path to a Terraform plan JSON file. See https://infracost.io/troubleshoot for how to generate this.
+
+ OVERALL TOTAL       $0.00 
+──────────────────────────────────
+No cloud resources were detected
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_multi_project_with_all_errors/breakdown_multi_project_with_all_errors.golden
+++ b/cmd/infracost/testdata/breakdown_multi_project_with_all_errors/breakdown_multi_project_with_all_errors.golden
@@ -1,9 +1,25 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_with_all_errors/dev
+Module path: dev
+
+Errors:
+  Error loading Terraform modules:
+    failed to inspect module path testdata/breakdown_multi_project_with_all_errors/dev diag:
+      Invalid block definition:
+        Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_with_all_errors/prod
+Module path: prod
+
+Errors:
+  Error loading Terraform modules:
+    failed to inspect module path testdata/breakdown_multi_project_with_all_errors/prod diag:
+      Invalid block definition:
+        Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
+
+ OVERALL TOTAL       $0.00 
+──────────────────────────────────
+No cloud resources were detected
 
 Err:
-Error: 2 errors occurred:
-	* project infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_with_all_errors/dev errored: 
-			Error loading Terraform modules: failed to inspect module path testdata/breakdown_multi_project_with_all_errors/dev diag: Invalid block definition: Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
-	* project infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_with_all_errors/prod errored: 
-			Error loading Terraform modules: failed to inspect module path testdata/breakdown_multi_project_with_all_errors/prod diag: Invalid block definition: Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
-
 

--- a/cmd/infracost/testdata/breakdown_multi_project_with_error/breakdown_multi_project_with_error.golden
+++ b/cmd/infracost/testdata/breakdown_multi_project_with_error/breakdown_multi_project_with_error.golden
@@ -3,9 +3,9 @@ Module path: dev
 
 Errors:
   Error loading Terraform modules:
-     failed to inspect module path testdata/breakdown_multi_project_with_error/dev diag:
-       Invalid block definition:
-         Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
+    failed to inspect module path testdata/breakdown_multi_project_with_error/dev diag:
+      Invalid block definition:
+        Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
 
 ──────────────────────────────────
 Project: infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_with_error/prod

--- a/cmd/infracost/testdata/breakdown_plan_error/breakdown_plan_error.golden
+++ b/cmd/infracost/testdata/breakdown_plan_error/breakdown_plan_error.golden
@@ -1,10 +1,12 @@
+Project: infracost/infracost/examples/terraform
 
-Err:
-
-Error: terraform plan failed: exit status 1
+Errors:
+  terraform plan failed:
+    exit status 1
 
   Terraform command failed with:
-    Error: Failed to read variables file
+    Error:
+      Failed to read variables file
     Given variables file invalid does not exist.
 
 You have two options:
@@ -12,3 +14,11 @@ You have two options:
      e.g. --path=path/to/code --terraform-plan-flags="-var-file=my.tfvars"
 
 2. Set --path to a Terraform plan JSON file. See https://infracost.io/troubleshoot for how to generate this.
+
+ OVERALL TOTAL       $0.00 
+──────────────────────────────────
+No cloud resources were detected
+
+Err:
+
+

--- a/cmd/infracost/testdata/config_file_nil_projects_errors/config_file_nil_projects_errors.golden
+++ b/cmd/infracost/testdata/config_file_nil_projects_errors/config_file_nil_projects_errors.golden
@@ -1,5 +1,5 @@
 
- OVERALL TOTAL-               
+ OVERALL TOTAL           - 
 
 Err:
 

--- a/cmd/infracost/testdata/errors.json
+++ b/cmd/infracost/testdata/errors.json
@@ -1,0 +1,71 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "test",
+    "vcsCommitSha": "1234",
+    "vcsCommitAuthorName": "hugo",
+    "vcsCommitAuthorEmail": "hugo@test.com",
+    "vcsCommitTimestamp": "2021-10-11T22:41:00.144866-04:00",
+    "vcsCommitMessage": "mymessage",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost.git"
+  },
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "infracost/infracost/examples/terraform",
+      "metadata": {
+        "path": "examples/terraform",
+        "type": "terraform_dir",
+        "vcsSubPath": "examples/terraform",
+        "errors": [
+          {
+            "code": 2,
+            "message": "No valid terraform files found given path, try a different directory",
+            "data": null
+          }
+        ]
+      },
+      "pastBreakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "breakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 0,
+        "totalSupportedResources": 0,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 0,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
+      }
+    }
+  ],
+  "totalHourlyCost": "0",
+  "totalMonthlyCost": "0",
+  "pastTotalHourlyCost": "0",
+  "pastTotalMonthlyCost": "0",
+  "diffTotalHourlyCost": "0",
+  "diffTotalMonthlyCost": "0",
+  "timeGenerated": "2023-02-13T13:59:41.908876Z",
+  "summary": {
+    "totalDetectedResources": 0,
+    "totalSupportedResources": 0,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 0,
+    "totalNoPriceResources": 0,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {}
+  }
+}

--- a/cmd/infracost/testdata/no_project.json
+++ b/cmd/infracost/testdata/no_project.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "test",
+    "vcsCommitSha": "1234",
+    "vcsCommitAuthorName": "hugo",
+    "vcsCommitAuthorEmail": "hugo@test.com",
+    "vcsCommitTimestamp": "2021-10-11T22:41:00.144866-04:00",
+    "vcsCommitMessage": "mymessage",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost.git"
+  },
+  "currency": "USD",
+  "projects": [],
+  "totalHourlyCost": "0",
+  "totalMonthlyCost": "0",
+  "pastTotalHourlyCost": "0",
+  "pastTotalMonthlyCost": "0",
+  "diffTotalHourlyCost": "0",
+  "diffTotalMonthlyCost": "0",
+  "timeGenerated": "2023-02-13T13:59:41.908876Z",
+  "summary": {
+    "totalDetectedResources": 0,
+    "totalSupportedResources": 0,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 0,
+    "totalNoPriceResources": 0,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {}
+  }
+}

--- a/cmd/infracost/testdata/output_format_git_hub_comment_no_project/output_format_git_hub_comment_no_project.golden
+++ b/cmd/infracost/testdata/output_format_git_hub_comment_no_project/output_format_git_hub_comment_no_project.golden
@@ -1,0 +1,12 @@
+
+💰 Infracost estimate: **monthly cost will not change**
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+──────────────────────────────────
+No cloud resources were detected
+```
+</details>
+

--- a/cmd/infracost/testdata/output_format_git_hub_comment_with_all_error/output_format_git_hub_comment_with_all_error.golden
+++ b/cmd/infracost/testdata/output_format_git_hub_comment_with_all_error/output_format_git_hub_comment_with_all_error.golden
@@ -1,0 +1,36 @@
+
+💰 Infracost estimate: **monthly cost will not change**
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Previous</td>
+    <td>New</td>
+    <td>Diff</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/examples/terraform</td>
+      <td align="right">$0</td>
+      <td align="right">$0</td>
+      <td>$0</td>
+    </tr>
+  </tbody>
+</table>
+
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+──────────────────────────────────
+
+The following projects could not be evaluated: 
+infracost/infracost/examples/terraform
+Run the following command to see more details: infracost breakdown --path=/path/to/code
+
+──────────────────────────────────
+Key: ~ changed, + added, - removed
+
+No cloud resources were detected
+```
+</details>
+

--- a/cmd/infracost/testdata/output_format_table_with_error/output_format_table_with_error.golden
+++ b/cmd/infracost/testdata/output_format_table_with_error/output_format_table_with_error.golden
@@ -3,9 +3,9 @@ Module path: dev
 
 Errors:
   Error loading Terraform modules:
-     failed to inspect module path testdata/breakdown_multi_project_with_error/dev diag:
-       Invalid block definition:
-         Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
+    failed to inspect module path testdata/breakdown_multi_project_with_error/dev diag:
+      Invalid block definition:
+        Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
 
 ──────────────────────────────────
 Project: infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_with_error/prod

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -261,13 +261,13 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 	}
 
 	err = tmpl.Execute(bufw, MarkdownCtx{
-		out,
-		skippedProjectCount,
-		erroredProjectCount,
-		skippedUnchangedProjectCount,
-		diffMsg,
-		opts,
-		markdownOpts})
+		Root:                         out,
+		SkippedProjectCount:          skippedProjectCount,
+		ErroredProjectCount:          erroredProjectCount,
+		SkippedUnchangedProjectCount: skippedUnchangedProjectCount,
+		DiffOutput:                   diffMsg,
+		Options:                      opts,
+		MarkdownOptions:              markdownOpts})
 	if err != nil {
 		return []byte{}, err
 	}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -55,7 +55,7 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 			s += ui.BoldString("Errors:") + "\n"
 
 			for _, diag := range project.Metadata.Errors {
-				pieces := strings.Split(diag.Message, ":")
+				pieces := strings.Split(diag.Message, ": ")
 				for x, piece := range pieces {
 					s += strings.Repeat("  ", x+1) + piece
 
@@ -65,6 +65,10 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 						s += ":\n"
 					}
 				}
+			}
+
+			if len(out.Projects) == 1 {
+				s += "\n"
 			}
 		} else {
 			tableOut := tableForBreakdown(out.Currency, *project.Breakdown, opts.Fields, includeProjectTotals)
@@ -91,9 +95,14 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 	totalOut := FormatCost2DP(out.Currency, out.TotalMonthlyCost)
 
 	overallTitle := formatTitleWithCurrency(" OVERALL TOTAL", out.Currency)
+	padding := 12
+	if tableLen > 0 {
+		padding = tableLen - (len(overallTitle) + 1)
+	}
+
 	s += fmt.Sprintf("%s%s",
 		ui.BoldString(overallTitle),
-		fmt.Sprintf("%*s ", tableLen-(len(overallTitle)+1), totalOut), // pad based on the last line length
+		fmt.Sprintf("%*s ", padding, totalOut), // pad based on the last line length
 	)
 
 	summaryMsg := out.summaryMessage(opts.ShowSkipped)

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -307,6 +307,7 @@ var CommentMarkdownWithHTMLTemplate = `
     </tr>
 {{- end}}
 💰 Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost true }}**
+{{- if gt (len .Root.Projects) 0  }}
 <table>
   <thead>
     <td>Project</td>
@@ -335,6 +336,7 @@ var CommentMarkdownWithHTMLTemplate = `
   {{- end }}
   </tbody>
 </table>
+{{- end }}
 {{- end }}
 
 {{- if not .MarkdownOptions.OmitDetails }}
@@ -401,6 +403,7 @@ var CommentMarkdownTemplate = `
 | **{{ truncateMiddle .Name 64 "..." }}**{{- range metadataHeaders }} | {{- end }} | **{{ formatCost .PastCost }}** | **{{ formatCost .Cost }}** | **{{ formatCostChange .PastCost .Cost }}** |
 {{- end }}
 ## Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost false }}**
+{{- if gt (len .Root.Projects) 0  }}
 
 | **Project**{{- range metadataHeaders }} | **{{ . }}** {{- end }} | **Previous** | **New** | **Diff** |
 | -----------{{- range metadataHeaders }} | ---------- {{- end }} | -----------: | ------: | -------- |
@@ -417,6 +420,7 @@ var CommentMarkdownTemplate = `
   {{- range .Root.Projects }}
     {{- template "summaryRow" dict "Name" .Name "MetadataFields" (. | metadataFields) "PastCost" .PastBreakdown.TotalMonthlyCost "Cost" .Breakdown.TotalMonthlyCost  }}
   {{- end }}
+{{- end }}
 {{- end }}
 
 {{- if not .MarkdownOptions.OmitDetails }}

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -64,14 +64,14 @@ func Detect(ctx *config.ProjectContext, includePastResources bool) (schema.Provi
 			return nil, providerErr
 		}
 
-		if err := validateProjectForHCL(ctx, path); err != nil {
+		if err := validateProjectForHCL(ctx); err != nil {
 			return h, err
 		}
 
 		return h, nil
 	case "terragrunt_dir":
 		h := terraform.NewTerragruntHCLProvider(ctx, includePastResources)
-		if err := validateProjectForHCL(ctx, path); err != nil {
+		if err := validateProjectForHCL(ctx); err != nil {
 			return h, err
 		}
 
@@ -93,22 +93,22 @@ func Detect(ctx *config.ProjectContext, includePastResources bool) (schema.Provi
 	return nil, fmt.Errorf("could not detect path type for '%s'", path)
 }
 
-func validateProjectForHCL(ctx *config.ProjectContext, path string) error {
+func validateProjectForHCL(ctx *config.ProjectContext) error {
 	if ctx.ProjectConfig.TerraformInitFlags != "" {
 		return &ValidationError{
-			err: "Flag terraform-init-flags is deprecated and only compatible with --terraform-force-cli.",
+			warn: "Flag terraform-init-flags is deprecated and only compatible with --terraform-force-cli.",
 		}
 	}
 
 	if ctx.ProjectConfig.TerraformPlanFlags != "" {
 		return &ValidationError{
-			err: "Flag terraform-plan-flags is deprecated and only compatible with --terraform-force-cli. If you want to pass Terraform variables use the --terraform-vars or --terraform-var-file flag.",
+			warn: "Flag terraform-plan-flags is deprecated and only compatible with --terraform-force-cli. If you want to pass Terraform variables use the --terraform-vars or --terraform-var-file flag.",
 		}
 	}
 
 	if ctx.ProjectConfig.TerraformUseState {
 		return &ValidationError{
-			err: "Flag terraform-use-state is deprecated and only compatible with --terraform-force-cli.",
+			warn: "Flag terraform-use-state is deprecated and only compatible with --terraform-force-cli.",
 		}
 	}
 


### PR DESCRIPTION
This change removes the early exit in the CLI if all projects have errored. This means that the CLI output will always return a successful list of projects even if all of them have errored. This means that the output JSON will be generated correctly if all projects have errored. This change also removes the output table from the comment if there are no projects in the output JSON.