### PR TITLE
fix: don't remove overlapping blocks when expanding dynamic blocks

### DIFF
--- a/cmd/infracost/testdata/breakdown_with_default_tags/breakdown_with_default_tags.golden
+++ b/cmd/infracost/testdata/breakdown_with_default_tags/breakdown_with_default_tags.golden
@@ -46,7 +46,8 @@
               "Project": "TestProject-var",
               "SomeDynamicBool": "true",
               "SomeDynamicFloat": "1.1",
-              "SomeDynamicNumber": "1"
+              "SomeDynamicNumber": "1",
+              "asgTag": "locasgtag"
             },
             "metadata": {
               "calls": [
@@ -55,7 +56,7 @@
                   "filename": "testdata/breakdown_with_default_tags/main.tf"
                 }
               ],
-              "checksum": "55255131d273d807964ccecbfa27d5d91c77b6a6f80949519cb83da946028275",
+              "checksum": "ea064bbcbd559c213f0baf5b0c3793ca2041f3a3e07160e5ac4472b06d1ccf35",
               "endLine": 100,
               "filename": "testdata/breakdown_with_default_tags/main.tf",
               "startLine": 75
@@ -190,7 +191,8 @@
               "Project": "TestProject-var",
               "SomeDynamicBool": "true",
               "SomeDynamicFloat": "1.1",
-              "SomeDynamicNumber": "1"
+              "SomeDynamicNumber": "1",
+              "asgTag": "locasgtag"
             },
             "metadata": {
               "calls": [
@@ -199,7 +201,7 @@
                   "filename": "testdata/breakdown_with_default_tags/main.tf"
                 }
               ],
-              "checksum": "55255131d273d807964ccecbfa27d5d91c77b6a6f80949519cb83da946028275",
+              "checksum": "ea064bbcbd559c213f0baf5b0c3793ca2041f3a3e07160e5ac4472b06d1ccf35",
               "endLine": 100,
               "filename": "testdata/breakdown_with_default_tags/main.tf",
               "startLine": 75

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -531,12 +531,12 @@ func (b *Block) InjectBlock(block *Block, name string) {
 	b.childBlocks = append(b.childBlocks, block)
 }
 
-// RemoveBlocks removes all the child Blocks of type name.
-func (b *Block) RemoveBlocks(name string) {
+// RemoveDynamicBlocks removes all the child Blocks of type name that have a parent of type "dynamic".
+func (b *Block) RemoveDynamicBlocks(name string) {
 	var filtered Blocks
 
 	for _, block := range b.childBlocks {
-		if block.Type() != name {
+		if block.Type() != name || block.parent.Type() != "dynamic" {
 			filtered = append(filtered, block)
 		}
 	}

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -397,7 +397,7 @@ func (e *Evaluator) expandDynamicBlock(b *Block) {
 		blockName := sub.TypeLabel()
 		// Remove all the child blocks with the blockName so that we don't inject the expanded blocks twice.
 		// This could happen if a module "reloads" and the input variables change.
-		b.RemoveBlocks(blockName)
+		b.RemoveDynamicBlocks(blockName)
 
 		expanded := e.expandBlockForEaches([]*Block{sub})
 		for _, ex := range expanded {

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -1088,6 +1088,11 @@ module "reload" {
 variable "input" {}
 
 resource "dynamic" "resource" {
+  child_block {
+    foo   = "10.0.2.0"
+    bar = "existing_child_block_should_be_kept"
+  }
+
   dynamic "child_block" {
     for_each = {
     	for i in var.input : i.ip => i
@@ -1124,11 +1129,12 @@ resource "dynamic" "resource" {
 
 	assert.JSONEq(
 		t,
-		values,
 		`[
+			{"foo":"10.0.2.0", "bar":"existing_child_block_should_be_kept"},		
 			{"foo":"10.0.0.0","bar":"input-mock"},
 			{"foo":"10.0.1.0","bar":"input-mock"}
 		]`,
+		values,
 	)
 
 }


### PR DESCRIPTION
@hugorut I think the parser_test changes explain the issue, but I'm not sure what you'll think of the fix.