### PR TITLE
fix: resolve blank repo metadata

### DIFF
--- a/internal/apiclient/dashboard.go
+++ b/internal/apiclient/dashboard.go
@@ -90,14 +90,7 @@ func newRunInput(ctx *config.RunContext, out output.Root) (*runInput, error) {
 	}
 
 	ctxValues["repoMetadata"] = metadata
-
 	if ctx.IsInfracostComment() {
-		// Clone the map to cleanup up the "command" key to show "comment".  It is
-		// currently set to the sub comment (e.g. "github")
-		ctxValues = make(map[string]interface{}, len(ctxValues))
-		for k, v := range ctx.ContextValues.Values() {
-			ctxValues[k] = v
-		}
 		ctxValues["command"] = "comment"
 	}
 


### PR DESCRIPTION
Resolves issue where repo metadata is blank for `infracost comment`. This fixes a regression that was introduced with the `ContextValues` concurrency fix. Prior to the concurrency fix RunContext Values was returning the value of the underlying map and not a copy for it. So setting `ctxValues['repoMetadata']` actually altered the RunContext Values. Hence why the old code which set the key before creating a clone actually worked. The old code with comments for better understanding:

```go
// This line actually alters ctx.Values as well as the local variable.
ctxValues["repoMetadata"] = metadata

if ctx.IsInfracostComment() {
	ctxValues = make(map[string]interface{}, len(ctxValues))
        // now ctx.ctx.GetContextValues returns the altered map so the clone contains the "repoMetadata" key.
	for k, v := range ctx.GetContextValues() {
		ctxValues[k] = v
	}
	ctxValues["command"] = "comment"
}
```

once this was changed to return a map copy `ctxValues` this meant:

```go
// This line only modified the local variable.
ctxValues["repoMetadata"] = metadata

if ctx.IsInfracostComment() {
	ctxValues = make(map[string]interface{}, len(ctxValues))
	// Then Values returns the unaltered ctx values (the correct behaviour).
	for k, v := range ctx.ContextValues.Values() {
		ctxValues[k] = v
	}
	ctxValues["command"] = "comment"
}
```

So `repoMetadata` was removed.

This fix removes the unecessary ctxValues copy (as it is already a local copy) and instead just sets the command to be the correct string.