### PR TITLE
fix: ignore duplicate variable diagnostics when loading var files

### DIFF
--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -466,9 +466,16 @@ func (p *Parser) loadVarFile(filename string) (map[string]cty.Value, error) {
 
 	variableFile, diags := parseFunc(filename)
 	if diags.HasErrors() {
-		p.logger.WithError(errors.New(diags.Error())).Debugf("could not parse supplied var file %s", filename)
+		// Check the diagnostics aren't all just Attribute Errors.
+		// We can safely ignore these Attribute errors and continue to get the raw attributes.
+		// The first value for the variable will be used.
+		if areDiagnosticsAttributeErrors(diags) {
+			p.logger.WithError(errors.New(diags.Error())).Debugf("duplicate variables detected parsing file %s, using the first values defined", filename)
+		} else {
+			p.logger.WithError(errors.New(diags.Error())).Debugf("could not parse supplied var file %s", filename)
 
-		return inputVars, nil
+			return inputVars, nil
+		}
 	}
 
 	attrs, _ := variableFile.Body.JustAttributes()
@@ -486,6 +493,16 @@ func (p *Parser) loadVarFile(filename string) (map[string]cty.Value, error) {
 
 	p.logger.WithFields(fields).Debugf("adding input vars from file %s", filename)
 	return inputVars, nil
+}
+
+func areDiagnosticsAttributeErrors(diags hcl.Diagnostics) bool {
+	for _, diag := range diags {
+		if diag.Summary != "Attribute redefined" {
+			return false
+		}
+	}
+
+	return true
 }
 
 type file struct {

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -176,6 +176,9 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 			},
 			warnings: []hcl.WarningCode{hcl.WarningMissingVars},
 		},
+		{
+			name: "shows correct duplicate variable warning",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/providers/terraform/testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/expected.json
@@ -1,0 +1,146 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.1.0",
+  "prior_state": {
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_instance.web_app",
+            "mode": "managed",
+            "type": "aws_instance",
+            "name": "web_app",
+            "schema_version": 0,
+            "values": {
+              "ami": "ami-674cbc1e",
+              "ebs_block_device": [
+                {
+                  "device_name": "my_data",
+                  "iops": 800,
+                  "volume_size": 1000,
+                  "volume_type": "io1"
+                }
+              ],
+              "instance_type": "m5.4xlarge",
+              "root_block_device": [
+                {
+                  "volume_size": 50
+                }
+              ]
+            },
+            "infracost_metadata": {
+              "calls": [
+                {
+                  "filename": "testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/main.tf",
+                  "blockName": "aws_instance.web_app"
+                }
+              ],
+              "filename": "testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/main.tf"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web_app",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web_app",
+          "schema_version": 0,
+          "values": {
+            "ami": "ami-674cbc1e",
+            "ebs_block_device": [
+              {
+                "device_name": "my_data",
+                "iops": 800,
+                "volume_size": 1000,
+                "volume_type": "io1"
+              }
+            ],
+            "instance_type": "m5.4xlarge",
+            "root_block_device": [
+              {
+                "volume_size": 50
+              }
+            ]
+          },
+          "infracost_metadata": {
+            "calls": [
+              {
+                "filename": "testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/main.tf",
+                "blockName": "aws_instance.web_app"
+              }
+            ],
+            "filename": "testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/main.tf"
+          }
+        }
+      ]
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_instance.web_app",
+          "mode": "managed",
+          "type": "aws_instance",
+          "name": "web_app",
+          "provider_config_key": "aws",
+          "expressions": {
+            "instance_type": {
+              "references": [
+                "var.instance_type"
+              ]
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  },
+  "infracost_resource_changes": [
+    {
+      "address": "aws_instance.web_app",
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "web_app",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "ami": "ami-674cbc1e",
+          "ebs_block_device": [
+            {
+              "device_name": "my_data",
+              "iops": 800,
+              "volume_size": 1000,
+              "volume_type": "io1"
+            }
+          ],
+          "instance_type": "m5.4xlarge",
+          "root_block_device": [
+            {
+              "volume_size": 50
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+variable "instance_type" {
+
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/terraform.tfvars
+++ b/internal/providers/terraform/testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/terraform.tfvars
@@ -1,0 +1,2 @@
+instance_type = "m5.4xlarge"
+instance_type = "m5.4xlarge"


### PR DESCRIPTION
Changes terraform var file loader to ignore the Attribute Redefined errors and continue to load the var file.