### PR TITLE
fix: support google self_link as a uuid attribute

### DIFF
--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -423,6 +423,10 @@ func SetUUIDAttributes(moduleBlock *Block, block *hcl.Block) {
 			if _, ok := body.Attributes["arn"]; !ok {
 				body.Attributes["arn"] = newArnAttribute("arn", withCount)
 			}
+
+			if _, ok := body.Attributes["self_link"]; !ok {
+				body.Attributes["self_link"] = newUniqueAttribute("self_link", withCount)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Adds `self_link` to the supported hcl generated uuid references. `self_link` is a specific google provider way to link resources (like id), see: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/getting_started#linking-gcp-resources, for more information.