### PR TITLE
feat(gcp): add iops & extend google_compute_disk to include pd-extreme and hyperdisk-extreme

### DIFF
--- a/internal/providers/terraform/google/compute_disk.go
+++ b/internal/providers/terraform/google/compute_disk.go
@@ -26,11 +26,14 @@ func newComputeDisk(d *schema.ResourceData, u *schema.UsageData) *schema.Resourc
 	diskType := d.Get("type").String()
 	size := computeDiskSize(d)
 
+	iops := computeIOPS(d, diskType)
+
 	r := &google.ComputeDisk{
 		Address: d.Address,
 		Region:  region,
 		Type:    diskType,
 		Size:    size,
+		IOPS:    iops,
 	}
 	r.PopulateUsage(u)
 
@@ -93,4 +96,21 @@ func computeSnapshotDiskSize(d *schema.ResourceData) float64 {
 	}
 
 	return 0
+}
+
+func computeIOPS(d *schema.ResourceData, diskType string) int64 {
+	if diskType == "pd-extreme" || diskType == "hyperdisk-extreme" {
+
+		if d.Get("provisioned_iops").Exists() {
+			return d.Get("provisioned_iops").Int()
+		}
+
+		return defaultIOPS()
+	}
+
+	return 0
+}
+
+func defaultIOPS() int64 {
+	return 2500
 }

