### PR TITLE
Revert "refactor: use terragrunt global cache for modules (#2584)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -266,4 +266,4 @@ replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
-replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20230721131056-60d6b19823f5
+replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20230627084705-f27e16c7e6bd

--- a/go.sum
+++ b/go.sum
@@ -831,8 +831,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/infracost/terragrunt v0.47.1-0.20230721131056-60d6b19823f5 h1:pQJDOjYSWRJHI9ubngM8h+eRrX1gVDsQl/x+2joB9lk=
-github.com/infracost/terragrunt v0.47.1-0.20230721131056-60d6b19823f5/go.mod h1:UUPeQZP+swqZpL5XCTtf8LT/ozO84uocbJ41FuoF6eE=
+github.com/infracost/terragrunt v0.47.1-0.20230627084705-f27e16c7e6bd h1:TQm106xMJQcZeYp1FzPdGMTAYer1UeVC5ovXIQcU1kg=
+github.com/infracost/terragrunt v0.47.1-0.20230627084705-f27e16c7e6bd/go.mod h1:UUPeQZP+swqZpL5XCTtf8LT/ozO84uocbJ41FuoF6eE=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -14,15 +14,18 @@ import (
 	"time"
 
 	tgcli "github.com/gruntwork-io/terragrunt/cli"
+	"github.com/gruntwork-io/terragrunt/cli/tfsource"
 	tgconfig "github.com/gruntwork-io/terragrunt/config"
 	tgconfigstack "github.com/gruntwork-io/terragrunt/configstack"
 	tgerrors "github.com/gruntwork-io/terragrunt/errors"
 	"github.com/gruntwork-io/terragrunt/options"
 	tgoptions "github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/hashicorp/go-getter"
 	hcl2 "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -34,13 +37,10 @@ import (
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/hcl"
 	"github.com/infracost/infracost/internal/schema"
-	infSync "github.com/infracost/infracost/internal/sync"
 	"github.com/infracost/infracost/internal/ui"
 )
 
