### PR TITLE
fix: ignore parent terragrunt.hcl files in a Terragrunt directory

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -366,6 +366,10 @@ func TestBreakdownTerragruntSkipPaths(t *testing.T) {
 	)
 }
 
+func TestBreakdownTerragruntWithParentInclude(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())}, nil)
+}
+
 func TestBreakdownTerragruntHCLDepsOutputInclude(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()+"/dev")}, nil)
 }

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/breakdown_terragrunt_with_parent_include.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/breakdown_terragrunt_with_parent_include.golden
@@ -1,0 +1,20 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/infra/us-east-1/dev
+Module path: infra/us-east-1/dev
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours       $560.64 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                      100  GB           $12.50 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ OVERALL TOTAL                                                                   $630.14 
+──────────────────────────────────
+1 cloud resource was detected:
+∙ 1 was estimated, it includes usage-based costs, see https://infracost.io/usage-file
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/infra/us-east-1/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/infra/us-east-1/dev/terragrunt.hcl
@@ -1,0 +1,14 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type                 = "m5.4xlarge"
+  root_block_device_volume_size = 50
+  block_device_volume_size      = 100
+  block_device_iops             = 800
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/infra/us-east-1/modules/example/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/infra/us-east-1/modules/example/main.tf
@@ -1,0 +1,35 @@
+variable "instance_type" {
+  description = "The EC2 instance type for the web app"
+  type        = string
+}
+
+variable "root_block_device_volume_size" {
+  description = "The size of the root block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_volume_size" {
+  description = "The size of the block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_iops" {
+  description = "The number of IOPS for the block device for the web app EC2 instance"
+  type        = number
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = var.root_block_device_volume_size
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = var.block_device_volume_size
+    iops        = var.block_device_iops
+  }
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/infra/us-east-1/regions.yml
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/infra/us-east-1/regions.yml
@@ -1,0 +1,1 @@
+region: "us-east-1"

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_parent_include/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+  regions = yamldecode(file("${find_in_parent_folders("regions.yml")}"))
+}
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region                      = "${local.regions.region}"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+EOF
+}


### PR DESCRIPTION
Resolves issue when a parent `terragrunt.hcl` file was using any `find` or `get` functions. These functions are called relative to the original Terragrunt config (the child `terragrunt.hcl` file). Thus any file include would fail with a not exists error. We now ignore parent `terragrunt.hcl` from initial evaluation and only read it when it is included by a child `terragrunt.hcl` (expected behaviour).