### PR TITLE
fix: handle nil metadata

### DIFF
--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -230,6 +230,14 @@ func (p *TerragruntHCLProvider) LoadResources(usage schema.UsageMap) ([]*schema.
 
 	wg.Wait()
 	sort.Slice(allProjects, func(i, j int) bool {
+		if allProjects[i].Metadata == nil {
+			return false
+		}
+
+		if allProjects[j].Metadata == nil {
+			return true
+		}
+
 		return allProjects[i].Metadata.TerraformModulePath < allProjects[j].Metadata.TerraformModulePath
 	})
 


### PR DESCRIPTION
from sentry
```
"runtime error: invalid memory address or nil pointer dereference"

], 
"stacktrace": 
"1: running [Created by errgroup.(*Group).Go @ errgroup.go:72]
   :24                                                             Stack()
   :270                                                            (*parallelRunner).run.func1.1()
   :884                                                            panic()
   :233                                                            (*TerragruntHCLProvider).LoadResources.func2()
   :299                                                            order2_func()
   :308                                                            median_func()
   :316                                                            medianAdjacent_func()
   :279                                                            choosePivot_func()
   :89                                                             pdqsort_func()
   :23                                                             Slice()
   :232                                                            (*TerragruntHCLProvider).LoadResources()
   ...
```  