### PR TITLE
Add MSSQL Elastic Pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,6 +144,7 @@ require (
 	github.com/creack/pty v1.1.11 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/frankban/quicktest v1.11.3 // indirect
 	github.com/go-errors/errors v1.0.2-0.20180813162953-d98b870cc4e0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -571,6 +571,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
+github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -145,7 +145,7 @@ resource_usage:
 
   aws_ebs_volume.my_standard_volume:
     monthly_standard_io_requests: 10000000 # Monthly I/O requests for standard volume (Magnetic storage).
-  
+
   aws_ec2_host.my_host:
     reserved_instance_term: 1_year # Term for Reserved Instances, can be: 1_year, 3_year.
     reserved_instance_payment_option: partial_upfront # Payment option for Reserved Instances, can be: no_upfront, partial_upfront, all_upfront.
@@ -189,7 +189,7 @@ resource_usage:
       rule_evaluations: 10000    # Number of rule evaluations on application/network load balancers
     elb:
       monthly_data_processed_gb: 10000 # Monthly data processed on classic loadbalaner
-    
+
   aws_elasticache_cluster.my_redis_snapshot:
     snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB.
     reserved_instance_term: 1_year                          # Term for Reserved Instances, can be: 1_year, 3_year.
@@ -262,7 +262,7 @@ resource_usage:
   aws_lambda_function.my_function:
     monthly_requests: 100000 # Monthly requests to the Lambda function.
     request_duration_ms: 500 # Average duration of each request in milliseconds.
-  
+
   aws_lambda_provisioned_concurrency_config.my_config:
     monthly_duration_hrs: 100 # Number of hours in a month that provisioned concurrency will be enabled.
     request_duration_ms: 350 # Average duration of each request in milliseconds during the enabled period.
@@ -1018,6 +1018,7 @@ resource_usage:
   azurerm_mssql_database.my_database:
     monthly_vcore_hours: 600             # Monthly number of used vCore-hours for serverless compute.
     long_term_retention_storage_gb: 1000 # Number of GBs used by long-term retention backup storage.
+    backup_storage_gb: 500               # Number of GBs used by Point-In-Time Restore (PITR) backup storage.
     extra_data_storage_gb: 250           # Override number of GBs used by extra data storage.
 
   azurerm_mysql_flexible_server.my_flexible_server:
@@ -1088,10 +1089,11 @@ resource_usage:
   azurerm_sql_database.my_database:
     monthly_vcore_hours: 600             # Monthly number of used vCore-hours for serverless compute.
     long_term_retention_storage_gb: 1000 # Number of GBs used by long-term retention backup storage.
+    backup_storage_gb: 500               # Number of GBs used by Point-In-Time Restore (PITR) backup storage.
     extra_data_storage_gb: 250           # Override number of GBs used by extra data storage.
-  
+
   azurerm_sql_managed_instance.my_database:
-    backup_storage_gb: 100            # Backup storage size dedicated for Point In Time Restoration
+    backup_storage_gb: 100            # Number of GBs used by Point-In-Time Restore (PITR) backup storage.
     long_term_retention_storage_gb: 5 # Number of GBs used by long-term retention backup storage.
 
   azurerm_synapse_spark_pool.my_spark_pool:

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -13,16 +13,16 @@ import (
 
 var (
 	sqlTierMapping = map[string]string{
-		"GP":   "General Purpose",
-		"GP_S": "General Purpose - Serverless",
-		"HS":   "Hyperscale",
-		"BC":   "Business Critical",
+		"gp":   "General Purpose",
+		"gp_s": "General Purpose - Serverless",
+		"hs":   "Hyperscale",
+		"bc":   "Business Critical",
 	}
 
 	sqlFamilyMapping = map[string]string{
-		"Gen5": "Compute Gen5",
-		"Gen4": "Compute Gen4",
-		"M":    "Compute M Series",
+		"gen5": "Compute Gen5",
+		"gen4": "Compute Gen4",
+		"m":    "Compute M Series",
 	}
 
 	dtuMap = dtuMapping{
@@ -126,13 +126,13 @@ func parseMSSQLSku(address, sku string) (skuConfig, error) {
 		return skuConfig{}, fmt.Errorf("Unrecognized MSSQL SKU format for resource %s: %s", address, sku)
 	}
 
-	tierKey := strings.Join(s[0:len(s)-2], "_")
+	tierKey := strings.ToLower(strings.Join(s[0:len(s)-2], "_"))
 	tier, ok := sqlTierMapping[tierKey]
 	if !ok {
 		return skuConfig{}, fmt.Errorf("Invalid tier in MSSQL SKU for resource %s: %s", address, sku)
 	}
 
-	familyKey := s[len(s)-2]
+	familyKey := strings.ToLower(s[len(s)-2])
 	family, ok := sqlFamilyMapping[familyKey]
 	if !ok {
 		return skuConfig{}, fmt.Errorf("Invalid family in MSSQL SKU for resource %s: %s", address, sku)

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -65,14 +65,6 @@ func newAzureRMMSSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schem
 
 	sku := d.GetStringOrDefault("sku_name", "GP_S_Gen5_2")
 
-	if strings.ToLower(sku) == "elasticpool" {
-		return &schema.Resource{
-			Name:      d.Address,
-			NoPrice:   true,
-			IsSkipped: true,
-		}
-	}
-
 	var maxSize *float64
 	if !d.IsEmpty("max_size_gb") {
 		val := d.Get("max_size_gb").Float()
@@ -97,7 +89,9 @@ func newAzureRMMSSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schem
 		ZoneRedundant:    d.Get("zone_redundant").Bool(),
 	}
 
-	if !dtuMap.usesDTUUnits(sku) {
+	if strings.ToLower(sku) == "elasticpool" || !d.IsEmpty("elastic_pool_id") {
+		r.IsElasticPool = true
+	} else if !dtuMap.usesDTUUnits(sku) {
 		c, err := parseMSSQLSku(d.Address, sku)
 		if err != nil {
 			log.Warnf(err.Error())

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -78,15 +78,17 @@ func newAzureRMMSSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schem
 	}
 
 	licenceType := d.GetStringOrDefault("license_type", "LicenseIncluded")
+	storageAccountType := d.GetStringOrDefault("storage_account_type", "Geo")
 
 	r := &azure.SQLDatabase{
-		Address:          d.Address,
-		Region:           region,
-		SKU:              sku,
-		LicenceType:      licenceType,
-		MaxSizeGB:        maxSize,
-		ReadReplicaCount: replicaCount,
-		ZoneRedundant:    d.Get("zone_redundant").Bool(),
+		Address:           d.Address,
+		Region:            region,
+		SKU:               sku,
+		LicenceType:       licenceType,
+		MaxSizeGB:         maxSize,
+		ReadReplicaCount:  replicaCount,
+		ZoneRedundant:     d.Get("zone_redundant").Bool(),
+		BackupStorageType: storageAccountType,
 	}
 
 	if strings.ToLower(sku) == "elasticpool" || !d.IsEmpty("elastic_pool_id") {

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -77,14 +77,14 @@ func newAzureRMMSSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schem
 		replicaCount = &val
 	}
 
-	licenceType := d.GetStringOrDefault("license_type", "LicenseIncluded")
+	licenseType := d.GetStringOrDefault("license_type", "LicenseIncluded")
 	storageAccountType := d.GetStringOrDefault("storage_account_type", "Geo")
 
 	r := &azure.SQLDatabase{
 		Address:           d.Address,
 		Region:            region,
 		SKU:               sku,
-		LicenceType:       licenceType,
+		LicenseType:       licenseType,
 		MaxSizeGB:         maxSize,
 		ReadReplicaCount:  replicaCount,
 		ZoneRedundant:     d.Get("zone_redundant").Bool(),

--- a/internal/providers/terraform/azure/mssql_elasticpool.go
+++ b/internal/providers/terraform/azure/mssql_elasticpool.go
@@ -36,7 +36,7 @@ func newMSSQLElasticPool(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 		maxSizeGB = d.Get("max_size_bytes").Float() / 1024.0 / 1024.0 / 1024.0
 	}
 
-	licenceType := d.GetStringOrDefault("license_type", "LicenseIncluded")
+	licenseType := d.GetStringOrDefault("license_type", "LicenseIncluded")
 
 	r := &azure.MSSQLElasticPool{
 		Address:       d.Address,
@@ -44,7 +44,7 @@ func newMSSQLElasticPool(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 		SKU:           sku,
 		Tier:          tier,
 		Family:        family,
-		LicenceType:   licenceType,
+		LicenseType:   licenseType,
 		MaxSizeGB:     &maxSizeGB,
 		ZoneRedundant: d.Get("zone_redundant").Bool(),
 	}

--- a/internal/providers/terraform/azure/mssql_elasticpool.go
+++ b/internal/providers/terraform/azure/mssql_elasticpool.go
@@ -1,0 +1,61 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/camelcase"
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getMSSQLElasticPoolRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_mssql_elasticpool",
+		RFunc: newMSSQLElasticPool,
+		ReferenceAttributes: []string{
+			"server_name",
+			"resource_group_name",
+		},
+	}
+}
+
+func newMSSQLElasticPool(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	region := lookupRegion(d, []string{"server_name", "resource_group_name"})
+
+	sku := d.Get("sku.0.name").String()
+	capacity := d.Get("sku.0.capacity").Int()
+	tier := strings.Join(camelcase.Split(d.Get("sku.0.tier").String()), " ")
+	family := fmt.Sprintf("Compute %s", d.Get("sku.0.family").String())
+
+	var maxSizeGB float64
+	if !d.IsEmpty("max_size_gb") {
+		maxSizeGB = d.Get("max_size_gb").Float()
+	}
+	if !d.IsEmpty("max_size_bytes") {
+		maxSizeGB = d.Get("max_size_bytes").Float() / 1024.0 / 1024.0 / 1024.0
+	}
+
+	licenceType := d.GetStringOrDefault("license_type", "LicenseIncluded")
+
+	r := &azure.MSSQLElasticPool{
+		Address:       d.Address,
+		Region:        region,
+		SKU:           sku,
+		Tier:          tier,
+		Family:        family,
+		LicenceType:   licenceType,
+		MaxSizeGB:     &maxSizeGB,
+		ZoneRedundant: d.Get("zone_redundant").Bool(),
+	}
+
+	s := strings.ToLower(r.SKU)
+	if s == "basicpool" || s == "standardpool" || s == "premiumpool" {
+		r.DTUCapacity = &capacity
+	} else {
+		r.Cores = &capacity
+	}
+
+	r.PopulateUsage(u)
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/azure/mssql_elasticpool_test.go
+++ b/internal/providers/terraform/azure/mssql_elasticpool_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
 )
 
-func TestSQLDatabase(t *testing.T) {
+func TestMSSQLElasticPool(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
 	opts := tftest.DefaultGoldenFileOptions()
 	opts.CaptureLogs = true
-	tftest.GoldenFileResourceTestsWithOpts(t, "sql_database_test", opts)
+	tftest.GoldenFileResourceTestsWithOpts(t, "mssql_elasticpool_test", opts)
 }

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -123,6 +123,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getVirtualNetworkPeeringRegistryItem(),
 	getPowerBIEmbeddedRegistryItem(),
 	getMSSQLElasticPoolRegistryItem(),
+	getSQLElasticPoolRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -122,6 +122,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getIoTHubDPSRegistryItem(),
 	getVirtualNetworkPeeringRegistryItem(),
 	getPowerBIEmbeddedRegistryItem(),
+	getMSSQLElasticPoolRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/sql_database.go
+++ b/internal/providers/terraform/azure/sql_database.go
@@ -98,15 +98,16 @@ func newSQLDatabase(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 	}
 
 	r := &azure.SQLDatabase{
-		Address:          d.Address,
-		Region:           region,
-		SKU:              config.sku,
-		Tier:             config.tier,
-		Family:           config.family,
-		Cores:            config.cores,
-		MaxSizeGB:        maxSizeGB,
-		ReadReplicaCount: readReplicas,
-		ZoneRedundant:    d.Get("zone_redundant").Bool(),
+		Address:           d.Address,
+		Region:            region,
+		SKU:               config.sku,
+		Tier:              config.tier,
+		Family:            config.family,
+		Cores:             config.cores,
+		MaxSizeGB:         maxSizeGB,
+		ReadReplicaCount:  readReplicas,
+		ZoneRedundant:     d.Get("zone_redundant").Bool(),
+		BackupStorageType: "Geo",
 	}
 	r.PopulateUsage(u)
 

--- a/internal/providers/terraform/azure/sql_elasticpool.go
+++ b/internal/providers/terraform/azure/sql_elasticpool.go
@@ -1,0 +1,47 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getSQLElasticPoolRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_sql_elasticpool",
+		RFunc: newSQLElasticPool,
+		ReferenceAttributes: []string{
+			"server_name",
+			"resource_group_name",
+		},
+	}
+}
+
+func newSQLElasticPool(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	tier := d.Get("edition").String()
+	sku := fmt.Sprintf("%sPool", strings.ToTitle(tier))
+	dtu := d.Get("dtu").Int()
+
+	region := lookupRegion(d, []string{"server_name", "resource_group_name"})
+	r := &azure.MSSQLElasticPool{
+		Address:       d.Address,
+		Region:        region,
+		SKU:           sku,
+		Family:        "",
+		Tier:          tier,
+		DTUCapacity:   &dtu,
+		LicenceType:   "LicenseIncluded",
+		ZoneRedundant: d.Get("zone_redundant").Bool(),
+	}
+
+	if !d.IsEmpty("pool_size") {
+		maxSizeGB := d.Get("pool_size").Float() / 1024.0
+		r.MaxSizeGB = &maxSizeGB
+	}
+
+	r.PopulateUsage(u)
+
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/azure/sql_elasticpool.go
+++ b/internal/providers/terraform/azure/sql_elasticpool.go
@@ -32,7 +32,7 @@ func newSQLElasticPool(d *schema.ResourceData, u *schema.UsageData) *schema.Reso
 		Family:        "",
 		Tier:          tier,
 		DTUCapacity:   &dtu,
-		LicenceType:   "LicenseIncluded",
+		LicenseType:   "LicenseIncluded",
 		ZoneRedundant: d.Get("zone_redundant").Bool(),
 	}
 

--- a/internal/providers/terraform/azure/sql_elasticpool_test.go
+++ b/internal/providers/terraform/azure/sql_elasticpool_test.go
@@ -1,0 +1,17 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestSQLElasticPool(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	opts := tftest.DefaultGoldenFileOptions()
+	opts.CaptureLogs = true
+	tftest.GoldenFileResourceTestsWithOpts(t, "sql_elasticpool_test", opts)
+}

--- a/internal/providers/terraform/azure/sql_managed_instance.go
+++ b/internal/providers/terraform/azure/sql_managed_instance.go
@@ -24,7 +24,7 @@ func newSQLManagedInstance(d *schema.ResourceData, u *schema.UsageData) *schema.
 
 	r.SKU = d.Get("sku_name").String()
 	r.Cores = d.Get("vcores").Int()
-	r.LicenceType = d.Get("license_type").String()
+	r.LicenseType = d.Get("license_type").String()
 	r.StorageAccountType = d.Get("storage_account_type").String()
 	if r.StorageAccountType == "" {
 		r.StorageAccountType = "LRS"

--- a/internal/providers/terraform/azure/sql_managed_instance_test.go
+++ b/internal/providers/terraform/azure/sql_managed_instance_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/infracost/infracost/internal/providers/terraform/tftest"
 )
 
-func TestSqlManagedInstanceGoldenFile(t *testing.T) {
+func TestSQLManagedInstance(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
@@ -1,12 +1,6 @@
 
  Name                                                             Monthly Qty  Unit                  Monthly Cost 
                                                                                                                   
- azurerm_mssql_database.LTR                                                                                       
- ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
- ├─ SQL license                                                         2,920  vCore-hours                $291.90 
- ├─ Storage                                                                 5  GB                           $0.58 
- └─ Long-term retention                                                 1,000  GB                          $50.00 
-                                                                                                                  
  azurerm_mssql_database.blank_sku                                                                                 
  ├─ Compute (serverless, GP_S_Gen5_2)                        Monthly cost depends on usage: $0.52 per vCore-hours 
  ├─ Storage                                                                 5  GB                           $0.58 
@@ -22,6 +16,9 @@
  ├─ Compute (provisioned, BC_M_8)                                         730  hours                    $9,804.08 
  ├─ SQL license                                                         5,840  vCore-hours              $2,190.00 
  ├─ Storage                                                                50  GB                          $12.50 
+ └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+                                                                                                                  
+ azurerm_mssql_database.elastic_pool                                                                              
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
                                                                                                                   
  azurerm_mssql_database.general_purpose_gen                                                                       
@@ -54,6 +51,30 @@
  ├─ SQL license                                                         1,460  vCore-hours                $145.95 
  └─ Storage                                                                 5  GB                           $0.50 
                                                                                                                   
+ azurerm_mssql_database.ltr_default                                                                               
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
+ ├─ SQL license                                                         2,920  vCore-hours                $291.90 
+ ├─ Storage                                                                 5  GB                           $0.58 
+ └─ Long-term retention                                                 1,000  GB                          $50.00 
+                                                                                                                  
+ azurerm_mssql_database.ltr_geo                                                                                   
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
+ ├─ SQL license                                                         2,920  vCore-hours                $291.90 
+ ├─ Storage                                                                 5  GB                           $0.58 
+ └─ Long-term retention                                                 1,000  GB                          $50.00 
+                                                                                                                  
+ azurerm_mssql_database.ltr_local                                                                                 
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
+ ├─ SQL license                                                         2,920  vCore-hours                $291.90 
+ ├─ Storage                                                                 5  GB                           $0.58 
+ └─ Long-term retention                                                 1,000  GB                          $25.00 
+                                                                                                                  
+ azurerm_mssql_database.ltr_zone                                                                                  
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
+ ├─ SQL license                                                         2,920  vCore-hours                $291.90 
+ ├─ Storage                                                                 5  GB                           $0.58 
+ └─ Long-term retention                                                 1,000  GB                          $31.30 
+                                                                                                                  
  azurerm_mssql_database.premium6                                                                                  
  ├─ Compute (P6)                                                          730  hours                    $3,650.00 
  ├─ Extra data storage                                                    500  GB                         $170.00 
@@ -79,12 +100,11 @@
  ├─ Extra data storage                                                    250  GB                          $42.50 
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
                                                                                                                   
- OVERALL TOTAL                                                                                         $28,939.97 
+ OVERALL TOTAL                                                                                         $31,257.12 
 ──────────────────────────────────
-17 cloud resources were detected:
-∙ 14 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
-∙ 3 were free:
-  ∙ 1 x azurerm_mssql_database
+20 cloud resources were detected:
+∙ 18 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free:
   ∙ 1 x azurerm_resource_group
   ∙ 1 x azurerm_sql_server
 Logs:
@@ -95,12 +115,18 @@ level=warning msg="'Multiple products found' are safe to ignore for 'Compute (pr
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API."
+level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API."
+level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API."
+level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, HS_Gen5_2)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, HS_Gen5_2)' due to limitations in the Azure API."
-level=warning msg="Multiple products with prices found for azurerm_mssql_database.LTR Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.business_critical_gen Compute (provisioned, BC_Gen5_8), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.business_critical_m Compute (provisioned, BC_M_8), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_without_license Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_zone Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_zone Zone redundancy (provisioned, GP_Gen5_4), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_database.ltr_default Compute (provisioned, GP_Gen5_4), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_database.ltr_geo Compute (provisioned, GP_Gen5_4), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_database.ltr_local Compute (provisioned, GP_Gen5_4), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_database.ltr_zone Compute (provisioned, GP_Gen5_4), using the first product"

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
@@ -1,43 +1,78 @@
 
  Name                                                             Monthly Qty  Unit                  Monthly Cost 
                                                                                                                   
+ azurerm_mssql_database.backup_default                                                                            
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
+ ├─ SQL license                                                         2,920  vCore-hours                $291.90 
+ ├─ Storage                                                                 5  GB                           $0.58 
+ ├─ Long-term retention (RA-GRS)                                        1,000  GB                          $50.00 
+ └─ PITR backup storage (RA-GRS)                                          500  GB                         $100.00 
+                                                                                                                  
+ azurerm_mssql_database.backup_geo                                                                                
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
+ ├─ SQL license                                                         2,920  vCore-hours                $291.90 
+ ├─ Storage                                                                 5  GB                           $0.58 
+ ├─ Long-term retention (RA-GRS)                                        1,000  GB                          $50.00 
+ └─ PITR backup storage (RA-GRS)                                          500  GB                         $100.00 
+                                                                                                                  
+ azurerm_mssql_database.backup_local                                                                              
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
+ ├─ SQL license                                                         2,920  vCore-hours                $291.90 
+ ├─ Storage                                                                 5  GB                           $0.58 
+ ├─ Long-term retention (LRS)                                           1,000  GB                          $25.00 
+ └─ PITR backup storage (LRS)                                             500  GB                          $50.00 
+                                                                                                                  
+ azurerm_mssql_database.backup_zone                                                                               
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
+ ├─ SQL license                                                         2,920  vCore-hours                $291.90 
+ ├─ Storage                                                                 5  GB                           $0.58 
+ ├─ Long-term retention (ZRS)                                           1,000  GB                          $31.30 
+ └─ PITR backup storage (ZRS)                                             500  GB                          $62.50 
+                                                                                                                  
  azurerm_mssql_database.blank_sku                                                                                 
  ├─ Compute (serverless, GP_S_Gen5_2)                        Monthly cost depends on usage: $0.52 per vCore-hours 
  ├─ Storage                                                                 5  GB                           $0.58 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.business_critical_gen                                                                     
  ├─ Compute (provisioned, BC_Gen5_8)                                      730  hours                    $1,777.90 
  ├─ SQL license                                                         5,840  vCore-hours              $2,190.00 
  ├─ Storage                                                                10  GB                           $2.50 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.business_critical_m                                                                       
  ├─ Compute (provisioned, BC_M_8)                                         730  hours                    $9,804.08 
  ├─ SQL license                                                         5,840  vCore-hours              $2,190.00 
  ├─ Storage                                                                50  GB                          $12.50 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.elastic_pool                                                                              
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.general_purpose_gen                                                                       
  ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
  ├─ SQL license                                                         2,920  vCore-hours                $291.90 
  ├─ Storage                                                                 5  GB                           $0.58 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.general_purpose_gen_without_license                                                       
  ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
  ├─ Storage                                                                 5  GB                           $0.58 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.general_purpose_gen_zone                                                                  
  ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
  ├─ Zone redundancy (provisioned, GP_Gen5_4)                              730  hours                      $266.68 
  ├─ SQL license                                                         2,920  vCore-hours                $291.90 
  ├─ Storage                                                                 5  GB                           $1.15 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.hyperscale_gen                                                                            
  ├─ Compute (provisioned, HS_Gen5_2)                                      730  hours                      $266.68 
@@ -51,56 +86,37 @@
  ├─ SQL license                                                         1,460  vCore-hours                $145.95 
  └─ Storage                                                                 5  GB                           $0.50 
                                                                                                                   
- azurerm_mssql_database.ltr_default                                                                               
- ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
- ├─ SQL license                                                         2,920  vCore-hours                $291.90 
- ├─ Storage                                                                 5  GB                           $0.58 
- └─ Long-term retention                                                 1,000  GB                          $50.00 
-                                                                                                                  
- azurerm_mssql_database.ltr_geo                                                                                   
- ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
- ├─ SQL license                                                         2,920  vCore-hours                $291.90 
- ├─ Storage                                                                 5  GB                           $0.58 
- └─ Long-term retention                                                 1,000  GB                          $50.00 
-                                                                                                                  
- azurerm_mssql_database.ltr_local                                                                                 
- ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
- ├─ SQL license                                                         2,920  vCore-hours                $291.90 
- ├─ Storage                                                                 5  GB                           $0.58 
- └─ Long-term retention                                                 1,000  GB                          $25.00 
-                                                                                                                  
- azurerm_mssql_database.ltr_zone                                                                                  
- ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
- ├─ SQL license                                                         2,920  vCore-hours                $291.90 
- ├─ Storage                                                                 5  GB                           $0.58 
- └─ Long-term retention                                                 1,000  GB                          $31.30 
-                                                                                                                  
  azurerm_mssql_database.premium6                                                                                  
  ├─ Compute (P6)                                                          730  hours                    $3,650.00 
  ├─ Extra data storage                                                    500  GB                         $170.00 
- └─ Long-term retention                                                 1,000  GB                          $50.00 
+ ├─ Long-term retention (RA-GRS)                                        1,000  GB                          $50.00 
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.serverless                                                                                
  ├─ Compute (serverless, GP_S_Gen5_4)                                     500  vCore-hours                $260.88 
  ├─ Storage                                                                 5  GB                           $0.58 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.serverless_zone                                                                           
  ├─ Compute (serverless, GP_S_Gen5_4)                        Monthly cost depends on usage: $0.52 per vCore-hours 
  ├─ Zone redundancy (serverless, GP_S_Gen5_4)                Monthly cost depends on usage: $0.31 per vCore-hours 
  ├─ Storage                                                                 5  GB                           $1.15 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.standard1                                                                                 
  ├─ Compute (S1)                                                          730  hours                       $29.43 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
  azurerm_mssql_database.standard12                                                                                
  ├─ Compute (S12)                                                         730  hours                    $4,415.59 
  ├─ Extra data storage                                                    250  GB                          $42.50 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB          
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB          
                                                                                                                   
- OVERALL TOTAL                                                                                         $31,257.12 
+ OVERALL TOTAL                                                                                         $31,569.62 
 ──────────────────────────────────
 20 cloud resources were detected:
 ∙ 18 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
@@ -120,13 +136,13 @@ level=warning msg="'Multiple products found' are safe to ignore for 'Compute (pr
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, HS_Gen5_2)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, HS_Gen5_2)' due to limitations in the Azure API."
+level=warning msg="Multiple products with prices found for azurerm_mssql_database.backup_default Compute (provisioned, GP_Gen5_4), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_database.backup_geo Compute (provisioned, GP_Gen5_4), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_database.backup_local Compute (provisioned, GP_Gen5_4), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_database.backup_zone Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.business_critical_gen Compute (provisioned, BC_Gen5_8), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.business_critical_m Compute (provisioned, BC_M_8), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_without_license Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_zone Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_zone Zone redundancy (provisioned, GP_Gen5_4), using the first product"
-level=warning msg="Multiple products with prices found for azurerm_mssql_database.ltr_default Compute (provisioned, GP_Gen5_4), using the first product"
-level=warning msg="Multiple products with prices found for azurerm_mssql_database.ltr_geo Compute (provisioned, GP_Gen5_4), using the first product"
-level=warning msg="Multiple products with prices found for azurerm_mssql_database.ltr_local Compute (provisioned, GP_Gen5_4), using the first product"
-level=warning msg="Multiple products with prices found for azurerm_mssql_database.ltr_zone Compute (provisioned, GP_Gen5_4), using the first product"

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
@@ -36,7 +36,8 @@
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
                                                                                                                   
  azurerm_mssql_database.general_purpose_gen_zone                                                                  
- ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $266.68 
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47 
+ ├─ Zone redundancy (provisioned, GP_Gen5_4)                              730  hours                      $266.68 
  ├─ SQL license                                                         2,920  vCore-hours                $291.90 
  ├─ Storage                                                                 5  GB                           $1.15 
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
@@ -54,7 +55,7 @@
  └─ Storage                                                                 5  GB                           $0.50 
                                                                                                                   
  azurerm_mssql_database.premium6                                                                                  
- ├─ Compute (P6)                                                           30  days                     $3,600.00 
+ ├─ Compute (P6)                                                          730  hours                    $3,650.00 
  ├─ Extra data storage                                                    500  GB                         $170.00 
  └─ Long-term retention                                                 1,000  GB                          $50.00 
                                                                                                                   
@@ -63,20 +64,25 @@
  ├─ Storage                                                                 5  GB                           $0.58 
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
                                                                                                                   
+ azurerm_mssql_database.serverless_zone                                                                           
+ ├─ Compute (serverless, GP_S_Gen5_4)                        Monthly cost depends on usage: $0.52 per vCore-hours 
+ ├─ Zone redundancy (serverless, GP_S_Gen5_4)                Monthly cost depends on usage: $0.31 per vCore-hours 
+ ├─ Storage                                                                 5  GB                           $1.15 
+ └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
+                                                                                                                  
  azurerm_mssql_database.standard1                                                                                 
- ├─ Compute (S1)                                                           30  days                        $29.03 
- ├─ Extra data storage                                       Monthly cost depends on usage: $0.17 per GB          
+ ├─ Compute (S1)                                                          730  hours                       $29.43 
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
                                                                                                                   
  azurerm_mssql_database.standard12                                                                                
- ├─ Compute (S12)                                                          30  days                     $4,355.10 
+ ├─ Compute (S12)                                                         730  hours                    $4,415.59 
  ├─ Extra data storage                                                    250  GB                          $42.50 
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB          
                                                                                                                   
- OVERALL TOTAL                                                                                         $28,383.46 
+ OVERALL TOTAL                                                                                         $28,939.97 
 ──────────────────────────────────
-16 cloud resources were detected:
-∙ 13 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+17 cloud resources were detected:
+∙ 14 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 3 were free:
   ∙ 1 x azurerm_mssql_database
   ∙ 1 x azurerm_resource_group
@@ -97,3 +103,4 @@ level=warning msg="Multiple products with prices found for azurerm_mssql_databas
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_without_license Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_zone Compute (provisioned, GP_Gen5_4), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_zone Zone redundancy (provisioned, GP_Gen5_4), using the first product"

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
@@ -69,6 +69,13 @@ resource "azurerm_mssql_database" "serverless" {
   sku_name  = "GP_S_Gen5_4"
 }
 
+resource "azurerm_mssql_database" "serverless_zone" {
+  name      = "acctest-db-d"
+  server_id = azurerm_sql_server.example.id
+  sku_name  = "GP_S_Gen5_4"
+  zone_redundant = true
+}
+
 resource "azurerm_mssql_database" "LTR" {
   name      = "acctest-db-d"
   server_id = azurerm_sql_server.example.id

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
@@ -70,36 +70,36 @@ resource "azurerm_mssql_database" "serverless" {
 }
 
 resource "azurerm_mssql_database" "serverless_zone" {
-  name      = "acctest-db-d"
-  server_id = azurerm_sql_server.example.id
-  sku_name  = "GP_S_Gen5_4"
+  name           = "acctest-db-d"
+  server_id      = azurerm_sql_server.example.id
+  sku_name       = "GP_S_Gen5_4"
   zone_redundant = true
 }
 
-resource "azurerm_mssql_database" "ltr_default" {
+resource "azurerm_mssql_database" "backup_default" {
   name      = "acctest-db-d"
   server_id = azurerm_sql_server.example.id
   sku_name  = "GP_Gen5_4"
 }
 
-resource "azurerm_mssql_database" "ltr_geo" {
-  name      = "acctest-db-d"
-  server_id = azurerm_sql_server.example.id
-  sku_name  = "GP_Gen5_4"
+resource "azurerm_mssql_database" "backup_geo" {
+  name                 = "acctest-db-d"
+  server_id            = azurerm_sql_server.example.id
+  sku_name             = "GP_Gen5_4"
   storage_account_type = "Geo"
 }
 
-resource "azurerm_mssql_database" "ltr_zone" {
-  name      = "acctest-db-d"
-  server_id = azurerm_sql_server.example.id
-  sku_name  = "GP_Gen5_4"
+resource "azurerm_mssql_database" "backup_zone" {
+  name                 = "acctest-db-d"
+  server_id            = azurerm_sql_server.example.id
+  sku_name             = "GP_Gen5_4"
   storage_account_type = "Zone"
 }
 
-resource "azurerm_mssql_database" "ltr_local" {
-  name      = "acctest-db-d"
-  server_id = azurerm_sql_server.example.id
-  sku_name  = "GP_Gen5_4"
+resource "azurerm_mssql_database" "backup_local" {
+  name                 = "acctest-db-d"
+  server_id            = azurerm_sql_server.example.id
+  sku_name             = "GP_Gen5_4"
   storage_account_type = "Local"
 }
 

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
@@ -76,10 +76,31 @@ resource "azurerm_mssql_database" "serverless_zone" {
   zone_redundant = true
 }
 
-resource "azurerm_mssql_database" "LTR" {
+resource "azurerm_mssql_database" "ltr_default" {
   name      = "acctest-db-d"
   server_id = azurerm_sql_server.example.id
   sku_name  = "GP_Gen5_4"
+}
+
+resource "azurerm_mssql_database" "ltr_geo" {
+  name      = "acctest-db-d"
+  server_id = azurerm_sql_server.example.id
+  sku_name  = "GP_Gen5_4"
+  storage_account_type = "Geo"
+}
+
+resource "azurerm_mssql_database" "ltr_zone" {
+  name      = "acctest-db-d"
+  server_id = azurerm_sql_server.example.id
+  sku_name  = "GP_Gen5_4"
+  storage_account_type = "Zone"
+}
+
+resource "azurerm_mssql_database" "ltr_local" {
+  name      = "acctest-db-d"
+  server_id = azurerm_sql_server.example.id
+  sku_name  = "GP_Gen5_4"
+  storage_account_type = "Local"
 }
 
 resource "azurerm_mssql_database" "standard1" {

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.usage.yml
@@ -2,7 +2,13 @@ version: 0.1
 resource_usage:
   azurerm_mssql_database.serverless:
     monthly_vcore_hours: 500
-  azurerm_mssql_database.LTR:
+  azurerm_mssql_database.ltr_default:
+    long_term_retention_storage_gb: 1000
+  azurerm_mssql_database.ltr_geo:
+    long_term_retention_storage_gb: 1000
+  azurerm_mssql_database.ltr_zone:
+    long_term_retention_storage_gb: 1000
+  azurerm_mssql_database.ltr_local:
     long_term_retention_storage_gb: 1000
   azurerm_mssql_database.premium6:
     long_term_retention_storage_gb: 1000

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.usage.yml
@@ -2,14 +2,18 @@ version: 0.1
 resource_usage:
   azurerm_mssql_database.serverless:
     monthly_vcore_hours: 500
-  azurerm_mssql_database.ltr_default:
+  azurerm_mssql_database.backup_default:
     long_term_retention_storage_gb: 1000
-  azurerm_mssql_database.ltr_geo:
+    backup_storage_gb: 500
+  azurerm_mssql_database.backup_geo:
     long_term_retention_storage_gb: 1000
-  azurerm_mssql_database.ltr_zone:
+    backup_storage_gb: 500
+  azurerm_mssql_database.backup_zone:
     long_term_retention_storage_gb: 1000
-  azurerm_mssql_database.ltr_local:
+    backup_storage_gb: 500
+  azurerm_mssql_database.backup_local:
     long_term_retention_storage_gb: 1000
+    backup_storage_gb: 500
   azurerm_mssql_database.premium6:
     long_term_retention_storage_gb: 1000
     extra_data_storage_gb: 500

--- a/internal/providers/terraform/azure/testdata/mssql_database_test_with_blank_location/mssql_database_test_with_blank_location.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test_with_blank_location/mssql_database_test_with_blank_location.golden
@@ -2,11 +2,11 @@
  Name                                            Monthly Qty  Unit            Monthly Cost 
                                                                                            
  azurerm_mssql_database.blank_server_location                                              
- ├─ Compute (S3)                                          30  days                 $145.16 
- ├─ Extra data storage                         Monthly cost depends on usage: $0.17 per GB 
- └─ Long-term retention                        Monthly cost depends on usage: $0.05 per GB 
+ ├─ Compute (S3)                                         730  hours                $147.18 
+ ├─ Long-term retention (RA-GRS)               Monthly cost depends on usage: $0.05 per GB 
+ └─ PITR backup storage (RA-GRS)               Monthly cost depends on usage: $0.20 per GB 
                                                                                            
- OVERALL TOTAL                                                                     $145.16 
+ OVERALL TOTAL                                                                     $147.18 
 ──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated, it includes usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/mssql_elasticpool_test/mssql_elasticpool_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_elasticpool_test/mssql_elasticpool_test.golden
@@ -20,7 +20,7 @@
                                                                                            
  azurerm_mssql_elasticpool.gp_gen5_zone_redundant                                          
  ├─ Compute (GP_Gen5, 4 vCore)                              730  hours             $488.92 
- ├─ Zone-redundancy (GP_Gen5, 4 vCore)                      730  hours             $293.35 
+ ├─ Zone redundancy (GP_Gen5, 4 vCore)                      730  hours             $293.35 
  ├─ SQL license                                           2,920  vCore-hours       $291.90 
  └─ Storage                                                 100  GB                 $27.40 
                                                                                            
@@ -45,10 +45,9 @@ level=warning msg="'Multiple products found' are safe to ignore for 'Compute (BC
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (GP_Gen5, 4 vCore)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (GP_Gen5, 4 vCore)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (GP_Gen5, 4 vCore)' due to limitations in the Azure API."
-level=warning msg="'Multiple products found' are safe to ignore for 'Zone-redundancy (GP_Gen5, 4 vCore)' due to limitations in the Azure API."
 level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.bc_dc Compute (BC_DC, 8 vCore), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.gp_gen5 Compute (GP_Gen5, 4 vCore), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.gp_gen5_zone_no_license Compute (GP_Gen5, 4 vCore), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.gp_gen5_zone_redundant Compute (GP_Gen5, 4 vCore), using the first product"
-level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.gp_gen5_zone_redundant Zone-redundancy (GP_Gen5, 4 vCore), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.gp_gen5_zone_redundant Zone redundancy (GP_Gen5, 4 vCore), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.premium_500 Compute (Premium, 500 DTUs), using the first product"

--- a/internal/providers/terraform/azure/testdata/mssql_elasticpool_test/mssql_elasticpool_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_elasticpool_test/mssql_elasticpool_test.golden
@@ -1,0 +1,54 @@
+
+ Name                                               Monthly Qty  Unit         Monthly Cost 
+                                                                                           
+ azurerm_mssql_elasticpool.basic_100                                                       
+ └─ Compute (Basic, 100 DTUs)                               730  hours             $147.22 
+                                                                                           
+ azurerm_mssql_elasticpool.bc_dc                                                           
+ ├─ Compute (BC_DC, 8 vCore)                                730  hours           $4,622.36 
+ ├─ SQL license                                           5,840  vCore-hours     $2,190.00 
+ └─ Storage                                                 100  GB                 $29.75 
+                                                                                           
+ azurerm_mssql_elasticpool.gp_gen5                                                         
+ ├─ Compute (GP_Gen5, 4 vCore)                              730  hours             $488.92 
+ ├─ SQL license                                           2,920  vCore-hours       $291.90 
+ └─ Storage                                                 100  GB                 $13.69 
+                                                                                           
+ azurerm_mssql_elasticpool.gp_gen5_zone_no_license                                         
+ ├─ Compute (GP_Gen5, 4 vCore)                              730  hours             $488.92 
+ └─ Storage                                                 100  GB                 $13.69 
+                                                                                           
+ azurerm_mssql_elasticpool.gp_gen5_zone_redundant                                          
+ ├─ Compute (GP_Gen5, 4 vCore)                              730  hours             $488.92 
+ ├─ Zone-redundancy (GP_Gen5, 4 vCore)                      730  hours             $293.35 
+ ├─ SQL license                                           2,920  vCore-hours       $291.90 
+ └─ Storage                                                 100  GB                 $27.40 
+                                                                                           
+ azurerm_mssql_elasticpool.premium_500                                                     
+ ├─ Compute (Premium, 500 DTUs)                             730  hours           $2,737.50 
+ └─ Extra data storage                                      274  GB                $121.11 
+                                                                                           
+ azurerm_mssql_elasticpool.standard_200                                                    
+ ├─ Compute (Standard, 200 DTUs)                            730  hours             $441.04 
+ └─ Extra data storage                                      100  GB                 $22.10 
+                                                                                           
+ OVERALL TOTAL                                                                  $12,709.77 
+──────────────────────────────────
+9 cloud resources were detected:
+∙ 7 were estimated
+∙ 2 were free:
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_sql_server
+Logs:
+
+level=warning msg="'Multiple products found' are safe to ignore for 'Compute (BC_DC, 8 vCore)' due to limitations in the Azure API."
+level=warning msg="'Multiple products found' are safe to ignore for 'Compute (GP_Gen5, 4 vCore)' due to limitations in the Azure API."
+level=warning msg="'Multiple products found' are safe to ignore for 'Compute (GP_Gen5, 4 vCore)' due to limitations in the Azure API."
+level=warning msg="'Multiple products found' are safe to ignore for 'Compute (GP_Gen5, 4 vCore)' due to limitations in the Azure API."
+level=warning msg="'Multiple products found' are safe to ignore for 'Zone-redundancy (GP_Gen5, 4 vCore)' due to limitations in the Azure API."
+level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.bc_dc Compute (BC_DC, 8 vCore), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.gp_gen5 Compute (GP_Gen5, 4 vCore), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.gp_gen5_zone_no_license Compute (GP_Gen5, 4 vCore), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.gp_gen5_zone_redundant Compute (GP_Gen5, 4 vCore), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.gp_gen5_zone_redundant Zone-redundancy (GP_Gen5, 4 vCore), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_mssql_elasticpool.premium_500 Compute (Premium, 500 DTUs), using the first product"

--- a/internal/providers/terraform/azure/testdata/mssql_elasticpool_test/mssql_elasticpool_test.tf
+++ b/internal/providers/terraform/azure/testdata/mssql_elasticpool_test/mssql_elasticpool_test.tf
@@ -1,0 +1,160 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "myexamplesqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = "eastus"
+  version                      = "12.0"
+  administrator_login          = "admin"
+  administrator_login_password = "password"
+}
+
+resource "azurerm_mssql_elasticpool" "gp_gen5" {
+  name                = "gp-gen5"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  license_type        = "LicenseIncluded"
+  max_size_gb         = 100
+
+  sku {
+    name     = "GP_Gen5"
+    tier     = "GeneralPurpose"
+    family   = "Gen5"
+    capacity = 4
+  }
+
+  per_database_settings {
+    min_capacity = 0.25
+    max_capacity = 4
+  }
+}
+
+resource "azurerm_mssql_elasticpool" "gp_gen5_zone_redundant" {
+  name                = "gp-gen5"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  license_type        = "LicenseIncluded"
+  zone_redundant      = true
+  max_size_gb         = 100
+
+  sku {
+    name     = "GP_Gen5"
+    tier     = "GeneralPurpose"
+    family   = "Gen5"
+    capacity = 4
+  }
+
+  per_database_settings {
+    min_capacity = 0.25
+    max_capacity = 4
+  }
+}
+
+resource "azurerm_mssql_elasticpool" "gp_gen5_zone_no_license" {
+  name                = "gp-gen5"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  license_type        = "BasePrice"
+  max_size_gb         = 100
+
+  sku {
+    name     = "GP_Gen5"
+    tier     = "GeneralPurpose"
+    family   = "Gen5"
+    capacity = 4
+  }
+
+  per_database_settings {
+    min_capacity = 0.25
+    max_capacity = 4
+  }
+}
+
+resource "azurerm_mssql_elasticpool" "bc_dc" {
+  name                = "bc-dc"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  license_type        = "LicenseIncluded"
+  max_size_gb         = 100
+
+  sku {
+    name     = "BC_DC"
+    tier     = "BusinessCritical"
+    family   = "DC"
+    capacity = 8
+  }
+
+  per_database_settings {
+    min_capacity = 0.25
+    max_capacity = 4
+  }
+}
+
+resource "azurerm_mssql_elasticpool" "basic_100" {
+  name                = "basic-100"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  max_size_gb         = 9.7656250
+
+  sku {
+    name     = "BasicPool"
+    tier     = "Basic"
+    capacity = 100
+  }
+
+  per_database_settings {
+    min_capacity = 1
+    max_capacity = 4
+  }
+}
+
+resource "azurerm_mssql_elasticpool" "standard_200" {
+  name                = "standard-200"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  max_size_gb         = 300 # 100 GB extra storage
+
+  sku {
+    name     = "StandardPool"
+    tier     = "Standard"
+    capacity = 200
+  }
+
+  per_database_settings {
+    min_capacity = 1
+    max_capacity = 4
+  }
+}
+
+resource "azurerm_mssql_elasticpool" "premium_500" {
+  name                = "premium-500"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  max_size_gb         = 1024 # 274 GB extra storage
+
+  sku {
+    name     = "PremiumPool"
+    tier     = "Premium"
+    capacity = 500
+  }
+
+  per_database_settings {
+    min_capacity = 1
+    max_capacity = 4
+  }
+}

--- a/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.golden
@@ -1,35 +1,41 @@
 
  Name                                                           Monthly Qty  Unit              Monthly Cost 
                                                                                                             
- azurerm_sql_database.LTR                                                                                   
+ azurerm_sql_database.backup                                                                                
  ├─ Compute (provisioned, GP_Gen5_4)                                    730  hours                  $444.47 
  ├─ Storage                                                               5  GB                       $0.58 
- └─ Long-term retention                                               1,000  GB                      $50.00 
+ ├─ Long-term retention (RA-GRS)                                      1,000  GB                      $50.00 
+ └─ PITR backup storage (RA-GRS)                                        500  GB                     $100.00 
                                                                                                             
  azurerm_sql_database.default_sql_database                                                                  
  ├─ Compute (provisioned, GP_Gen5_2)                                    730  hours                  $222.24 
  ├─ Storage                                                               5  GB                       $0.58 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB    
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB    
                                                                                                             
  azurerm_sql_database.premium6                                                                              
  ├─ Compute (P6)                                                        730  hours                $3,650.00 
  ├─ Extra data storage                                                  500  GB                     $170.00 
- └─ Long-term retention                                               1,000  GB                      $50.00 
+ ├─ Long-term retention (RA-GRS)                                      1,000  GB                      $50.00 
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB    
                                                                                                             
  azurerm_sql_database.serverless                                                                            
  ├─ Compute (serverless, GP_S_Gen5_4)                                   500  vCore-hours            $260.88 
  ├─ Storage                                                               5  GB                       $0.58 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB    
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB    
                                                                                                             
  azurerm_sql_database.sql_database_with_edition_critical                                                    
  ├─ Compute (provisioned, BC_Gen5_2)                                    730  hours                  $444.48 
  ├─ Storage                                                               5  GB                       $1.25 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB    
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB    
                                                                                                             
  azurerm_sql_database.sql_database_with_edition_gen                                                         
  ├─ Compute (provisioned, GP_Gen5_2)                                    730  hours                  $222.24 
  ├─ Storage                                                               5  GB                       $0.58 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB    
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB    
                                                                                                             
  azurerm_sql_database.sql_database_with_edition_hyper                                                       
  ├─ Compute (provisioned, HS_Gen5_2)                                    730  hours                  $266.68 
@@ -38,23 +44,27 @@
                                                                                                             
  azurerm_sql_database.sql_database_with_edition_premium                                                     
  ├─ Compute (P1)                                                        730  hours                  $456.25 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB    
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB    
                                                                                                             
  azurerm_sql_database.sql_database_with_edition_standard                                                    
  ├─ Compute (S0)                                                        730  hours                   $14.72 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB    
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB    
                                                                                                             
  azurerm_sql_database.sql_database_with_max_size                                                            
  ├─ Compute (provisioned, GP_Gen5_2)                                    730  hours                  $222.24 
  ├─ Storage                                                              10  GB                       $1.15 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB    
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB    
                                                                                                             
  azurerm_sql_database.sql_database_with_service_object_name                                                 
  ├─ Compute (provisioned, BC_Gen5_2)                                    730  hours                  $444.48 
  ├─ Storage                                                               5  GB                       $1.25 
- └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
+ ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB    
+ └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB    
                                                                                                             
- OVERALL TOTAL                                                                                    $6,925.12 
+ OVERALL TOTAL                                                                                    $7,025.12 
 ──────────────────────────────────
 13 cloud resources were detected:
 ∙ 11 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
@@ -70,7 +80,7 @@ level=warning msg="'Multiple products found' are safe to ignore for 'Compute (pr
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_2)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API."
 level=warning msg="'Multiple products found' are safe to ignore for 'Compute (provisioned, HS_Gen5_2)' due to limitations in the Azure API."
-level=warning msg="Multiple products with prices found for azurerm_sql_database.LTR Compute (provisioned, GP_Gen5_4), using the first product"
+level=warning msg="Multiple products with prices found for azurerm_sql_database.backup Compute (provisioned, GP_Gen5_4), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_sql_database.default_sql_database Compute (provisioned, GP_Gen5_2), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_sql_database.sql_database_with_edition_critical Compute (provisioned, BC_Gen5_2), using the first product"
 level=warning msg="Multiple products with prices found for azurerm_sql_database.sql_database_with_edition_gen Compute (provisioned, GP_Gen5_2), using the first product"

--- a/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.golden
@@ -38,12 +38,10 @@
                                                                                                             
  azurerm_sql_database.sql_database_with_edition_premium                                                     
  ├─ Compute (P1)                                                        730  hours                  $456.25 
- ├─ Extra data storage                                       Monthly cost depends on usage: $0.34 per GB    
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
                                                                                                             
  azurerm_sql_database.sql_database_with_edition_standard                                                    
  ├─ Compute (S0)                                                        730  hours                   $14.72 
- ├─ Extra data storage                                       Monthly cost depends on usage: $0.17 per GB    
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
                                                                                                             
  azurerm_sql_database.sql_database_with_max_size                                                            

--- a/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.golden
@@ -12,7 +12,7 @@
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
                                                                                                             
  azurerm_sql_database.premium6                                                                              
- ├─ Compute (P6)                                                         30  days                 $3,600.00 
+ ├─ Compute (P6)                                                        730  hours                $3,650.00 
  ├─ Extra data storage                                                  500  GB                     $170.00 
  └─ Long-term retention                                               1,000  GB                      $50.00 
                                                                                                             
@@ -37,12 +37,12 @@
  └─ Storage                                                               5  GB                       $0.50 
                                                                                                             
  azurerm_sql_database.sql_database_with_edition_premium                                                     
- ├─ Compute (P1)                                                         30  days                   $450.00 
+ ├─ Compute (P1)                                                        730  hours                  $456.25 
  ├─ Extra data storage                                       Monthly cost depends on usage: $0.34 per GB    
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
                                                                                                             
  azurerm_sql_database.sql_database_with_edition_standard                                                    
- ├─ Compute (S0)                                                         30  days                    $14.52 
+ ├─ Compute (S0)                                                        730  hours                   $14.72 
  ├─ Extra data storage                                       Monthly cost depends on usage: $0.17 per GB    
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
                                                                                                             
@@ -56,7 +56,7 @@
  ├─ Storage                                                               5  GB                       $1.25 
  └─ Long-term retention                                      Monthly cost depends on usage: $0.05 per GB    
                                                                                                             
- OVERALL TOTAL                                                                                    $6,868.66 
+ OVERALL TOTAL                                                                                    $6,925.12 
 ──────────────────────────────────
 13 cloud resources were detected:
 ∙ 11 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.tf
@@ -88,7 +88,7 @@ resource "azurerm_sql_database" "serverless" {
   requested_service_objective_name = "GP_S_Gen5_4"
 }
 
-resource "azurerm_sql_database" "LTR" {
+resource "azurerm_sql_database" "backup" {
   name                             = "myexamplesqldatabase9"
   resource_group_name              = azurerm_resource_group.example.name
   location                         = "eastus"

--- a/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.usage.yml
@@ -2,8 +2,9 @@ version: 0.1
 resource_usage:
   azurerm_sql_database.serverless:
     monthly_vcore_hours: 500
-  azurerm_sql_database.LTR:
+  azurerm_sql_database.backup:
     long_term_retention_storage_gb: 1000
+    backup_storage_gb: 500
   azurerm_sql_database.premium6:
     long_term_retention_storage_gb: 1000
     extra_data_storage_gb: 500

--- a/internal/providers/terraform/azure/testdata/sql_elasticpool_test/sql_elasticpool_test.golden
+++ b/internal/providers/terraform/azure/testdata/sql_elasticpool_test/sql_elasticpool_test.golden
@@ -1,0 +1,24 @@
+
+ Name                                  Monthly Qty  Unit   Monthly Cost 
+                                                                        
+ azurerm_sql_elasticpool.basic_100                                      
+ └─ Compute (Basic, 100 DTUs)                  730  hours       $147.22 
+                                                                        
+ azurerm_sql_elasticpool.premium_500                                    
+ ├─ Compute (Premium, 500 DTUs)                730  hours     $2,737.50 
+ └─ Extra data storage                         274  GB          $121.11 
+                                                                        
+ azurerm_sql_elasticpool.standard_200                                   
+ ├─ Compute (Standard, 200 DTUs)               730  hours       $441.04 
+ └─ Extra data storage                         100  GB           $22.10 
+                                                                        
+ OVERALL TOTAL                                                $3,468.97 
+──────────────────────────────────
+5 cloud resources were detected:
+∙ 3 were estimated
+∙ 2 were free:
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_sql_server
+Logs:
+
+level=warning msg="Multiple products with prices found for azurerm_sql_elasticpool.premium_500 Compute (Premium, 500 DTUs), using the first product"

--- a/internal/providers/terraform/azure/testdata/sql_elasticpool_test/sql_elasticpool_test.tf
+++ b/internal/providers/terraform/azure/testdata/sql_elasticpool_test/sql_elasticpool_test.tf
@@ -1,0 +1,54 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_sql_server" "example" {
+  name                         = "myexamplesqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = "eastus"
+  version                      = "12.0"
+  administrator_login          = "admin"
+  administrator_login_password = "password"
+}
+
+resource "azurerm_sql_elasticpool" "basic_100" {
+  name                = "basic-100"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  edition             = "Basic"
+  dtu                 = 100
+  db_dtu_min          = 0
+  db_dtu_max          = 5
+  pool_size           = 5000
+}
+
+resource "azurerm_sql_elasticpool" "standard_200" {
+  name                = "standard-200"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  edition             = "Standard"
+  dtu                 = 200
+  db_dtu_min          = 0
+  db_dtu_max          = 5
+  pool_size           = 307200
+}
+
+resource "azurerm_sql_elasticpool" "premium_500" {
+  name                = "premium-500"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  server_name         = azurerm_sql_server.example.name
+  edition             = "Premium"
+  dtu                 = 500
+  db_dtu_min          = 0
+  db_dtu_max          = 5
+  pool_size           = 1048576
+}

--- a/internal/providers/terraform/azure/testdata/sql_managed_instance_test/sql_managed_instance_test.golden
+++ b/internal/providers/terraform/azure/testdata/sql_managed_instance_test/sql_managed_instance_test.golden
@@ -4,20 +4,20 @@
  azurerm_sql_managed_instance.example                                                  
  ├─ Compute (GP_GEN5 4 Cores)                      730  hours                  $488.92 
  ├─ Storage                                         32  GB                       $4.38 
- ├─ PITR Backup storage (LRS)                      100  GB                      $11.90 
+ ├─ PITR backup storage (LRS)                      100  GB                      $11.90 
  ├─ SQL license                                  2,920  vCore-hours            $291.90 
  └─ LTR Backup Storage (LRS)                         5  GB                       $0.15 
                                                                                        
  azurerm_sql_managed_instance.example2                                                 
  ├─ Compute (GP_GEN5 16 Cores)                     730  hours                $1,955.69 
  ├─ Storage                                         32  GB                       $4.38 
- ├─ PITR Backup storage (LRS)           Monthly cost depends on usage: $0.12 per GB    
+ ├─ PITR backup storage (LRS)           Monthly cost depends on usage: $0.12 per GB    
  └─ LTR Backup Storage (LRS)            Monthly cost depends on usage: $0.0298 per GB  
                                                                                        
  azurerm_sql_managed_instance.example3                                                 
  ├─ Compute (BC_GEN5 40 Cores)                     730  hours                $9,778.47 
  ├─ Storage                                         32  GB                       $4.38 
- ├─ PITR Backup storage (ZRS)                      100  GB                      $14.90 
+ ├─ PITR backup storage (ZRS)                      100  GB                      $14.90 
  └─ LTR Backup Storage (ZRS)                       100  GB                       $3.72 
                                                                                        
  OVERALL TOTAL                                                              $12,558.78 

--- a/internal/resources/azure/mssql_elasticpool.go
+++ b/internal/resources/azure/mssql_elasticpool.go
@@ -32,7 +32,7 @@ type MSSQLElasticPool struct {
 	Address       string
 	Region        string
 	SKU           string
-	LicenceType   string
+	LicenseType   string
 	Tier          string
 	Family        string
 	Cores         *int64
@@ -68,7 +68,7 @@ func (r *MSSQLElasticPool) PopulateUsage(u *schema.UsageData) {
 // Elastic pools that follow a vCore pricing model have the following costs associated with them:
 //
 //  1. Costs based on the number of vCores the resource has
-//  2. Additional charge for SQL Server licencing based on vCores amount
+//  2. Additional charge for SQL Server licensing based on vCores amount
 //  3. Charges for storage used
 //  4. Charges for long term data backup - this is configured using MSSQLElasticPool.LongTermRetentionStorageGB
 //
@@ -142,7 +142,7 @@ func (r *MSSQLElasticPool) dtuCostComponents() []*schema.CostComponent {
 func (r *MSSQLElasticPool) vCoreCostComponents() []*schema.CostComponent {
 	costComponents := r.computeHoursCostComponents()
 
-	if strings.ToLower(r.LicenceType) == "licenseincluded" {
+	if strings.ToLower(r.LicenseType) == "licenseincluded" {
 		costComponents = append(costComponents, r.sqlLicenseCostComponent())
 	}
 

--- a/internal/resources/azure/mssql_elasticpool.go
+++ b/internal/resources/azure/mssql_elasticpool.go
@@ -1,0 +1,223 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+var mssqlElasticPoolPremiumDTUIncludedStorage = map[int]float64{
+	125:  250,
+	250:  500,
+	500:  750,
+	1000: 1024,
+	1500: 1536,
+	2000: 2048,
+	2500: 2560,
+	3000: 3072,
+	3500: 3584,
+	4000: 4096,
+}
+
+// MSSQLElasticPool represents an Azure MSSQL Elastic Pool instance.
+//
+// More resource information here: https://azure.microsoft.com/en-gb/products/azure-sql/database/
+// Pricing information here: https://azure.microsoft.com/en-gb/pricing/details/azure-sql-database/
+type MSSQLElasticPool struct {
+	Address       string
+	Region        string
+	SKU           string
+	LicenceType   string
+	Tier          string
+	Family        string
+	Cores         *int64
+	DTUCapacity   *int64
+	MaxSizeGB     *float64
+	ZoneRedundant bool
+}
+
+var MSSQLElasticPoolUsageSchema = []*schema.UsageItem{}
+
+// PopulateUsage parses the u schema.UsageData into the MSSQLElasticPool.
+func (r *MSSQLElasticPool) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid MSSQLElasticPool.
+// It returns a MSSQLElasticPool as a *schema.Resource with cost components initialized.
+//
+// MSSQLElasticPool splits pricing into two different models. DTU & vCores.
+//
+//	Database Transaction Unit (DTU) is made a performance metric representing a mixture of performance metrics
+//	in Azure SQL. Some include: CPU, I/O, Memory. DTU is used as Azure tries to simplify billing by using a single metric.
+//
+//	Virtual Core (vCore) pricing is designed to translate from on premise hardware metrics (cores) into the cloud
+//	SQL instance. vCore is designed to allow users to better estimate their resource limits, e.g. RAM.
+//
+// Elastic pools that follow a DTU pricing model have the following costs associated with them:
+//
+//  1. Costs based on the number of DTUs that the SQL database has
+//  2. Extra backup data costs - this is configured using MSSQLElasticPool.ExtraDataStorageGB
+//  3. Long term data backup costs - this is configured using MSSQLElasticPool.LongTermRetentionStorageGB
+//
+// Elastic pools that follow a vCore pricing model have the following costs associated with them:
+//
+//  1. Costs based on the number of vCores the resource has
+//  2. Additional charge for SQL Server licencing based on vCores amount
+//  3. Charges for storage used
+//  4. Charges for long term data backup - this is configured using MSSQLElasticPool.LongTermRetentionStorageGB
+//
+// This method is called after the resource is initialized by an IaC provider. MSSQLElasticPool is used by both mssql_elasticpool
+// and sql_elasticpool Terraform resources.
+func (r *MSSQLElasticPool) BuildResource() *schema.Resource {
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    MSSQLElasticPoolUsageSchema,
+		CostComponents: r.costComponents(),
+	}
+}
+
+func (r *MSSQLElasticPool) costComponents() []*schema.CostComponent {
+	s := strings.ToLower(r.SKU)
+	if s == "basicpool" || s == "standardpool" || s == "premiumpool" {
+		return r.dtuCostComponents()
+	}
+
+	return r.vCoreCostComponents()
+}
+
+func (r *MSSQLElasticPool) dtuCostComponents() []*schema.CostComponent {
+	productName := fmt.Sprintf("SQL Database Elastic Pool - %s", r.Tier)
+
+	var dtuCapacity int64
+	if r.DTUCapacity != nil {
+		dtuCapacity = *r.DTUCapacity
+	}
+
+	// This is a bit of a hack, but the Azure pricing API returns the price per day
+	// and the Azure pricing calculator uses 730 hours to show the cost
+	// so we need to convert the price per day to price per hour.
+	// Use precision 24 to avoid rounding errors later since the default decimal precision is 16.
+	daysInMonth := schema.HourToMonthUnitMultiplier.DivRound(decimal.NewFromInt(24), 24)
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name:            fmt.Sprintf("Compute (%s, %d DTUs)", r.Tier, dtuCapacity),
+			Unit:            "hours",
+			UnitMultiplier:  daysInMonth.DivRound(schema.HourToMonthUnitMultiplier, 24),
+			MonthlyQuantity: decimalPtr(daysInMonth),
+			ProductFilter: r.productFilter([]*schema.AttributeFilter{
+				{Key: "productName", ValueRegex: regexPtr(productName)},
+				{Key: "skuName", Value: strPtr(fmt.Sprintf("%d DTU Pack", dtuCapacity))},
+				{Key: "meterName", Value: strPtr("eDTUs")},
+			}),
+			PriceFilter: priceFilterConsumption,
+		},
+	}
+
+	var extraStorageGB float64
+
+	if strings.ToLower(r.Tier) == "standard" && r.MaxSizeGB != nil {
+		includedStorageGB := float64(dtuCapacity)
+		extraStorageGB = *r.MaxSizeGB - includedStorageGB
+	} else if strings.ToLower(r.Tier) == "premium" && r.MaxSizeGB != nil {
+		includedStorageGB, ok := mssqlElasticPoolPremiumDTUIncludedStorage[int(*r.DTUCapacity)]
+		if ok {
+			extraStorageGB = *r.MaxSizeGB - includedStorageGB
+		}
+	}
+
+	if extraStorageGB > 0 {
+		costComponents = append(costComponents, r.extraDataStorageCostComponent(extraStorageGB))
+	}
+
+	return costComponents
+}
+
+func (r *MSSQLElasticPool) vCoreCostComponents() []*schema.CostComponent {
+	costComponents := []*schema.CostComponent{
+		r.computeHoursCostComponent(),
+	}
+
+	if r.ZoneRedundant {
+		costComponents = append(costComponents, r.zoneRedundancyCostComponent())
+	}
+
+	if strings.ToLower(r.LicenceType) == "licenseincluded" {
+		costComponents = append(costComponents, r.sqlLicenseCostComponent())
+	}
+
+	costComponents = append(costComponents, r.storageCostComponent())
+
+	return costComponents
+}
+
+func (r *MSSQLElasticPool) computeHoursCostComponent() *schema.CostComponent {
+	var cores int64
+	if r.Cores != nil {
+		cores = *r.Cores
+	}
+
+	skuName := fmt.Sprintf("%d vCore", cores)
+	productNameRegex := fmt.Sprintf("/%s - %s/", r.Tier, r.Family)
+	name := fmt.Sprintf("Compute (%s, %d vCore)", r.SKU, cores)
+
+	log.Warnf("'Multiple products found' are safe to ignore for '%s' due to limitations in the Azure API.", name)
+
+	return &schema.CostComponent{
+		Name:           name,
+		Unit:           "hours",
+		UnitMultiplier: decimal.NewFromInt(1),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: r.productFilter([]*schema.AttributeFilter{
+			{Key: "productName", ValueRegex: strPtr(productNameRegex)},
+			{Key: "skuName", Value: strPtr(skuName)},
+		}),
+		PriceFilter: priceFilterConsumption,
+	}
+}
+
+func (r *MSSQLElasticPool) zoneRedundancyCostComponent() *schema.CostComponent {
+	var cores int64
+	if r.Cores != nil {
+		cores = *r.Cores
+	}
+
+	skuName := fmt.Sprintf("%d vCore Zone Redundancy", cores)
+	productNameRegex := fmt.Sprintf("/%s - %s/", r.Tier, r.Family)
+	name := fmt.Sprintf("Zone-redundancy (%s, %d vCore)", r.SKU, cores)
+	log.Warnf("'Multiple products found' are safe to ignore for '%s' due to limitations in the Azure API.", name)
+
+	return &schema.CostComponent{
+		Name:           name,
+		Unit:           "hours",
+		UnitMultiplier: decimal.NewFromInt(1),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: r.productFilter([]*schema.AttributeFilter{
+			{Key: "productName", ValueRegex: strPtr(productNameRegex)},
+			{Key: "skuName", Value: strPtr(skuName)},
+		}),
+		PriceFilter: priceFilterConsumption,
+	}
+}
+
+func (r *MSSQLElasticPool) extraDataStorageCostComponent(extraStorageGB float64) *schema.CostComponent {
+	return mssqlExtraDataStorageCostComponent(r.Region, r.Tier, extraStorageGB)
+}
+
+func (r *MSSQLElasticPool) sqlLicenseCostComponent() *schema.CostComponent {
+	return mssqlLicenseCostComponent(r.Region, r.Cores, r.Tier)
+}
+
+func (r *MSSQLElasticPool) storageCostComponent() *schema.CostComponent {
+	return mssqlStorageCostComponent(r.Region, r.Tier, r.ZoneRedundant, r.MaxSizeGB)
+}
+
+func (r *MSSQLElasticPool) productFilter(filters []*schema.AttributeFilter) *schema.ProductFilter {
+	return mssqlProductFilter(r.Region, filters)
+}

--- a/internal/resources/azure/sql_database.go
+++ b/internal/resources/azure/sql_database.go
@@ -48,7 +48,7 @@ type SQLDatabase struct {
 	Region            string
 	SKU               string
 	IsElasticPool     bool
-	LicenceType       string
+	LicenseType       string
 	Tier              string
 	Family            string
 	Cores             *int64
@@ -101,7 +101,7 @@ var SQLDatabaseUsageSchema = []*schema.UsageItem{
 //
 //  1. Costs based on the number of vCores the resource has
 //  2. Extra pricing if any database read replicas have been provisioned
-//  3. Additional charge for SQL Server licencing based on vCores amount
+//  3. Additional charge for SQL Server licensing based on vCores amount
 //  4. Charges for storage used
 //  5. Charges for long term data backup - this is configured using SQLDatabase.LongTermRetentionStorageGB
 //
@@ -188,7 +188,7 @@ func (r *SQLDatabase) vCoreCostComponents() []*schema.CostComponent {
 		costComponents = append(costComponents, r.readReplicaCostComponent())
 	}
 
-	if strings.ToLower(r.Tier) != sqlServerlessTier && strings.ToLower(r.LicenceType) == "licenseincluded" {
+	if strings.ToLower(r.Tier) != sqlServerlessTier && strings.ToLower(r.LicenseType) == "licenseincluded" {
 		costComponents = append(costComponents, r.sqlLicenseCostComponent())
 	}
 

--- a/internal/resources/azure/sql_database.go
+++ b/internal/resources/azure/sql_database.go
@@ -41,6 +41,7 @@ type SQLDatabase struct {
 	Address          string
 	Region           string
 	SKU              string
+	IsElasticPool    bool
 	LicenceType      string
 	Tier             string
 	Family           string
@@ -105,6 +106,10 @@ func (r *SQLDatabase) BuildResource() *schema.Resource {
 }
 
 func (r *SQLDatabase) costComponents() []*schema.CostComponent {
+	if r.IsElasticPool {
+		return r.elasticPoolCostComponents()
+	}
+
 	if r.Cores != nil {
 		return r.vCoreCostComponents()
 	}
@@ -183,6 +188,12 @@ func (r *SQLDatabase) vCoreCostComponents() []*schema.CostComponent {
 	}
 
 	return costComponents
+}
+
+func (r *SQLDatabase) elasticPoolCostComponents() []*schema.CostComponent {
+	return []*schema.CostComponent{
+		r.longTermRetentionCostComponent(),
+	}
 }
 
 func (r *SQLDatabase) computeHoursCostComponents() []*schema.CostComponent {

--- a/internal/resources/azure/sql_database.go
+++ b/internal/resources/azure/sql_database.go
@@ -12,9 +12,6 @@ import (
 )
 
 const (
-	sqlServiceName   = "SQL Database"
-	sqlProductFamily = "Databases"
-
 	sqlServerlessTier = "general purpose - serverless"
 	sqlHyperscaleTier = "hyperscale"
 )
@@ -26,7 +23,16 @@ var (
 	}
 )
 
-// SQLDatabase represents an azure sql database instance.
+var mssqlPremiumDTUIncludedStorage = map[string]float64{
+	"p1":  500,
+	"p2":  500,
+	"p4":  500,
+	"p6":  500,
+	"p11": 4096,
+	"p15": 4096,
+}
+
+// SQLDatabase represents an Azure SQL database instance.
 //
 // More resource information here: https://azure.microsoft.com/en-gb/products/azure-sql/database/
 // Pricing information here: https://azure.microsoft.com/en-gb/pricing/details/azure-sql-database/single/
@@ -43,7 +49,7 @@ type SQLDatabase struct {
 	ZoneRedundant    bool
 
 	// ExtraDataStorageGB represents a usage cost of additional backup storage used by the sql database.
-	ExtraDataStorageGB *int64 `infracost_usage:"extra_data_storage_gb"`
+	ExtraDataStorageGB *float64 `infracost_usage:"extra_data_storage_gb"`
 	// MonthlyVCoreHours represents a usage param that allows users to define how many hours of usage a serverless sql database instance uses.
 	MonthlyVCoreHours *int64 `infracost_usage:"monthly_vcore_hours"`
 	// LongTermRetentionStorageGB defines a usage param that allows users to define how many gb of cold storage the database uses.
@@ -56,16 +62,22 @@ func (r *SQLDatabase) PopulateUsage(u *schema.UsageData) {
 	resources.PopulateArgsWithUsage(r, u)
 }
 
+var SQLDatabaseUsageSchema = []*schema.UsageItem{
+	{Key: "extra_data_storage_gb", DefaultValue: 0.0, ValueType: schema.Float64},
+	{Key: "monthly_vcore_hours", DefaultValue: 0, ValueType: schema.Int64},
+	{Key: "long_term_retention_storage_gb", DefaultValue: 0, ValueType: schema.Int64},
+}
+
 // BuildResource builds a schema.Resource from a valid SQLDatabase.
 // It returns a SQLDatabase as a *schema.Resource with cost components initialized.
 //
 // SQLDatabase splits pricing into two different models. DTU & vCores.
 //
 //	Database Transaction Unit (DTU) is made a performance metric representing a mixture of performance metrics
-//	in azure sql. Some include: CPU, I/O, Memory. DTU is used as Azure tries to simplify billing by using a single metric.
+//	in Azure SQL. Some include: CPU, I/O, Memory. DTU is used as Azure tries to simplify billing by using a single metric.
 //
 //	Virtual Core (vCore) pricing is designed to translate from on premise hardware metrics (cores) into the cloud
-//	sql instance. vCore is designed to allow users to better estimate their resource limits, e.g. RAM.
+//	SQL instance. vCore is designed to allow users to better estimate their resource limits, e.g. RAM.
 //
 // SQL databases that follow a DTU pricing model have the following costs associated with them:
 //
@@ -77,45 +89,46 @@ func (r *SQLDatabase) PopulateUsage(u *schema.UsageData) {
 //
 //  1. Costs based on the number of vCores the resource has
 //  2. Extra pricing if any database read replicas have been provisioned
-//  3. Additional charge for sql server licencing based on vCores amount
+//  3. Additional charge for SQL Server licencing based on vCores amount
 //  4. Charges for storage used
 //  5. Charges for long term data backup - this is configured using SQLDatabase.LongTermRetentionStorageGB
 //
 // This method is called after the resource is initialized by an IaC provider. SQLDatabase is used by both mssql_database
-// and sql_database terraform resources to build a sql database costing.
+// and sql_database Terraform resources.
 func (r *SQLDatabase) BuildResource() *schema.Resource {
 	return &schema.Resource{
-		Name: r.Address,
-		UsageSchema: []*schema.UsageItem{
-			{Key: "extra_data_storage_gb", DefaultValue: 0, ValueType: schema.Int64},
-			{Key: "monthly_vcore_hours", DefaultValue: 0, ValueType: schema.Int64},
-			{Key: "long_term_retention_storage_gb", DefaultValue: 0, ValueType: schema.Int64},
-		},
+		Name:           r.Address,
+		UsageSchema:    SQLDatabaseUsageSchema,
 		CostComponents: r.costComponents(),
 	}
 }
 
 func (r *SQLDatabase) costComponents() []*schema.CostComponent {
 	if r.Cores != nil {
-		return r.vCorePurchaseCostComponents()
+		return r.vCoreCostComponents()
 	}
 
-	return r.dtuPurchaseCostComponents()
+	return r.dtuCostComponents()
 }
 
-func (r *SQLDatabase) dtuPurchaseCostComponents() []*schema.CostComponent {
+func (r *SQLDatabase) dtuCostComponents() []*schema.CostComponent {
 	skuName := strings.ToLower(r.SKU)
 	if skuName == "basic" {
 		skuName = "b"
 	}
 
+	// This is a bit of a hack, but the Azure pricing API returns the price per day
+	// and the Azure pricing calculator uses 730 hours to show the cost
+	// so we need to convert the price per day to price per hour.
+	// Use precision 24 to avoid rounding errors later since the default decimal precision is 16.
+	daysInMonth := schema.HourToMonthUnitMultiplier.DivRound(decimal.NewFromInt(24), 24)
+
 	costComponents := []*schema.CostComponent{
 		{
-			Name:           fmt.Sprintf("Compute (%s)", strings.ToTitle(r.SKU)),
-			Unit:           "days",
-			UnitMultiplier: decimal.NewFromInt(1),
-			// This is not the same as the 730h/month value we use elsewhere but it looks more understandable than seeing `30.4166` in the output
-			MonthlyQuantity: decimalPtr(decimal.NewFromInt(30)),
+			Name:            fmt.Sprintf("Compute (%s)", strings.ToTitle(r.SKU)),
+			Unit:            "hours",
+			UnitMultiplier:  daysInMonth.DivRound(schema.HourToMonthUnitMultiplier, 24),
+			MonthlyQuantity: decimalPtr(daysInMonth),
 			ProductFilter: r.productFilter([]*schema.AttributeFilter{
 				{Key: "productName", ValueRegex: regexPtr("^SQL Database Single")},
 				{Key: "skuName", ValueRegex: regexPtr(fmt.Sprintf("^%s$", skuName))},
@@ -125,52 +138,30 @@ func (r *SQLDatabase) dtuPurchaseCostComponents() []*schema.CostComponent {
 		},
 	}
 
-	if skuName != "b" {
-		costComponents = append(costComponents, r.extraDataStorageCostComponent())
+	var extraStorageGB float64
+
+	if strings.ToLower(r.SKU) != "basic" && r.ExtraDataStorageGB != nil {
+		extraStorageGB = *r.ExtraDataStorageGB
+	} else if strings.ToLower(r.SKU) == "standard" && r.MaxSizeGB != nil {
+		includedStorageGB := 250.0
+		extraStorageGB = *r.MaxSizeGB - includedStorageGB
+	} else if strings.ToLower(r.SKU) == "premium" && r.MaxSizeGB != nil {
+		includedStorageGB, ok := mssqlPremiumDTUIncludedStorage[strings.ToLower(r.SKU)]
+		if ok {
+			extraStorageGB = *r.MaxSizeGB - includedStorageGB
+		}
 	}
 
-	costComponents = append(costComponents, r.longTermRetentionMSSQLCostComponent())
+	if extraStorageGB > 0 {
+		costComponents = append(costComponents, r.extraDataStorageCostComponent(extraStorageGB))
+	}
+
+	costComponents = append(costComponents, r.longTermRetentionCostComponent())
 
 	return costComponents
 }
 
-func (r *SQLDatabase) extraDataStorageCostComponent() *schema.CostComponent {
-	sn := tierMapping[strings.ToLower(r.SKU)[:1]]
-
-	var storageGB *decimal.Decimal
-	if r.MaxSizeGB != nil {
-		storageGB = decimalPtr(decimal.NewFromFloat(*r.MaxSizeGB))
-
-		if strings.ToLower(sn) == "premium" {
-			storageGB = decimalPtr(storageGB.Sub(decimal.NewFromInt(500)))
-		} else {
-			storageGB = decimalPtr(storageGB.Sub(decimal.NewFromInt(250)))
-		}
-
-		if storageGB.IsNegative() {
-			storageGB = nil
-		}
-	}
-
-	if r.ExtraDataStorageGB != nil {
-		storageGB = decimalPtr(decimal.NewFromInt(*r.ExtraDataStorageGB))
-	}
-
-	return &schema.CostComponent{
-		Name:            "Extra data storage",
-		Unit:            "GB",
-		UnitMultiplier:  decimal.NewFromInt(1),
-		MonthlyQuantity: storageGB,
-		ProductFilter: r.productFilter([]*schema.AttributeFilter{
-			{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/SQL Database %s - Storage/i", sn))},
-			{Key: "skuName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", sn))},
-			{Key: "meterName", Value: strPtr("Data Stored")},
-		}),
-		PriceFilter: priceFilterConsumption,
-	}
-}
-
-func (r *SQLDatabase) vCorePurchaseCostComponents() []*schema.CostComponent {
+func (r *SQLDatabase) vCoreCostComponents() []*schema.CostComponent {
 	costComponents := []*schema.CostComponent{
 		r.computeHoursCostComponent(),
 	}
@@ -183,10 +174,10 @@ func (r *SQLDatabase) vCorePurchaseCostComponents() []*schema.CostComponent {
 		costComponents = append(costComponents, r.sqlLicenseCostComponent())
 	}
 
-	costComponents = append(costComponents, r.mssqlStorageComponent())
+	costComponents = append(costComponents, r.storageCostComponent())
 
 	if strings.ToLower(r.Tier) != sqlHyperscaleTier {
-		costComponents = append(costComponents, r.longTermRetentionMSSQLCostComponent())
+		costComponents = append(costComponents, r.longTermRetentionCostComponent())
 	}
 
 	return costComponents
@@ -208,7 +199,7 @@ func (r *SQLDatabase) serverlessComputeHoursCostComponent() *schema.CostComponen
 		vCoreHours = decimalPtr(decimal.NewFromInt(*r.MonthlyVCoreHours))
 	}
 
-	serverlessSkuName := r.mssqlSkuName(1)
+	serverlessSkuName := mssqlSkuName(1, r.ZoneRedundant)
 	return &schema.CostComponent{
 		Name:            fmt.Sprintf("Compute (serverless, %s)", r.SKU),
 		Unit:            "vCore-hours",
@@ -224,7 +215,7 @@ func (r *SQLDatabase) serverlessComputeHoursCostComponent() *schema.CostComponen
 }
 
 func (r *SQLDatabase) provisionedComputeCostComponent() *schema.CostComponent {
-	skuName := r.mssqlSkuName(*r.Cores)
+	skuName := mssqlSkuName(*r.Cores, r.ZoneRedundant)
 	productNameRegex := fmt.Sprintf("/%s - %s/", r.Tier, r.Family)
 	name := fmt.Sprintf("Compute (provisioned, %s)", r.SKU)
 
@@ -245,7 +236,7 @@ func (r *SQLDatabase) provisionedComputeCostComponent() *schema.CostComponent {
 
 func (r *SQLDatabase) readReplicaCostComponent() *schema.CostComponent {
 	productNameRegex := fmt.Sprintf("/%s - %s/", r.Tier, r.Family)
-	skuName := r.mssqlSkuName(*r.Cores)
+	skuName := mssqlSkuName(*r.Cores, r.ZoneRedundant)
 
 	var replicaCount *decimal.Decimal
 	if r.ReadReplicaCount != nil {
@@ -265,51 +256,111 @@ func (r *SQLDatabase) readReplicaCostComponent() *schema.CostComponent {
 	}
 }
 
+func (r *SQLDatabase) extraDataStorageCostComponent(extraStorageGB float64) *schema.CostComponent {
+	tier := tierMapping[strings.ToLower(r.SKU)[:1]]
+	return mssqlExtraDataStorageCostComponent(r.Region, tier, extraStorageGB)
+}
+
 func (r *SQLDatabase) sqlLicenseCostComponent() *schema.CostComponent {
+	return mssqlLicenseCostComponent(r.Region, r.Cores, r.Tier)
+}
+
+func (r *SQLDatabase) storageCostComponent() *schema.CostComponent {
+	return mssqlStorageCostComponent(r.Region, r.Tier, r.ZoneRedundant, r.MaxSizeGB)
+}
+
+func (r *SQLDatabase) longTermRetentionCostComponent() *schema.CostComponent {
+	return mssqlLongTermRetentionCostComponent(r.Region, r.LongTermRetentionStorageGB)
+}
+
+func (r *SQLDatabase) productFilter(filters []*schema.AttributeFilter) *schema.ProductFilter {
+	return mssqlProductFilter(r.Region, filters)
+}
+
+func mssqlSkuName(cores int64, zoneRedundant bool) string {
+	sku := fmt.Sprintf("%d vCore", cores)
+
+	if zoneRedundant {
+		sku += " Zone Redundancy"
+	}
+	return sku
+}
+
+func mssqlProductFilter(region string, filters []*schema.AttributeFilter) *schema.ProductFilter {
+	return &schema.ProductFilter{
+		VendorName:       strPtr(vendorName),
+		Region:           strPtr(region),
+		Service:          strPtr("SQL Database"),
+		ProductFamily:    strPtr("Databases"),
+		AttributeFilters: filters,
+	}
+}
+
+func mssqlExtraDataStorageCostComponent(region string, tier string, extraStorageGB float64) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Extra data storage",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromFloat(extraStorageGB)),
+		ProductFilter: mssqlProductFilter(region, []*schema.AttributeFilter{
+			{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/SQL Database %s - Storage/i", tier))},
+			{Key: "skuName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", tier))},
+			{Key: "meterName", Value: strPtr("Data Stored")},
+		}),
+		PriceFilter: priceFilterConsumption,
+	}
+}
+
+func mssqlLicenseCostComponent(region string, cores *int64, tier string) *schema.CostComponent {
 	licenseRegion := "Global"
-	if strings.Contains(r.Region, "usgov") {
+	if strings.Contains(region, "usgov") {
 		licenseRegion = "US Gov"
 	}
 
-	if strings.Contains(r.Region, "china") {
+	if strings.Contains(region, "china") {
 		licenseRegion = "China"
 	}
 
-	if strings.Contains(r.Region, "germany") {
+	if strings.Contains(region, "germany") {
 		licenseRegion = "Germany"
+	}
+
+	coresVal := int64(1)
+	if cores != nil {
+		coresVal = *cores
 	}
 
 	return &schema.CostComponent{
 		Name:           "SQL license",
 		Unit:           "vCore-hours",
 		UnitMultiplier: decimal.NewFromInt(1),
-		HourlyQuantity: decimalPtr(decimal.NewFromInt(*r.Cores)),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(coresVal)),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr(vendorName),
 			Region:        strPtr(licenseRegion),
-			Service:       strPtr(sqlServiceName),
-			ProductFamily: strPtr(sqlProductFamily),
+			Service:       strPtr("SQL Database"),
+			ProductFamily: strPtr("Databases"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/%s - %s/", r.Tier, "SQL License"))},
+				{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/%s - %s/", tier, "SQL License"))},
 			},
 		},
 		PriceFilter: priceFilterConsumption,
 	}
 }
 
-func (r *SQLDatabase) mssqlStorageComponent() *schema.CostComponent {
+func mssqlStorageCostComponent(region string, tier string, zoneRedundant bool, maxSizeGB *float64) *schema.CostComponent {
 	storageGB := decimalPtr(decimal.NewFromInt(5))
-	if r.MaxSizeGB != nil {
-		storageGB = decimalPtr(decimal.NewFromFloat(*r.MaxSizeGB))
+	if maxSizeGB != nil {
+		storageGB = decimalPtr(decimal.NewFromFloat(*maxSizeGB))
 	}
 
-	storageTier := r.Tier
+	storageTier := tier
 	if strings.ToLower(storageTier) == "general purpose - serverless" {
 		storageTier = "General Purpose"
 	}
 
 	skuName := storageTier
-	if r.ZoneRedundant {
+	if zoneRedundant {
 		skuName += " Zone Redundancy"
 	}
 
@@ -320,7 +371,7 @@ func (r *SQLDatabase) mssqlStorageComponent() *schema.CostComponent {
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: storageGB,
-		ProductFilter: r.productFilter([]*schema.AttributeFilter{
+		ProductFilter: mssqlProductFilter(region, []*schema.AttributeFilter{
 			{Key: "productName", ValueRegex: strPtr(productNameRegex)},
 			{Key: "skuName", Value: strPtr(skuName)},
 			{Key: "meterName", ValueRegex: regexPtr("Data Stored$")},
@@ -328,10 +379,10 @@ func (r *SQLDatabase) mssqlStorageComponent() *schema.CostComponent {
 	}
 }
 
-func (r *SQLDatabase) longTermRetentionMSSQLCostComponent() *schema.CostComponent {
+func mssqlLongTermRetentionCostComponent(region string, longTermRetentionStorageGB *int64) *schema.CostComponent {
 	var retention *decimal.Decimal
-	if r.LongTermRetentionStorageGB != nil {
-		retention = decimalPtr(decimal.NewFromInt(*r.LongTermRetentionStorageGB))
+	if longTermRetentionStorageGB != nil {
+		retention = decimalPtr(decimal.NewFromInt(*longTermRetentionStorageGB))
 	}
 
 	return &schema.CostComponent{
@@ -339,30 +390,11 @@ func (r *SQLDatabase) longTermRetentionMSSQLCostComponent() *schema.CostComponen
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: retention,
-		ProductFilter: r.productFilter([]*schema.AttributeFilter{
+		ProductFilter: mssqlProductFilter(region, []*schema.AttributeFilter{
 			{Key: "productName", Value: strPtr("SQL Database - LTR Backup Storage")},
 			{Key: "skuName", Value: strPtr("Backup RA-GRS")},
 			{Key: "meterName", ValueRegex: strPtr("/RA-GRS Data Stored/i")},
 		}),
 		PriceFilter: priceFilterConsumption,
-	}
-}
-
-func (r *SQLDatabase) mssqlSkuName(cores int64) string {
-	sku := fmt.Sprintf("%d vCore", cores)
-
-	if r.ZoneRedundant {
-		sku += " Zone Redundancy"
-	}
-	return sku
-}
-
-func (r *SQLDatabase) productFilter(filters []*schema.AttributeFilter) *schema.ProductFilter {
-	return &schema.ProductFilter{
-		VendorName:       strPtr(vendorName),
-		Region:           strPtr(r.Region),
-		Service:          strPtr(sqlServiceName),
-		ProductFamily:    strPtr(sqlProductFamily),
-		AttributeFilters: filters,
 	}
 }

--- a/internal/resources/azure/sql_managed_instance.go
+++ b/internal/resources/azure/sql_managed_instance.go
@@ -31,7 +31,7 @@ type SQLManagedInstance struct {
 	// LongTermRetentionStorageGB defines a usage param that allows users to define how many gb of cold storage the database uses.
 	// This is storage that can be kept for up to 10 years.
 	LongTermRetentionStorageGB *int64 `infracost_usage:"long_term_retention_storage_gb"`
-	BackupStorageGb            *int64 `infracost_usage:"backup_storage_gb"`
+	BackupStorageGB            *int64 `infracost_usage:"backup_storage_gb"`
 }
 
 // PopulateUsage parses the u schema.UsageData into the SQLManagedInstance.
@@ -133,12 +133,12 @@ func (r *SQLManagedInstance) sqlMIStorageCostComponent() *schema.CostComponent {
 func (r *SQLManagedInstance) sqlMIBackupCostComponent() *schema.CostComponent {
 	var backup *decimal.Decimal
 
-	if r.BackupStorageGb != nil {
-		backup = decimalPtr(decimal.NewFromInt(*r.BackupStorageGb))
+	if r.BackupStorageGB != nil {
+		backup = decimalPtr(decimal.NewFromInt(*r.BackupStorageGB))
 	}
 
 	return &schema.CostComponent{
-		Name:            fmt.Sprintf("PITR Backup storage (%s)", r.StorageAccountType),
+		Name:            fmt.Sprintf("PITR backup storage (%s)", r.StorageAccountType),
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: backup,

--- a/internal/resources/azure/sql_managed_instance.go
+++ b/internal/resources/azure/sql_managed_instance.go
@@ -24,7 +24,7 @@ type SQLManagedInstance struct {
 	Address            string
 	Region             string
 	SKU                string
-	LicenceType        string
+	LicenseType        string
 	Cores              int64
 	StorageSizeInGb    int64
 	StorageAccountType string
@@ -79,7 +79,7 @@ func (r *SQLManagedInstance) costComponents() []*schema.CostComponent {
 
 	costComponents = append(costComponents, r.sqlMIStorageCostComponent(), r.sqlMIBackupCostComponent())
 
-	if r.LicenceType == "LicenseIncluded" {
+	if r.LicenseType == "LicenseIncluded" {
 		costComponents = append(costComponents, r.sqlMILicenseCostComponent())
 	}
 

--- a/internal/schema/cost_component.go
+++ b/internal/schema/cost_component.go
@@ -65,6 +65,7 @@ func (c *CostComponent) CustomPrice() *decimal.Decimal {
 }
 
 func (c *CostComponent) UnitMultiplierPrice() decimal.Decimal {
+	// Round the final number to 16 decimal places to avoid floating point issues.
 	return c.Price().Mul(c.UnitMultiplier)
 }
 
@@ -78,6 +79,7 @@ func (c *CostComponent) UnitMultiplierHourlyQuantity() *decimal.Decimal {
 	if c.UnitMultiplier.IsZero() {
 		m = decimal.Zero
 	} else {
+		// Round the final number to 16 decimal places to avoid floating point issues.
 		m = c.HourlyQuantity.Div(c.UnitMultiplier)
 	}
 
@@ -94,6 +96,7 @@ func (c *CostComponent) UnitMultiplierMonthlyQuantity() *decimal.Decimal {
 	if c.UnitMultiplier.IsZero() {
 		m = decimal.Zero
 	} else {
+		// Round the final number to 16 decimal places to avoid floating point issues.
 		m = c.MonthlyQuantity.Div(c.UnitMultiplier)
 	}
 


### PR DESCRIPTION
This adds support for the `azurerm_mssql_elasticpool` resource and the deprecated `azurerm_sql_elasticpool` resource.
It also fixes some issues with the existing `azurerm_mssql_database` resource:
1. Fix zone redundancy costs. These are added on top of the compute costs, not instead of.
2. Don't show extra data prices if there's no usage.
3. Support the different storage types for long term retention
4. Add PITR cost component
5. Show DTU cost components as hours so the units and costs match the Azure dashboard and pricing calculator.
6. Fix some issues to support non-case-sensitive attribute values

I think we can remove the `extra_data_storage_gb` usage param from `azurerm_mssql_database` since its value is always defined in Terraform. I haven't done that as part of this PR though.