-// terragruntSourceLock is the global lock which works across TerragrunHCLProviders to provide
-// concurrency safe downloading.
-var terragruntSourceLock = infSync.KeyMutex{}
+const terragruntSourceVersionFile = ".terragrunt-source-version"
 
 type panicError struct {
 	msg string
@@ -543,10 +543,7 @@ func (p *TerragruntHCLProvider) runTerragrunt(opts *tgoptions.TerragruntOptions)
 		return
 	}
 	if sourceURL != "" {
-		unlock := terragruntSourceLock.Lock(sourceURL)
-		updatedTerragruntOptions, err := tgcli.DownloadTerraformSource(sourceURL, opts, terragruntConfig)
-		unlock()
-
+		updatedTerragruntOptions, err := p.downloadTerraformSource(sourceURL, opts, terragruntConfig)
 		if err != nil {
 			info.error = err
 			return
@@ -934,6 +931,263 @@ func generateTypeFromValuesMap(valMap map[string]cty.Value) cty.Type {
 		outType[k] = v.Type()
 	}
 	return cty.Object(outType)
+}
+
+// 1. Download the given source URL, which should use Terraform's module source syntax, into a temporary folder
+// 2. Check if module directory exists in temporary folder
+// 3. Copy the contents of terragruntOptions.WorkingDir into the temporary folder.
+// 4. Set terragruntOptions.WorkingDir to the temporary folder.
+//
+// See the NewTerraformSource method for how we determine the temporary folder so we can reuse it across multiple
+// runs of Terragrunt to avoid downloading everything from scratch every time.
+// Copied from github.com/gruntwork-io/terragrunt
+func (p *TerragruntHCLProvider) downloadTerraformSource(source string, terragruntOptions *tgoptions.TerragruntOptions, terragruntConfig *tgconfig.TerragruntConfig) (*tgoptions.TerragruntOptions, error) {
+	terraformSource, err := tfsource.NewTerraformSource(source, terragruntOptions.DownloadDir, terragruntOptions.WorkingDir, terragruntOptions.Logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.downloadTerraformSourceIfNecessary(terraformSource, terragruntOptions, terragruntConfig); err != nil {
+		return nil, err
+	}
+
+	if _, ok := p.sourceCache[terraformSource.CanonicalSourceURL.String()]; !ok {
+		terragruntOptions.Logger.Debugf("Adding %s to the source cache", terraformSource.CanonicalSourceURL.String())
+		p.sourceCache[terraformSource.CanonicalSourceURL.String()] = terraformSource.DownloadDir
+	}
+
+	terragruntOptions.Logger.Debugf("Copying files from %s into %s", terragruntOptions.WorkingDir, terraformSource.WorkingDir)
+	var includeInCopy []string
+	if terragruntConfig.Terraform != nil && terragruntConfig.Terraform.IncludeInCopy != nil {
+		includeInCopy = *terragruntConfig.Terraform.IncludeInCopy
+	}
+	if err := util.CopyFolderContents(terragruntOptions.WorkingDir, terraformSource.WorkingDir, tgcli.MODULE_MANIFEST_NAME, includeInCopy); err != nil {
+		return nil, err
+	}
+
+	updatedTerragruntOptions := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
+
+	terragruntOptions.Logger.Debugf("Setting working directory to %s", terraformSource.WorkingDir)
+	updatedTerragruntOptions.WorkingDir = terraformSource.WorkingDir
+
+	return updatedTerragruntOptions, nil
+}
+
+// copyLocalSource copies the contents of a previously downloaded source folder into the destination folder
+func (p *TerragruntHCLProvider) copyLocalSource(prevDest string, dest string, terragruntOptions *tgoptions.TerragruntOptions) error {
+	err := os.MkdirAll(dest, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create directory '%s': %w", dest, err)
+	}
+
+	// Skip dotfiles and, but keep:
+	// 1. Terraform lock files - these are normally committed to source control
+	// 2. .terragrunt-source-version files - these are used to determine if the source has changed
+	// 3. .infracost dir - this contains any cached third party modules. We can remove this when we move this directory to the root path
+	opt := copy.Options{
+		Skip: func(src string) (bool, error) {
+			base := filepath.Base(src)
+			if base == util.TerraformLockFile || base == terragruntSourceVersionFile || base == config.InfracostDir {
+				return false, nil
+			}
+
+			return strings.HasPrefix(base, "."), nil
+		},
+		OnSymlink: func(src string) copy.SymlinkAction {
+			return copy.Shallow
+		},
+	}
+
+	err = copy.Copy(prevDest, dest, opt)
+	if err != nil {
+		return fmt.Errorf("failed to copy source from '%s' to '%s': %w", prevDest, dest, err)
+	}
+
+	return nil
+}
+
+// Download the specified TerraformSource if the latest code hasn't already been downloaded.
+// Copied from github.com/gruntwork-io/terragrunt
+func (p *TerragruntHCLProvider) downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSource, terragruntOptions *tgoptions.TerragruntOptions, terragruntConfig *tgconfig.TerragruntConfig) error {
+	alreadyLatest, err := p.alreadyHaveLatestCode(terraformSource, terragruntOptions)
+	if err != nil {
+		return err
+	}
+
+	if alreadyLatest {
+		if err := p.validateWorkingDir(terraformSource); err != nil {
+			return err
+		}
+		terragruntOptions.Logger.Debugf("Terraform files in %s are up to date. Will not download again.", terraformSource.WorkingDir)
+		return nil
+	}
+
+	var previousVersion = ""
+	// read previous source version
+	// https://github.com/gruntwork-io/terragrunt/issues/1921
+	if util.FileExists(terraformSource.VersionFile) {
+		previousVersion, err = p.readVersionFile(terraformSource)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Check if the directory has already been downloaded during this run and is in the source cache
+	// If so, we can just copy the files from the previous download to avoid downloading again
+	if prevDownloadDir, ok := p.sourceCache[terraformSource.CanonicalSourceURL.String()]; ok {
+		terragruntOptions.Logger.Debugf("Source files have already been downloading. Copying files from %s into %s", prevDownloadDir, terraformSource.DownloadDir)
+		err := p.copyLocalSource(prevDownloadDir, terraformSource.DownloadDir, terragruntOptions)
+		if err != nil {
+			terragruntOptions.Logger.Debugf("Failed to copy local source from %s to %s: %v. Will try to redownload", prevDownloadDir, terraformSource.DownloadDir, err)
+		} else {
+			terragruntOptions.Logger.Debugf("Successfully copied files from %s to %s. Will not download again", prevDownloadDir, terraformSource.DownloadDir)
+			return nil
+		}
+	}
+
+	// When downloading source, we need to process any hooks waiting on `init-from-module`. Therefore, we clone the
+	// options struct, set the command to the value the hooks are expecting, and run the download action surrounded by
+	// before and after hooks (if any).
+	// terragruntOptionsForDownload := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
+	// terragruntOptionsForDownload.TerraformCommand = tgcli.CMD_INIT_FROM_MODULE
+	// downloadErr := runActionWithHooks("download source", terragruntOptionsForDownload, terragruntConfig, func() error {
+	//	return downloadSource(terraformSource, terragruntOptions, terragruntConfig)
+	// })
+	downloadErr := p.downloadSource(terraformSource, terragruntOptions, terragruntConfig)
+
+	if downloadErr != nil {
+		return downloadErr
+	}
+
+	if err := terraformSource.WriteVersionFile(); err != nil {
+		return err
+	}
+
+	if err := p.validateWorkingDir(terraformSource); err != nil {
+		return err
+	}
+
+	currentVersion, err := terraformSource.EncodeSourceVersion()
+	if err != nil {
+		return fmt.Errorf("could not encode source version: %w", err)
+	}
+	// if source versions are different, create file to run init
+	// https://github.com/gruntwork-io/terragrunt/issues/1921
+	if previousVersion != currentVersion {
+		initFile := util.JoinPath(terraformSource.WorkingDir, ".terragrunt-init-required")
+		f, createErr := os.Create(initFile)
+		if createErr != nil {
+			return createErr
+		}
+		defer f.Close()
+	}
+
+	return nil
+}
+
+// Download the code from the Canonical Source URL into the Download Folder using the go-getter library
+// Copied from github.com/gruntwork-io/terragrunt
+func (p *TerragruntHCLProvider) downloadSource(terraformSource *tfsource.TerraformSource, terragruntOptions *tgoptions.TerragruntOptions, terragruntConfig *tgconfig.TerragruntConfig) error {
+	terragruntOptions.Logger.Debugf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
+
+	if err := getter.GetAny(terraformSource.DownloadDir, terraformSource.CanonicalSourceURL.String(), p.updateGetters(terragruntConfig)); err != nil {
+		return tgerrors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+// updateGetters returns the customized go-getter interfaces that Terragrunt relies on. Specifically:
+//   - Local file path getter is updated to copy the files instead of creating symlinks, which is what go-getter defaults
+//     to.
+//   - Include the customized getter for fetching sources from the Terraform Registry.
+//
+// This creates a closure that returns a function so that we have access to the terragrunt configuration, which is
+// necessary for customizing the behavior of the file getter.
+// Copied from github.com/gruntwork-io/terragrunt
+func (p *TerragruntHCLProvider) updateGetters(terragruntConfig *tgconfig.TerragruntConfig) func(*getter.Client) error {
+	return func(client *getter.Client) error {
+		// We copy all the default getters from the go-getter library, but replace the "file" getter. We shallow clone the
+		// getter map here rather than using getter.Getters directly because (a) we shouldn't change the original,
+		// globally-shared getter.Getters map and (b) Terragrunt may run this code from many goroutines concurrently during
+		// xxx-all calls, so creating a new map each time ensures we don't a "concurrent map writes" error.
+		client.Getters = map[string]getter.Getter{}
+		for getterName, getterValue := range getter.Getters {
+			if getterName == "file" {
+				var includeInCopy []string
+				if terragruntConfig.Terraform != nil && terragruntConfig.Terraform.IncludeInCopy != nil {
+					includeInCopy = *terragruntConfig.Terraform.IncludeInCopy
+				}
+				client.Getters[getterName] = &tgcli.FileCopyGetter{IncludeInCopy: includeInCopy}
+			} else {
+				client.Getters[getterName] = getterValue
+			}
+		}
+
+		// Load in custom getters that are only supported in Terragrunt
+		client.Getters["tfr"] = &TerraformRegistryGetter{}
+
+		return nil
+	}
+}
+
+// Check if working terraformSource.WorkingDir exists and is directory
+// Copied from github.com/gruntwork-io/terragrunt
+func (p *TerragruntHCLProvider) validateWorkingDir(terraformSource *tfsource.TerraformSource) error {
+	workingLocalDir := strings.ReplaceAll(terraformSource.WorkingDir, terraformSource.DownloadDir+filepath.FromSlash("/"), "")
+	if util.IsFile(terraformSource.WorkingDir) {
+		return tgcli.WorkingDirNotDir{Dir: workingLocalDir, Source: terraformSource.CanonicalSourceURL.String()}
+	}
+	if !util.IsDir(terraformSource.WorkingDir) {
+		return tgcli.WorkingDirNotFound{Dir: workingLocalDir, Source: terraformSource.CanonicalSourceURL.String()}
+	}
+
+	return nil
+}
+
+// Returns true if the specified TerraformSource, of the exact same version, has already been downloaded into the
+// DownloadFolder. This helps avoid downloading the same code multiple times. Note that if the TerraformSource points
+// to a local file path, we assume the user is doing local development and always return false to ensure the latest
+// code is downloaded (or rather, copied) every single time. See the ProcessTerraformSource method for more info.
+// Copied from github.com/gruntwork-io/terragrunt
+func (p *TerragruntHCLProvider) alreadyHaveLatestCode(terraformSource *tfsource.TerraformSource, terragruntOptions *tgoptions.TerragruntOptions) (bool, error) {
+	if tfsource.IsLocalSource(terraformSource.CanonicalSourceURL) ||
+		!util.FileExists(terraformSource.DownloadDir) ||
+		!util.FileExists(terraformSource.WorkingDir) ||
+		!util.FileExists(terraformSource.VersionFile) {
+
+		return false, nil
+	}
+
+	tfFiles, err := filepath.Glob(fmt.Sprintf("%s/*.tf", terraformSource.WorkingDir))
+	if err != nil {
+		return false, tgerrors.WithStackTrace(err)
+	}
+
+	if len(tfFiles) == 0 {
+		terragruntOptions.Logger.Debugf("Working dir %s exists but contains no Terraform files, so assuming code needs to be downloaded again.", terraformSource.WorkingDir)
+		return false, nil
+	}
+
+	currentVersion, err := terraformSource.EncodeSourceVersion()
+	if err != nil {
+		return false, fmt.Errorf("could not encode source version: %w", err)
+	}
+
+	previousVersion, err := p.readVersionFile(terraformSource)
+	if err != nil {
+		return false, err
+	}
+
+	return previousVersion == currentVersion, nil
+}
+
+// Return the version number stored in the DownloadDir. This version number can be used to check if the Terraform code
+// that has already been downloaded is the same as the version the user is currently requesting. The version number is
+// calculated using the encodeSourceVersion method.
+// Copied from github.com/gruntwork-io/terragrunt
+func (p *TerragruntHCLProvider) readVersionFile(terraformSource *tfsource.TerraformSource) (string, error) {
+	return util.ReadFileAsString(terraformSource.VersionFile)
 }
 
 type terragruntDependency struct {


### PR DESCRIPTION
This reverts commit 610eb5ca315b9dc12524bc7468ba70f58e49363b.

Reverting this just now since it's causing issues with project warnings.