### PR TITLE
fix: price spot like preemptible, not on-demand (#2359)

### DIFF
--- a/internal/providers/terraform/google/container_cluster.go
+++ b/internal/providers/terraform/google/container_cluster.go
@@ -134,7 +134,7 @@ func newContainerNodeConfig(d gjson.Result) *google.ContainerNodeConfig {
 	}
 
 	purchaseOption := "on_demand"
-	if d.Get("preemptible").Bool() {
+	if d.Get("preemptible").Bool() || d.Get("spot").Bool() {
 		purchaseOption = "preemptible"
 	}
 

--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
@@ -1,118 +1,128 @@
 
- Name                                                        Monthly Qty  Unit   Monthly Cost 
-                                                                                              
- google_container_cluster.default_regional                                                    
- ├─ Cluster management fee                                           730  hours        $73.00 
- └─ default_pool                                                                              
-    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)           2,190  hours        $73.38 
-    └─ Standard provisioned storage (pd-standard)                    300  GB           $12.00 
-                                                                                              
- google_container_cluster.default_zonal                                                       
- ├─ Cluster management fee                                           730  hours        $73.00 
- └─ default_pool                                                                              
-    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)           6,570  hours       $220.13 
-    └─ Standard provisioned storage (pd-standard)                    900  GB           $36.00 
-                                                                                              
- google_container_cluster.node_locations_regional                                             
- ├─ Cluster management fee                                           730  hours        $73.00 
- └─ default_pool                                                                              
-    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)           4,380  hours       $146.76 
-    └─ Standard provisioned storage (pd-standard)                    600  GB           $24.00 
-                                                                                              
- google_container_cluster.node_locations_usage                                                
- ├─ Cluster management fee                                           730  hours        $73.00 
- └─ default_pool                                                                              
-    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)           4,380  hours       $146.76 
-    └─ Standard provisioned storage (pd-standard)                    600  GB           $24.00 
-                                                                                              
- google_container_cluster.node_locations_zonal                                                
- ├─ Cluster management fee                                           730  hours        $73.00 
- └─ default_pool                                                                              
-    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)           4,380  hours       $146.76 
-    └─ Standard provisioned storage (pd-standard)                    600  GB           $24.00 
-                                                                                              
- google_container_cluster.regional_usage                                                      
- ├─ Cluster management fee                                           730  hours        $73.00 
- └─ default_pool                                                                              
-    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)           6,570  hours       $220.13 
-    └─ Standard provisioned storage (pd-standard)                    900  GB           $36.00 
-                                                                                              
- google_container_cluster.zonal_usage                                                         
- ├─ Cluster management fee                                           730  hours        $73.00 
- └─ default_pool                                                                              
-    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)           2,190  hours        $73.38 
-    └─ Standard provisioned storage (pd-standard)                    300  GB           $12.00 
-                                                                                              
- google_container_node_pool.autoscaling_regional                                              
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              1,460  hours        $48.92 
- └─ Standard provisioned storage (pd-standard)                       200  GB            $8.00 
-                                                                                              
- google_container_node_pool.autoscaling_zonal                                                 
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              4,380  hours       $146.76 
- └─ Standard provisioned storage (pd-standard)                       600  GB           $24.00 
-                                                                                              
- google_container_node_pool.cluster_node_locations_regional                                   
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              2,920  hours        $97.84 
- └─ Standard provisioned storage (pd-standard)                       400  GB           $16.00 
-                                                                                              
- google_container_node_pool.cluster_node_locations_zonal                                      
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              2,920  hours        $97.84 
- └─ Standard provisioned storage (pd-standard)                       400  GB           $16.00 
-                                                                                              
- google_container_node_pool.default_regional                                                  
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              2,190  hours        $73.38 
- └─ Standard provisioned storage (pd-standard)                       300  GB           $12.00 
-                                                                                              
- google_container_node_pool.default_zonal                                                     
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              6,570  hours       $220.13 
- └─ Standard provisioned storage (pd-standard)                       900  GB           $36.00 
-                                                                                              
- google_container_node_pool.initial_node_count_regional                                       
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              2,920  hours        $97.84 
- └─ Standard provisioned storage (pd-standard)                       400  GB           $16.00 
-                                                                                              
- google_container_node_pool.initial_node_count_zonal                                          
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              8,760  hours       $293.51 
- └─ Standard provisioned storage (pd-standard)                     1,200  GB           $48.00 
-                                                                                              
- google_container_node_pool.node_locations_regional                                           
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              2,920  hours        $97.84 
- └─ Standard provisioned storage (pd-standard)                       400  GB           $16.00 
-                                                                                              
- google_container_node_pool.node_locations_usage                                              
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              5,840  hours       $195.67 
- └─ Standard provisioned storage (pd-standard)                       800  GB           $32.00 
-                                                                                              
- google_container_node_pool.node_locations_zonal                                              
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              2,920  hours        $97.84 
- └─ Standard provisioned storage (pd-standard)                       400  GB           $16.00 
-                                                                                              
- google_container_node_pool.regional_usage                                                    
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              8,760  hours       $293.51 
- └─ Standard provisioned storage (pd-standard)                     1,200  GB           $48.00 
-                                                                                              
- google_container_node_pool.with_custom_instance                                              
- ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 6 vCPUs)        2,190  hours       $305.13 
- ├─ Custom Instance RAM (Linux/UNIX, on-demand, N1 20 GB)          2,190  hours       $136.31 
- └─ Standard provisioned storage (pd-standard)                       300  GB           $12.00 
-                                                                                              
- google_container_node_pool.with_guest_accelerator_a100                                       
- ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)         2,190  hours     $1,165.07 
- ├─ SSD provisioned storage (pd-ssd)                                 360  GB           $61.20 
- ├─ Local SSD provisioned storage                                  1,125  GB           $90.00 
- └─ NVIDIA Tesla A100 (on-demand)                                  8,760  hours    $17,990.72 
-                                                                                              
- google_container_node_pool.with_node_config_regional                                         
- ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)         2,190  hours     $1,165.07 
- ├─ SSD provisioned storage (pd-ssd)                                 360  GB           $61.20 
- ├─ Local SSD provisioned storage                                  1,125  GB           $90.00 
- └─ NVIDIA Tesla K80 (on-demand)                                   8,760  hours     $2,759.40 
-                                                                                              
- google_container_node_pool.zonal_usage                                                       
- ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)              2,920  hours        $97.84 
- └─ Standard provisioned storage (pd-standard)                       400  GB           $16.00 
-                                                                                              
- OVERALL TOTAL                                                                     $27,705.30 
+ Name                                                          Monthly Qty  Unit   Monthly Cost 
+                                                                                                
+ google_container_cluster.default_regional                                                      
+ ├─ Cluster management fee                                             730  hours        $73.00 
+ └─ default_pool                                                                                
+    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)             2,190  hours        $73.38 
+    └─ Standard provisioned storage (pd-standard)                      300  GB           $12.00 
+                                                                                                
+ google_container_cluster.default_zonal                                                         
+ ├─ Cluster management fee                                             730  hours        $73.00 
+ └─ default_pool                                                                                
+    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)             6,570  hours       $220.13 
+    └─ Standard provisioned storage (pd-standard)                      900  GB           $36.00 
+                                                                                                
+ google_container_cluster.node_locations_regional                                               
+ ├─ Cluster management fee                                             730  hours        $73.00 
+ └─ default_pool                                                                                
+    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)             4,380  hours       $146.76 
+    └─ Standard provisioned storage (pd-standard)                      600  GB           $24.00 
+                                                                                                
+ google_container_cluster.node_locations_usage                                                  
+ ├─ Cluster management fee                                             730  hours        $73.00 
+ └─ default_pool                                                                                
+    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)             4,380  hours       $146.76 
+    └─ Standard provisioned storage (pd-standard)                      600  GB           $24.00 
+                                                                                                
+ google_container_cluster.node_locations_zonal                                                  
+ ├─ Cluster management fee                                             730  hours        $73.00 
+ └─ default_pool                                                                                
+    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)             4,380  hours       $146.76 
+    └─ Standard provisioned storage (pd-standard)                      600  GB           $24.00 
+                                                                                                
+ google_container_cluster.regional_usage                                                        
+ ├─ Cluster management fee                                             730  hours        $73.00 
+ └─ default_pool                                                                                
+    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)             6,570  hours       $220.13 
+    └─ Standard provisioned storage (pd-standard)                      900  GB           $36.00 
+                                                                                                
+ google_container_cluster.zonal_usage                                                           
+ ├─ Cluster management fee                                             730  hours        $73.00 
+ └─ default_pool                                                                                
+    ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)             2,190  hours        $73.38 
+    └─ Standard provisioned storage (pd-standard)                      300  GB           $12.00 
+                                                                                                
+ google_container_node_pool.autoscaling_regional                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                1,460  hours        $48.92 
+ └─ Standard provisioned storage (pd-standard)                         200  GB            $8.00 
+                                                                                                
+ google_container_node_pool.autoscaling_zonal                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                4,380  hours       $146.76 
+ └─ Standard provisioned storage (pd-standard)                         600  GB           $24.00 
+                                                                                                
+ google_container_node_pool.cluster_node_locations_regional                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                2,920  hours        $97.84 
+ └─ Standard provisioned storage (pd-standard)                         400  GB           $16.00 
+                                                                                                
+ google_container_node_pool.cluster_node_locations_zonal                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                2,920  hours        $97.84 
+ └─ Standard provisioned storage (pd-standard)                         400  GB           $16.00 
+                                                                                                
+ google_container_node_pool.default_regional                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                2,190  hours        $73.38 
+ └─ Standard provisioned storage (pd-standard)                         300  GB           $12.00 
+                                                                                                
+ google_container_node_pool.default_zonal                                                       
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                6,570  hours       $220.13 
+ └─ Standard provisioned storage (pd-standard)                         900  GB           $36.00 
+                                                                                                
+ google_container_node_pool.initial_node_count_regional                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                2,920  hours        $97.84 
+ └─ Standard provisioned storage (pd-standard)                         400  GB           $16.00 
+                                                                                                
+ google_container_node_pool.initial_node_count_zonal                                            
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                8,760  hours       $293.51 
+ └─ Standard provisioned storage (pd-standard)                       1,200  GB           $48.00 
+                                                                                                
+ google_container_node_pool.node_locations_regional                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                2,920  hours        $97.84 
+ └─ Standard provisioned storage (pd-standard)                         400  GB           $16.00 
+                                                                                                
+ google_container_node_pool.node_locations_usage                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                5,840  hours       $195.67 
+ └─ Standard provisioned storage (pd-standard)                         800  GB           $32.00 
+                                                                                                
+ google_container_node_pool.node_locations_zonal                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                2,920  hours        $97.84 
+ └─ Standard provisioned storage (pd-standard)                         400  GB           $16.00 
+                                                                                                
+ google_container_node_pool.regional_usage                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                8,760  hours       $293.51 
+ └─ Standard provisioned storage (pd-standard)                       1,200  GB           $48.00 
+                                                                                                
+ google_container_node_pool.with_custom_instance                                                
+ ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 6 vCPUs)          2,190  hours       $305.13 
+ ├─ Custom Instance RAM (Linux/UNIX, on-demand, N1 20 GB)            2,190  hours       $136.31 
+ └─ Standard provisioned storage (pd-standard)                         300  GB           $12.00 
+                                                                                                
+ google_container_node_pool.with_guest_accelerator_a100                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)           2,190  hours     $1,165.07 
+ ├─ SSD provisioned storage (pd-ssd)                                   360  GB           $61.20 
+ ├─ Local SSD provisioned storage                                    1,125  GB           $90.00 
+ └─ NVIDIA Tesla A100 (on-demand)                                    8,760  hours    $17,990.72 
+                                                                                                
+ google_container_node_pool.with_node_config_regional                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)           2,190  hours     $1,165.07 
+ ├─ SSD provisioned storage (pd-ssd)                                   360  GB           $61.20 
+ ├─ Local SSD provisioned storage                                    1,125  GB           $90.00 
+ └─ NVIDIA Tesla K80 (on-demand)                                     8,760  hours     $2,759.40 
+                                                                                                
+ google_container_node_pool.with_preemptible_instance                                           
+ ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours        $91.72 
+ ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $41.17 
+ └─ Standard provisioned storage (pd-standard)                         300  GB           $12.00 
+                                                                                                
+ google_container_node_pool.with_spot_instance                                                  
+ ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours        $91.72 
+ ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $41.17 
+ └─ Standard provisioned storage (pd-standard)                         300  GB           $12.00 
+                                                                                                
+ google_container_node_pool.zonal_usage                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                2,920  hours        $97.84 
+ └─ Standard provisioned storage (pd-standard)                         400  GB           $16.00 
+                                                                                                
+ OVERALL TOTAL                                                                       $27,995.08 
 ──────────────────────────────────
-23 cloud resources were detected:
-∙ 23 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+25 cloud resources were detected:
+∙ 25 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.tf
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.tf
@@ -51,6 +51,30 @@ resource "google_container_node_pool" "with_custom_instance" {
   }
 }
 
+resource "google_container_node_pool" "with_preemptible_instance" {
+  name       = "with-preemptible-instance"
+  cluster    = google_container_cluster.default_regional.id
+  node_count = 3
+
+  node_config {
+    machine_type = "n1-custom-6-20480"
+    preemptible  = true
+  }
+
+}
+
+resource "google_container_node_pool" "with_spot_instance" {
+  name       = "with-preemptible-instance"
+  cluster    = google_container_cluster.default_regional.id
+  node_count = 3
+
+  node_config {
+    machine_type = "n1-custom-6-20480"
+    spot         = true
+  }
+
+}
+
 resource "google_container_node_pool" "with_guest_accelerator_a100" {
   name       = "with-a100"
   cluster    = google_container_cluster.default_regional.id


### PR DESCRIPTION
This is a fix of #2359 for the spot instance pools in GKE, which are now priced like on-demand instances, while they should be priced like the preemptible instances.