### PR TITLE
feat: add remaining azure app service terraform components

### DIFF
--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -110,6 +110,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getDataFactoryIntegrationRuntimeSelfHostedRegistryItem(),
 	getLogAnalyticsSolutionRegistryItem(),
 	getMySQLFlexibleServerRegistryItem(),
+	getServicePlanRegistryItem(),
 	getSentinelDataConnectorAwsCloudTrailRegistryItem(),
 	getSentinelDataConnectorAzureActiveDirectoryRegistryItem(),
 	getSentinelDataConnectorAzureAdvancedThreatProtectionRegistryItem(),
@@ -457,6 +458,10 @@ var FreeResources = []string{
 	"azurerm_virtual_desktop_workspace",
 	"azurerm_virtual_desktop_workspace_application_group_association",
 	"azurerm_virtual_desktop_host_pool",
+
+	// Azure Service Plan
+	"azurerm_windows_web_app",
+	"azurerm_linux_web_app",
 
 	// Azure Synapse Analytics
 	"azurerm_synapse_firewall_rule",

--- a/internal/providers/terraform/azure/service_plan.go
+++ b/internal/providers/terraform/azure/service_plan.go
@@ -1,0 +1,25 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getServicePlanRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:  "azurerm_service_plan",
+		RFunc: NewServicePlan,
+	}
+}
+func NewServicePlan(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	r := &azure.ServicePlan{
+		Address:     d.Address,
+		Region:      lookupRegion(d, []string{}),
+		SKUName:     d.Get("sku_name").String(),
+		WorkerCount: d.GetInt64OrDefault("worker_count", 1),
+		OSType:      d.Get("os_type").String(),
+	}
+
+	r.PopulateUsage(u)
+	return r.BuildResource()
+}

--- a/internal/providers/terraform/azure/service_plan.go
+++ b/internal/providers/terraform/azure/service_plan.go
@@ -7,19 +7,15 @@ import (
 
 func getServicePlanRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
-		Name:  "azurerm_service_plan",
-		RFunc: NewServicePlan,
+		Name: "azurerm_service_plan",
+		CoreRFunc: func(d *schema.ResourceData) schema.CoreResource {
+			return &azure.ServicePlan{
+				Address:     d.Address,
+				Region:      lookupRegion(d, []string{}),
+				SKUName:     d.Get("sku_name").String(),
+				WorkerCount: d.GetInt64OrDefault("worker_count", 1),
+				OSType:      d.Get("os_type").String(),
+			}
+		},
 	}
-}
-func NewServicePlan(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	r := &azure.ServicePlan{
-		Address:     d.Address,
-		Region:      lookupRegion(d, []string{}),
-		SKUName:     d.Get("sku_name").String(),
-		WorkerCount: d.GetInt64OrDefault("worker_count", 1),
-		OSType:      d.Get("os_type").String(),
-	}
-
-	r.PopulateUsage(u)
-	return r.BuildResource()
 }

--- a/internal/providers/terraform/azure/service_plan_test.go
+++ b/internal/providers/terraform/azure/service_plan_test.go
@@ -1,0 +1,15 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureRMServicePlan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "service_plan_test", &tftest.GoldenFileOptions{CaptureLogs: true})
+}

--- a/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.golden
+++ b/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.golden
@@ -7,6 +7,12 @@
  azurerm_app_service_plan.default_capacity                                   
  └─ Instance usage (B2)                             730  hours        $24.82 
                                                                              
+ azurerm_app_service_plan.isolated                                           
+ └─ Instance usage (I1)                             730  hours       $219.00 
+                                                                             
+ azurerm_app_service_plan.isolated_v2                                        
+ └─ Instance usage (I1v2)                           730  hours       $281.78 
+                                                                             
  azurerm_app_service_plan.pc2                                                
  └─ Instance usage (PC2)                            730  hours       $118.59 
                                                                              
@@ -25,9 +31,9 @@
  azurerm_app_service_plan.standard_s2                                        
  └─ Instance usage (S1)                           3,650  hours       $365.00 
                                                                              
- OVERALL TOTAL                                                     $5,120.09 
+ OVERALL TOTAL                                                     $5,620.87 
 ──────────────────────────────────
-9 cloud resources were detected:
-∙ 8 were estimated
+11 cloud resources were detected:
+∙ 10 were estimated
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group

--- a/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.tf
+++ b/internal/providers/terraform/azure/testdata/app_service_plan_test/app_service_plan_test.tf
@@ -50,6 +50,36 @@ resource "azurerm_app_service_plan" "premium_v1" {
   }
 }
 
