### PR TITLE
feat(azure): add support for Storage File Shares

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -1105,6 +1105,22 @@ resource_usage:
     monthly_data_write_gb: 1000                           # Monthly number of data write in GB.
     blob_index_tags: 100000                               # Total number of Blob indexes.
 
+  azurerm_storage_queue.my_queue:
+    monthly_storage_gb: 1000000                       # Monthly amount of storage used in GB.
+    monthly_class_1_operations: 10000                 # Monthly number of Class 1 operations
+    monthly_class_2_operations: 1000000               # Monthly number of Class 2 operations
+    monthly_geo_replication_data_transfer_gb: 1000000 # Monthly amount of Geo-replication data transfer in GB
+
+  azurerm_storage_share.my_share:
+    storage_gb: 1000000                # Total size of storage in GB. Overrides any provided `quota`.
+    monthly_write_operations: 1000000  # Monthly number of Write operations.
+    monthly_list_operations: 1000000   # Monthly number of List and Create Container operations.
+    monthly_read_operations: 100000    # Monthly number of Read operations.
+    monthly_other_operations: 1000000  # Monthly number of All other operations.
+    monthly_data_retrieval_gb: 1000    # Monthly number of data retrieval in GB.
+    snapshots_storage_gb: 10000        # Total size of Snapshots in GB
+    metadata_at_rest_storage_gb: 10000 # Total size of Metadata in GB
+
   azurerm_sql_database.my_database:
     monthly_vcore_hours: 600             # Monthly number of used vCore-hours for serverless compute.
     long_term_retention_storage_gb: 1000 # Number of GBs used by long-term retention backup storage.

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -137,6 +137,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getRecoveryServicesVaultRegistryItem(),
 	getBackupProtectedVmRegistryItem(),
 	getStorageQueueRegistryItem(),
+	getStorageShareRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/storage_share.go
+++ b/internal/providers/terraform/azure/storage_share.go
@@ -1,0 +1,50 @@
+package azure
+
+import (
+	"strings"
+
+	"github.com/infracost/infracost/internal/logging"
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getStorageShareRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "azurerm_storage_share",
+		CoreRFunc: newStorageShare,
+		ReferenceAttributes: []string{
+			"storage_account_name",
+		},
+	}
+}
+
+func newStorageShare(d *schema.ResourceData) schema.CoreResource {
+	region := lookupRegion(d, []string{"storage_account_name"})
+
+	accountReplicationType := "LRS"
+
+	accessTier := d.Get("access_tier").String()
+	if accessTier == "" {
+		accessTier = "TransactionOptimized"
+	}
+	quota := d.Get("quota").Int()
+
+	if len(d.References("storage_account_name")) > 0 {
+		storageAccount := d.References("storage_account_name")[0]
+		accountKind := storageAccount.Get("account_kind").String()
+		accountReplicationType = storageAccount.Get("account_replication_type").String()
+
+		if strings.EqualFold(accessTier, "premium") && !strings.EqualFold(accountKind, "filestorage") {
+			logging.Logger.Warnf("Skipping resource %s. Premium access tier is only supported for FileStorage accounts", d.Address)
+			return nil
+		}
+	}
+
+	return &azure.StorageShare{
+		Address:                d.Address,
+		Region:                 region,
+		AccountReplicationType: accountReplicationType,
+		AccessTier:             accessTier,
+		Quota:                  quota,
+	}
+}

--- a/internal/providers/terraform/azure/storage_share_test.go
+++ b/internal/providers/terraform/azure/storage_share_test.go
@@ -1,0 +1,17 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestStorageShare(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	opts := tftest.DefaultGoldenFileOptions()
+	opts.CaptureLogs = true
+	tftest.GoldenFileResourceTestsWithOpts(t, "storage_share_test", opts)
+}

