### PR TITLE
fix: avoid possible nil logger when calculating block name

### DIFF
--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -626,6 +626,10 @@ type ModuleMetadata struct {
 }
 
 func (b *Block) setLogger(logger *logrus.Entry) {
+	// Use the provided logger as is initially so we avoid a nil pointer in the case where we need to log
+	// an error while calculating b.FullName().
+	b.logger = logger
+
 	blockLogger := logger.WithFields(logrus.Fields{
 		"block_name": b.FullName(),
 	})


### PR DESCRIPTION
From sentry: 
```
runtime error: invalid memory address or nil pointer dereference
"stacktrace": 
"1: running [Created by terraform.(*HCLProvider).Modules @ hcl_provider.go:339]
   :24                                                             Stack()
   :289                                                            (*Parser).ParseDirectory.func1()
   :884                                                            panic()
   :126                                                            (*Entry).WithFields()
   :121                                                            (*Entry).WithField()
   :107                                                            (*Entry).WithError()
   :980                                                            (*Block).Reference()
   :991                                                            (*Block).LocalName()
   :1015                                                           (*Block).FullName()
   :628                                                            (*Block).setLogger()
   :303                                                            BlockBuilder.NewBlock()
   :284                                                            BlockBuilder.NewBlock()
   :284                                                            BlockBuilder.NewBlock()
```