### PR TITLE
fix: propagate tags at launch

### DIFF
--- a/cmd/infracost/testdata/breakdown_format_json_with_tags/breakdown_format_json_with_tags.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags/breakdown_format_json_with_tags.golden
@@ -34,6 +34,27 @@
       "pastBreakdown": {
         "resources": [
           {
+            "name": "aws_autoscaling_group.bar",
+            "resourceType": "aws_autoscaling_group",
+            "tags": {
+              "foo": "bar"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_autoscaling_group.bar",
+                  "endLine": 65,
+                  "filename": "testdata/breakdown_format_json_with_tags/main.tf",
+                  "startLine": 45
+                }
+              ],
+              "checksum": "78ad6fe00b08040616d8503e00877f13cab24fa8c7e6c6d1045d7d075e8b5940",
+              "endLine": 65,
+              "filename": "testdata/breakdown_format_json_with_tags/main.tf",
+              "startLine": 45
+            }
+          },
+          {
             "name": "aws_sns_topic_subscription.sns_topic_noTags",
             "resourceType": "aws_sns_topic_subscription",
             "metadata": {
@@ -168,6 +189,27 @@
       },
       "breakdown": {
         "resources": [
+          {
+            "name": "aws_autoscaling_group.bar",
+            "resourceType": "aws_autoscaling_group",
+            "tags": {
+              "foo": "bar"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_autoscaling_group.bar",
+                  "endLine": 65,
+                  "filename": "testdata/breakdown_format_json_with_tags/main.tf",
+                  "startLine": 45
+                }
+              ],
+              "checksum": "78ad6fe00b08040616d8503e00877f13cab24fa8c7e6c6d1045d7d075e8b5940",
+              "endLine": 65,
+              "filename": "testdata/breakdown_format_json_with_tags/main.tf",
+              "startLine": 45
+            }
+          },
           {
             "name": "aws_sns_topic_subscription.sns_topic_noTags",
             "resourceType": "aws_sns_topic_subscription",
@@ -307,10 +349,10 @@
         "totalMonthlyCost": "0"
       },
       "summary": {
-        "totalDetectedResources": 4,
-        "totalSupportedResources": 4,
+        "totalDetectedResources": 5,
+        "totalSupportedResources": 5,
         "totalUnsupportedResources": 0,
-        "totalUsageBasedResources": 4,
+        "totalUsageBasedResources": 5,
         "totalNoPriceResources": 0,
         "unsupportedResourceCounts": {},
         "noPriceResourceCounts": {}
@@ -325,10 +367,10 @@
   "diffTotalMonthlyCost": "0",
   "timeGenerated": "REPLACED_TIME",
   "summary": {
-    "totalDetectedResources": 4,
-    "totalSupportedResources": 4,
+    "totalDetectedResources": 5,
+    "totalSupportedResources": 5,
     "totalUnsupportedResources": 0,
-    "totalUsageBasedResources": 4,
+    "totalUsageBasedResources": 5,
     "totalNoPriceResources": 0,
     "unsupportedResourceCounts": {},
     "noPriceResourceCounts": {}

--- a/cmd/infracost/testdata/breakdown_format_json_with_tags/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags/main.tf
@@ -41,3 +41,25 @@ resource "aws_sqs_queue" "sqs_withTags" {
     ResourceTag     = "sqs-hi"
   }
 }
+
+resource "aws_autoscaling_group" "bar" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+
+  tag {
+    key                 = "foo"
+    value               = "bar"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "lorem"
+    value               = "ipsum"
+    propagate_at_launch = false
+  }
+}

--- a/cmd/infracost/testdata/breakdown_with_default_tags/breakdown_with_default_tags.golden
+++ b/cmd/infracost/testdata/breakdown_with_default_tags/breakdown_with_default_tags.golden
@@ -46,8 +46,7 @@
               "Project": "TestProject-var",
               "SomeDynamicBool": "true",
               "SomeDynamicFloat": "1.1",
-              "SomeDynamicNumber": "1",
-              "asgTag": "locasgtag"
+              "SomeDynamicNumber": "1"
             },
             "metadata": {
               "calls": [
@@ -193,8 +192,7 @@
               "Project": "TestProject-var",
               "SomeDynamicBool": "true",
               "SomeDynamicFloat": "1.1",
-              "SomeDynamicNumber": "1",
-              "asgTag": "locasgtag"
+              "SomeDynamicNumber": "1"
             },
             "metadata": {
               "calls": [

--- a/internal/providers/terraform/aws/aws.go
+++ b/internal/providers/terraform/aws/aws.go
@@ -1,8 +1,9 @@
 package aws
 
 import (
-	"github.com/infracost/infracost/internal/providers/terraform/provider_schemas"
 	"strings"
+
+	"github.com/infracost/infracost/internal/providers/terraform/provider_schemas"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -118,9 +119,16 @@ func ParseTags(defaultTags *map[string]string, resourceType string, r gjson.Resu
 	if supportsTagBlock {
 		for _, el := range r.Get("tag").Array() {
 			k := el.Get("key").String()
-			if k != "" {
-				tags[k] = el.Get("value").String()
+			if k == "" {
+				continue
 			}
+
+			propagate := el.Get("propagate_at_launch")
+			if propagate.Exists() && !propagate.Bool() {
+				continue
+			}
+
+			tags[k] = el.Get("value").String()
 		}
 	}
 


### PR DESCRIPTION
Resolves issue where resources that contained tag blocks that defined `progagate_at_launch` as false to still pass tag policies.