### PR TITLE
fix: hide table if all projects are invalid

### DIFF
--- a/cmd/infracost/testdata/output_format_git_hub_comment_with_all_error/output_format_git_hub_comment_with_all_error.golden
+++ b/cmd/infracost/testdata/output_format_git_hub_comment_with_all_error/output_format_git_hub_comment_with_all_error.golden
@@ -1,21 +1,5 @@
 
 💰 Infracost estimate: **monthly cost will not change**
-<table>
-  <thead>
-    <td>Project</td>
-    <td>Previous</td>
-    <td>New</td>
-    <td>Diff</td>
-  </thead>
-  <tbody>
-    <tr>
-      <td>infracost/infracost/examples/terraform</td>
-      <td align="right">$0</td>
-      <td align="right">$0</td>
-      <td>$0</td>
-    </tr>
-  </tbody>
-</table>
 
 <details>
 <summary><strong>Infracost output</strong></summary>

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -191,6 +191,16 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) ([]byte, e
 
 			return true // has diff
 		},
+		"validProjects": func() Projects {
+			var valid Projects
+			for _, project := range out.Projects {
+				if !project.Metadata.HasErrors() {
+					valid = append(valid, project)
+				}
+			}
+
+			return valid
+		},
 		"metadataHeaders": func() []string {
 			headers := []string{}
 			if hasModulePath {

--- a/internal/output/templates.go
+++ b/internal/output/templates.go
@@ -307,7 +307,7 @@ var CommentMarkdownWithHTMLTemplate = `
     </tr>
 {{- end}}
 💰 Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost true }}**
-{{- if gt (len .Root.Projects) 0  }}
+{{- if gt (len validProjects) 0  }}
 <table>
   <thead>
     <td>Project</td>
@@ -332,7 +332,7 @@ var CommentMarkdownWithHTMLTemplate = `
 {{- else }}
   <tbody>
   {{- range .Root.Projects }}
-    {{- template "summaryRow" dict "Name" .Name "MetadataFields" (. | metadataFields) "PastCost" .PastBreakdown.TotalMonthlyCost "Cost" .Breakdown.TotalMonthlyCost  }}
+	{{- template "summaryRow" dict "Name" .Name "MetadataFields" (. | metadataFields) "PastCost" .PastBreakdown.TotalMonthlyCost "Cost" .Breakdown.TotalMonthlyCost  }}
   {{- end }}
   </tbody>
 </table>
@@ -403,7 +403,7 @@ var CommentMarkdownTemplate = `
 | **{{ truncateMiddle .Name 64 "..." }}**{{- range metadataHeaders }} | {{- end }} | **{{ formatCost .PastCost }}** | **{{ formatCost .Cost }}** | **{{ formatCostChange .PastCost .Cost }}** |
 {{- end }}
 ## Infracost estimate: **{{ formatCostChangeSentence .Root.Currency .Root.PastTotalMonthlyCost .Root.TotalMonthlyCost false }}**
-{{- if gt (len .Root.Projects) 0  }}
+{{- if gt (len validProjects) 0  }}
 
 | **Project**{{- range metadataHeaders }} | **{{ . }}** {{- end }} | **Previous** | **New** | **Diff** |
 | -----------{{- range metadataHeaders }} | ---------- {{- end }} | -----------: | ------: | -------- |


### PR DESCRIPTION
Resolves issue where the template attempts to render a single errored/invalid project.