### PR TITLE
fix: Fix for_each blocks not picking up references

### DIFF
--- a/internal/providers/terraform/azure/testdata/monitor_action_group_test/monitor_action_group_test.golden
+++ b/internal/providers/terraform/azure/testdata/monitor_action_group_test/monitor_action_group_test.golden
@@ -1,47 +1,47 @@
 
- Name                                                                  Monthly Qty  Unit                      Monthly Cost 
-                                                                                                                           
- azurerm_monitor_action_group.everything_example_with_usage                                                                
- ├─ Email notifications (2)                                                 26,000  emails                           $0.52 
- ├─ ITSM connectors (1)                                                     13,000  events                          $65.00 
- ├─ Push notifications (1)                                                  13,000  notifications                    $0.26 
- ├─ Secure web hooks (1)                                                    13,000  notifications                    $0.78 
- ├─ Web hooks (2)                                                           26,000  notifications                    $0.16 
- ├─ SMS messages                                                                                                           
- │  └─ Country code 1 (1)                                                   13,000  messages                        $83.85 
- └─ Voice calls                                                                                                            
-    └─ Country code 86 (1)                                                  13,000  calls                          $780.00 
-                                                                                                                           
- azurerm_monitor_action_group.everything_example_without_usage                                                             
- ├─ Email notifications (2)                                     Monthly cost depends on usage: $0.00002 per emails         
- ├─ ITSM connectors (1)                                         Monthly cost depends on usage: $0.005 per events           
- ├─ Push notifications (1)                                      Monthly cost depends on usage: $0.00002 per notifications  
- ├─ Secure web hooks (1)                                        Monthly cost depends on usage: $0.00006 per notifications  
- ├─ Web hooks (2)                                               Monthly cost depends on usage: $0.000006 per notifications 
- ├─ SMS messages                                                                                                           
- │  └─ Country code 1 (1)                                       Monthly cost depends on usage: $0.00645 per messages       
- └─ Voice calls                                                                                                            
-    └─ Country code 86 (1)                                      Monthly cost depends on usage: $0.06 per calls             
-                                                                                                                           
- azurerm_monitor_action_group.partial_example_with_usage                                                                   
- ├─ Web hooks (1)                                                           16,000  notifications                    $0.10 
- ├─ SMS messages                                                                                                           
- │  ├─ Country code 1 (1)                                                   16,000  messages                       $103.20 
- │  └─ Country code 34 (1)                                                  16,000  messages                     $1,408.00 
- └─ Voice calls                                                                                                            
-    ├─ Country code 64 (1)                                                  16,000  calls                        $1,280.00 
-    └─ Country code 86 (1)                                                  16,000  calls                          $960.00 
-                                                                                                                           
- azurerm_monitor_action_group.partial_example_without_usage                                                                
- ├─ Web hooks (1)                                               Monthly cost depends on usage: $0.000006 per notifications 
- ├─ SMS messages                                                                                                           
- │  ├─ Country code 1 (1)                                       Monthly cost depends on usage: $0.00645 per messages       
- │  └─ Country code 34 (1)                                      Monthly cost depends on usage: $0.088 per messages         
- └─ Voice calls                                                                                                            
-    ├─ Country code 64 (1)                                      Monthly cost depends on usage: $0.08 per calls             
-    └─ Country code 86 (1)                                      Monthly cost depends on usage: $0.06 per calls             
-                                                                                                                           
- OVERALL TOTAL                                                                                                   $4,681.86 
+ Name                                                                     Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                              
+ azurerm_monitor_action_group.everything_example["with_usage"]                                                                
+ ├─ Email notifications (2)                                                    26,000  emails                           $0.52 
+ ├─ ITSM connectors (1)                                                        13,000  events                          $65.00 
+ ├─ Push notifications (1)                                                     13,000  notifications                    $0.26 
+ ├─ Secure web hooks (1)                                                       13,000  notifications                    $0.78 
+ ├─ Web hooks (2)                                                              26,000  notifications                    $0.16 
+ ├─ SMS messages                                                                                                              
+ │  └─ Country code 1 (1)                                                      13,000  messages                        $83.85 
+ └─ Voice calls                                                                                                               
+    └─ Country code 86 (1)                                                     13,000  calls                          $780.00 
+                                                                                                                              
+ azurerm_monitor_action_group.everything_example["without_usage"]                                                             
+ ├─ Email notifications (2)                                        Monthly cost depends on usage: $0.00002 per emails         
+ ├─ ITSM connectors (1)                                            Monthly cost depends on usage: $0.005 per events           
+ ├─ Push notifications (1)                                         Monthly cost depends on usage: $0.00002 per notifications  
+ ├─ Secure web hooks (1)                                           Monthly cost depends on usage: $0.00006 per notifications  
+ ├─ Web hooks (2)                                                  Monthly cost depends on usage: $0.000006 per notifications 
+ ├─ SMS messages                                                                                                              
+ │  └─ Country code 1 (1)                                          Monthly cost depends on usage: $0.00645 per messages       
+ └─ Voice calls                                                                                                               
+    └─ Country code 86 (1)                                         Monthly cost depends on usage: $0.06 per calls             
+                                                                                                                              
+ azurerm_monitor_action_group.partial_example["with_usage"]                                                                   
+ ├─ Web hooks (1)                                                              16,000  notifications                    $0.10 
+ ├─ SMS messages                                                                                                              
+ │  ├─ Country code 1 (1)                                                      16,000  messages                       $103.20 
+ │  └─ Country code 34 (1)                                                     16,000  messages                     $1,408.00 
+ └─ Voice calls                                                                                                               
+    ├─ Country code 64 (1)                                                     16,000  calls                        $1,280.00 
+    └─ Country code 86 (1)                                                     16,000  calls                          $960.00 
+                                                                                                                              
+ azurerm_monitor_action_group.partial_example["without_usage"]                                                                
+ ├─ Web hooks (1)                                                  Monthly cost depends on usage: $0.000006 per notifications 
+ ├─ SMS messages                                                                                                              
+ │  ├─ Country code 1 (1)                                          Monthly cost depends on usage: $0.00645 per messages       
+ │  └─ Country code 34 (1)                                         Monthly cost depends on usage: $0.088 per messages         
+ └─ Voice calls                                                                                                               
+    ├─ Country code 64 (1)                                         Monthly cost depends on usage: $0.08 per calls             
+    └─ Country code 86 (1)                                         Monthly cost depends on usage: $0.06 per calls             
+                                                                                                                              
+ OVERALL TOTAL                                                                                                      $4,681.86 
 ──────────────────────────────────
 5 cloud resources were detected:
 ∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/monitor_action_group_test/monitor_action_group_test.tf