+
+resource "azurerm_app_service_plan" "isolated" {
+  name                = "api-appserviceplan-pro"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  kind                = "Linux"
+  reserved            = false
+
+  sku {
+    tier     = "Isolated"
+    size     = "I1"
+    capacity = 1
+  }
+}
+
+
+resource "azurerm_app_service_plan" "isolated_v2" {
+  name                = "api-appserviceplan-pro"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  kind                = "Linux"
+  reserved            = false
+
+  sku {
+    tier     = "Isolated"
+    size     = "I1v2"
+    capacity = 1
+  }
+}
+
 resource "azurerm_app_service_plan" "premium_v2" {
   name                = "api-appserviceplan-pro"
   location            = azurerm_resource_group.example.location

--- a/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.golden
+++ b/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.golden
@@ -1,0 +1,612 @@
+
+ Name                                                       Monthly Qty  Unit   Monthly Cost 
+                                                                                             
+ azurerm_service_plan.example["Linux.B1.1"]                                                  
+ └─ Instance usage (B1)                                             730  hours        $12.41 
+                                                                                             
+ azurerm_service_plan.example["Linux.B1.2"]                                                  
+ └─ Instance usage (B1)                                           1,460  hours        $24.82 
+                                                                                             
+ azurerm_service_plan.example["Linux.B1.3"]                                                  
+ └─ Instance usage (B1)                                           2,190  hours        $37.23 
+                                                                                             
+ azurerm_service_plan.example["Linux.B2.1"]                                                  
+ └─ Instance usage (B2)                                             730  hours        $24.82 
+                                                                                             
+ azurerm_service_plan.example["Linux.B2.2"]                                                  
+ └─ Instance usage (B2)                                           1,460  hours        $49.64 
+                                                                                             
+ azurerm_service_plan.example["Linux.B2.3"]                                                  
+ └─ Instance usage (B2)                                           2,190  hours        $74.46 
+                                                                                             
+ azurerm_service_plan.example["Linux.B3.1"]                                                  
+ └─ Instance usage (B3)                                             730  hours        $48.91 
+                                                                                             
+ azurerm_service_plan.example["Linux.B3.2"]                                                  
+ └─ Instance usage (B3)                                           1,460  hours        $97.82 
+                                                                                             
+ azurerm_service_plan.example["Linux.B3.3"]                                                  
+ └─ Instance usage (B3)                                           2,190  hours       $146.73 
+                                                                                             
+ azurerm_service_plan.example["Linux.D1.1"]                                                  
+ └─ Instance usage (D1)                                             730  hours         $9.49 
+                                                                                             
+ azurerm_service_plan.example["Linux.D1.2"]                                                  
+ └─ Instance usage (D1)                                           1,460  hours        $18.98 
+                                                                                             
+ azurerm_service_plan.example["Linux.D1.3"]                                                  
+ └─ Instance usage (D1)                                           2,190  hours        $28.47 
+                                                                                             
+ azurerm_service_plan.example["Linux.F1.1"]                                                  
+ └─ Instance usage (F1)                                             730  hours         $0.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.F1.2"]                                                  
+ └─ Instance usage (F1)                                           1,460  hours         $0.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.F1.3"]                                                  
+ └─ Instance usage (F1)                                           2,190  hours         $0.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I1.1"]                                                  
+ └─ Instance usage (I1)                                             730  hours       $219.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I1.2"]                                                  
+ └─ Instance usage (I1)                                           1,460  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I1.3"]                                                  
+ └─ Instance usage (I1)                                           2,190  hours       $657.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I1v2.1"]                                                
+ └─ Instance usage (I1v2)                                           730  hours       $281.78 
+                                                                                             
+ azurerm_service_plan.example["Linux.I1v2.2"]                                                
+ └─ Instance usage (I1v2)                                         1,460  hours       $563.56 
+                                                                                             
+ azurerm_service_plan.example["Linux.I1v2.3"]                                                
+ └─ Instance usage (I1v2)                                         2,190  hours       $845.34 
+                                                                                             
+ azurerm_service_plan.example["Linux.I2.1"]                                                  
+ └─ Instance usage (I2)                                             730  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I2.2"]                                                  
+ └─ Instance usage (I2)                                           1,460  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I2.3"]                                                  
+ └─ Instance usage (I2)                                           2,190  hours     $1,314.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I2v2.1"]                                                
+ └─ Instance usage (I2v2)                                           730  hours       $563.56 
+                                                                                             
+ azurerm_service_plan.example["Linux.I2v2.2"]                                                
+ └─ Instance usage (I2v2)                                         1,460  hours     $1,127.12 
+                                                                                             
+ azurerm_service_plan.example["Linux.I2v2.3"]                                                
+ └─ Instance usage (I2v2)                                         2,190  hours     $1,690.68 
+                                                                                             
+ azurerm_service_plan.example["Linux.I3.1"]                                                  
+ └─ Instance usage (I3)                                             730  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I3.2"]                                                  
+ └─ Instance usage (I3)                                           1,460  hours     $1,752.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I3.3"]                                                  
+ └─ Instance usage (I3)                                           2,190  hours     $2,628.00 
+                                                                                             
+ azurerm_service_plan.example["Linux.I3v2.1"]                                                
+ └─ Instance usage (I3v2)                                           730  hours     $1,127.12 
+                                                                                             
+ azurerm_service_plan.example["Linux.I3v2.2"]                                                
+ └─ Instance usage (I3v2)                                         1,460  hours     $2,254.24 
+                                                                                             
+ azurerm_service_plan.example["Linux.I3v2.3"]                                                
+ └─ Instance usage (I3v2)                                         2,190  hours     $3,381.36 
+                                                                                             
+ azurerm_service_plan.example["Linux.P1v2.1"]                                                
+ └─ Instance usage (P1v2)                                           730  hours        $73.73 
+                                                                                             
+ azurerm_service_plan.example["Linux.P1v2.2"]                                                
+ └─ Instance usage (P1v2)                                         1,460  hours       $147.46 
+                                                                                             
+ azurerm_service_plan.example["Linux.P1v2.3"]                                                
+ └─ Instance usage (P1v2)                                         2,190  hours       $221.19 
+                                                                                             
+ azurerm_service_plan.example["Linux.P1v3.1"]                                                
+ └─ Instance usage (P1v3)                                           730  hours       $113.15 
+                                                                                             
+ azurerm_service_plan.example["Linux.P1v3.2"]                                                
+ └─ Instance usage (P1v3)                                         1,460  hours       $226.30 
+                                                                                             
+ azurerm_service_plan.example["Linux.P1v3.3"]                                                
+ └─ Instance usage (P1v3)                                         2,190  hours       $339.45 
+                                                                                             
+ azurerm_service_plan.example["Linux.P2v2.1"]                                                
+ └─ Instance usage (P2v2)                                           730  hours       $147.46 
+                                                                                             
+ azurerm_service_plan.example["Linux.P2v2.2"]                                                
+ └─ Instance usage (P2v2)                                         1,460  hours       $294.92 
+                                                                                             
+ azurerm_service_plan.example["Linux.P2v2.3"]                                                
+ └─ Instance usage (P2v2)                                         2,190  hours       $442.38 
+                                                                                             
+ azurerm_service_plan.example["Linux.P2v3.1"]                                                
+ └─ Instance usage (P2v3)                                           730  hours       $226.30 
+                                                                                             
+ azurerm_service_plan.example["Linux.P2v3.2"]                                                
+ └─ Instance usage (P2v3)                                         1,460  hours       $452.60 
+                                                                                             
+ azurerm_service_plan.example["Linux.P2v3.3"]                                                
+ └─ Instance usage (P2v3)                                         2,190  hours       $678.90 
+                                                                                             
+ azurerm_service_plan.example["Linux.P3v2.1"]                                                
+ └─ Instance usage (P3v2)                                           730  hours       $294.19 
+                                                                                             
+ azurerm_service_plan.example["Linux.P3v2.2"]                                                
+ └─ Instance usage (P3v2)                                         1,460  hours       $588.38 
+                                                                                             
+ azurerm_service_plan.example["Linux.P3v2.3"]                                                
+ └─ Instance usage (P3v2)                                         2,190  hours       $882.57 
+                                                                                             
+ azurerm_service_plan.example["Linux.P3v3.1"]                                                
+ └─ Instance usage (P3v3)                                           730  hours       $452.60 
+                                                                                             
+ azurerm_service_plan.example["Linux.P3v3.2"]                                                
+ └─ Instance usage (P3v3)                                         1,460  hours       $905.20 
+                                                                                             
+ azurerm_service_plan.example["Linux.P3v3.3"]                                                
+ └─ Instance usage (P3v3)                                         2,190  hours     $1,357.80 
+                                                                                             
+ azurerm_service_plan.example["Linux.S1.1"]                                                  
+ └─ Instance usage (S1)                                             730  hours        $69.35 
+                                                                                             
+ azurerm_service_plan.example["Linux.S1.2"]                                                  
+ └─ Instance usage (S1)                                           1,460  hours       $138.70 
+                                                                                             
+ azurerm_service_plan.example["Linux.S1.3"]                                                  
+ └─ Instance usage (S1)                                           2,190  hours       $208.05 
+                                                                                             
+ azurerm_service_plan.example["Linux.S2.1"]                                                  
+ └─ Instance usage (S2)                                             730  hours       $138.70 
+                                                                                             
+ azurerm_service_plan.example["Linux.S2.2"]                                                  
+ └─ Instance usage (S2)                                           1,460  hours       $277.40 
+                                                                                             
+ azurerm_service_plan.example["Linux.S2.3"]                                                  
+ └─ Instance usage (S2)                                           2,190  hours       $416.10 
+                                                                                             
+ azurerm_service_plan.example["Linux.S3.1"]                                                  
+ └─ Instance usage (S3)                                             730  hours       $277.40 
+                                                                                             
+ azurerm_service_plan.example["Linux.S3.2"]                                                  
+ └─ Instance usage (S3)                                           1,460  hours       $554.80 
+                                                                                             
+ azurerm_service_plan.example["Linux.S3.3"]                                                  
+ └─ Instance usage (S3)                                           2,190  hours       $832.20 
+                                                                                             
+ azurerm_service_plan.example["Linux.SHARED.1"]                                              
+ └─ Instance usage (SHARED)                                         730  hours         $9.49 
+                                                                                             
+ azurerm_service_plan.example["Linux.SHARED.2"]                                              
+ └─ Instance usage (SHARED)                                       1,460  hours        $18.98 
+                                                                                             
+ azurerm_service_plan.example["Linux.SHARED.3"]                                              
+ └─ Instance usage (SHARED)                                       2,190  hours        $28.47 
+                                                                                             
+ azurerm_service_plan.example["Linux.Y1.1"]                                                  
+ └─ Instance usage (Y1)                                             730  hours         $9.49 
+                                                                                             
+ azurerm_service_plan.example["Linux.Y1.2"]                                                  
+ └─ Instance usage (Y1)                                           1,460  hours        $18.98 
+                                                                                             
+ azurerm_service_plan.example["Linux.Y1.3"]                                                  
+ └─ Instance usage (Y1)                                           2,190  hours        $28.47 
+                                                                                             
+ azurerm_service_plan.example["Windows.B1.1"]                                                
+ └─ Instance usage (B1)                                             730  hours        $54.75 
+                                                                                             
+ azurerm_service_plan.example["Windows.B1.2"]                                                
+ └─ Instance usage (B1)                                           1,460  hours       $109.50 
+                                                                                             
+ azurerm_service_plan.example["Windows.B1.3"]                                                
+ └─ Instance usage (B1)                                           2,190  hours       $164.25 
+                                                                                             
+ azurerm_service_plan.example["Windows.B2.1"]                                                
+ └─ Instance usage (B2)                                             730  hours       $109.50 
+                                                                                             
+ azurerm_service_plan.example["Windows.B2.2"]                                                
+ └─ Instance usage (B2)                                           1,460  hours       $219.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.B2.3"]                                                
+ └─ Instance usage (B2)                                           2,190  hours       $328.50 
+                                                                                             
+ azurerm_service_plan.example["Windows.B3.1"]                                                
+ └─ Instance usage (B3)                                             730  hours       $219.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.B3.2"]                                                
+ └─ Instance usage (B3)                                           1,460  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.B3.3"]                                                
+ └─ Instance usage (B3)                                           2,190  hours       $657.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.D1.1"]                                                
+ └─ Instance usage (D1)                                             730  hours         $9.49 
+                                                                                             
+ azurerm_service_plan.example["Windows.D1.2"]                                                
+ └─ Instance usage (D1)                                           1,460  hours        $18.98 
+                                                                                             
+ azurerm_service_plan.example["Windows.D1.3"]                                                
+ └─ Instance usage (D1)                                           2,190  hours        $28.47 
+                                                                                             
+ azurerm_service_plan.example["Windows.F1.1"]                                                
+ └─ Instance usage (F1)                                             730  hours         $0.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.F1.2"]                                                
+ └─ Instance usage (F1)                                           1,460  hours         $0.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.F1.3"]                                                
+ └─ Instance usage (F1)                                           2,190  hours         $0.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I1.1"]                                                
+ └─ Instance usage (I1)                                             730  hours       $219.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I1.2"]                                                
+ └─ Instance usage (I1)                                           1,460  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I1.3"]                                                
+ └─ Instance usage (I1)                                           2,190  hours       $657.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I1v2.1"]                                              
+ └─ Instance usage (I1v2)                                           730  hours       $399.31 
+                                                                                             
+ azurerm_service_plan.example["Windows.I1v2.2"]                                              
+ └─ Instance usage (I1v2)                                         1,460  hours       $798.62 
+                                                                                             
+ azurerm_service_plan.example["Windows.I1v2.3"]                                              
+ └─ Instance usage (I1v2)                                         2,190  hours     $1,197.93 
+                                                                                             
+ azurerm_service_plan.example["Windows.I2.1"]                                                
+ └─ Instance usage (I2)                                             730  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I2.2"]                                                
+ └─ Instance usage (I2)                                           1,460  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I2.3"]                                                
+ └─ Instance usage (I2)                                           2,190  hours     $1,314.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I2v2.1"]                                              
+ └─ Instance usage (I2v2)                                           730  hours       $798.62 
+                                                                                             
+ azurerm_service_plan.example["Windows.I2v2.2"]                                              
+ └─ Instance usage (I2v2)                                         1,460  hours     $1,597.24 
+                                                                                             
+ azurerm_service_plan.example["Windows.I2v2.3"]                                              
+ └─ Instance usage (I2v2)                                         2,190  hours     $2,395.86 
+                                                                                             
+ azurerm_service_plan.example["Windows.I3.1"]                                                
+ └─ Instance usage (I3)                                             730  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I3.2"]                                                
+ └─ Instance usage (I3)                                           1,460  hours     $1,752.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I3.3"]                                                
+ └─ Instance usage (I3)                                           2,190  hours     $2,628.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.I3v2.1"]                                              
+ └─ Instance usage (I3v2)                                           730  hours     $1,597.24 
+                                                                                             
+ azurerm_service_plan.example["Windows.I3v2.2"]                                              
+ └─ Instance usage (I3v2)                                         1,460  hours     $3,194.48 
+                                                                                             
+ azurerm_service_plan.example["Windows.I3v2.3"]                                              
+ └─ Instance usage (I3v2)                                         2,190  hours     $4,791.72 
+                                                                                             
+ azurerm_service_plan.example["Windows.P1v2.1"]                                              
+ └─ Instance usage (P1v2)                                           730  hours       $146.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.P1v2.2"]                                              
+ └─ Instance usage (P1v2)                                         1,460  hours       $292.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.P1v2.3"]                                              
+ └─ Instance usage (P1v2)                                         2,190  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.P1v3.1"]                                              
+ └─ Instance usage (P1v3)                                           730  hours       $229.95 
+                                                                                             
+ azurerm_service_plan.example["Windows.P1v3.2"]                                              
+ └─ Instance usage (P1v3)                                         1,460  hours       $459.90 
+                                                                                             
+ azurerm_service_plan.example["Windows.P1v3.3"]                                              
+ └─ Instance usage (P1v3)                                         2,190  hours       $689.85 
+                                                                                             
+ azurerm_service_plan.example["Windows.P2v2.1"]                                              
+ └─ Instance usage (P2v2)                                           730  hours       $292.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.P2v2.2"]                                              
+ └─ Instance usage (P2v2)                                         1,460  hours       $584.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.P2v2.3"]                                              
+ └─ Instance usage (P2v2)                                         2,190  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.P2v3.1"]                                              
+ └─ Instance usage (P2v3)                                           730  hours       $459.90 
+                                                                                             
+ azurerm_service_plan.example["Windows.P2v3.2"]                                              
+ └─ Instance usage (P2v3)                                         1,460  hours       $919.80 
+                                                                                             
+ azurerm_service_plan.example["Windows.P2v3.3"]                                              
+ └─ Instance usage (P2v3)                                         2,190  hours     $1,379.70 
+                                                                                             
+ azurerm_service_plan.example["Windows.P3v2.1"]                                              
+ └─ Instance usage (P3v2)                                           730  hours       $584.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.P3v2.2"]                                              
+ └─ Instance usage (P3v2)                                         1,460  hours     $1,168.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.P3v2.3"]                                              
+ └─ Instance usage (P3v2)                                         2,190  hours     $1,752.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.P3v3.1"]                                              
+ └─ Instance usage (P3v3)                                           730  hours       $919.80 
+                                                                                             
+ azurerm_service_plan.example["Windows.P3v3.2"]                                              
+ └─ Instance usage (P3v3)                                         1,460  hours     $1,839.60 
+                                                                                             
+ azurerm_service_plan.example["Windows.P3v3.3"]                                              
+ └─ Instance usage (P3v3)                                         2,190  hours     $2,759.40 
+                                                                                             
+ azurerm_service_plan.example["Windows.S1.1"]                                                
+ └─ Instance usage (S1)                                             730  hours        $73.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.S1.2"]                                                
+ └─ Instance usage (S1)                                           1,460  hours       $146.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.S1.3"]                                                
+ └─ Instance usage (S1)                                           2,190  hours       $219.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.S2.1"]                                                
+ └─ Instance usage (S2)                                             730  hours       $146.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.S2.2"]                                                
+ └─ Instance usage (S2)                                           1,460  hours       $292.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.S2.3"]                                                
+ └─ Instance usage (S2)                                           2,190  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.S3.1"]                                                
+ └─ Instance usage (S3)                                             730  hours       $292.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.S3.2"]                                                
+ └─ Instance usage (S3)                                           1,460  hours       $584.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.S3.3"]                                                
+ └─ Instance usage (S3)                                           2,190  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["Windows.SHARED.1"]                                            
+ └─ Instance usage (SHARED)                                         730  hours         $9.49 
+                                                                                             
+ azurerm_service_plan.example["Windows.SHARED.2"]                                            
+ └─ Instance usage (SHARED)                                       1,460  hours        $18.98 
+                                                                                             
+ azurerm_service_plan.example["Windows.SHARED.3"]                                            
+ └─ Instance usage (SHARED)                                       2,190  hours        $28.47 
+                                                                                             
+ azurerm_service_plan.example["Windows.Y1.1"]                                                
+ └─ Instance usage (Y1)                                             730  hours         $9.49 
+                                                                                             
+ azurerm_service_plan.example["Windows.Y1.2"]                                                
+ └─ Instance usage (Y1)                                           1,460  hours        $18.98 
+                                                                                             
+ azurerm_service_plan.example["Windows.Y1.3"]                                                
+ └─ Instance usage (Y1)                                           2,190  hours        $28.47 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.B1.1"]                                       
+ └─ Instance usage (B1)                                             730  hours        $54.75 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.B1.2"]                                       
+ └─ Instance usage (B1)                                           1,460  hours       $109.50 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.B1.3"]                                       
+ └─ Instance usage (B1)                                           2,190  hours       $164.25 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.B2.1"]                                       
+ └─ Instance usage (B2)                                             730  hours       $109.50 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.B2.2"]                                       
+ └─ Instance usage (B2)                                           1,460  hours       $219.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.B2.3"]                                       
+ └─ Instance usage (B2)                                           2,190  hours       $328.50 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.B3.1"]                                       
+ └─ Instance usage (B3)                                             730  hours       $219.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.B3.2"]                                       
+ └─ Instance usage (B3)                                           1,460  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.B3.3"]                                       
+ └─ Instance usage (B3)                                           2,190  hours       $657.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.D1.1"]                                       
+ └─ Instance usage (D1)                                             730  hours         $9.49 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.D1.2"]                                       
+ └─ Instance usage (D1)                                           1,460  hours        $18.98 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.D1.3"]                                       
+ └─ Instance usage (D1)                                           2,190  hours        $28.47 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.F1.1"]                                       
+ └─ Instance usage (F1)                                             730  hours         $0.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.F1.2"]                                       
+ └─ Instance usage (F1)                                           1,460  hours         $0.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.F1.3"]                                       
+ └─ Instance usage (F1)                                           2,190  hours         $0.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I1.1"]                                       
+ └─ Instance usage (I1)                                             730  hours       $219.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I1.2"]                                       
+ └─ Instance usage (I1)                                           1,460  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I1.3"]                                       
+ └─ Instance usage (I1)                                           2,190  hours       $657.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I1v2.1"]                                     
+ └─ Instance usage (I1v2)                                           730  hours       $399.31 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I1v2.2"]                                     
+ └─ Instance usage (I1v2)                                         1,460  hours       $798.62 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I1v2.3"]                                     
+ └─ Instance usage (I1v2)                                         2,190  hours     $1,197.93 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I2.1"]                                       
+ └─ Instance usage (I2)                                             730  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I2.2"]                                       
+ └─ Instance usage (I2)                                           1,460  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I2.3"]                                       
+ └─ Instance usage (I2)                                           2,190  hours     $1,314.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I2v2.1"]                                     
+ └─ Instance usage (I2v2)                                           730  hours       $798.62 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I2v2.2"]                                     
+ └─ Instance usage (I2v2)                                         1,460  hours     $1,597.24 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I2v2.3"]                                     
+ └─ Instance usage (I2v2)                                         2,190  hours     $2,395.86 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I3.1"]                                       
+ └─ Instance usage (I3)                                             730  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I3.2"]                                       
+ └─ Instance usage (I3)                                           1,460  hours     $1,752.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I3.3"]                                       
+ └─ Instance usage (I3)                                           2,190  hours     $2,628.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I3v2.1"]                                     
+ └─ Instance usage (I3v2)                                           730  hours     $1,597.24 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I3v2.2"]                                     
+ └─ Instance usage (I3v2)                                         1,460  hours     $3,194.48 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.I3v2.3"]                                     
+ └─ Instance usage (I3v2)                                         2,190  hours     $4,791.72 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P1v2.1"]                                     
+ └─ Instance usage (P1v2)                                           730  hours       $146.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P1v2.2"]                                     
+ └─ Instance usage (P1v2)                                         1,460  hours       $292.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P1v2.3"]                                     
+ └─ Instance usage (P1v2)                                         2,190  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P1v3.1"]                                     
+ └─ Instance usage (P1v3)                                           730  hours       $229.95 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P1v3.2"]                                     
+ └─ Instance usage (P1v3)                                         1,460  hours       $459.90 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P1v3.3"]                                     
+ └─ Instance usage (P1v3)                                         2,190  hours       $689.85 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P2v2.1"]                                     
+ └─ Instance usage (P2v2)                                           730  hours       $292.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P2v2.2"]                                     
+ └─ Instance usage (P2v2)                                         1,460  hours       $584.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P2v2.3"]                                     
+ └─ Instance usage (P2v2)                                         2,190  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P2v3.1"]                                     
+ └─ Instance usage (P2v3)                                           730  hours       $459.90 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P2v3.2"]                                     
+ └─ Instance usage (P2v3)                                         1,460  hours       $919.80 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P2v3.3"]                                     
+ └─ Instance usage (P2v3)                                         2,190  hours     $1,379.70 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P3v2.1"]                                     
+ └─ Instance usage (P3v2)                                           730  hours       $584.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P3v2.2"]                                     
+ └─ Instance usage (P3v2)                                         1,460  hours     $1,168.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P3v2.3"]                                     
+ └─ Instance usage (P3v2)                                         2,190  hours     $1,752.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P3v3.1"]                                     
+ └─ Instance usage (P3v3)                                           730  hours       $919.80 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P3v3.2"]                                     
+ └─ Instance usage (P3v3)                                         1,460  hours     $1,839.60 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.P3v3.3"]                                     
+ └─ Instance usage (P3v3)                                         2,190  hours     $2,759.40 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.S1.1"]                                       
+ └─ Instance usage (S1)                                             730  hours        $73.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.S1.2"]                                       
+ └─ Instance usage (S1)                                           1,460  hours       $146.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.S1.3"]                                       
+ └─ Instance usage (S1)                                           2,190  hours       $219.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.S2.1"]                                       
+ └─ Instance usage (S2)                                             730  hours       $146.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.S2.2"]                                       
+ └─ Instance usage (S2)                                           1,460  hours       $292.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.S2.3"]                                       
+ └─ Instance usage (S2)                                           2,190  hours       $438.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.S3.1"]                                       
+ └─ Instance usage (S3)                                             730  hours       $292.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.S3.2"]                                       
+ └─ Instance usage (S3)                                           1,460  hours       $584.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.S3.3"]                                       
+ └─ Instance usage (S3)                                           2,190  hours       $876.00 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.SHARED.1"]                                   
+ └─ Instance usage (SHARED)                                         730  hours         $9.49 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.SHARED.2"]                                   
+ └─ Instance usage (SHARED)                                       1,460  hours        $18.98 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.SHARED.3"]                                   
+ └─ Instance usage (SHARED)                                       2,190  hours        $28.47 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.Y1.1"]                                       
+ └─ Instance usage (Y1)                                             730  hours         $9.49 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.Y1.2"]                                       
+ └─ Instance usage (Y1)                                           1,460  hours        $18.98 
+                                                                                             
+ azurerm_service_plan.example["WindowsContainer.Y1.3"]                                       
+ └─ Instance usage (Y1)                                           2,190  hours        $28.47 
+                                                                                             
+ OVERALL TOTAL                                                                   $127,068.18 
+──────────────────────────────────
+253 cloud resources were detected:
+∙ 198 were estimated
+∙ 55 were free:
+  ∙ 54 x azurerm_service_plan
+  ∙ 1 x azurerm_resource_group
+Logs:
+
+level=warning msg="Multiple prices found for azurerm_service_plan.example[\"Windows.F1.1\"] Instance usage (F1), using the first price"
+level=warning msg="Multiple prices found for azurerm_service_plan.example[\"Windows.F1.2\"] Instance usage (F1), using the first price"
+level=warning msg="Multiple prices found for azurerm_service_plan.example[\"Windows.F1.3\"] Instance usage (F1), using the first price"
+level=warning msg="Multiple prices found for azurerm_service_plan.example[\"WindowsContainer.F1.1\"] Instance usage (F1), using the first price"
+level=warning msg="Multiple prices found for azurerm_service_plan.example[\"WindowsContainer.F1.2\"] Instance usage (F1), using the first price"
+level=warning msg="Multiple prices found for azurerm_service_plan.example[\"WindowsContainer.F1.3\"] Instance usage (F1), using the first price"

--- a/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.tf
+++ b/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.tf
@@ -1,0 +1,38 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "exampleRG1"
+  location = "eastus"
+}
+
+locals {
+  os_types = ["Windows", "Linux", "WindowsContainer"]
+  skus = ["B1", "B2", "B3", "D1", "F1", "I1", "I2", "I3", "I1v2", "I2v2", "I3v2", "P1v2", "P2v2", "P3v2", "P1v3", "P2v3", "P3v3", "S1", "S2", "S3", "SHARED", "EP1", "EP2", "EP3", "WS1", "WS2", "WS3", "Y1"]
+  worker_counts = [1, 2, 3]
+
+  permutations = distinct(flatten([
+    for os_type in local.os_types : [
+      for sku in local.skus :[
+        for worker in local.worker_counts : {
+          sku       = sku
+          worker    = worker
+          os_type   = os_type
+        }
+      ]
+    ]
+  ]))
+}
+
+resource "azurerm_service_plan" "example" {
+  for_each = {for entry in local.permutations : "${entry.os_type}.${entry.sku}.${entry.worker}" => entry}
+
+  name                = "example-app-service-plan-${each.value.os_type}-${each.value.sku}-${each.value.worker}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = each.value.sku
+  os_type             = each.value.os_type
+  worker_count        = each.value.worker
+}