--- a/internal/providers/terraform/google/compute_disk.go
+++ b/internal/providers/terraform/google/compute_disk.go
@@ -55,10 +55,16 @@ func computeDiskSize(d *schema.ResourceData) float64 {
 
 func defaultDiskSize(diskType string) float64 {
 	diskType = strings.ToLower(diskType)
+
 	if diskType == "pd-balanced" || diskType == "pd-ssd" || diskType == "pd-standard" {
 		return 10
+	} else if diskType == "pd-extreme" {
+		return 500
+	} else if diskType == "hyperdisk-extreme" {
+		return 64
 	}
-	return 500
+
+	return 10
 }
 
 func computeImageDiskSize(d *schema.ResourceData) float64 {

--- a/internal/providers/terraform/google/compute_disk.go
+++ b/internal/providers/terraform/google/compute_disk.go
@@ -55,8 +55,8 @@ func computeDiskSize(d *schema.ResourceData) float64 {
 
 func defaultDiskSize(diskType string) float64 {
 	diskType = strings.ToLower(diskType)
-	if diskType == "pd-balanced" || diskType == "pd-ssd" {
-		return 100
+	if diskType == "pd-balanced" || diskType == "pd-ssd" || diskType == "pd-standard" {
+		return 10
 	}
 	return 500
 }

--- a/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.golden
@@ -1,6 +1,14 @@
 
  Name                                           Monthly Qty  Unit  Monthly Cost 
                                                                                 
+   google_compute_disk.extreme_default                                           
+ └─ Extreme provisioned storage (pd-extreme)            500  GB          $62.50
+ └─ Provisioned IOPS                                   2500  IOPS       $162.50
+
+ google_compute_disk.hyperdisk_default                                           
+ └─ Hyperdisk provisioned storage (hyperdisk-extreme)    64  GB           $8.00
+ └─ Provisioned IOPS                                   2500  IOPS        $80.00  
+ 
  google_compute_disk.image_disk_size                                            
  └─ Standard provisioned storage (pd-standard)           30  GB           $1.20 
                                                                                 
@@ -12,6 +20,10 @@
                                                                                 
  google_compute_disk.size                                                       
  └─ Standard provisioned storage (pd-standard)           20  GB           $0.80 
+
+ google_compute_disk.size_iops                                                         
+ ├─ Hyperdisk provisioned storage (hyperdisk-extreme)   140  GB           $17.50 
+ └─ Provisioned IOPS                                  6,000  IOPS        $192.00 
                                                                                 
  google_compute_disk.snapshot_source_disk                                       
  └─ Standard provisioned storage (pd-standard)           20  GB           $0.80 
@@ -34,7 +46,7 @@
  google_compute_snapshot.snapshot_source_disk                                   
  └─ Storage                                              20  GB           $0.52 
                                                                                 
- OVERALL TOTAL                                                           $11.42 
+ OVERALL TOTAL                                                          $533.92 
 ──────────────────────────────────
-11 cloud resources were detected:
-∙ 11 were estimated, 4 of which include usage-based costs, see https://infracost.io/usage-file
+14 cloud resources were detected:
+∙ 14 were estimated, 4 of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.golden
@@ -17,10 +17,10 @@
  └─ Standard provisioned storage (pd-standard)           20  GB           $0.80 
                                                                                 
  google_compute_disk.ssd_default                                                
- └─ SSD provisioned storage (pd-ssd)                    100  GB          $17.00 
+ └─ SSD provisioned storage (pd-ssd)                     10  GB           $1.70 
                                                                                 
  google_compute_disk.standard_default                                           
- └─ Standard provisioned storage (pd-standard)          500  GB          $20.00 
+ └─ Standard provisioned storage (pd-standard)           10  GB           $0.40 
                                                                                 
  google_compute_image.image_disk_size                                           
  └─ Storage                                              30  GB           $1.50 
@@ -34,7 +34,7 @@
  google_compute_snapshot.snapshot_source_disk                                   
  └─ Storage                                              20  GB           $0.52 
                                                                                 
- OVERALL TOTAL                                                           $46.32 
+ OVERALL TOTAL                                                           $11.42 
 ──────────────────────────────────
 11 cloud resources were detected:
 ∙ 11 were estimated, 4 of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.tf
+++ b/internal/providers/terraform/google/testdata/compute_disk_test/compute_disk_test.tf
@@ -13,10 +13,27 @@ resource "google_compute_disk" "ssd_default" {
   type = "pd-ssd"
 }
 
+resource "google_compute_disk" "extreme_default" {
+  name = "extreme_default"
+  type = "pd-extreme"
+}
+
+resource "google_compute_disk" "hyperdisk_default" {
+  name = "hyperdisk_default"
+  type = "hyperdisk-extreme"
+}
+
 resource "google_compute_disk" "size" {
   name = "size"
   type = "pd-standard"
   size = 20
+}
+
+resource "google_compute_disk" "size_iops" {
+  name             = "size_iops"
+  type             = "hyperdisk-extreme"
+  size             = 140
+  provisioned_iops = 6000
 }
 
 resource "google_compute_image" "image_disk_size" {

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -257,7 +257,7 @@ func computeDiskCostComponent(region string, diskType string, diskSize float64, 
 
 	return &schema.CostComponent{
 		Name:            diskTypeLabel,
-		Unit:            "GB"
+		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: size,
 		ProductFilter: &schema.ProductFilter{
@@ -267,6 +267,36 @@ func computeDiskCostComponent(region string, diskType string, diskSize float64, 
 			ProductFamily: strPtr("Storage"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "description", ValueRegex: strPtr(diskTypeDesc)},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			EndUsageAmount: strPtr(""), // use the non-free tier
+		},
+	}
+}
+
+func computeDiskIOPSCostComponent(region string, diskType string, diskSize float64, instanceCount int64, iops int64) *schema.CostComponent {
+	var iopsTypeDesc string
+
+	switch diskType {
+	case "pd-extreme":
+		iopsTypeDesc = "/^Extreme PD IOPS/"
+	case "hyperdisk-extreme":
+		iopsTypeDesc = "/^Hyperdisk Extreme IOPS( in .*)?$/"
+	}
+
+	return &schema.CostComponent{
+		Name:            "Provisioned IOPS",
+		Unit:            "IOPS",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: decimalPtr(decimal.NewFromInt(iops)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("gcp"),
+			Region:        strPtr(region),
+			Service:       strPtr("Compute Engine"),
+			ProductFamily: strPtr("Storage"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "description", ValueRegex: strPtr(iopsTypeDesc)},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{

--- a/internal/resources/google/compute_cost_component_helpers.go
+++ b/internal/resources/google/compute_cost_component_helpers.go
@@ -245,13 +245,19 @@ func computeDiskCostComponent(region string, diskType string, diskSize float64, 
 	case "pd-ssd":
 		diskTypeDesc = "/^SSD backed PD Capacity/"
 		diskTypeLabel = "SSD provisioned storage (pd-ssd)"
+	case "pd-extreme":
+		diskTypeDesc = "/^Extreme PD Capacity/"
+		diskTypeLabel = "Extreme provisioned storage (pd-extreme)"
+	case "hyperdisk-extreme":
+		diskTypeDesc = "/^Hyperdisk Extreme Capacity( in .*)?$/"
+		diskTypeLabel = "Hyperdisk provisioned storage (hyperdisk-extreme)"
 	}
 
 	size := decimalPtr(decimal.NewFromInt(instanceCount).Mul(decimal.NewFromFloat(diskSize)))
 
 	return &schema.CostComponent{
 		Name:            diskTypeLabel,
-		Unit:            "GB",
+		Unit:            "GB"
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: size,
 		ProductFilter: &schema.ProductFilter{

--- a/internal/resources/google/compute_disk.go
+++ b/internal/resources/google/compute_disk.go
@@ -11,6 +11,9 @@ type ComputeDisk struct {
 	Region  string
 	Type    string
 	Size    float64
+
+	// applicable for pd-extreme and hyperdisk-extreme
+	IOPS int64
 }
 
 // ComputeDiskUsageSchema defines a list which represents the usage schema of ComputeDisk.
@@ -28,6 +31,10 @@ func (r *ComputeDisk) PopulateUsage(u *schema.UsageData) {
 func (r *ComputeDisk) BuildResource() *schema.Resource {
 	costComponents := []*schema.CostComponent{
 		computeDiskCostComponent(r.Region, r.Type, r.Size, 1),
+	}
+
+	if r.Type == "pd-extreme" || r.Type == "hyperdisk-extreme" {
+		costComponents = append(costComponents, computeDiskIOPSCostComponent(r.Region, r.Type, r.Size, 1, r.IOPS))
 	}
 
 	return &schema.Resource{


### PR DESCRIPTION
## Objective:

Add support for google_compute_disk - IOPS and pd-extreme and hyperdisk-extreme. Fixes #2403 #2066 .

## Pricing details:

[Pricing Reference](https://cloud.google.com/compute/all-pricing#disk) 
[Minimum Disk Size Capacity](https://cloud.google.com/compute/docs/disks)
The [gcp online calculator](https://cloud.google.com/products/calculator) is limited and does not differentiate between pd-extreme and hyperdisk-extreme... wrt minimum size and price per unit. 

## Status:

- [ ] Generated the resource files
- [X] Updated the internal/resources file
- [X] Updated the internal/provider/terraform/.../resources file
- [ ] Added usage parameters to infracost-usage-example.yml
- [X] Added test cases without usage-file
- [ ] Added test cases with usage-file
- [ ] Compared test case output to cloud cost calculator
- [ ] Created a PR to update "Supported Resources" in the [docs](<LINK TO DOCS PULL REQUEST>)

## Issues:

None