### PR TITLE
fix: fix panic when a child block is a resource block without labels

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -459,11 +459,11 @@ func (e *Evaluator) expandBlockForEaches(blocks Blocks) Blocks {
 		}
 
 		if block.IsCountExpanded() || !block.IsForEachReferencedExpanded(blocks) || !shouldExpandBlock(block) {
-			parent := block.parent.GetAttribute("for_each")
-			if !parent.HasChanged() {
+			original := block.original.GetAttribute("for_each")
+			if !original.HasChanged() {
 				expanded = append(expanded, block)
 			} else {
-				haveChanged[block.parent.FullName()] = block.parent
+				haveChanged[block.original.FullName()] = block.original
 			}
 
 			continue
@@ -546,11 +546,11 @@ func (e *Evaluator) expandBlockCounts(blocks Blocks) Blocks {
 		}
 
 		if block.IsCountExpanded() || !shouldExpandBlock(block) {
-			parent := block.parent.GetAttribute("count")
-			if !parent.HasChanged() {
+			original := block.original.GetAttribute("count")
+			if !original.HasChanged() {
 				expanded = append(expanded, block)
 			} else {
-				haveChanged[block.parent.FullName()] = block.parent
+				haveChanged[block.original.FullName()] = block.original
 			}
 
 			continue

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -378,7 +378,7 @@ func (p *Parser) parseDirectoryFiles(files []file) (Blocks, error) {
 		for _, fileBlock := range fileBlocks {
 			blocks = append(
 				blocks,
-				p.blockBuilder.NewBlock(file.path, p.initialPath, fileBlock, nil, nil),
+				p.blockBuilder.NewBlock(file.path, p.initialPath, fileBlock, nil, nil, nil),
 			)
 		}
 	}


### PR DESCRIPTION
e.g:
```hcl
resource "type" "name" {
  resource {}
}
```