### PR TITLE
fix: `INFRACOST_LOG_LEVEL` overriding `--log-level` flag

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -149,6 +148,7 @@ func newRootCmd(ctx *config.RunContext) *cobra.Command {
 			}
 
 			loadCloudSettings(ctx)
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -312,25 +312,10 @@ func loadGlobalFlags(ctx *config.RunContext, cmd *cobra.Command) error {
 	if ctx.IsCIRun() {
 		ctx.Config.NoColor = true
 	}
-	if cmd.Flags().Changed("no-color") {
-		ctx.Config.NoColor, _ = cmd.Flags().GetBool("no-color")
-	}
-	color.NoColor = ctx.Config.NoColor
 
-	if cmd.Flags().Changed("log-level") {
-		ctx.Config.LogLevel, _ = cmd.Flags().GetString("log-level")
-		err := logging.ConfigureBaseLogger(ctx.Config)
-		if err != nil {
-			return err
-		}
-	}
-
-	if cmd.Flags().Changed("debug-report") {
-		ctx.Config.DebugReport, _ = cmd.Flags().GetBool("debug-report")
-		err := logging.ConfigureBaseLogger(ctx.Config)
-		if err != nil {
-			return err
-		}
+	err := ctx.Config.LoadGlobalFlags(cmd)
+	if err != nil {
+		return err
 	}
 
 	ctx.SetContextValue("dashboardEnabled", ctx.Config.EnableDashboard)

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -757,7 +757,7 @@ func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {
 
 	if hasConfigFile {
 		cfgFilePath, _ := cmd.Flags().GetString("config-file")
-		err := cfg.LoadFromConfigFile(cfgFilePath)
+		err := cfg.LoadFromConfigFile(cfgFilePath, cmd)
 
 		if err != nil {
 			return err

--- a/cmd/infracost/scan.go
+++ b/cmd/infracost/scan.go
@@ -66,7 +66,7 @@ func (s scanCmd) loadRunFlags(cfg *config.Config) error {
 	}
 
 	if s.ConfigFile != "" {
-		err := cfg.LoadFromConfigFile(s.ConfigFile)
+		err := cfg.LoadFromConfigFile(s.ConfigFile, s.cmd)
 		if err != nil {
 			return err
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,7 +123,7 @@ projects:
 				}()
 			}
 
-			err = c.LoadFromConfigFile(path)
+			err = c.LoadFromConfigFile(path, &cobra.Command{})
 
 			require.Equal(t, tt.error, err)
 			require.EqualValues(t, tt.expected, c.Projects)


### PR DESCRIPTION
When a config file was used, the `INFRACOST_LOG_LEVEL` env var was overriding the `--log-level` flag. The flag should have precendence over the env var.