### PR TITLE
fix: only lock terraform cli projects to run sync

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -204,7 +204,9 @@ func newParallelRunner(cmd *cobra.Command, runCtx *config.RunContext) (*parallel
 	// can't run multiple operations in parallel on the same path.
 	pathMuxs := map[string]*sync.Mutex{}
 	for _, projectCfg := range runCtx.Config.Projects {
-		pathMuxs[projectCfg.Path] = &sync.Mutex{}
+		if projectCfg.TerraformForceCLI {
+			pathMuxs[projectCfg.Path] = &sync.Mutex{}
+		}
 	}
 
 	var prior *output.Root


### PR DESCRIPTION
Removes the requirement for projects with the same path to be run sync. Speeds up config file runs for HCL.