### PR TITLE
fix: variables evaluated correctly when module expands based on another module

### DIFF
--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -160,6 +160,10 @@ func (blocks Blocks) Matching(pattern BlockMatcher) *Block {
 		search = blocks.OfType(pattern.Type)
 	}
 
+	if pattern.Label == "" && len(search) > 0 {
+		return search[0]
+	}
+
 	for _, block := range search {
 		label := block.Label()
 		if pattern.StripCount {
@@ -169,10 +173,6 @@ func (blocks Blocks) Matching(pattern BlockMatcher) *Block {
 		if pattern.Label == label {
 			return block
 		}
-	}
-
-	if len(search) > 0 {
-		return search[0]
 	}
 
 	return nil
@@ -571,7 +571,7 @@ func (b *Block) IsForEachReferencedExpanded(moduleBlocks Blocks) bool {
 
 	label := r.String()
 	if blockType == "module" {
-		label = r.typeLabel
+		label = r.nameLabel
 	}
 
 	referenced := moduleBlocks.Matching(BlockMatcher{


### PR DESCRIPTION
This fixes the case where `var.input` was mocked for the following case:

```tf
module "mod1" {
  source = "./mod1"
  count  = 2
}

module "mod2" {
  source   = "./mod2"
  for_each = module.mod1
  input    = each.value.output
}
```