### PR TITLE
Add example Wolfi Dockerfiles

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,0 +1,57 @@
+FROM cgr.dev/chainguard/go:latest-dev as builder
+
+ARG ARCH=linux
+ARG DEFAULT_TERRAFORM_VERSION=0.15.5
+ARG TERRAGRUNT_VERSION=0.31.8
+
+# Set Environment Variables
+SHELL ["/bin/bash", "-c"]
+ENV HOME /app
+ENV CGO_ENABLED 0
+
+RUN apk add bash wget
+# Install latest of each Terraform version after 0.12 as we don't support versions before that
+RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.31 0.13.7 0.14.11 ${DEFAULT_TERRAFORM_VERSION} 1.0.2 1.0.10" && \
+    for VERSION in ${AVAILABLE_TERRAFORM_VERSIONS}; do \
+    wget -q https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_linux_amd64.zip && \
+    wget -q https://releases.hashicorp.com/terraform/${VERSION}/terraform_${VERSION}_SHA256SUMS && \
+    sed -n "/terraform_${VERSION}_linux_amd64.zip/p" terraform_${VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip terraform_${VERSION}_linux_amd64.zip -d /tmp && \
+    mv /tmp/terraform /usr/bin/terraform_${VERSION} && \
+    chmod +x /usr/bin/terraform_${VERSION} && \
+    rm terraform_${VERSION}_linux_amd64.zip && \
+    rm terraform_${VERSION}_SHA256SUMS; \
+    done && \
+    ln -s /usr/bin/terraform_0.12.31 /usr/bin/terraform_0.12 && \
+    ln -s /usr/bin/terraform_0.13.7 /usr/bin/terraform_0.13 && \
+    ln -s /usr/bin/terraform_0.14.11 /usr/bin/terraform_0.14 && \
+    ln -s /usr/bin/terraform_1.0.10 /usr/bin/terraform_1.0 && \
+    ln -s /usr/bin/terraform_${DEFAULT_TERRAFORM_VERSION} /usr/bin/terraform_0.15 && \
+    ln -s /usr/bin/terraform_${DEFAULT_TERRAFORM_VERSION} /usr/bin/terraform
+
+# Install Terragrunt
+RUN wget -q https://github.com/gruntwork-io/terragrunt/releases/download/v$TERRAGRUNT_VERSION/terragrunt_linux_amd64
+RUN mv terragrunt_linux_amd64 /usr/bin/terragrunt && \
+    chmod +x /usr/bin/terragrunt
+
+WORKDIR /app
+
+# Build Application
+COPY . .
+RUN make deps
+RUN NO_DIRTY=true make build
+RUN chmod +x /app/build/infracost
+
+# Application
+FROM cgr.dev/chainguard/wolfi-base as app
+# Tools needed for running diffs in CI integrations
+RUN apk --no-cache add ca-certificates openssl openssh-client curl git bash jq
+
+WORKDIR /root/
+# Scripts are used by CI integrations and other use-cases
+COPY scripts /scripts
+COPY --from=builder /usr/bin/terraform* /usr/bin/
+COPY --from=builder /usr/bin/terragrunt /usr/bin/
+COPY --from=builder /app/build/infracost /usr/bin/
+
+ENTRYPOINT [ "infracost" ]

--- a/Dockerfile.wolfi-ci
+++ b/Dockerfile.wolfi-ci
@@ -1,0 +1,37 @@
+FROM cgr.dev/chainguard/go as builder
+
+ARG ARCH=linux64
+
+# Set Environment Variables
+SHELL ["/bin/bash", "-c"]
+ENV HOME /app
+ENV CGO_ENABLED 0
+
+WORKDIR /app
+
+# Build Application
+COPY . .
+RUN make deps
+RUN NO_DIRTY=true make build
+RUN chmod +x /app/build/infracost
+
+# Application
+FROM cgr.dev/chainguard/wolfi-base as app
+# Tools needed for running diffs in CI integrations
+RUN apk --no-cache add bash curl git nodejs openssh-client jq
+
+# Install the latest compost version
+RUN npm install -g @infracost/compost
+
+WORKDIR /root/
+
+# Scripts are used by CI integrations and other use-cases
+COPY scripts/ci/comment.sh /scripts/ci/
+
+COPY --from=builder /app/build/infracost /usr/bin/
+
+ENV INFRACOST_CI_IMAGE=true
+ENV INFRACOST_SKIP_UPDATE_CHECK='true'
+ENV INFRACOST_LOG_LEVEL=info
+
+ENTRYPOINT ["infracost"]

--- a/Dockerfile.wolfi-latest
+++ b/Dockerfile.wolfi-latest
@@ -1,0 +1,23 @@
+FROM cgr.dev/chainguard/go:latest-dev as builder
+
+ENV HOME /app
+WORKDIR /app
+ENV CGO_ENABLED 0
+
+# Build Application
+COPY . .
+RUN make deps
+RUN NO_DIRTY=true make build
+RUN chmod +x /app/build/infracost
+
+# Application
+FROM cgr.dev/chainguard/wolfi-base as app
+# Tools needed for running diffs in CI integrations
+RUN apk --no-cache add ca-certificates openssl openssh-client curl git bash jq terraform terragrunt
+
+WORKDIR /root/
+# Scripts are used by CI integrations and other use-cases
+COPY scripts /scripts
+COPY --from=builder /app/build/infracost /usr/bin/
+
+ENTRYPOINT [ "infracost" ]


### PR DESCRIPTION
Hey, I think I owe you this from a while back.

Here's a PR with wolfi versions of the Dockerfiles. `Dockerfile.wolfi` is a straight port from the regular Dockerfile. `Dockerfile.wolfi-ci` is a straight port of `Dockerfile.ci`. You should find the wolfi images have less vulns, though there does seem to be a couple from the infracost libs ~~and also some from libssl (which seems to be an issue with our openssh-client package that I'm currently investigating).~~ (turns out the libssl vuln was my fault for building with a slightly old version of wolfi-base)

`Dockerfile.wolfi-latest` is a bit more interesting - it only includes the latest versions of terraform and terragrunt (I did notice the versions specified in the Dockerfile are pretty out-of-date). This cuts the image down to 220MB and probably works for the majority of your users - it might be worth offering as an alternative image?

Anyway, thought you might find it interesting!