--- a/internal/resources/azure/app_service_plan.go
+++ b/internal/resources/azure/app_service_plan.go
@@ -41,16 +41,16 @@ func (r *AppServicePlan) BuildResource() *schema.Resource {
 		}
 	}
 
-	switch strings.ToLower(r.SKUSize[2:]) {
-	case "v1":
-		sku = r.SKUSize[:2]
-		productName = "Premium Plan"
-	case "v2":
-		sku = r.SKUSize[:2] + " " + r.SKUSize[2:]
-		productName = "Premium v2 Plan"
-	case "v3":
-		sku = r.SKUSize[:2] + " " + r.SKUSize[2:]
-		productName = "Premium v3 Plan"
+	var additionalAttributeFilters []*schema.AttributeFilter
+
+	switch strings.ToLower(r.SKUSize[:1]) {
+	case "s":
+		sku = "S" + r.SKUSize[1:]
+	case "b":
+		sku = "B" + r.SKUSize[1:]
+		productName = "Basic Plan"
+	case "p", "i":
+		sku, productName, additionalAttributeFilters = getVersionedAppServicePlanSKU(r.SKUSize, os)
 	}
 
 	switch strings.ToLower(r.SKUSize[:2]) {
@@ -62,32 +62,33 @@ func (r *AppServicePlan) BuildResource() *schema.Resource {
 		productName = "Shared Plan"
 	}
 
-	switch strings.ToLower(r.SKUSize[:1]) {
-	case "s":
-		sku = "S" + r.SKUSize[1:]
-	case "b":
-		sku = "B" + r.SKUSize[1:]
-		productName = "Basic Plan"
-	}
-
 	if r.Kind != "" {
 		os = strings.ToLower(r.Kind)
 	}
 	if os == "app" {
 		os = "windows"
 	}
-	if os != "windows" && productName != "Premium Plan" {
+	if os != "windows" && productName != "Premium Plan" && productName != "Isolated Plan" {
 		productName += " - Linux"
 	}
 
 	return &schema.Resource{
-		Name:           r.Address,
-		CostComponents: []*schema.CostComponent{r.appServicePlanCostComponent(fmt.Sprintf("Instance usage (%s)", r.SKUSize), productName, sku, capacity)},
-		UsageSchema:    AppServicePlanUsageSchema,
+		Name: r.Address,
+		CostComponents: []*schema.CostComponent{
+			servicePlanCostComponent(
+				r.Region,
+				fmt.Sprintf("Instance usage (%s)", r.SKUSize),
+				productName,
+				sku,
+				capacity,
+				additionalAttributeFilters...,
+			),
+		},
+		UsageSchema: AppServicePlanUsageSchema,
 	}
 }
 
-func (r *AppServicePlan) appServicePlanCostComponent(name, productName, skuRefactor string, capacity int64) *schema.CostComponent {
+func servicePlanCostComponent(region, name, productName, skuRefactor string, capacity int64, additionalAttributeFilters ...*schema.AttributeFilter) *schema.CostComponent {
 	return &schema.CostComponent{
 		Name:           name,
 		Unit:           "hours",
@@ -95,16 +96,43 @@ func (r *AppServicePlan) appServicePlanCostComponent(name, productName, skuRefac
 		HourlyQuantity: decimalPtr(decimal.NewFromInt(capacity)),
 		ProductFilter: &schema.ProductFilter{
 			VendorName:    strPtr("azure"),
-			Region:        strPtr(r.Region),
+			Region:        strPtr(region),
 			Service:       strPtr("Azure App Service"),
 			ProductFamily: strPtr("Compute"),
-			AttributeFilters: []*schema.AttributeFilter{
+			AttributeFilters: append([]*schema.AttributeFilter{
 				{Key: "productName", Value: strPtr("Azure App Service " + productName)},
-				{Key: "skuName", ValueRegex: strPtr(fmt.Sprintf("/%s/i", skuRefactor))},
-			},
+				{Key: "skuName", ValueRegex: strPtr(fmt.Sprintf("/%s$/i", skuRefactor))},
+			}, additionalAttributeFilters...),
 		},
 		PriceFilter: &schema.PriceFilter{
 			PurchaseOption: strPtr("Consumption"),
 		},
 	}
+}
+
+func getVersionedAppServicePlanSKU(skuName, os string) (string, string, []*schema.AttributeFilter) {
+	tier := "Premium"
+	if strings.ToLower(skuName[:1]) == "i" {
+		tier = "Isolated"
+	}
+
+	version := strings.ToLower(skuName[2:])
+	if version == "v1" {
+		version = ""
+	}
+
+	formattedSku := strings.TrimSpace(skuName[:2] + " " + version)
+
+	productName := strings.ReplaceAll(tier+" "+version+" Plan", "  ", " ")
+
+	if version == "v3" && os == "linux" {
+		return formattedSku, productName, []*schema.AttributeFilter{
+			{
+				Key:        "armSkuName",
+				ValueRegex: strPtr(fmt.Sprintf("/%s$/i", strings.ReplaceAll(formattedSku, " ", "_"))),
+			},
+		}
+	}
+
+	return formattedSku, productName, nil
 }

--- a/internal/resources/azure/service_plan.go
+++ b/internal/resources/azure/service_plan.go
@@ -21,6 +21,14 @@ type ServicePlan struct {
 	Region      string
 }
 
+func (r *ServicePlan) CoreType() string {
+	return "ServicePlan"
+}
+
+func (r *ServicePlan) UsageSchema() []*schema.UsageItem {
+	return nil
+}
+
 // PopulateUsage parses the u schema.UsageData into the ServicePlan struct
 // It uses the `infracost_usage` struct tags to populate data into the ServicePlan
 func (r *ServicePlan) PopulateUsage(u *schema.UsageData) {
@@ -81,6 +89,5 @@ func (r *ServicePlan) BuildResource() *schema.Resource {
 				r.WorkerCount,
 				additionalAttributeFilters...),
 		},
-		UsageSchema: []*schema.UsageItem{},
 	}
 }

--- a/internal/resources/azure/service_plan.go
+++ b/internal/resources/azure/service_plan.go
@@ -1,0 +1,86 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+
+	"fmt"
+	"strings"
+)
+
+// ServicePlan struct represents a user commitment to an App Service Plan. A service plan has a dedicated
+// amount of compute and storage and can be used to run any number of apps/containers.
+//
+// Resource information: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
+// Pricing information: https://azure.microsoft.com/en-gb/pricing/details/app-service/windows/
+type ServicePlan struct {
+	Address     string
+	SKUName     string
+	WorkerCount int64
+	OSType      string
+	Region      string
+}
+
+// PopulateUsage parses the u schema.UsageData into the ServicePlan struct
+// It uses the `infracost_usage` struct tags to populate data into the ServicePlan
+func (r *ServicePlan) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid ServicePlan struct.
+//
+// ServicePlan only has one cost component associated with the compute cost of the plan.
+func (r *ServicePlan) BuildResource() *schema.Resource {
+	productName := "Standard Plan"
+	sku := r.SKUName
+
+	if len(r.SKUName) < 2 || strings.ToLower(r.SKUName[:2]) == "ep" || strings.ToLower(r.SKUName[:2]) == "ws" {
+		return &schema.Resource{
+			Name:      r.Address,
+			IsSkipped: true,
+			NoPrice:   true, UsageSchema: AppServicePlanUsageSchema,
+		}
+	}
+
+	firstLetter := strings.ToLower(r.SKUName[:1])
+	os := strings.ToLower(r.OSType)
+	var additionalAttributeFilters []*schema.AttributeFilter
+
+	switch firstLetter {
+	case "s":
+		sku = "S" + r.SKUName[1:]
+	case "b":
+		sku = "B" + r.SKUName[1:]
+		productName = "Basic Plan"
+	case "f":
+		productName = "Free Plan"
+	case "y", "d":
+		sku = "Shared"
+		productName = "Shared Plan"
+	case "p", "i":
+		sku, productName, additionalAttributeFilters = getVersionedAppServicePlanSKU(sku, os)
+	}
+
+	if strings.ToLower(r.SKUName) == "shared" {
+		sku = "Shared"
+		productName = "Shared Plan"
+	}
+
+	if os == "linux" && productName != "Isolated Plan" && productName != "Premium Plan" && productName != "Shared Plan" {
+		productName += " - Linux"
+	}
+
+	return &schema.Resource{
+		Name: r.Address,
+		CostComponents: []*schema.CostComponent{
+			servicePlanCostComponent(
+				r.Region,
+				fmt.Sprintf("Instance usage (%s)", r.SKUName),
+				productName,
+				sku,
+				r.WorkerCount,
+				additionalAttributeFilters...),
+		},
+		UsageSchema: []*schema.UsageItem{},
+	}
+}


### PR DESCRIPTION
closes https://github.com/infracost/infracost/issues/2329

* adds `service_plan` resource
* changes `app_service_plan` resource to pick up new plan types
* marks web apps as free resource as these have no costs associated with then, due to the service plan