### PR TITLE
feat: add support for AKS Windows node pools

### DIFF
--- a/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
+++ b/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
@@ -55,7 +55,23 @@ func aksClusterNodePool(name, region string, n gjson.Result, nodeCount decimal.D
 		monthlyHours = u.GetFloat("monthly_hrs")
 	}
 
-	costComponents = append(costComponents, linuxVirtualMachineCostComponent(region, instanceType, monthlyHours))
+	os := "Linux"
+	if n.Get("os_type").Type != gjson.Null {
+		os = n.Get("os_type").String()
+	}
+
+	if n.Get("os_sku").Type != gjson.Null {
+		if strings.HasPrefix(strings.ToLower(n.Get("os_sku").String()), "windows") {
+			os = "Windows"
+		}
+	}
+
+	if strings.EqualFold(os, "windows") {
+		costComponents = append(costComponents, windowsVirtualMachineCostComponent(region, instanceType, "None", monthlyHours))
+	} else {
+		costComponents = append(costComponents, linuxVirtualMachineCostComponent(region, instanceType, monthlyHours))
+	}
+
 	mainResource.CostComponents = costComponents
 	schema.MultiplyQuantities(mainResource, nodeCount)
 

--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -67,7 +67,7 @@ func linuxVirtualMachineCostComponent(region string, instanceType string, monthl
 	}
 
 	return &schema.CostComponent{
-		Name:            fmt.Sprintf("Instance usage (%s, %s)", purchaseOptionLabel, instanceType),
+		Name:            fmt.Sprintf("Instance usage (Linux, %s, %s)", purchaseOptionLabel, instanceType),
 		Unit:            "hours",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: decimalPtr(qty),

--- a/internal/providers/terraform/azure/testdata/image_test/image_test.golden
+++ b/internal/providers/terraform/azure/testdata/image_test/image_test.golden
@@ -1,73 +1,73 @@
 
- Name                                                       Monthly Qty  Unit                      Monthly Cost 
-                                                                                                                
- azurerm_image.disk["data"]                                                                                     
- └─ Storage                                                          60  GB                               $3.00 
-                                                                                                                
- azurerm_image.disk["managed"]                                                                                  
- └─ Storage                                                         140  GB                               $7.00 
-                                                                                                                
- azurerm_image.disk["spec"]                                                                                     
- └─ Storage                                                          30  GB                               $1.50 
-                                                                                                                
- azurerm_image.vm["data_disk"]                                                                                  
- └─ Storage                                                         158  GB                               $7.90 
-                                                                                                                
- azurerm_image.vm["md"]                                                                                         
- └─ Storage                                                         128  GB                               $6.40 
-                                                                                                                
- azurerm_image.vm["premium"]                                                                                    
- └─ Storage                                                         128  GB                               $6.40 
-                                                                                                                
- azurerm_image.vm["standard"]                                                                                   
- └─ Storage                                                         128  GB                               $6.40 
-                                                                                                                
- azurerm_image.vm_usage["data_disk"]                                                                            
- └─ Storage                                                         300  GB                              $15.00 
-                                                                                                                
- azurerm_image.vm_usage["md"]                                                                                   
- └─ Storage                                                         300  GB                              $15.00 
-                                                                                                                
- azurerm_image.vm_usage["premium"]                                                                              
- └─ Storage                                                         300  GB                              $15.00 
-                                                                                                                
- azurerm_image.vm_usage["standard"]                                                                             
- └─ Storage                                                         300  GB                              $15.00 
-                                                                                                                
- azurerm_managed_disk.example                                                                                   
- ├─ Storage (S10, LRS)                                                1  months                           $5.89 
- └─ Disk operations                                  Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                                
- azurerm_virtual_machine.example["data_disk"]                                                                   
- ├─ Instance usage (pay as you go, Standard_DS1_v2)                 730  hours                           $49.57 
- ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $5.69 per vCPU              
- ├─ storage_os_disk                                                                                             
- │  └─ Storage (P4, LRS)                                              1  months                           $5.81 
- ├─ storage_data_disk                                                                                           
- │  └─ Storage (P4, LRS)                                              1  months                           $5.81 
- └─ storage_data_disk                                                                                           
-    └─ Storage (P1, LRS)                                              1  months                           $0.78 
-                                                                                                                
- azurerm_virtual_machine.example["md"]                                                                          
- ├─ Instance usage (pay as you go, Standard_DS1_v2)                 730  hours                           $49.57 
- ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $5.69 per vCPU              
- └─ storage_os_disk                                                                                             
-    └─ Storage (P4, LRS)                                              1  months                           $5.81 
-                                                                                                                
- azurerm_virtual_machine.example["premium"]                                                                     
- ├─ Instance usage (pay as you go, Standard_DS1_v2)                 730  hours                           $49.57 
- ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $5.69 per vCPU              
- └─ storage_os_disk                                                                                             
-    └─ Storage (P4, LRS)                                              1  months                           $5.81 
-                                                                                                                
- azurerm_virtual_machine.example["standard"]                                                                    
- ├─ Instance usage (pay as you go, Standard_D1_v2)                  730  hours                           $49.57 
- ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $5.69 per vCPU              
- └─ storage_os_disk                                                                                             
-    ├─ Storage (E4, LRS)                                              1  months                           $2.40 
-    └─ Disk operations                               Monthly cost depends on usage: $0.002 per 10k operations   
-                                                                                                                
- OVERALL TOTAL                                                                                          $329.16 
+ Name                                                              Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                       
+ azurerm_image.disk["data"]                                                                                            
+ └─ Storage                                                                 60  GB                               $3.00 
+                                                                                                                       
+ azurerm_image.disk["managed"]                                                                                         
+ └─ Storage                                                                140  GB                               $7.00 
+                                                                                                                       
+ azurerm_image.disk["spec"]                                                                                            
+ └─ Storage                                                                 30  GB                               $1.50 
+                                                                                                                       
+ azurerm_image.vm["data_disk"]                                                                                         
+ └─ Storage                                                                158  GB                               $7.90 
+                                                                                                                       
+ azurerm_image.vm["md"]                                                                                                
+ └─ Storage                                                                128  GB                               $6.40 
+                                                                                                                       
+ azurerm_image.vm["premium"]                                                                                           
+ └─ Storage                                                                128  GB                               $6.40 
+                                                                                                                       
+ azurerm_image.vm["standard"]                                                                                          
+ └─ Storage                                                                128  GB                               $6.40 
+                                                                                                                       
+ azurerm_image.vm_usage["data_disk"]                                                                                   
+ └─ Storage                                                                300  GB                              $15.00 
+                                                                                                                       
+ azurerm_image.vm_usage["md"]                                                                                          
+ └─ Storage                                                                300  GB                              $15.00 
+                                                                                                                       
+ azurerm_image.vm_usage["premium"]                                                                                     
+ └─ Storage                                                                300  GB                              $15.00 
+                                                                                                                       
+ azurerm_image.vm_usage["standard"]                                                                                    
+ └─ Storage                                                                300  GB                              $15.00 
+                                                                                                                       
+ azurerm_managed_disk.example                                                                                          
+ ├─ Storage (S10, LRS)                                                       1  months                           $5.89 
+ └─ Disk operations                                         Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                       
+ azurerm_virtual_machine.example["data_disk"]                                                                          
+ ├─ Instance usage (Linux, pay as you go, Standard_DS1_v2)                 730  hours                           $49.57 
+ ├─ Ultra disk reservation (if unattached)                  Monthly cost depends on usage: $5.69 per vCPU              
+ ├─ storage_os_disk                                                                                                    
+ │  └─ Storage (P4, LRS)                                                     1  months                           $5.81 
+ ├─ storage_data_disk                                                                                                  
+ │  └─ Storage (P4, LRS)                                                     1  months                           $5.81 
+ └─ storage_data_disk                                                                                                  
+    └─ Storage (P1, LRS)                                                     1  months                           $0.78 
+                                                                                                                       
+ azurerm_virtual_machine.example["md"]                                                                                 
+ ├─ Instance usage (Linux, pay as you go, Standard_DS1_v2)                 730  hours                           $49.57 
+ ├─ Ultra disk reservation (if unattached)                  Monthly cost depends on usage: $5.69 per vCPU              
+ └─ storage_os_disk                                                                                                    
+    └─ Storage (P4, LRS)                                                     1  months                           $5.81 
+                                                                                                                       
+ azurerm_virtual_machine.example["premium"]                                                                            
+ ├─ Instance usage (Linux, pay as you go, Standard_DS1_v2)                 730  hours                           $49.57 
+ ├─ Ultra disk reservation (if unattached)                  Monthly cost depends on usage: $5.69 per vCPU              
+ └─ storage_os_disk                                                                                                    
+    └─ Storage (P4, LRS)                                                     1  months                           $5.81 
+                                                                                                                       
+ azurerm_virtual_machine.example["standard"]                                                                           
+ ├─ Instance usage (Linux, pay as you go, Standard_D1_v2)                  730  hours                           $49.57 
+ ├─ Ultra disk reservation (if unattached)                  Monthly cost depends on usage: $5.69 per vCPU              
+ └─ storage_os_disk                                                                                                    
+    ├─ Storage (E4, LRS)                                                     1  months                           $2.40 
+    └─ Disk operations                                      Monthly cost depends on usage: $0.002 per 10k operations   
+                                                                                                                       
+ OVERALL TOTAL                                                                                                 $329.16 
 ──────────────────────────────────
 20 cloud resources were detected:
 ∙ 16 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
@@ -3,45 +3,55 @@
                                                                                                            
  azurerm_kubernetes_cluster.example                                                                        
  └─ default_node_pool                                                                                      
-    ├─ Instance usage (pay as you go, Standard_D2_v2)                            730  hours        $106.58 
+    ├─ Instance usage (Linux, pay as you go, Standard_D2_v2)                     730  hours        $106.58 
     └─ os_disk                                                                                             
        └─ Storage (P10, LRS)                                                       1  months        $19.71 
                                                                                                            
  azurerm_kubernetes_cluster_node_pool.Standard_DS2_v2                                                      
- └─ Instance usage (pay as you go, Standard_DS2_v2)                            1,460  hours        $213.16 
+ └─ Instance usage (Linux, pay as you go, Standard_DS2_v2)                     1,460  hours        $213.16 
                                                                                                            
  azurerm_kubernetes_cluster_node_pool.basic_A2                                                             
- ├─ Instance usage (pay as you go, Basic_A2)                                     730  hours         $57.67 
+ ├─ Instance usage (Linux, pay as you go, Basic_A2)                              730  hours         $57.67 
  └─ os_disk                                                                                                
     └─ Storage (P10, LRS)                                                          1  months        $19.71 
                                                                                                            
  azurerm_kubernetes_cluster_node_pool.example                                                              
- ├─ Instance usage (pay as you go, Standard_DS2_v2)                              730  hours        $106.58 
+ ├─ Instance usage (Linux, pay as you go, Standard_DS2_v2)                       730  hours        $106.58 
  └─ os_disk                                                                                                
     └─ Storage (P10, LRS)                                                          1  months        $19.71 
                                                                                                            
  azurerm_kubernetes_cluster_node_pool.usage_basic_A2                                                       
- ├─ Instance usage (pay as you go, Basic_A2)                                     900  hours         $71.10 
+ ├─ Instance usage (Linux, pay as you go, Basic_A2)                              900  hours         $71.10 
  └─ os_disk                                                                                                
     └─ Storage (P10, LRS)                                                          2  months        $39.42 
                                                                                                            
- azurerm_kubernetes_cluster_node_pool.with_min_count                                                       
- └─ Instance usage (pay as you go, Standard_DS2_v2)                            1,460  hours        $213.16 
-                                                                                                           
- azurerm_kubernetes_cluster_node_pool.zero_min_count_default_node_count                                    
- ├─ Instance usage (pay as you go, Standard_DS2_v2)                              730  hours        $106.58 
+ azurerm_kubernetes_cluster_node_pool.windows                                                              
+ ├─ Instance usage (Windows, pay as you go, Basic_A2)                            730  hours         $97.09 
  └─ os_disk                                                                                                
     └─ Storage (P10, LRS)                                                          1  months        $19.71 
                                                                                                            
- OVERALL TOTAL                                                                                     $993.09 
+ azurerm_kubernetes_cluster_node_pool.windows_sku                                                          
+ ├─ Instance usage (Windows, pay as you go, Standard_DS2_v2)                     730  hours        $183.96 
+ └─ os_disk                                                                                                
+    └─ Storage (P10, LRS)                                                          1  months        $19.71 
+                                                                                                           
+ azurerm_kubernetes_cluster_node_pool.with_min_count                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_DS2_v2)                     1,460  hours        $213.16 
+                                                                                                           
+ azurerm_kubernetes_cluster_node_pool.zero_min_count_default_node_count                                    
+ ├─ Instance usage (Linux, pay as you go, Standard_DS2_v2)                       730  hours        $106.58 
+ └─ os_disk                                                                                                
+    └─ Storage (P10, LRS)                                                          1  months        $19.71 
+                                                                                                           
+ OVERALL TOTAL                                                                                   $1,313.56 
 ──────────────────────────────────