--- a/internal/providers/terraform/azure/testdata/storage_share_test/storage_share_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_share_test/storage_share_test.golden
@@ -1,0 +1,141 @@
+
+ Name                                                               Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                        
+ azurerm_storage_account.filestorage["LRS"]                                                                             
+ ├─ Data at rest                                             Monthly cost depends on usage: $0.18 per GB                
+ └─ Snapshots                                                Monthly cost depends on usage: $0.15 per GB                
+                                                                                                                        
+ azurerm_storage_account.filestorage["ZRS"]                                                                             
+ ├─ Data at rest                                             Monthly cost depends on usage: $0.22 per GB                
+ └─ Snapshots                                                Monthly cost depends on usage: $0.19 per GB                
+                                                                                                                        
+ azurerm_storage_account.premium                                                                                        
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.20 per GB                
+ ├─ Write operations                                         Monthly cost depends on usage: $0.0228 per 10k operations  
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.065 per 10k operations   
+ ├─ Read operations                                          Monthly cost depends on usage: $0.00182 per 10k operations 
+ └─ All other operations                                     Monthly cost depends on usage: $0.00182 per 10k operations 
+                                                                                                                        
+ azurerm_storage_account.standard["GRS"]                                                                                
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.0458 per GB              
+ ├─ Write operations                                         Monthly cost depends on usage: $0.11 per 10k operations    
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.11 per 10k operations    
+ ├─ Read operations                                          Monthly cost depends on usage: $0.0044 per 10k operations  
+ ├─ All other operations                                     Monthly cost depends on usage: $0.0044 per 10k operations  
+ └─ Blob index                                               Monthly cost depends on usage: $0.069 per 10k tags         
+                                                                                                                        
+ azurerm_storage_account.standard["LRS"]                                                                                
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.0208 per GB              
+ ├─ Write operations                                         Monthly cost depends on usage: $0.055 per 10k operations   
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.055 per 10k operations   
+ ├─ Read operations                                          Monthly cost depends on usage: $0.0044 per 10k operations  
+ ├─ All other operations                                     Monthly cost depends on usage: $0.0044 per 10k operations  
+ └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+                                                                                                                        
+ azurerm_storage_account.standard["ZRS"]                                                                                
+ ├─ Capacity                                                 Monthly cost depends on usage: $0.026 per GB               
+ ├─ List and create container operations                     Monthly cost depends on usage: $0.06875 per 10k operations 
+ ├─ Read operations                                          Monthly cost depends on usage: $0.0044 per 10k operations  
+ ├─ All other operations                                     Monthly cost depends on usage: $0.0044 per 10k operations  
+ └─ Blob index                                               Monthly cost depends on usage: $0.039 per 10k tags         
+                                                                                                                        
+ azurerm_storage_share.premium-filestorage["Premium.LRS"]                                                               
+ ├─ Data at rest                                                             50  GB                               $8.80 
+ └─ Snapshots                                                            10,000  GB                           $1,500.00 
+                                                                                                                        
+ azurerm_storage_share.premium-filestorage["Premium.ZRS"]                                                               
+ ├─ Data at rest                                                             50  GB                              $11.00 
+ └─ Snapshots                                                            10,000  GB                           $1,870.00 
+                                                                                                                        
+ azurerm_storage_share.standard["Cool.GRS"]                                                                             
+ ├─ Data at rest                                                      2,000,000  GB                         $100,200.00 
+ ├─ Snapshots                                                            20,000  GB                           $1,002.00 
+ ├─ Metadata at rest                                                     20,000  GB                           $1,310.00 
+ ├─ Read operations                                                          20  10k operations                   $0.26 
+ ├─ Write operations                                                        200  10k operations                  $52.00 
+ ├─ List operations                                                         200  10k operations                  $28.60 
+ ├─ Other operations                                                        200  10k operations                   $1.14 
+ └─ Data retrieval                                                        2,000  GB                              $20.00 
+                                                                                                                        
+ azurerm_storage_share.standard["Cool.LRS"]                                                                             
+ ├─ Data at rest                                                      2,000,000  GB                          $45,600.00 
+ ├─ Snapshots                                                            20,000  GB                             $456.00 
+ ├─ Metadata at rest                                                     20,000  GB                             $594.00 
+ ├─ Read operations                                                          20  10k operations                   $0.26 
+ ├─ Write operations                                                        200  10k operations                  $26.00 
+ ├─ List operations                                                         200  10k operations                  $14.30 
+ ├─ Other operations                                                        200  10k operations                   $1.14 
+ └─ Data retrieval                                                        2,000  GB                              $20.00 
+                                                                                                                        
+ azurerm_storage_share.standard["Cool.ZRS"]                                                                             
+ ├─ Data at rest                                                      2,000,000  GB                          $57,000.00 
+ ├─ Snapshots                                                            20,000  GB                             $570.00 
+ ├─ Metadata at rest                                                     20,000  GB                             $742.00 
+ ├─ Read operations                                                          20  10k operations                   $0.26 
+ ├─ Write operations                                                        200  10k operations                  $26.00 
+ ├─ List operations                                                         200  10k operations                  $17.88 
+ ├─ Other operations                                                        200  10k operations                   $1.14 
+ └─ Data retrieval                                                        2,000  GB                              $20.00 
+                                                                                                                        
+ azurerm_storage_share.standard["Hot.GRS"]                                                                              
+ ├─ Data at rest                                                      2,000,000  GB                         $126,400.00 
+ ├─ Snapshots                                                            20,000  GB                           $1,264.00 
+ ├─ Metadata at rest                                                     20,000  GB                           $1,310.00 
+ ├─ Read operations                                                          20  10k operations                   $0.11 
+ ├─ Write operations                                                        200  10k operations                  $28.60 
+ ├─ List operations                                                         200  10k operations                  $28.60 
+ └─ Other operations                                                        200  10k operations                   $1.14 
+                                                                                                                        
+ azurerm_storage_share.standard["Hot.LRS"]                                                                              
+ ├─ Data at rest                                                      2,000,000  GB                          $57,400.00 
+ ├─ Snapshots                                                            20,000  GB                             $574.00 
+ ├─ Metadata at rest                                                     20,000  GB                             $594.00 
+ ├─ Read operations                                                          20  10k operations                   $0.11 
+ ├─ Write operations                                                        200  10k operations                  $14.30 
+ ├─ List operations                                                         200  10k operations                  $14.30 
+ └─ Other operations                                                        200  10k operations                   $1.14 
+                                                                                                                        
+ azurerm_storage_share.standard["Hot.ZRS"]                                                                              
+ ├─ Data at rest                                                      2,000,000  GB                          $72,000.00 
+ ├─ Snapshots                                                            20,000  GB                             $720.00 
+ ├─ Metadata at rest                                                     20,000  GB                             $742.00 
+ ├─ Read operations                                                          20  10k operations                   $0.11 
+ ├─ Write operations                                                        200  10k operations                  $17.88 
+ ├─ List operations                                                         200  10k operations                  $17.88 
+ └─ Other operations                                                        200  10k operations                   $1.14 
+                                                                                                                        
+ azurerm_storage_share.standard["TransactionOptimized.GRS"]                                                             
+ ├─ Data at rest                                                      2,000,000  GB                         $200,000.00 
+ ├─ Snapshots                                                            20,000  GB                           $2,000.00 
+ ├─ Read operations                                                          20  10k operations                   $0.03 
+ ├─ Write operations                                                        200  10k operations                   $6.00 
+ ├─ List operations                                                         200  10k operations                   $3.00 
+ └─ Other operations                                                        200  10k operations                   $0.30 
+                                                                                                                        
+ azurerm_storage_share.standard["TransactionOptimized.LRS"]                                                             
+ ├─ Data at rest                                                      2,000,000  GB                         $120,000.00 
+ ├─ Snapshots                                                            20,000  GB                           $1,200.00 
+ ├─ Read operations                                                          20  10k operations                   $0.03 
+ ├─ Write operations                                                        200  10k operations                   $3.00 
+ ├─ List operations                                                         200  10k operations                   $3.00 
+ └─ Other operations                                                        200  10k operations                   $0.30 
+                                                                                                                        
+ azurerm_storage_share.standard["TransactionOptimized.ZRS"]                                                             
+ ├─ Data at rest                                                      2,000,000  GB                         $150,000.00 
+ ├─ Snapshots                                                            20,000  GB                           $1,500.00 
+ ├─ Read operations                                                          20  10k operations                   $0.03 
+ ├─ Write operations                                                        200  10k operations                   $3.75 
+ ├─ List operations                                                         200  10k operations                   $3.00 
+ └─ Other operations                                                        200  10k operations                   $0.30 
+                                                                                                                        
+ OVERALL TOTAL                                                                                              $946,944.87 
+──────────────────────────────────
+19 cloud resources were detected:
+∙ 17 were estimated, 6 of which include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free:
+  ∙ 1 x azurerm_resource_group
+∙ 1 is not supported yet, see https://infracost.io/requested-resources:
+  ∙ 1 x azurerm_storage_share
+Logs:
+
+level=warning msg="Skipping resource azurerm_storage_share.unsupported. Premium access tier is only supported for FileStorage accounts"

