### PR TITLE
feat: add support for data.aws_default_tags block

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -277,20 +277,20 @@ func (e *Evaluator) evaluate(lastContext hcl.EvalContext) {
 func (e *Evaluator) evaluateStep(i int) {
 	e.logger.Debugf("starting context evaluation iteration %d", i+1)
 
-	e.ctx.Set(e.getValuesByBlockType("variable"), "var")
-	e.ctx.Set(e.getValuesByBlockType("locals"), "local")
-
 	providers := e.getValuesByBlockType("provider")
 	for key, provider := range providers.AsValueMap() {
 		e.ctx.Set(provider, key)
 	}
+
+	e.ctx.Set(e.getValuesByBlockType("variable"), "var")
+	e.ctx.Set(e.getValuesByBlockType("data"), "data")
+	e.ctx.Set(e.getValuesByBlockType("locals"), "local")
 
 	resources := e.getValuesByBlockType("resource")
 	for key, resource := range resources.AsValueMap() {
 		e.ctx.Set(resource, key)
 	}
 
-	e.ctx.Set(e.getValuesByBlockType("data"), "data")
 	e.ctx.Set(e.getValuesByBlockType("output"), "output")
 
 	e.evaluateModules()

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -1416,7 +1416,7 @@ provider "aws" {
 variable "tags" {
   type        = map(string)
   default     = {
-    "foo"          = "bar"
+    "foo" = "bar"
   }
 }
 
@@ -1428,7 +1428,6 @@ locals {
     var.tags
   )
 }
-
 `)
 
 	logger := newDiscardLogger()

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -1402,3 +1402,51 @@ resource "random_shuffle" "bad" {
 		"id", "arn", "self_link", "name",
 	)
 }
+
+func Test_LocalsMergeWithDataTags(t *testing.T) {
+	path := createTestFile("test.tf", `
+provider "aws" {
+ default_tags {
+   tags = {
+     Environment = "Test"
+   }
+ }
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {
+    "foo"          = "bar"
+  }
+}
+
+data "aws_default_tags" "current" {}
+
+locals {
+  asg_tags = merge(
+    data.aws_default_tags.current.tags,
+    var.tags
+  )
+}
+
+`)
+
+	logger := newDiscardLogger()
+	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	parsers, err := LoadParsers(
+		config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}),
+		filepath.Dir(path),
+		loader,
+		nil,
+		logger)
+	require.NoError(t, err)
+	module, err := parsers[0].ParseDirectory()
+	require.NoError(t, err)
+
+	blocks := module.Blocks
+	assertBlockEqualsJSON(
+		t,
+		`{"asg_tags":{"foo":"bar","Environment":"Test"}}`,
+		blocks.Matching(BlockMatcher{Type: "locals"}).Values(),
+	)
+}

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -297,13 +297,13 @@ func (p *HCLProvider) LoadPlanJSONs() []HCLProject {
 
 	for i, module := range mods {
 		if module.Error == nil {
-			b, err := p.modulesToPlanJSON(module.Module)
-			if err != nil {
-				module.Error = err
-			} else {
-				module.JSON = b
+			module.JSON, module.Error = p.modulesToPlanJSON(module.Module)
+			if os.Getenv("INFRACOST_JSON_DUMP") == "true" {
+				err := os.WriteFile(fmt.Sprintf("%s-out.json", strings.ReplaceAll(module.Module.ModulePath, "/", "-")), module.JSON, os.ModePerm)
+				if err != nil {
+					p.logger.WithError(err).Debug("failed to write to json dump")
+				}
 			}
-
 		}
 
 		jsons[i] = module


### PR DESCRIPTION
Adds support for the `data.aws_default_tags` which returns the provider default tags. This PR also adds support to save the infracost generated plan JSON to the local filesytem. This aids debugging, in particular seeing what final values are for the evaluated blocks.

Work on this PR exposed a serious limitation to the HCL evaluator. See this issue https://github.com/infracost/infracost/issues/2596 for more info. The code changes in this PR go some way to solving this issue but we need more work to fully solve it.