### PR TITLE
fix: support RDS gp3 volumes

### DIFF
--- a/internal/providers/terraform/aws/db_instance.go
+++ b/internal/providers/terraform/aws/db_instance.go
@@ -25,6 +25,13 @@ func NewDBInstance(d *schema.ResourceData) schema.CoreResource {
 		}
 	}
 
+	iops := d.Get("iops").Float()
+	defaultStorageType := "gp2"
+	if iops > 0 {
+		defaultStorageType = "io1"
+	}
+
+	storageType := d.GetStringOrDefault("storage_type", defaultStorageType)
 	r := &aws.DBInstance{
 		Address:                              d.Address,
 		Region:                               d.Get("region").String(),
@@ -33,8 +40,8 @@ func NewDBInstance(d *schema.ResourceData) schema.CoreResource {
 		MultiAZ:                              d.Get("multi_az").Bool(),
 		LicenseModel:                         d.Get("license_model").String(),
 		BackupRetentionPeriod:                d.Get("backup_retention_period").Int(),
-		IOPS:                                 d.Get("iops").Float(),
-		StorageType:                          d.Get("storage_type").String(),
+		IOPS:                                 iops,
+		StorageType:                          storageType,
 		PerformanceInsightsEnabled:           piEnabled,
 		PerformanceInsightsLongTermRetention: piLongTerm,
 	}

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
@@ -16,6 +16,24 @@
  ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
  └─ Additional backup storage                               Monthly cost depends on usage: $0.021 per GB            
                                                                                                                     
+ aws_db_instance.gp3["above_high_baseline"]                                                                         
+ ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                730  hours                         $23.36 
+ ├─ Storage (general purpose SSD, gp3)                                    400  GB                            $46.00 
+ └─ Provisioned GP3 IOPS (above 12,000)                                 2,000  IOPS                          $40.00 
+                                                                                                                    
+ aws_db_instance.gp3["above_low_baseline"]                                                                          
+ ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                730  hours                         $23.36 
+ ├─ Storage (general purpose SSD, gp3)                                     20  GB                             $2.30 
+ └─ Provisioned GP3 IOPS (above 3,000)                                  1,000  IOPS                          $20.00 
+                                                                                                                    
+ aws_db_instance.gp3["below_high_baseline"]                                                                         
+ ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                730  hours                         $23.36 
+ └─ Storage (general purpose SSD, gp3)                                    400  GB                            $46.00 
+                                                                                                                    
+ aws_db_instance.gp3["below_low_baseline"]                                                                          
+ ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                730  hours                         $23.36 
+ └─ Storage (general purpose SSD, gp3)                                     20  GB                             $2.30 
+                                                                                                                    
  aws_db_instance.mariadb                                                                                            
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
  ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
@@ -173,7 +191,7 @@
  ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
  └─ Additional backup storage                                           1,000  GB                            $95.00 
                                                                                                                     
- OVERALL TOTAL                                                                                            $7,541.23 
+ OVERALL TOTAL                                                                                            $7,791.27 
 ──────────────────────────────────
-37 cloud resources were detected:
-∙ 37 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+41 cloud resources were detected:
+∙ 41 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.tf
@@ -48,6 +48,33 @@ resource "aws_db_instance" "mysql-iops-below-min" {
   iops              = 500
 }
 
+resource "aws_db_instance" "gp3" {
+  for_each = {
+    "below_low_baseline" : {
+      storage : 20,
+      iops : 2000,
+    }
+    "above_low_baseline" : {
+      storage : 20,
+      iops : 4000,
+    }
+    "below_high_baseline" : {
+      storage : 400,
+      iops : 11000,
+    }
+    "above_high_baseline" : {
+      storage : 400,
+      iops : 14000,
+    }
+  }
+
+  engine            = "mysql"
+  instance_class    = "db.t4g.small"
+  storage_type      = "gp3"
+  allocated_storage = each.value.storage
+  iops              = each.value.iops
+}
+
 resource "aws_db_instance" "mysql-iops" {
   engine            = "mysql"
   instance_class    = "db.t3.large"


### PR DESCRIPTION
closes: https://github.com/infracost/infracost/issues/2284

Adds support for gp3 volumes and provisioned GP3 IOPS. These IOPS are only shown when above the stated baseline/threshold that aws provides for the DB size.