--- a/internal/providers/terraform/azure/testdata/storage_share_test/storage_share_test.tf
+++ b/internal/providers/terraform/azure/testdata/storage_share_test/storage_share_test.tf
@@ -1,0 +1,119 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "westus"
+}
+
+locals {
+  share_premium_options = [
+    {
+      access_tiers              = ["Premium"]
+      account_replication_types = ["LRS", "ZRS"],
+    },
+  ]
+
+  share_standard_options = [
+    {
+      access_tiers              = ["Cool", "Hot", "TransactionOptimized"]
+      account_replication_types = ["LRS", "GRS", "ZRS"],
+    },
+  ]
+
+  storage_account_premium_permutations = distinct(flatten([
+    for share_premium_option in local.share_premium_options : [
+      for account_replication_type in share_premium_option.account_replication_types : {
+        account_replication_type = account_replication_type
+      }
+    ]
+  ]))
+
+  share_premium_permuations = distinct(flatten([
+    for share_premium_option in local.share_premium_options : [
+      for account_replication_type in share_premium_option.account_replication_types : [
+        for access_tier in share_premium_option.access_tiers : {
+          access_tier              = access_tier
+          account_replication_type = account_replication_type
+        }
+      ]
+    ]
+  ]))
+
+  storage_account_standard_permutations = distinct(flatten([
+    for share_standard_option in local.share_standard_options : [
+      for account_replication_type in share_standard_option.account_replication_types : {
+        account_replication_type = account_replication_type
+      }
+    ]
+  ]))
+
+  share_standard_permuations = distinct(flatten([
+    for share_standard_option in local.share_standard_options : [
+      for account_replication_type in share_standard_option.account_replication_types : [
+        for access_tier in share_standard_option.access_tiers : {
+          access_tier              = access_tier
+          account_replication_type = account_replication_type
+        }
+      ]
+    ]
+  ]))
+}
+
+resource "azurerm_storage_account" "filestorage" {
+  for_each = { for entry in local.storage_account_premium_permutations : "${entry.account_replication_type}" => entry }
+
+  name                     = substr(lower("filestorage${each.value.account_replication_type}"), 0, 24)
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "FileStorage"
+  account_tier             = "Premium"
+  account_replication_type = each.value.account_replication_type
+}
+
+resource "azurerm_storage_share" "premium-filestorage" {
+  for_each = { for entry in local.share_premium_permuations : "${entry.access_tier}.${entry.account_replication_type}" => entry }
+
+  name                 = substr(lower("premium${each.value.access_tier}${each.value.account_replication_type}"), 0, 24)
+  storage_account_name = azurerm_storage_account.filestorage["${each.value.account_replication_type}"].name
+  quota                = 50
+  access_tier          = each.value.access_tier
+}
+
+resource "azurerm_storage_account" "standard" {
+  for_each = { for entry in local.storage_account_standard_permutations : "${entry.account_replication_type}" => entry }
+
+  name                     = substr(lower("standard${each.value.account_replication_type}"), 0, 24)
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = each.value.account_replication_type
+}
+
+resource "azurerm_storage_share" "standard" {
+  for_each = { for entry in local.share_standard_permuations : "${entry.access_tier}.${entry.account_replication_type}" => entry }
+
+  name                 = substr(lower("standard${each.value.access_tier}${each.value.account_replication_type}"), 0, 24)
+  storage_account_name = azurerm_storage_account.standard["${each.value.account_replication_type}"].name
+  quota                = 50
+  access_tier          = each.value.access_tier
+}
+
+resource "azurerm_storage_account" "premium" {
+  name                     = "premium"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "StorageV2"
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_share" "unsupported" {
+  name                 = "unsupported"
+  storage_account_name = azurerm_storage_account.premium.name
+  quota                = 50
+  access_tier          = "Premium"
+}