+++ b/internal/providers/terraform/azure/testdata/monitor_action_group_test/monitor_action_group_test.tf
@@ -11,7 +11,9 @@ resource "azurerm_resource_group" "example" {
 data "azurerm_client_config" "current" {
 }
 
-resource "azurerm_monitor_action_group" "everything_example_with_usage" {
+resource "azurerm_monitor_action_group" "everything_example" {
+  for_each = toset(["with_usage", "without_usage"])
+
   name                = "NotifyEverything"
   resource_group_name = azurerm_resource_group.example.name
   short_name          = "ne"
@@ -105,137 +107,9 @@ resource "azurerm_monitor_action_group" "everything_example_with_usage" {
   }
 }
 
-resource "azurerm_monitor_action_group" "everything_example_without_usage" {
-  name                = "NotifyEverything"
-  resource_group_name = azurerm_resource_group.example.name
-  short_name          = "ne"
+resource "azurerm_monitor_action_group" "partial_example" {
+  for_each = toset(["with_usage", "without_usage"])
 
-  arm_role_receiver {
-    name                    = "armroleaction"
-    role_id                 = "de139f84-1756-47ae-9be6-808fbbe84772"
-    use_common_alert_schema = true
-  }
-
-  automation_runbook_receiver {
-    name                    = "action_name_1"
-    automation_account_id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-runbooks/providers/microsoft.automation/automationaccounts/aaa001"
-    runbook_name            = "my runbook"
-    webhook_resource_id     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg-runbooks/providers/microsoft.automation/automationaccounts/aaa001/webhooks/webhook_alert"
-    is_global_runbook       = true
-    service_uri             = "https://s13events.azure-automation.net/webhooks?token=randomtoken"
-    use_common_alert_schema = true
-  }
-
-  azure_app_push_receiver {
-    name          = "pushtoadmin"
-    email_address = "admin@contoso.com"
-  }
-
-  azure_function_receiver {
-    name                     = "funcaction"
-    function_app_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-funcapp/providers/Microsoft.Web/sites/funcapp"
-    function_name            = "myfunc"
-    http_trigger_url         = "https://example.com/trigger"
-    use_common_alert_schema  = true
-  }
-
-  email_receiver {
-    name          = "sendtoadmin"
-    email_address = "admin@contoso.com"
-  }
-
-  email_receiver {
-    name                    = "sendtodevops"
-    email_address           = "devops@contoso.com"
-    use_common_alert_schema = true
-  }
-
-  itsm_receiver {
-    name                 = "createorupdateticket"
-    workspace_id         = "00000000-0000-0000-0000-000000000000|00000000-0000-0000-0000-000000000000"
-    connection_id        = "53de6956-42b4-41ba-be3c-b154cdf17b13"
-    ticket_configuration = "{\"PayloadRevision\":0,\"WorkItemType\":\"Incident\",\"UseTemplate\":false,\"WorkItemData\":\"{}\",\"CreateOneWIPerCI\":false}"
-    region               = "southcentralus"
-  }
-
-  logic_app_receiver {
-    name                    = "logicappaction"
-    resource_id             = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-logicapp/providers/Microsoft.Logic/workflows/logicapp"
-    callback_url            = "https://logicapptriggerurl/..."
-    use_common_alert_schema = true
-  }
-
-  sms_receiver {
-    name         = "oncallmsg"
-    country_code = "1"
-    phone_number = "1231231234"
-  }
-
-  voice_receiver {
-    name         = "remotesupport"
-    country_code = "86"
-    phone_number = "13888888888"
-  }
-
-  webhook_receiver {
-    name                    = "callmyapiaswell1"
-    service_uri             = "http://example.com/alert"
-    use_common_alert_schema = true
-  }
-
-  webhook_receiver {
-    name                    = "callmyapiaswell2"
-    service_uri             = "http://example.com/alert"
-    use_common_alert_schema = true
-  }
-
-  webhook_receiver {
-    name                    = "callmyapiaswell3"
-    service_uri             = "http://example.com/alert"
-    use_common_alert_schema = true
-    aad_auth {
-      object_id = "00000000-0000-0000-0000-000000000000"
-    }
-  }
-}
-
-resource "azurerm_monitor_action_group" "partial_example_with_usage" {
-  name                = "NotifySomethings"
-  resource_group_name = azurerm_resource_group.example.name
-  short_name          = "ps"
-
-  sms_receiver {
-    name         = "oncallmsg"
-    country_code = "1"
-    phone_number = "1231231234"
-  }
-
-  sms_receiver {
-    name         = "oncallmsg"
-    country_code = "34"
-    phone_number = "1231231234"
-  }
-
-  voice_receiver {
-    name         = "remotesupport"
-    country_code = "86"
-    phone_number = "13888888888"
-  }
-
-  voice_receiver {
-    name         = "remotesupport"
-    country_code = "64"
-    phone_number = "13888888888"
-  }
-
-  webhook_receiver {
-    name                    = "callmyapiaswell"
-    service_uri             = "http://example.com/alert"
-    use_common_alert_schema = true
-  }
-}
-
-resource "azurerm_monitor_action_group" "partial_example_without_usage" {
   name                = "NotifySomethings"
   resource_group_name = azurerm_resource_group.example.name
   short_name          = "ps"

--- a/internal/providers/terraform/azure/testdata/monitor_action_group_test/monitor_action_group_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/monitor_action_group_test/monitor_action_group_test.usage.yml
@@ -1,6 +1,6 @@
 version: 0.1
 resource_usage:
-  azurerm_monitor_action_group.everything_example_with_usage:
+  azurerm_monitor_action_group.everything_example["with_usage"]:
     monthly_notifications: 13000
-  azurerm_monitor_action_group.partial_example_with_usage:
+  azurerm_monitor_action_group.partial_example["with_usage"]:
     monthly_notifications: 16000

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -485,7 +485,7 @@ func (p *HCLProvider) getResourceOutput(block *hcl.Block) ResourceOutput {
 		Address:       block.FullName(),
 		Mode:          "managed",
 		Type:          block.TypeLabel(),
-		Name:          stripCount(block.NameLabel()),
+		Name:          stripCountOrForEach(block.NameLabel()),
 		Index:         block.Index(),
 		SchemaVersion: 0,
 		InfracostMetadata: map[string]interface{}{
@@ -499,7 +499,7 @@ func (p *HCLProvider) getResourceOutput(block *hcl.Block) ResourceOutput {
 		ModuleAddress: newString(block.ModuleAddress()),
 		Mode:          "managed",
 		Type:          block.TypeLabel(),
-		Name:          stripCount(block.NameLabel()),
+		Name:          stripCountOrForEach(block.NameLabel()),
 		Index:         block.Index(),
 		Change: ResourceChange{
 			Actions: []string{"create"},
@@ -530,20 +530,20 @@ func (p *HCLProvider) getResourceOutput(block *hcl.Block) ResourceOutput {
 	var configuration ResourceData
 	if block.HasModuleBlock() {
 		configuration = ResourceData{
-			Address:           stripCount(block.LocalName()),
+			Address:           stripCountOrForEach(block.LocalName()),
 			Mode:              "managed",
 			Type:              block.TypeLabel(),
-			Name:              stripCount(block.NameLabel()),
+			Name:              stripCountOrForEach(block.NameLabel()),
 			ProviderConfigKey: block.ModuleName() + ":" + block.Provider(),
 			Expressions:       blockToReferences(block),
 			CountExpression:   p.countReferences(block),
 		}
 	} else {
 		configuration = ResourceData{
-			Address:           stripCount(block.FullName()),
+			Address:           stripCountOrForEach(block.FullName()),
 			Mode:              "managed",
 			Type:              block.TypeLabel(),
-			Name:              stripCount(block.NameLabel()),
+			Name:              stripCountOrForEach(block.NameLabel()),
 			ProviderConfigKey: providerConfigKey,
 			Expressions:       blockToReferences(block),
 			CountExpression:   p.countReferences(block),
@@ -818,8 +818,8 @@ func newString(s string) *string {
 	return &s
 }
 
-var countRegex = regexp.MustCompile(`\[\d+\]$`)
+var countRegex = regexp.MustCompile(`\[.+\]$`)
 
-func stripCount(s string) string {
+func stripCountOrForEach(s string) string {
 	return countRegex.ReplaceAllString(s, "")
 }


### PR DESCRIPTION
@hugorut this fixes the issue I was seeing and I think it makes sense - at least the `configuration` block in a terraform generate plan.json doesn't contain the for_each names either.