-8 cloud resources were detected:
-∙ 7 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+10 cloud resources were detected:
+∙ 9 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestAzureRMKubernetesClusterNodePoolGoldenFile     ┃ $993         ┃
+┃ TestAzureRMKubernetesClusterNodePoolGoldenFile     ┃ $1,314       ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
@@ -66,3 +66,18 @@ resource "azurerm_kubernetes_cluster_node_pool" "zero_min_count_default_node_cou
   min_count             = 0
   max_count             = 3
 }
+
+resource "azurerm_kubernetes_cluster_node_pool" "windows" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
+  vm_size               = "Basic_A2"
+  os_type               = "Windows"
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "windows_sku" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
+  vm_size               = "Standard_DS2_v2"
+  os_sku                = "Windows2022"
+}
+

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
@@ -1,51 +1,58 @@
 
- Name                                                   Monthly Qty  Unit    Monthly Cost 
-                                                                                          
- azurerm_kubernetes_cluster.free_D2V2                                                     
- └─ default_node_pool                                                                     
-    ├─ Instance usage (pay as you go, Standard_D2_v2)           730  hours        $106.58 
-    └─ os_disk                                                                            
-       └─ Storage (P10, LRS)                                      1  months        $19.71 
-                                                                                          
- azurerm_kubernetes_cluster.min_count                                                     
- ├─ Uptime SLA                                                  730  hours         $73.00 
- └─ default_node_pool                                                                     
-    ├─ Instance usage (pay as you go, Standard_DS2_v2)        2,190  hours        $319.74 
-    └─ os_disk                                                                            
-       └─ Storage (P10, LRS)                                      3  months        $59.13 
-                                                                                          
- azurerm_kubernetes_cluster.paid_5nc_32gb                                                 
- ├─ Uptime SLA                                                  730  hours         $73.00 
- └─ default_node_pool                                                                     
-    ├─ Instance usage (pay as you go, Standard_D2_v2)         3,650  hours        $532.90 
-    └─ os_disk                                                                            
-       └─ Storage (P4, LRS)                                       5  months        $26.40 
-                                                                                          
- azurerm_kubernetes_cluster.paid_D2SV2_3nc_128gb                                          
- ├─ Uptime SLA                                                  730  hours         $73.00 
- └─ default_node_pool                                                                     
-    ├─ Instance usage (pay as you go, Standard_DS2_v2)        2,190  hours        $319.74 
-    └─ os_disk                                                                            
-       └─ Storage (P10, LRS)                                      3  months        $59.13 
-                                                                                          
- azurerm_kubernetes_cluster.usage_ephemeral                                               
- ├─ Uptime SLA                                                  730  hours         $73.00 
- ├─ default_node_pool                                                                     
- │  └─ Instance usage (pay as you go, Standard_D2_v2)           900  hours        $131.40 
- ├─ Load Balancer                                                                         
- │  └─ Data processed                                           100  GB             $0.50 
- └─ DNS                                                                                   
-    └─ Hosted zone                                                1  months         $0.50 
-                                                                                          
- OVERALL TOTAL                                                                  $1,867.73 
+ Name                                                           Monthly Qty  Unit    Monthly Cost 
+                                                                                                  
+ azurerm_kubernetes_cluster.free_D2V2                                                             
+ └─ default_node_pool                                                                             
+    ├─ Instance usage (Linux, pay as you go, Standard_D2_v2)            730  hours        $106.58 
+    └─ os_disk                                                                                    
+       └─ Storage (P10, LRS)                                              1  months        $19.71 
+                                                                                                  
+ azurerm_kubernetes_cluster.min_count                                                             
+ ├─ Uptime SLA                                                          730  hours         $73.00 
+ └─ default_node_pool                                                                             
+    ├─ Instance usage (Linux, pay as you go, Standard_DS2_v2)         2,190  hours        $319.74 
+    └─ os_disk                                                                                    
+       └─ Storage (P10, LRS)                                              3  months        $59.13 
+                                                                                                  
+ azurerm_kubernetes_cluster.paid_5nc_32gb                                                         
+ ├─ Uptime SLA                                                          730  hours         $73.00 
+ └─ default_node_pool                                                                             
+    ├─ Instance usage (Linux, pay as you go, Standard_D2_v2)          3,650  hours        $532.90 
+    └─ os_disk                                                                                    
+       └─ Storage (P4, LRS)                                               5  months        $26.40 
+                                                                                                  
+ azurerm_kubernetes_cluster.paid_D2SV2_3nc_128gb                                                  
+ ├─ Uptime SLA                                                          730  hours         $73.00 
+ └─ default_node_pool                                                                             
+    ├─ Instance usage (Linux, pay as you go, Standard_DS2_v2)         2,190  hours        $319.74 
+    └─ os_disk                                                                                    
+       └─ Storage (P10, LRS)                                              3  months        $59.13 
+                                                                                                  
+ azurerm_kubernetes_cluster.usage_ephemeral                                                       
+ ├─ Uptime SLA                                                          730  hours         $73.00 
+ ├─ default_node_pool                                                                             
+ │  └─ Instance usage (Linux, pay as you go, Standard_D2_v2)            900  hours        $131.40 
+ ├─ Load Balancer                                                                                 
+ │  └─ Data processed                                                   100  GB             $0.50 
+ └─ DNS                                                                                           
+    └─ Hosted zone                                                        1  months         $0.50 
+                                                                                                  
+ azurerm_kubernetes_cluster.windows                                                               
+ ├─ Uptime SLA                                                          730  hours         $73.00 
+ └─ default_node_pool                                                                             
+    ├─ Instance usage (Windows, pay as you go, Standard_D2_v2)        3,650  hours        $919.80 
+    └─ os_disk                                                                                    
+       └─ Storage (P4, LRS)                                               5  months        $26.40 
+                                                                                                  
+ OVERALL TOTAL                                                                          $2,886.93 
 ──────────────────────────────────
