### PR TITLE
refactor: change auto detect logic to include tfvars

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -842,3 +842,15 @@ func TestBreakdownWithLocalPathDataBlock(t *testing.T) {
 		}, &GoldenFileOptions{CaptureLogs: true},
 	)
 }
+
+func TestBreakdownAutoWithMultiVarfileProjects(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", dir,
+		}, nil)
+}

--- a/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/breakdown_auto_with_multi_varfile_projects.golden
+++ b/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/breakdown_auto_with_multi_varfile_projects.golden
@@ -1,0 +1,62 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/multi-prod
+Module path: multi
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.8xlarge)          730  hours     $1,121.28 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ Project total                                                                 $1,303.28 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/multi-dev
+Module path: multi
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours       $560.64 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ Project total                                                                   $742.64 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/single
+Module path: single
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.8xlarge)          730  hours     $1,121.28 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ Project total                                                                 $1,303.28 
+
+ OVERALL TOTAL                                                                 $3,349.20 
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 3 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...ti_varfile_projects/multi-prod ┃ $1,303       ┃
+┃ infracost/infracost/cmd/infraco...lti_varfile_projects/multi-dev ┃ $743         ┃
+┃ infracost/infracost/cmd/infraco..._multi_varfile_projects/single ┃ $1,303       ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/multi/dev.tfvars.json
+++ b/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/multi/dev.tfvars.json
@@ -1,0 +1,3 @@
+{
+  "instance_size": "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/multi/main.tf
+++ b/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/multi/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+variable "instance_size" {}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_size
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1" # <<<<< Try changing this to gp2 to compare costs
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/multi/prod.tfvars
+++ b/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/multi/prod.tfvars
@@ -1,0 +1,1 @@
+instance_size = "m5.8xlarge"

--- a/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/single/infra.tfvars
+++ b/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/single/infra.tfvars
@@ -1,0 +1,1 @@
+instance_size = "m5.8xlarge"

--- a/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/single/main.tf
+++ b/cmd/infracost/testdata/breakdown_auto_with_multi_varfile_projects/single/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+variable "instance_size" {}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_size
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1" # <<<<< Try changing this to gp2 to compare costs
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/internal/hcl/module.go
+++ b/internal/hcl/module.go
@@ -34,7 +34,12 @@ type Module struct {
 	Parent   *Module
 	Warnings []Warning
 
-	HasChanges bool
+	HasChanges         bool
+	TerraformVarsPaths []string
+
+	// ModuleSuffix is a unique name that can be optionally appended to the Module's project name.
+	// This is only applicable to root modules.
+	ModuleSuffix string
 }
 
 // Index returns the count index of the Module using the name.

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -53,7 +53,7 @@ data "cats_cat" "the-cats-mother" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(filepath.Dir(path), loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -561,7 +561,7 @@ output "mod_result" {
 	logger := newDiscardLogger()
 	dir := filepath.Dir(path)
 	loader := modules.NewModuleLoader(dir, nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(path, loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	rootModule, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -621,7 +621,7 @@ output "mod_result" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(path, loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	rootModule, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -818,7 +818,7 @@ resource "test_resource_two" "test" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(filepath.Dir(path), loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -880,7 +880,7 @@ output "mod_result" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(path, loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -1028,7 +1028,7 @@ output "mod_result" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(path, loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -1105,7 +1105,7 @@ resource "dynamic" "resource" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(path, loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -1165,7 +1165,7 @@ resource "azurerm_linux_function_app" "function" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(filepath.Dir(path), loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -1211,7 +1211,7 @@ resource "test_resource" "second" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(filepath.Dir(path), loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -1261,7 +1261,7 @@ data "google_compute_zones" "us" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(filepath.Dir(path), loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -1312,7 +1312,7 @@ data "aws_availability_zones" "ne" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(filepath.Dir(path), loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)
@@ -1359,7 +1359,7 @@ resource "random_shuffle" "bad" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
-	parsers, err := LoadParsers(filepath.Dir(path), loader, nil, logger)
+	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
 	require.NoError(t, err)

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -189,7 +189,9 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 			logger.SetOutput(io.Discard)
 			entry := logrus.NewEntry(logger)
 
+			ctx := config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{})
 			parsers, err := hcl.LoadParsers(
+				ctx,
 				testPath,
 				modules.NewModuleLoader(testPath, nil, config.TerraformSourceMap{}, entry, &sync.KeyMutex{}),
 				nil,
@@ -208,7 +210,7 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 			p := HCLProvider{
 				parsers: parsers,
 				logger:  entry,
-				ctx:     &config.ProjectContext{RunContext: &config.RunContext{Config: &config.Config{}}},
+				ctx:     ctx,
 			}
 			got := p.LoadPlanJSONs()
 			require.NoError(t, err)

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"bytes"
-	"encoding/json"
+	stdJson "encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -845,14 +845,14 @@ func gjsonEqual(a, b gjson.Result) bool {
 	var err error
 
 	var aOut bytes.Buffer
-	err = json.Compact(&aOut, []byte(a.Raw))
+	err = stdJson.Compact(&aOut, []byte(a.Raw))
 	if err != nil {
 		logging.Logger.Debugf("error indenting JSON: %s", err)
 		return false
 	}
 
 	var bOut bytes.Buffer
-	err = json.Compact(&bOut, []byte(b.Raw))
+	err = stdJson.Compact(&bOut, []byte(b.Raw))
 	if err != nil {
 		logging.Logger.Debugf("error indenting JSON: %s", err)
 		return false

--- a/internal/providers/terraform/plan_cache.go
+++ b/internal/providers/terraform/plan_cache.go
@@ -1,7 +1,6 @@
 package terraform
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/internal/providers/terraform/terragrunt_provider.go
+++ b/internal/providers/terraform/terragrunt_provider.go
@@ -2,7 +2,6 @@ package terraform
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/internal/providers/terraform/terragrunt_registry_service.go
+++ b/internal/providers/terraform/terragrunt_registry_service.go
@@ -3,7 +3,6 @@ package terraform
 // Contents of this file were copied from github.com/gruntwork-io/terragrunt
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"


### PR DESCRIPTION
Changes auto detection logic so that terraform var files are automatically taken into consideration:

1. If a single terraform var file is found under a project, we add it to the evaluator
2. If more than one are found under a project, we split the project into multiples. One for each var file discovered.

This functionality is solely for auto detection and once a user defines a config file, we no longer adhear to these rules.

Also added a `jsoniter` refactor into this pr to speed up the parsing logic. Let me know if you want me to separate it out.