### PR TITLE
fix: support name as a global aws resource ref

### DIFF
--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -428,6 +428,10 @@ func SetUUIDAttributes(moduleBlock *Block, block *hcl.Block) {
 				body.Attributes["id"] = newUniqueAttribute("id", withCount, withEach)
 			}
 
+			if _, ok := body.Attributes["name"]; !ok {
+				body.Attributes["name"] = newUniqueAttribute("name", withCount, withEach)
+			}
+
 			if _, ok := body.Attributes["arn"]; !ok {
 				body.Attributes["arn"] = newArnAttribute("arn", withCount, withEach)
 			}

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -662,7 +662,7 @@ data "aws_ami" "my_ami" {
 locals {
   defaults = {
     platform = "linux"
-    ami = data.aws_ami.my_ami.*.name[0]
+    ami = data.aws_ami.my_ami.*.bad[0]
   }
 }
 

--- a/internal/providers/terraform/aws/aws.go
+++ b/internal/providers/terraform/aws/aws.go
@@ -3,9 +3,10 @@ package aws
 import (
 	"strings"
 
-	"github.com/infracost/infracost/internal/schema"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+
+	"github.com/infracost/infracost/internal/schema"
 )
 
 var DefaultProviderRegion = "us-east-1"
@@ -23,8 +24,7 @@ var arnAttributeMap = map[string]string{
 }
 
 func GetDefaultRefIDFunc(d *schema.ResourceData) []string {
-
-	defaultRefs := []string{d.Get("id").String()}
+	defaultRefs := []string{d.Get("id").String(), d.Get("name").String()}
 
 	arnAttr, ok := arnAttributeMap[d.Type]
 	if !ok {

--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.golden
@@ -43,6 +43,17 @@
     └─ ebs_block_device[1]                                                                         
        └─ Storage (general purpose SSD, gp3)                          20  GB                 $1.60 
                                                                                                    
+ aws_autoscaling_group.asg_lc_min_size_name_ref                                                    
+ └─ aws_launch_configuration.lc_basic                                                              
+    ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)           1,460  hours             $67.74 
+    ├─ EC2 detailed monitoring                                        14  metrics            $4.20 
+    ├─ root_block_device                                                                           
+    │  └─ Storage (general purpose SSD, gp2)                          20  GB                 $2.00 
+    ├─ ebs_block_device[0]                                                                         
+    │  └─ Storage (general purpose SSD, gp2)                          20  GB                 $2.00 
+    └─ ebs_block_device[1]                                                                         
+       └─ Storage (general purpose SSD, gp3)                          20  GB                 $1.60 
+                                                                                                   
  aws_autoscaling_group.asg_lc_min_size_zero                                                        
  └─ aws_launch_configuration.lc_basic                                                              
     ├─ Instance usage (Linux/UNIX, on-demand, t2.medium)             730  hours             $33.87 
@@ -173,10 +184,10 @@
     └─ block_device_mapping[0]                                                                     
        └─ Storage (general purpose SSD, gp2)                          10  GB                 $1.00 
                                                                                                    
- OVERALL TOTAL                                                                           $3,507.42 
+ OVERALL TOTAL                                                                           $3,584.96 
 ──────────────────────────────────
-52 cloud resources were detected:
-∙ 27 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+53 cloud resources were detected:
+∙ 28 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 23 were free:
   ∙ 12 x aws_launch_template
   ∙ 11 x aws_launch_configuration

--- a/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.tf
+++ b/internal/providers/terraform/aws/testdata/autoscaling_group_test/autoscaling_group_test.tf
@@ -42,6 +42,12 @@ resource "aws_autoscaling_group" "asg_lc_min_size" {
   min_size             = 2
 }
 
+resource "aws_autoscaling_group" "asg_lc_min_size_name_ref" {
+  launch_configuration = aws_launch_configuration.lc_basic.name
+  max_size             = 3
+  min_size             = 2
+}
+
 resource "aws_autoscaling_group" "asg_lc_min_size_zero" {
   launch_configuration = aws_launch_configuration.lc_basic.id
   max_size             = 3


### PR DESCRIPTION
This PR adds support to use `name` as a global resource reference. This resolves issues with resources that reference dependent resources with `name`. For example aws_autoscaling_group.launch_configuration:

```
resource "aws_autoscaling_group" "asg_lc_min_size_name_ref" {
  launch_configuration = aws_launch_configuration.lc_basic.name
  max_size             = 3
  min_size             = 2
}
```

Prior to this change `asg_lc_min_size_name_ref` would have blank references. I've decided to put move the `name` into the default resource ID func as I believe referencing a resource by `name` is probably quite a common pattern across a wide range of resources.