### PR TITLE
fix: prevent expanding dynamic blocks injecting more than once

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -372,6 +372,10 @@ func (e *Evaluator) expandDynamicBlock(b *Block) {
 		e.logger.Debugf("expanding block %s because a dynamic block was found %s", b.LocalName(), sub.LocalName())
 
 		blockName := sub.TypeLabel()
+		// Remove all the child blocks with the blockName so that we don't inject the expanded blocks twice.
+		// This could happen if a module "reloads" and the input variables change.
+		b.RemoveBlocks(blockName)
+
 		expanded := e.expandBlockForEaches([]*Block{sub})
 		for _, ex := range expanded {
 			if content := ex.GetChildBlock("content"); content != nil {


### PR DESCRIPTION
Resolves issue where dynamic blocks add duplicate expanded blocks into the `childBlocks` of the parent module. For example:

Take the following root module definition:

```
data "bad_state" "bad" {}

module "reload" {
  source         = "./baz"
  input = [
    {
      "ip"        = "10.0.0.0"
      "mock" = data.bad_state.bad.my_bad["10.0.0.0/24"].id
    },
    {
      "ip"        = "10.0.1.0"
      "mock" = data.bad_state.bad.my_bad["10.0.0.0/24"].id
    }
  ]
}
```

which calls out to a module with the following terraform:

```
variable "input" {}

resource "dynamic" "resource" {
  dynamic "child_block" {
    for_each = {
    	for i in var.input : i.ip => i
    }

    content {
      bar = child_block.value.mock
      foo = child_block.value.ip
    }
  }
}
```

Prior to this change the `length` of `child_block` would be 4 instead of the expected 2. This is because on first evaluation `data.bad_state.bad.my_bad["10.0.0.0/24"].id` is `null` and then on second evaluation we mock it. This means that we "reload" the underlying module `baz` which expands the `child_block` again. The second expansion simply injects two more blocks into `childBlocks` without clearing the prior expanded blocks.

We now `RemoveBlocks` of all type before `InjectBlock` so any prior expanded blocks will be overwritten.