-6 cloud resources were detected:
-∙ 5 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+7 cloud resources were detected:
+∙ 6 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestAzureRMKubernetesClusterGoldenFile             ┃ $1,868       ┃
+┃ TestAzureRMKubernetesClusterGoldenFile             ┃ $2,887       ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.tf
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.tf
@@ -105,3 +105,23 @@ resource "azurerm_kubernetes_cluster" "usage_ephemeral" {
   }
 }
 
+resource "azurerm_kubernetes_cluster" "windows" {
+  name                = "example-aks1"
+  location            = "eastus"
+  resource_group_name = azurerm_resource_group.example.name
+  dns_prefix          = "exampleaks1"
+  sku_tier            = "Standard"
+
+  default_node_pool {
+    name            = "default"
+    node_count      = 5
+    vm_size         = "Standard_D2_v2"
+    os_disk_size_gb = 32
+    os_sku          = "Windows2022"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_scale_set_test/linux_virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_scale_set_test/linux_virtual_machine_scale_set_test.golden
@@ -2,13 +2,13 @@
  Name                                                           Monthly Qty  Unit                      Monthly Cost 
                                                                                                                     
  azurerm_linux_virtual_machine_scale_set.basic_a2                                                                   
- ├─ Instance usage (pay as you go, Basic_A2)                          2,190  hours                          $173.01 
+ ├─ Instance usage (Linux, pay as you go, Basic_A2)                   2,190  hours                          $173.01 
  └─ os_disk                                                                                                         
     ├─ Storage (S4, LRS)                                                  3  months                           $4.61 
     └─ Disk operations                                   Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                     
  azurerm_linux_virtual_machine_scale_set.basic_a2_usage                                                             
- ├─ Instance usage (pay as you go, Basic_A2)                          2,920  hours                          $230.68 
+ ├─ Instance usage (Linux, pay as you go, Basic_A2)                   2,920  hours                          $230.68 
  └─ os_disk                                                                                                         
     ├─ Storage (S4, LRS)                                                  4  months                           $6.14 
     └─ Disk operations                                   Monthly cost depends on usage: $0.0005 per 10k operations  

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
@@ -2,49 +2,49 @@
  Name                                                             Monthly Qty  Unit                      Monthly Cost 
                                                                                                                       
  azurerm_linux_virtual_machine.basic_a2                                                                               
- ├─ Instance usage (pay as you go, Basic_A2)                              730  hours                           $57.67 
+ ├─ Instance usage (Linux, pay as you go, Basic_A2)                       730  hours                           $57.67 
  └─ os_disk                                                                                                           
     ├─ Storage (S4, LRS)                                                    1  months                           $1.54 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
  azurerm_linux_virtual_machine.basic_b1                                                                               
- ├─ Instance usage (pay as you go, Standard_B1s)                          730  hours                            $7.59 
+ ├─ Instance usage (Linux, pay as you go, Standard_B1s)                   730  hours                            $7.59 
  └─ os_disk                                                                                                           
     ├─ Storage (S4, LRS)                                                    1  months                           $1.54 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
  azurerm_linux_virtual_machine.basic_b1_lowercase                                                                     
- ├─ Instance usage (pay as you go, standard_b1s)                          730  hours                            $7.59 
+ ├─ Instance usage (Linux, pay as you go, standard_b1s)                   730  hours                            $7.59 
  └─ os_disk                                                                                                           
     ├─ Storage (S4, LRS)                                                    1  months                           $1.54 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
  azurerm_linux_virtual_machine.basic_b1_withMonthlyHours                                                              
- ├─ Instance usage (pay as you go, Standard_B1s)                          100  hours                            $1.04 
+ ├─ Instance usage (Linux, pay as you go, Standard_B1s)                   100  hours                            $1.04 
  └─ os_disk                                                                                                           
     ├─ Storage (S4, LRS)                                                    1  months                           $1.54 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
  azurerm_linux_virtual_machine.standard_a2_ultra_enabled                                                              
- ├─ Instance usage (pay as you go, Standard_A2_v2)                        730  hours                           $66.43 
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                 730  hours                           $66.43 
  ├─ Ultra disk reservation (if unattached)                 Monthly cost depends on usage: $4.38 per vCPU              
  └─ os_disk                                                                                                           
     ├─ Storage (E4, LRS)                                                    1  months                           $2.40 
     └─ Disk operations                                     Monthly cost depends on usage: $0.002 per 10k operations   
                                                                                                                       
  azurerm_linux_virtual_machine.standard_a2_v2_custom_disk                                                             
- ├─ Instance usage (pay as you go, Standard_A2_v2)                        730  hours                           $66.43 
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                 730  hours                           $66.43 
  └─ os_disk                                                                                                           
     ├─ Storage (E30, LRS)                                                   1  months                          $76.80 
     └─ Disk operations                                                      2  10k operations                   $0.00 
                                                                                                                       
  azurerm_linux_virtual_machine.standard_f2_lowercase                                                                  
- ├─ Instance usage (pay as you go, standard_f2)                           730  hours                           $72.27 
+ ├─ Instance usage (Linux, pay as you go, standard_f2)                    730  hours                           $72.27 
  └─ os_disk                                                                                                           
     └─ Storage (P4, LRS)                                                    1  months                           $5.28 
                                                                                                                       
  azurerm_linux_virtual_machine.standard_f2_premium_disk                                                               
- ├─ Instance usage (pay as you go, Standard_F2)                           730  hours                           $72.27 
+ ├─ Instance usage (Linux, pay as you go, Standard_F2)                    730  hours                           $72.27 
  └─ os_disk                                                                                                           
     └─ Storage (P4, LRS)                                                    1  months                           $5.28 
                                                                                                                       

--- a/internal/providers/terraform/azure/testdata/recovery_services_vault_test/recovery_services_vault_test.golden
+++ b/internal/providers/terraform/azure/testdata/recovery_services_vault_test/recovery_services_vault_test.golden
@@ -170,7 +170,7 @@
     └─ ZRS data stored                                                                               400  GB                              $11.20 
                                                                                                                                                  
  azurerm_virtual_machine.large                                                                                                                   
- ├─ Instance usage (pay as you go, Standard_F2)                                                      730  hours                           $83.22 
+ ├─ Instance usage (Linux, pay as you go, Standard_F2)                                               730  hours                           $83.22 
  ├─ Ultra disk reservation (if unattached)                                            Monthly cost depends on usage: $5.69 per vCPU              
  ├─ storage_os_disk                                                                                                                              
  │  ├─ Storage (S4, LRS)                                                                               1  months                           $1.54 
@@ -183,7 +183,7 @@
     └─ Disk operations                                                                Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                                                  
  azurerm_virtual_machine.medium                                                                                                                  
- ├─ Instance usage (pay as you go, Standard_F2)                                                      730  hours                           $83.22 
+ ├─ Instance usage (Linux, pay as you go, Standard_F2)                                               730  hours                           $83.22 
  ├─ Ultra disk reservation (if unattached)                                            Monthly cost depends on usage: $5.69 per vCPU              
  ├─ storage_os_disk                                                                                                                              
  │  ├─ Storage (S4, LRS)                                                                               1  months                           $1.54 
@@ -193,7 +193,7 @@
     └─ Disk operations                                                                Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                                                  
  azurerm_virtual_machine.small                                                                                                                   
- ├─ Instance usage (pay as you go, Standard_F2)                                                      730  hours                           $83.22 
+ ├─ Instance usage (Linux, pay as you go, Standard_F2)                                               730  hours                           $83.22 
  ├─ Ultra disk reservation (if unattached)                                            Monthly cost depends on usage: $5.69 per vCPU              
  ├─ storage_os_disk                                                                                                                              
  │  ├─ Storage (S4, LRS)                                                                               1  months                           $1.54 

--- a/internal/providers/terraform/azure/testdata/virtual_machine_scale_set_test/virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_scale_set_test/virtual_machine_scale_set_test.golden
@@ -1,31 +1,31 @@
 
- Name                                                    Monthly Qty  Unit                      Monthly Cost 
-                                                                                                             
- azurerm_virtual_machine_scale_set.linux                                                                     
- ├─ Instance usage (pay as you go, Standard_F2)                1,460  hours                          $166.44 
- ├─ storage_os_disk                                                                                          
- │  ├─ Storage (S4, LRS)                                           1  months                           $1.54 
- │  └─ Disk operations                            Monthly cost depends on usage: $0.0005 per 10k operations  
- ├─ storage_data_disk                                                                                        
- │  ├─ Storage (E4, LRS)                                           1  months                           $2.40 
- │  └─ Disk operations                            Monthly cost depends on usage: $0.002 per 10k operations   
- └─ storage_data_disk                                                                                        
-    ├─ Storage (S4, LRS)                                           1  months                           $1.54 
-    └─ Disk operations                            Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                             
- azurerm_virtual_machine_scale_set.windows                                                                   
- ├─ Instance usage (hybrid benefit, Standard_F2)               2,190  hours                          $249.66 
- ├─ storage_os_disk                                                                                          
- │  ├─ Storage (S4, LRS)                                           1  months                           $1.54 
- │  └─ Disk operations                                           100  10k operations                   $0.05 
- ├─ storage_data_disk                                                                                        
- │  ├─ Storage (E4, LRS)                                           1  months                           $2.40 
- │  └─ Disk operations                                           200  10k operations                   $0.40 
- └─ storage_data_disk                                                                                        
-    ├─ Storage (S4, LRS)                                           1  months                           $1.54 
-    └─ Disk operations                                           200  10k operations                   $0.10 
-                                                                                                             
- OVERALL TOTAL                                                                                       $427.59 
+ Name                                                             Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                      
+ azurerm_virtual_machine_scale_set.linux                                                                              
+ ├─ Instance usage (Linux, pay as you go, Standard_F2)                  1,460  hours                          $166.44 
+ ├─ storage_os_disk                                                                                                   
+ │  ├─ Storage (S4, LRS)                                                    1  months                           $1.54 
+ │  └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
+ ├─ storage_data_disk                                                                                                 
+ │  ├─ Storage (E4, LRS)                                                    1  months                           $2.40 
+ │  └─ Disk operations                                     Monthly cost depends on usage: $0.002 per 10k operations   
+ └─ storage_data_disk                                                                                                 
+    ├─ Storage (S4, LRS)                                                    1  months                           $1.54 
+    └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                      
+ azurerm_virtual_machine_scale_set.windows                                                                            
+ ├─ Instance usage (Windows, hybrid benefit, Standard_F2)               2,190  hours                          $249.66 
+ ├─ storage_os_disk                                                                                                   
+ │  ├─ Storage (S4, LRS)                                                    1  months                           $1.54 
+ │  └─ Disk operations                                                    100  10k operations                   $0.05 
+ ├─ storage_data_disk                                                                                                 
+ │  ├─ Storage (E4, LRS)                                                    1  months                           $2.40 
+ │  └─ Disk operations                                                    200  10k operations                   $0.40 
+ └─ storage_data_disk                                                                                                 
+    ├─ Storage (S4, LRS)                                                    1  months                           $1.54 
+    └─ Disk operations                                                    200  10k operations                   $0.10 
+                                                                                                                      
+ OVERALL TOTAL                                                                                                $427.59 
 ──────────────────────────────────
 5 cloud resources were detected:
 ∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
@@ -1,47 +1,47 @@
 
- Name                                                       Monthly Qty  Unit                      Monthly Cost 
-                                                                                                                
- azurerm_virtual_machine.linux                                                                                  
- ├─ Instance usage (pay as you go, Standard_DS1_v2)                 730  hours                           $53.29 
- ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $4.38 per vCPU              
- └─ storage_os_disk                                                                                             
-    ├─ Storage (S4, LRS)                                              1  months                           $1.54 
-    └─ Disk operations                               Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                                
- azurerm_virtual_machine.linux_withMonthlyHours                                                                 
- ├─ Instance usage (pay as you go, Standard_DS1_v2)                 100  hours                            $7.30 
- ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $4.38 per vCPU              
- └─ storage_os_disk                                                                                             
-    ├─ Storage (S4, LRS)                                              1  months                           $1.54 
-    └─ Disk operations                               Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                                
- azurerm_virtual_machine.windows                                                                                
- ├─ Instance usage (pay as you go, Standard_DS1_v2)                 730  hours                           $91.98 
- ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $4.38 per vCPU              
- ├─ storage_os_disk                                                                                             
- │  ├─ Storage (S4, LRS)                                              1  months                           $1.54 
- │  └─ Disk operations                                              100  10k operations                   $0.05 
- ├─ storage_data_disk                                                                                           
- │  ├─ Storage (S4, LRS)                                              1  months                           $1.54 
- │  └─ Disk operations                                              200  10k operations                   $0.10 
- ├─ storage_data_disk                                                                                           
- │  ├─ Storage (E4, LRS)                                              1  months                           $2.40 
- │  └─ Disk operations                                              200  10k operations                   $0.40 
- ├─ storage_data_disk                                                                                           
- │  └─ Storage (P4, LRS)                                              1  months                           $5.28 
- └─ storage_data_disk                                                                                           
-    ├─ Storage (ultra, 1024 GiB)                                  1,024  GiB                            $122.59 
-    ├─ Provisioned IOPS                                           2,048  IOPS                           $101.66 
-    └─ Throughput                                                     8  MB/s                             $2.80 
-                                                                                                                
- azurerm_virtual_machine.windows_withMonthlyHours                                                               
- ├─ Instance usage (pay as you go, Standard_DS1_v2)                 100  hours                           $12.60 
- ├─ Ultra disk reservation (if unattached)           Monthly cost depends on usage: $4.38 per vCPU              
- └─ storage_os_disk                                                                                             
-    ├─ Storage (S4, LRS)                                              1  months                           $1.54 
-    └─ Disk operations                               Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                                
- OVERALL TOTAL                                                                                          $408.13 
+ Name                                                                Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                         
+ azurerm_virtual_machine.linux                                                                                           
+ ├─ Instance usage (Linux, pay as you go, Standard_DS1_v2)                   730  hours                           $53.29 
+ ├─ Ultra disk reservation (if unattached)                    Monthly cost depends on usage: $4.38 per vCPU              
+ └─ storage_os_disk                                                                                                      
+    ├─ Storage (S4, LRS)                                                       1  months                           $1.54 
+    └─ Disk operations                                        Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                         
+ azurerm_virtual_machine.linux_withMonthlyHours                                                                          
+ ├─ Instance usage (Linux, pay as you go, Standard_DS1_v2)                   100  hours                            $7.30 
+ ├─ Ultra disk reservation (if unattached)                    Monthly cost depends on usage: $4.38 per vCPU              
+ └─ storage_os_disk                                                                                                      
+    ├─ Storage (S4, LRS)                                                       1  months                           $1.54 
+    └─ Disk operations                                        Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                         
+ azurerm_virtual_machine.windows                                                                                         
+ ├─ Instance usage (Windows, pay as you go, Standard_DS1_v2)                 730  hours                           $91.98 
+ ├─ Ultra disk reservation (if unattached)                    Monthly cost depends on usage: $4.38 per vCPU              
+ ├─ storage_os_disk                                                                                                      
+ │  ├─ Storage (S4, LRS)                                                       1  months                           $1.54 
+ │  └─ Disk operations                                                       100  10k operations                   $0.05 
+ ├─ storage_data_disk                                                                                                    
+ │  ├─ Storage (S4, LRS)                                                       1  months                           $1.54 
+ │  └─ Disk operations                                                       200  10k operations                   $0.10 
+ ├─ storage_data_disk                                                                                                    
+ │  ├─ Storage (E4, LRS)                                                       1  months                           $2.40 
+ │  └─ Disk operations                                                       200  10k operations                   $0.40 
+ ├─ storage_data_disk                                                                                                    
+ │  └─ Storage (P4, LRS)                                                       1  months                           $5.28 
+ └─ storage_data_disk                                                                                                    
+    ├─ Storage (ultra, 1024 GiB)                                           1,024  GiB                            $122.59 
+    ├─ Provisioned IOPS                                                    2,048  IOPS                           $101.66 
+    └─ Throughput                                                              8  MB/s                             $2.80 
+                                                                                                                         
+ azurerm_virtual_machine.windows_withMonthlyHours                                                                        
+ ├─ Instance usage (Windows, pay as you go, Standard_DS1_v2)                 100  hours                           $12.60 
+ ├─ Ultra disk reservation (if unattached)                    Monthly cost depends on usage: $4.38 per vCPU              
+ └─ storage_os_disk                                                                                                      
+    ├─ Storage (S4, LRS)                                                       1  months                           $1.54 
+    └─ Disk operations                                        Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                         
+ OVERALL TOTAL                                                                                                   $408.13 
 ──────────────────────────────────
 8 cloud resources were detected:
 ∙ 4 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_scale_set_test/windows_virtual_machine_scale_set_test.golden
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_scale_set_test/windows_virtual_machine_scale_set_test.golden
@@ -2,13 +2,13 @@
  Name                                                             Monthly Qty  Unit                      Monthly Cost 
                                                                                                                       
  azurerm_windows_virtual_machine_scale_set.basic_a2                                                                   
- ├─ Instance usage (pay as you go, Basic_A2)                            2,190  hours                          $291.27 
+ ├─ Instance usage (Windows, pay as you go, Basic_A2)                   2,190  hours                          $291.27 
  └─ os_disk                                                                                                           
     ├─ Storage (S4, LRS)                                                    3  months                           $4.61 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
  azurerm_windows_virtual_machine_scale_set.basic_a2_usage                                                             
- ├─ Instance usage (pay as you go, Basic_A2)                            2,920  hours                          $388.36 
+ ├─ Instance usage (Windows, pay as you go, Basic_A2)                   2,920  hours                          $388.36 
  └─ os_disk                                                                                                           
     ├─ Storage (S4, LRS)                                                    4  months                           $6.14 
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  

--- a/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/windows_virtual_machine_test/windows_virtual_machine_test.golden
@@ -1,49 +1,49 @@
 
- Name                                                                  Monthly Qty  Unit                      Monthly Cost 
-                                                                                                                           
- azurerm_windows_virtual_machine.Standard_E16-8as_v4                                                                       
- ├─ Instance usage (pay as you go, Standard_E16-8as_v4)                        730  hours                        $1,273.12 
- └─ os_disk                                                                                                                
-    ├─ Storage (S4, LRS)                                                         1  months                           $1.54 
-    └─ Disk operations                                          Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                                           
- azurerm_windows_virtual_machine.basic_a2                                                                                  
- ├─ Instance usage (pay as you go, Basic_A2)                                   730  hours                           $97.09 
- └─ os_disk                                                                                                                
-    ├─ Storage (S4, LRS)                                                         1  months                           $1.54 
-    └─ Disk operations                                          Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                                           
- azurerm_windows_virtual_machine.basic_a2_withMonthlyHours                                                                 
- ├─ Instance usage (pay as you go, Basic_A2)                                   100  hours                           $13.30 
- └─ os_disk                                                                                                                
-    ├─ Storage (S4, LRS)                                                         1  months                           $1.54 
-    └─ Disk operations                                          Monthly cost depends on usage: $0.0005 per 10k operations  
-                                                                                                                           
- azurerm_windows_virtual_machine.standard_a2_ultra_enabled                                                                 
- ├─ Instance usage (pay as you go, Standard_A2_v2)                             730  hours                           $99.28 
- ├─ Ultra disk reservation (if unattached)                      Monthly cost depends on usage: $4.38 per vCPU              
- └─ os_disk                                                                                                                
-    ├─ Storage (E4, LRS)                                                         1  months                           $2.40 
-    └─ Disk operations                                          Monthly cost depends on usage: $0.002 per 10k operations   
-                                                                                                                           
- azurerm_windows_virtual_machine.standard_a2_v2_custom_disk                                                                
- ├─ Instance usage (pay as you go, Standard_A2_v2)                             730  hours                           $99.28 
- └─ os_disk                                                                                                                
-    ├─ Storage (E30, LRS)                                                        1  months                          $76.80 
-    └─ Disk operations                                                           2  10k operations                   $0.00 
-                                                                                                                           
- azurerm_windows_virtual_machine.standard_d2_v4_hybrid_benefit                                                             
- ├─ Instance usage (hybrid benefit, Standard_D2_v4)                            730  hours                           $70.08 
- └─ os_disk                                                                                                                
-    ├─ Storage (E30, LRS)                                                        1  months                          $76.80 
-    └─ Disk operations                                          Monthly cost depends on usage: $0.002 per 10k operations   
-                                                                                                                           
- azurerm_windows_virtual_machine.standard_f2_premium_disk                                                                  
- ├─ Instance usage (pay as you go, Standard_F2)                                730  hours                          $140.16 
- └─ os_disk                                                                                                                
-    └─ Storage (P4, LRS)                                                         1  months                           $5.28 
-                                                                                                                           
- OVERALL TOTAL                                                                                                   $1,958.20 
+ Name                                                                    Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                             
+ azurerm_windows_virtual_machine.Standard_E16-8as_v4                                                                         
+ ├─ Instance usage (Windows, pay as you go, Standard_E16-8as_v4)                 730  hours                        $1,273.12 
+ └─ os_disk                                                                                                                  
+    ├─ Storage (S4, LRS)                                                           1  months                           $1.54 
+    └─ Disk operations                                            Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                             
+ azurerm_windows_virtual_machine.basic_a2                                                                                    
+ ├─ Instance usage (Windows, pay as you go, Basic_A2)                            730  hours                           $97.09 
+ └─ os_disk                                                                                                                  
+    ├─ Storage (S4, LRS)                                                           1  months                           $1.54 
+    └─ Disk operations                                            Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                             
+ azurerm_windows_virtual_machine.basic_a2_withMonthlyHours                                                                   
+ ├─ Instance usage (Windows, pay as you go, Basic_A2)                            100  hours                           $13.30 
+ └─ os_disk                                                                                                                  
+    ├─ Storage (S4, LRS)                                                           1  months                           $1.54 
+    └─ Disk operations                                            Monthly cost depends on usage: $0.0005 per 10k operations  
+                                                                                                                             
+ azurerm_windows_virtual_machine.standard_a2_ultra_enabled                                                                   
+ ├─ Instance usage (Windows, pay as you go, Standard_A2_v2)                      730  hours                           $99.28 
+ ├─ Ultra disk reservation (if unattached)                        Monthly cost depends on usage: $4.38 per vCPU              
+ └─ os_disk                                                                                                                  
+    ├─ Storage (E4, LRS)                                                           1  months                           $2.40 
+    └─ Disk operations                                            Monthly cost depends on usage: $0.002 per 10k operations   
+                                                                                                                             
+ azurerm_windows_virtual_machine.standard_a2_v2_custom_disk                                                                  
+ ├─ Instance usage (Windows, pay as you go, Standard_A2_v2)                      730  hours                           $99.28 
+ └─ os_disk                                                                                                                  
+    ├─ Storage (E30, LRS)                                                          1  months                          $76.80 
+    └─ Disk operations                                                             2  10k operations                   $0.00 
+                                                                                                                             
+ azurerm_windows_virtual_machine.standard_d2_v4_hybrid_benefit                                                               
+ ├─ Instance usage (Windows, hybrid benefit, Standard_D2_v4)                     730  hours                           $70.08 
+ └─ os_disk                                                                                                                  
+    ├─ Storage (E30, LRS)                                                          1  months                          $76.80 
+    └─ Disk operations                                            Monthly cost depends on usage: $0.002 per 10k operations   
+                                                                                                                             
+ azurerm_windows_virtual_machine.standard_f2_premium_disk                                                                    
+ ├─ Instance usage (Windows, pay as you go, Standard_F2)                         730  hours                          $140.16 
+ └─ os_disk                                                                                                                  
+    └─ Storage (P4, LRS)                                                           1  months                           $5.28 
+                                                                                                                             
+ OVERALL TOTAL                                                                                                     $1,958.20 
 ──────────────────────────────────
 7 cloud resources were detected:
 ∙ 7 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/azure/windows_virtual_machine.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine.go
@@ -72,7 +72,7 @@ func windowsVirtualMachineCostComponent(region string, instanceType string, lice
 	}
 
 	return &schema.CostComponent{
-		Name:            fmt.Sprintf("Instance usage (%s, %s)", purchaseOptionLabel, instanceType),
+		Name:            fmt.Sprintf("Instance usage (Windows, %s, %s)", purchaseOptionLabel, instanceType),
 		Unit:            "hours",
 		UnitMultiplier:  decimal.NewFromInt(1),
 		MonthlyQuantity: decimalPtr(qty),


### PR DESCRIPTION
This also adds `Windows` or `Linux` into the cost component name across all Azure compute resources, consistent with what we do with AWS.

Fixes https://github.com/infracost/infracost/issues/2416