--- a/internal/providers/terraform/azure/testdata/storage_share_test/storage_share_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/storage_share_test/storage_share_test.usage.yml
@@ -1,0 +1,21 @@
+version: 0.1
+resource_usage:
+  azurerm_storage_share.premium-filestorage[*]:
+    snapshots_storage_gb: 10000
+    metadata_at_rest_storage_gb: 10000
+    monthly_write_operations: 1000000
+    monthly_list_operations: 1000000
+    monthly_read_operations: 100000
+    monthly_other_operations: 1000000
+    monthly_data_retrieval_gb: 1000
+    metadata_at_rest_storage_gb: 50000
+
+  azurerm_storage_share.standard[*]:
+    storage_gb: 2000000
+    snapshots_storage_gb: 20000
+    metadata_at_rest_storage_gb: 20000
+    monthly_write_operations: 2000000
+    monthly_list_operations: 2000000
+    monthly_read_operations: 200000
+    monthly_other_operations: 2000000
+    monthly_data_retrieval_gb: 2000

--- a/internal/resources/azure/storage_account.go
+++ b/internal/resources/azure/storage_account.go
@@ -560,7 +560,7 @@ func (r *StorageAccount) readOperationsCostComponents() []*schema.CostComponent 
 	if r.isStorageV2() && r.NFSv3 {
 		meterName = "(?<!Iterative) Read Operations"
 	}
