### PR TITLE
updated check for OS disks provisioned for AKS #2407

### DIFF
--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
@@ -5,7 +5,7 @@
  └─ default_node_pool                                                                                      
     ├─ Instance usage (Linux, pay as you go, Standard_D2_v2)                     730  hours        $106.58 
     └─ os_disk                                                                                             
-       └─ Storage (P10, LRS)                                                       1  months        $19.71 
+       └─ Storage (S10, LRS)                                                       1  months         $5.89 
                                                                                                            
  azurerm_kubernetes_cluster_node_pool.Standard_DS2_v2                                                      
  └─ Instance usage (Linux, pay as you go, Standard_DS2_v2)                     1,460  hours        $213.16 
@@ -13,22 +13,27 @@
  azurerm_kubernetes_cluster_node_pool.basic_A2                                                             
  ├─ Instance usage (Linux, pay as you go, Basic_A2)                              730  hours         $57.67 
  └─ os_disk                                                                                                
-    └─ Storage (P10, LRS)                                                          1  months        $19.71 
+    └─ Storage (S10, LRS)                                                          1  months         $5.89 
                                                                                                            
  azurerm_kubernetes_cluster_node_pool.example                                                              
  ├─ Instance usage (Linux, pay as you go, Standard_DS2_v2)                       730  hours        $106.58 
  └─ os_disk                                                                                                
     └─ Storage (P10, LRS)                                                          1  months        $19.71 
                                                                                                            
+ azurerm_kubernetes_cluster_node_pool.non_premium                                                          
+ ├─ Instance usage (Linux, pay as you go, Standard_D2_v3)                        730  hours         $70.08 
+ └─ os_disk                                                                                                
+    └─ Storage (S10, LRS)                                                          1  months         $5.89 
+                                                                                                           
  azurerm_kubernetes_cluster_node_pool.usage_basic_A2                                                       
  ├─ Instance usage (Linux, pay as you go, Basic_A2)                              900  hours         $71.10 
  └─ os_disk                                                                                                
-    └─ Storage (P10, LRS)                                                          2  months        $39.42 
+    └─ Storage (S10, LRS)                                                          2  months        $11.78 
                                                                                                            
  azurerm_kubernetes_cluster_node_pool.windows                                                              
  ├─ Instance usage (Windows, pay as you go, Basic_A2)                            730  hours         $97.09 
  └─ os_disk                                                                                                
-    └─ Storage (P10, LRS)                                                          1  months        $19.71 
+    └─ Storage (S10, LRS)                                                          1  months         $5.89 
                                                                                                            
  azurerm_kubernetes_cluster_node_pool.windows_sku                                                          
  ├─ Instance usage (Windows, pay as you go, Standard_DS2_v2)                     730  hours        $183.96 
@@ -43,15 +48,15 @@
  └─ os_disk                                                                                                
     └─ Storage (P10, LRS)                                                          1  months        $19.71 
                                                                                                            
- OVERALL TOTAL                                                                                   $1,313.56 
+ OVERALL TOTAL                                                                                   $1,320.42 
 ──────────────────────────────────
-10 cloud resources were detected:
-∙ 9 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+11 cloud resources were detected:
+∙ 10 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestAzureRMKubernetesClusterNodePoolGoldenFile     ┃ $1,314       ┃
+┃ TestAzureRMKubernetesClusterNodePoolGoldenFile     ┃ $1,320       ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
@@ -81,3 +81,8 @@ resource "azurerm_kubernetes_cluster_node_pool" "windows_sku" {
   os_sku                = "Windows2022"
 }
 
+resource "azurerm_kubernetes_cluster_node_pool" "non_premium" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
+  vm_size               = "Standard_D2_v31"
+}

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
@@ -84,5 +84,5 @@ resource "azurerm_kubernetes_cluster_node_pool" "windows_sku" {
 resource "azurerm_kubernetes_cluster_node_pool" "non_premium" {
   name                  = "internal"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
-  vm_size               = "Standard_D2_v31"
+  vm_size               = "Standard_D2_v3"
 }


### PR DESCRIPTION
### Issue >
 Infracost uses Premium disk for AKS even though it's not available for given VM family #2407

### Changes made> 

[kubernetes_cluster_node_pool.go](https://github.com/infracost/infracost/blob/master/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go)

in the below function, added the instaceType to the calling function of `aksOSDiskSubResource()`
```go
func aksClusterNodePool()
{
    // rest of the code
    osDisk := aksOSDiskSubResource(region, diskSize, instanceType)

}
```

in the below function `aksOSDiskSubResource()` added the call to the new function `aksGetStorageType()` which returns a string whether the OS Disk provisioned is **Premium** or **Standard** based on the naming convention subfamily has any known premium prefixes (DS, GS, and M), and if so, it returns “Premium”. If not, it checks if the subfamily contains an 's' as an 'Additive Feature', as specified in the Azure VM naming conventions with the help of the **regex**. If it finds a match, it also returns “Premium”. Otherwise, it returns “Standard”.

```go
func aksOSDiskSubResource(region string, diskSize int, instanceType string) *schema.Resource {
	diskType := aksGetStorageType(instanceType)
        // rest of the code
}
```

