### PR TITLE
fix: Strip count from module name as configuration key when marshalling

### DIFF
--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -491,7 +491,7 @@ func (p *HCLProvider) marshalModule(module *hcl.Module) ModuleOut {
 	})
 
 	for _, m := range module.Modules {
-		pieces := strings.Split(m.Name, ".")
+		pieces := strings.Split(removeAddressArrayPart(m.Name), ".")
 		modKey := pieces[len(pieces)-1]
 
 		mo := p.marshalModule(m)

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -179,6 +179,9 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 		{
 			name: "shows correct duplicate variable warning",
 		},
+		{
+			name: "builds module configuration correctly with count",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/expected.json
@@ -1,0 +1,205 @@
+{
+  "format_version": "1.0",
+  "terraform_version": "1.1.0",
+  "prior_state": {
+    "values": {
+      "root_module": {
+        "child_modules": [
+          {
+            "address": "module.gateway_test",
+            "child_modules": [
+              {
+                "resources": [
+                  {
+                    "address": "module.gateway_test.module.gateway_proxy[0].aws_customer_gateway.example",
+                    "mode": "managed",
+                    "type": "aws_customer_gateway",
+                    "name": "example",
+                    "schema_version": 0,
+                    "values": {
+                      "bgp_asn": 65000,
+                      "ip_address": "172.0.0.1",
+                      "tags": {
+                        "Name": "name-b",
+                        "resource_tag": "tag"
+                      },
+                      "type": "ipsec.1"
+                    },
+                    "infracost_metadata": {
+                      "calls": [
+                        {
+                          "filename": "testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/main.tf",
+                          "blockName": "module.gateway_test",
+                          "startLine": 15,
+                          "endLine": 17
+                        },
+                        {
+                          "filename": "testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway_proxy/main.tf",
+                          "blockName": "module.gateway_proxy",
+                          "startLine": 5,
+                          "endLine": 13
+                        },
+                        {
+                          "filename": "testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway/main.tf",
+                          "blockName": "aws_customer_gateway.example",
+                          "startLine": 12,
+                          "endLine": 18
+                        }
+                      ],
+                      "checksum": "d24cafbbebdccfee9553dd5da467372400f5915eec04885252911859209ab368",
+                      "endLine": 18,
+                      "filename": "testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway/main.tf",
+                      "startLine": 12
+                    }
+                  }
+                ],
+                "address": "module.gateway_test.module.gateway_proxy[0]"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "planned_values": {
+    "root_module": {
+      "child_modules": [
+        {
+          "address": "module.gateway_test",
+          "child_modules": [
+            {
+              "resources": [
+                {
+                  "address": "module.gateway_test.module.gateway_proxy[0].aws_customer_gateway.example",
+                  "mode": "managed",
+                  "type": "aws_customer_gateway",
+                  "name": "example",
+                  "schema_version": 0,
+                  "values": {
+                    "bgp_asn": 65000,
+                    "ip_address": "172.0.0.1",
+                    "tags": {
+                      "Name": "name-b",
+                      "resource_tag": "tag"
+                    },
+                    "type": "ipsec.1"
+                  },
+                  "infracost_metadata": {
+                    "calls": [
+                      {
+                        "filename": "testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/main.tf",
+                        "blockName": "module.gateway_test",
+                        "startLine": 15,
+                        "endLine": 17
+                      },
+                      {
+                        "filename": "testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway_proxy/main.tf",
+                        "blockName": "module.gateway_proxy",
+                        "startLine": 5,
+                        "endLine": 13
+                      },
+                      {
+                        "filename": "testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway/main.tf",
+                        "blockName": "aws_customer_gateway.example",
+                        "startLine": 12,
+                        "endLine": 18
+                      }
+                    ],
+                    "checksum": "d24cafbbebdccfee9553dd5da467372400f5915eec04885252911859209ab368",
+                    "endLine": 18,
+                    "filename": "testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway/main.tf",
+                    "startLine": 12
+                  }
+                }
+              ],
+              "address": "module.gateway_test.module.gateway_proxy[0]"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "expressions": {
+          "default_tags": [
+            {
+              "tags": {
+                "constant_value": {
+                  "Version": "1.0.0"
+                }
+              }
+            }
+          ],
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        },
+        "infracost_metadata": {
+          "end_line": 13,
+          "filename": "testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/main.tf",
+          "start_line": 1
+        }
+      }
+    },
+    "root_module": {
+      "module_calls": {
+        "gateway_test": {
+          "source": "./module/gateway_proxy",
+          "module": {
+            "module_calls": {
+              "gateway_proxy": {
+                "source": "./../gateway",
+                "module": {
+                  "resources": [
+                    {
+                      "address": "aws_customer_gateway.example",
+                      "mode": "managed",
+                      "type": "aws_customer_gateway",
+                      "name": "example",
+                      "provider_config_key": "gateway_proxy[0]:aws",
+                      "expressions": {
+                        "tags": {
+                          "references": [
+                            "locals.tags"
+                          ]
+                        }
+                      },
+                      "schema_version": 0
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "infracost_resource_changes": [
+    {
+      "address": "module.gateway_test.module.gateway_proxy[0].aws_customer_gateway.example",
+      "module_address": "module.gateway_test.module.gateway_proxy[0]",
+      "mode": "managed",
+      "type": "aws_customer_gateway",
+      "name": "example",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "bgp_asn": 65000,
+          "ip_address": "172.0.0.1",
+          "tags": {
+            "Name": "name-b",
+            "resource_tag": "tag"
+          },
+          "type": "ipsec.1"
+        }
+      }
+    }
+  ]
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/main.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+
+  default_tags {
+    tags = {
+      Version = "1.0.0"
+    }
+  }
+}
+
+module "gateway_test" {
+  source = "./module/gateway_proxy"
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway/main.tf
@@ -1,0 +1,18 @@
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+locals {
+  tags = merge(var.tags, {
+    "resource_tag" = "tag"
+  })
+}
+
+resource "aws_customer_gateway" "example" {
+  bgp_asn    = 65000
+  ip_address = "172.0.0.1"
+  type       = "ipsec.1"
+
+  tags = local.tags
+}

--- a/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway_proxy/main.tf
+++ b/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/module/gateway_proxy/main.tf
@@ -1,0 +1,13 @@
+locals {
+  names_map = [{ name = "name-a", name = "name-b" }]
+}
+
+module "gateway_proxy" {
+  for_each = local.names_map
+
+  source = "./../gateway"
+
+  tags = {
+    Name = each.value.name
+  }
+}


### PR DESCRIPTION
Default tags were not applied to the resources of a module with count:
the configuration key contained the count part, but the lookup used just
the module name. Thus the tags were not found.