-	if r.isStorageV1() && contains([]string{"GRS", "RA-GRS"}, strings.ToUpper(r.AccountReplicationType)) {
+	if r.isStorageV1() && contains([]string{"RA-GRS"}, strings.ToUpper(r.AccountReplicationType)) {
 		// Storage V1 GRS/RA-GRS doesn't always have a Read Operations meter name, but we can
 		// use the Other Operations meter instead since it's the same price.
 		meterName = "Other Operations"

--- a/internal/resources/azure/storage_share.go
+++ b/internal/resources/azure/storage_share.go
@@ -1,0 +1,389 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// StorageShare struct represents an Azure Files Storage Shares
+//
+// Resource information: https://azure.microsoft.com/en-gb/pricing/details/storage/files/
+// Pricing information: https://azure.microsoft.com/en-gb/pricing/details/storage/files/#pricing
+type StorageShare struct {
+	Address                string
+	Region                 string
+	AccountReplicationType string
+	AccessTier             string
+	Quota                  int64
+
+	// "usage" args
+	MonthlyStorageGB        *float64 `infracost_usage:"storage_gb"`
+	MonthlyReadOperations   *int64   `infracost_usage:"monthly_read_operations"`
+	MonthlyWriteOperations  *int64   `infracost_usage:"monthly_write_operations"`
+	MonthlyListOperations   *int64   `infracost_usage:"monthly_list_operations"`
+	MonthlyOtherOperations  *int64   `infracost_usage:"monthly_other_operations"`
+	MonthlyDataRetrievalGB  *float64 `infracost_usage:"monthly_data_retrieval_gb"`
+	SnapshotsStorageGB      *float64 `infracost_usage:"snapshots_storage_gb"`
+	MetadataAtRestStorageGB *float64 `infracost_usage:"metadata_at_rest_storage_gb"`
+}
+
+// CoreType returns the name of this resource type
+func (r *StorageShare) CoreType() string {
+	return "StorageShare"
+}
+
+// UsageSchema defines a list which represents the usage schema of StorageShare.
+func (r *StorageShare) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+		{Key: "monthly_read_operations", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_write_operations", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_list_operations", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_other_operations", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_data_retrieval_gb", DefaultValue: 0, ValueType: schema.Float64},
+		{Key: "snapshots_storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+		{Key: "metadata_at_rest_storage_gb", DefaultValue: 0, ValueType: schema.Float64},
+	}
+}
+
+// PopulateUsage parses the u schema.UsageData into the StorageShare.
+// It uses the `infracost_usage` struct tags to populate data into the StorageShare.
+func (r *StorageShare) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid StorageShare struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *StorageShare) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{
+		r.dataStorageCostComponent(),
+	}
+
+	costComponents = append(costComponents, r.snapshotCostComponents()...)
+	costComponents = append(costComponents, r.metadataCostComponents()...)
+	costComponents = append(costComponents, r.readOperationsCostComponents()...)
+	costComponents = append(costComponents, r.writeOperationsCostComponents()...)
+	costComponents = append(costComponents, r.listOperationsCostComponents()...)
+	costComponents = append(costComponents, r.otherOperationsCostComponents()...)
+	costComponents = append(costComponents, r.dataRetrievalCostComponents()...)
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    r.UsageSchema(),
+		CostComponents: costComponents,
+	}
+}
+
+func (r *StorageShare) productName() string {
+	if r.accessTier() == "Premium" {
+		return "Premium Files"
+	}
+
+	return "Files v2"
+}
+
+func (r *StorageShare) accessTier() string {
+	return map[string]string{
+		"hot":                  "Hot",
+		"cool":                 "Cool",
+		"transactionoptimized": "Standard",
+		"premium":              "Premium",
+	}[strings.ToLower(r.AccessTier)]
+}
+
+func (r *StorageShare) dataStorageCostComponent() *schema.CostComponent {
+	var qty *decimal.Decimal
+
+	if r.accessTier() == "Premium" {
+		qty = decimalPtr(decimal.NewFromInt(r.Quota))
+	}
+
+	if r.MonthlyStorageGB != nil {
+		qty = decimalPtr(decimal.NewFromFloat(*r.MonthlyStorageGB))
+	}
+
+	skuName := fmt.Sprintf("%s %s", r.accessTier(), strings.ToUpper(r.AccountReplicationType))
+	meterName := "Data Stored"
+	if r.accessTier() == "Premium" {
+		meterName = "Provisioned"
+	}
+
+	return &schema.CostComponent{
+		Name:            "Data at rest",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Storage"),
+			ProductFamily: strPtr("Storage"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr(r.productName())},
+				{Key: "skuName", Value: strPtr(skuName)},
+				{Key: "meterName", ValueRegex: regexPtr(fmt.Sprintf("%s$", meterName))},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("0"),
+		},
+	}
+}
+
+func (r *StorageShare) snapshotCostComponents() []*schema.CostComponent {
+	var qty *decimal.Decimal
+	if r.SnapshotsStorageGB != nil {
+		qty = decimalPtr(decimal.NewFromFloat(*r.SnapshotsStorageGB))
+	}
+
+	skuName := fmt.Sprintf("%s %s", r.accessTier(), strings.ToUpper(r.AccountReplicationType))
+	meterName := "Data Stored"
+	if r.accessTier() == "Premium" {
+		meterName = "Snapshots"
+	}
+
+	return []*schema.CostComponent{{
+		Name:            "Snapshots",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Storage"),
+			ProductFamily: strPtr("Storage"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr(r.productName())},
+				{Key: "skuName", Value: strPtr(skuName)},
+				{Key: "meterName", ValueRegex: regexPtr(fmt.Sprintf("%s$", meterName))},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("0"),
+		},
+	}}
+}
+
+func (r *StorageShare) metadataCostComponents() []*schema.CostComponent {
+	if contains([]string{"Premium", "Standard"}, r.accessTier()) {
+		return []*schema.CostComponent{}
+	}
+
+	var qty *decimal.Decimal
+	if r.MetadataAtRestStorageGB != nil {
+		qty = decimalPtr(decimal.NewFromFloat(*r.MetadataAtRestStorageGB))
+	}
+
+	skuName := fmt.Sprintf("%s %s", r.accessTier(), strings.ToUpper(r.AccountReplicationType))
+
+	return []*schema.CostComponent{{
+		Name:            "Metadata at rest",
+		Unit:            "GB",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Storage"),
+			ProductFamily: strPtr("Storage"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr(r.productName())},
+				{Key: "skuName", Value: strPtr(skuName)},
+				{Key: "meterName", ValueRegex: regexPtr("Metadata$")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("0"),
+		},
+	}}
+}
+
+func (r *StorageShare) readOperationsCostComponents() []*schema.CostComponent {
+	if r.accessTier() == "Premium" {
+		return []*schema.CostComponent{}
+	}
+
+	var qty *decimal.Decimal
+	if r.MonthlyReadOperations != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyReadOperations).Div(decimal.NewFromInt(10000)))
+	}
+
+	skuName := fmt.Sprintf("%s %s", r.accessTier(), strings.ToUpper(r.AccountReplicationType))
+
+	return []*schema.CostComponent{{
+		Name:            "Read operations",
+		Unit:            "10k operations",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Storage"),
+			ProductFamily: strPtr("Storage"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr(r.productName())},
+				{Key: "skuName", Value: strPtr(skuName)},
+				{Key: "meterName", ValueRegex: regexPtr("Read Operations$")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("0"),
+		},
+	}}
+}
+
+func (r *StorageShare) writeOperationsCostComponents() []*schema.CostComponent {
+	if r.accessTier() == "Premium" {
+		return []*schema.CostComponent{}
+	}
+
+	var qty *decimal.Decimal
+	if r.MonthlyWriteOperations != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyWriteOperations).Div(decimal.NewFromInt(10000)))
+	}
+
+	skuName := fmt.Sprintf("%s %s", r.accessTier(), strings.ToUpper(r.AccountReplicationType))
+
+	return []*schema.CostComponent{{
+		Name:            "Write operations",
+		Unit:            "10k operations",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Storage"),
+			ProductFamily: strPtr("Storage"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr(r.productName())},
+				{Key: "skuName", Value: strPtr(skuName)},
+				{Key: "meterName", ValueRegex: regexPtr("Write Operations$")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("0"),
+		},
+	}}
+}
+
+func (r *StorageShare) listOperationsCostComponents() []*schema.CostComponent {
+	if r.accessTier() == "Premium" {
+		return []*schema.CostComponent{}
+	}
+
+	var qty *decimal.Decimal
+	if r.MonthlyListOperations != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyListOperations).Div(decimal.NewFromInt(10000)))
+	}
+
+	skuName := fmt.Sprintf("%s %s", r.accessTier(), strings.ToUpper(r.AccountReplicationType))
+
+	return []*schema.CostComponent{{
+		Name:            "List operations",
+		Unit:            "10k operations",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Storage"),
+			ProductFamily: strPtr("Storage"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr(r.productName())},
+				{Key: "skuName", Value: strPtr(skuName)},
+
+				{Key: "meterName", ValueRegex: regexPtr("List Operations$")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("0"),
+		},
+	}}
+}
+
+func (r *StorageShare) otherOperationsCostComponents() []*schema.CostComponent {
+	if r.accessTier() == "Premium" {
+		return []*schema.CostComponent{}
+	}
+
+	var qty *decimal.Decimal
+	if r.MonthlyOtherOperations != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyOtherOperations).Div(decimal.NewFromInt(10000)))
+	}
+
+	skuName := fmt.Sprintf("%s %s", r.accessTier(), strings.ToUpper(r.AccountReplicationType))
+	meterName := "Other Operations"
+	if r.accessTier() == "Standard" {
+		meterName = "Protocol Operations"
+	}
+
+	return []*schema.CostComponent{
+		{
+			Name:            "Other operations",
+			Unit:            "10k operations",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: qty,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("azure"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Storage"),
+				ProductFamily: strPtr("Storage"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr(r.productName())},
+					{Key: "skuName", Value: strPtr(skuName)},
+					{Key: "meterName", ValueRegex: regexPtr(fmt.Sprintf("%s$", meterName))},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption:   strPtr("Consumption"),
+				StartUsageAmount: strPtr("0"),
+			},
+		}}
+}
+
+func (r *StorageShare) dataRetrievalCostComponents() []*schema.CostComponent {
+	if contains([]string{"Premium", "Standard", "Hot"}, r.accessTier()) || strings.ToUpper(r.AccountReplicationType) == "GZRS" {
+		return []*schema.CostComponent{}
+	}
+
+	var qty *decimal.Decimal
+	if r.MonthlyDataRetrievalGB != nil {
+		qty = decimalPtr(decimal.NewFromFloat(*r.MonthlyDataRetrievalGB))
+	}
+
+	skuName := fmt.Sprintf("%s %s", r.accessTier(), strings.ToUpper(r.AccountReplicationType))
+
+	return []*schema.CostComponent{
+		{
+			Name:            "Data retrieval",
+			Unit:            "GB",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: qty,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("azure"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Storage"),
+				ProductFamily: strPtr("Storage"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr(r.productName())},
+					{Key: "skuName", Value: strPtr(skuName)},
+					{Key: "meterName", ValueRegex: regexPtr("Data Retrieval$")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption:   strPtr("Consumption"),
+				StartUsageAmount: strPtr("0"),
+			},
+		}}
+}


### PR DESCRIPTION
This adds support for Azure File Shares. There's some overlap with `azurerm_storage_account` when `account_kind = FileStorage`, but I think that's okay since there's more flexibility with what they can do with `azure_storage_share` and we shouldn't break backwards compatibility. Everything can be adjusted with the usage file to make sure one resource get the cost.

There's also some overlapping logic with this and `azurerm_storage_account` but I decided to keep it separate for just now - unpicking the `azurerm_storage_account` resource was getting a bit messy.