### PR TITLE
fix: ensure that terragrunt remote source modules with refs and versions are downloaded to different directories

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -389,6 +390,79 @@ func TestBreakdownPlanError(t *testing.T) {
 
 func TestBreakdownTerragrunt(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "../../examples/terragrunt"}, nil)
+}
+
+func TestBreakdownTerragruntWithRemoteSource(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	cacheDir := filepath.Join(dir, ".infracost")
+	require.NoError(t, os.RemoveAll(cacheDir))
+
+	GoldenFileCommandTest(
+		t,
+		testName,
+		[]string{
+			"breakdown",
+			"--config-file", filepath.Join(dir, "infracost.yml"),
+		},
+		nil)
+
+	dirs, err := getGitBranchesInDirs(filepath.Join(cacheDir, ".terragrunt-cache"))
+	assert.NoError(t, err)
+
+	// check that there are 4 directories in the download directory as 2 of the 6 projects use the same ref.
+	require.Len(t, dirs, 4)
+	assert.Equal(t, dirs["nY--fMGWRYoen8N6OqfdCB8CBnc"], "1f94a2fd07b3e29deea4706b5d2fdc68c1d02aad")
+	assert.Equal(t, dirs["F_iCrGgnzJEf5w4HUBrbeCRMQo0"], "b6fa04f65bdcb26869215fb840f5ee088a096bc8")
+	assert.Equal(t, dirs["KaCyCQXaN6-S634qsDqQ2wwYENc"], "74725d6e91aa91d7283642b7ed3316d12f271212")
+	assert.Equal(t, dirs["vo8pQqWUeCu_1_TBy7LGvx51SW0"], "master")
+}
+
+func getGitRef(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	branch := strings.TrimRight(string(output), "\n")
+
+	if branch == "HEAD" {
+		// in detached head state, get the commit hash
+		cmd := exec.Command("git", "rev-parse", "HEAD")
+		cmd.Dir = dir
+		output, err = cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		branch = strings.TrimRight(string(output), "\n")
+	}
+
+	return branch, nil
+}
+
+func getGitBranchesInDirs(root string) (map[string]string, error) {
+	var dirs = make(map[string]string)
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() && filepath.Base(path) == ".git" {
+			dir := filepath.Dir(path)
+			branch, err := getGitRef(dir)
+			if err != nil {
+				return err
+			}
+
+			dirs[filepath.Base(dir)] = branch
+			return filepath.SkipDir
+		}
+		return nil
+	})
+
+	return dirs, err
 }
 
 func TestBreakdownTerragruntWithProjectError(t *testing.T) {

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -83,8 +83,7 @@ func GetCommandOutput(t *testing.T, args []string, testOptions *GoldenFileOption
 	}
 
 	for k, v := range testOptions.Env {
-		os.Setenv(k, v)
-		defer os.Unsetenv(k)
+		t.Setenv(k, v)
 	}
 
 	// Fix the VCS repo URL so the golden files don't fail on forks

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
@@ -1,0 +1,175 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref1
+Module path: submod-ref1
+
+ Name                                                            Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                       
+ aws_instance.web_app                                                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.16xlarge)                  730  hours                          $2,242.56 
+ ├─ root_block_device                                                                                                  
+ │  └─ Storage (general purpose SSD, gp2)                                100  GB                                $10.00 
+ └─ ebs_block_device[0]                                                                                                
+    ├─ Storage (provisioned IOPS SSD, io1)                             1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                  800  IOPS                              $52.00 
+                                                                                                                       
+ aws_lambda_function.hello_world                                                                                       
+ ├─ Requests                                             Monthly cost depends on usage: $0.20 per 1M requests          
+ ├─ Ephemeral storage                                    Monthly cost depends on usage: $0.0000000309 per GB-seconds   
+ └─ Duration (first 6B)                                  Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                       
+ Project total                                                                                               $2,429.56 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref1-2
+Module path: submod-ref1-2
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+ ├─ root_block_device                                                                                                 
+ │  └─ Storage (general purpose SSD, gp2)                               100  GB                                $10.00 
+ └─ ebs_block_device[0]                                                                                               
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ ├─ Ephemeral storage                                   Monthly cost depends on usage: $0.0000000309 per GB-seconds   
+ └─ Duration (first 6B)                                 Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ Project total                                                                                                $747.64 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref3
+Module path: submod-ref3
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.8xlarge)                  730  hours                          $1,121.28 
+ ├─ root_block_device                                                                                                 
+ │  └─ Storage (general purpose SSD, gp2)                               100  GB                                $10.00 
+ └─ ebs_block_device[0]                                                                                               
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ ├─ Ephemeral storage                                   Monthly cost depends on usage: $0.0000000309 per GB-seconds   
+ └─ Duration (first 6B)                                 Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ Project total                                                                                              $1,308.28 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref1
+Module path: ref1
+
+ Name                                                                         Monthly Qty  Unit                    Monthly Cost 
+                                                                                                                                
+ aws_cloudwatch_log_group.this[0]                                                                                               
+ ├─ Data ingested                                                       Monthly cost depends on usage: $0.50 per GB             
+ ├─ Archival Storage                                                    Monthly cost depends on usage: $0.03 per GB             
+ └─ Insights queries data scanned                                       Monthly cost depends on usage: $0.005 per GB            
+                                                                                                                                
+ aws_eks_cluster.this[0]                                                                                                        
+ └─ EKS cluster                                                                       730  hours                         $73.00 
+                                                                                                                                
+ module.eks_managed_node_group["blue"].aws_eks_node_group.this[0]                                                               
+ └─ module.eks_managed_node_group["blue"].aws_launch_template.this[0]                                                           
+    ├─ Instance usage (Linux/UNIX, on-demand, m6i.large)                              730  hours                         $70.08 
+    └─ EC2 detailed monitoring                                                          7  metrics                        $2.10 
+                                                                                                                                
+ module.eks_managed_node_group["green"].aws_eks_node_group.this[0]                                                              
+ └─ module.eks_managed_node_group["green"].aws_launch_template.this[0]                                                          
+    ├─ Instance usage (Linux/UNIX, on-demand, t3.large)                               730  hours                         $60.74 
+    └─ EC2 detailed monitoring                                                          7  metrics                        $2.10 
+                                                                                                                                
+ module.fargate_profile["default"].aws_eks_fargate_profile.this[0]                                                              
+ ├─ Per GB per hour                                                                     1  GB                             $3.24 
+ └─ Per vCPU per hour                                                                   1  CPU                           $29.55 
+                                                                                                                                
+ module.kms.aws_kms_key.this[0]                                                                                                 
+ ├─ Customer master key                                                                 1  months                         $1.00 
+ ├─ Requests                                                            Monthly cost depends on usage: $0.03 per 10k requests   
+ ├─ ECC GenerateDataKeyPair requests                                    Monthly cost depends on usage: $0.10 per 10k requests   
+ └─ RSA GenerateDataKeyPair requests                                    Monthly cost depends on usage: $0.10 per 10k requests   
+                                                                                                                                
+ module.self_managed_node_group["one"].aws_autoscaling_group.this[0]                                                            
+ └─ module.self_managed_node_group["one"].aws_launch_template.this[0]                                                           
+    ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                             1,460  hours                        $140.16 
+    └─ EC2 detailed monitoring                                                         14  metrics                        $4.20 
+                                                                                                                                
+ Project total                                                                                                          $386.17 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref1-submod
+Module path: ref1-submod
+
+ Name                             Monthly Qty  Unit  Monthly Cost 
+                                                                  
+ aws_eks_fargate_profile.this[0]                                  
+ ├─ Per GB per hour                         1  GB           $3.24 
+ └─ Per vCPU per hour                       1  CPU         $29.55 
+                                                                  
+ Project total                                             $32.80 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref2
+Module path: ref2
+
+ Name                                                                         Monthly Qty  Unit                    Monthly Cost 
+                                                                                                                                
+ aws_cloudwatch_log_group.this[0]                                                                                               
+ ├─ Data ingested                                                       Monthly cost depends on usage: $0.50 per GB             
+ ├─ Archival Storage                                                    Monthly cost depends on usage: $0.03 per GB             
+ └─ Insights queries data scanned                                       Monthly cost depends on usage: $0.005 per GB            
+                                                                                                                                
+ aws_eks_cluster.this[0]                                                                                                        
+ └─ EKS cluster                                                                       730  hours                         $73.00 
+                                                                                                                                
+ module.eks_managed_node_group["blue"].aws_eks_node_group.this[0]                                                               
+ └─ module.eks_managed_node_group["blue"].aws_launch_template.this[0]                                                           
+    ├─ Instance usage (Linux/UNIX, on-demand, m6i.large)                              730  hours                         $70.08 
+    └─ EC2 detailed monitoring                                                          7  metrics                        $2.10 
+                                                                                                                                
+ module.eks_managed_node_group["green"].aws_eks_node_group.this[0]                                                              
+ └─ module.eks_managed_node_group["green"].aws_launch_template.this[0]                                                          
+    ├─ Instance usage (Linux/UNIX, on-demand, t3.large)                               730  hours                         $60.74 
+    └─ EC2 detailed monitoring                                                          7  metrics                        $2.10 
+                                                                                                                                
+ module.fargate_profile["default"].aws_eks_fargate_profile.this[0]                                                              
+ ├─ Per GB per hour                                                                     1  GB                             $3.24 
+ └─ Per vCPU per hour                                                                   1  CPU                           $29.55 
+                                                                                                                                
+ module.kms.aws_kms_key.this[0]                                                                                                 
+ ├─ Customer master key                                                                 1  months                         $1.00 
+ ├─ Requests                                                            Monthly cost depends on usage: $0.03 per 10k requests   
+ ├─ ECC GenerateDataKeyPair requests                                    Monthly cost depends on usage: $0.10 per 10k requests   
+ └─ RSA GenerateDataKeyPair requests                                    Monthly cost depends on usage: $0.10 per 10k requests   
+                                                                                                                                
+ module.self_managed_node_group["one"].aws_autoscaling_group.this[0]                                                            
+ └─ module.self_managed_node_group["one"].aws_launch_template.this[0]                                                           
+    ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                             1,460  hours                        $140.16 
+    └─ EC2 detailed monitoring                                                         14  metrics                        $4.20 
+                                                                                                                                
+ Project total                                                                                                          $386.17 
+
+ OVERALL TOTAL                                                                                                        $5,290.62 
+──────────────────────────────────
+114 cloud resources were detected:
+∙ 21 were estimated, 14 of which include usage-based costs, see https://infracost.io/usage-file
+∙ 93 were free, rerun with --show-skipped to see details
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...with_remote_source/submod-ref1 ┃ $2,430       ┃
+┃ infracost/infracost/cmd/infraco...th_remote_source/submod-ref1-2 ┃ $748         ┃
+┃ infracost/infracost/cmd/infraco...with_remote_source/submod-ref3 ┃ $1,308       ┃
+┃ infracost/infracost/cmd/infraco...agrunt_with_remote_source/ref1 ┃ $386         ┃
+┃ infracost/infracost/cmd/infraco...with_remote_source/ref1-submod ┃ $33          ┃
+┃ infracost/infracost/cmd/infraco...agrunt_with_remote_source/ref2 ┃ $386         ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/infracost.yml
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/infracost.yml
@@ -1,0 +1,9 @@
+version: 0.1
+
+projects:
+  - path: ./testdata/breakdown_terragrunt_with_remote_source/submod-ref1
+  - path: ./testdata/breakdown_terragrunt_with_remote_source/submod-ref1-2
+  - path: ./testdata/breakdown_terragrunt_with_remote_source/submod-ref3
+  - path: ./testdata/breakdown_terragrunt_with_remote_source/ref1
+  - path: ./testdata/breakdown_terragrunt_with_remote_source/ref1-submod
+  - path: ./testdata/breakdown_terragrunt_with_remote_source/ref2

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref1-submod/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref1-submod/terragrunt.hcl
@@ -1,0 +1,18 @@
+terraform {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-eks.git//modules/fargate-profile?ref=v19.15.2"
+}
+
+inputs = {
+  name         = "separate-fargate-profile"
+  cluster_name = "my-cluster"
+
+  subnet_ids = ["subnet-abcde012", "subnet-bcde012a", "subnet-fghi345a"]
+  selectors = [{
+    namespace = "kube-system"
+  }]
+
+  tags = {
+    Environment = "dev"
+    Terraform   = "true"
+  }
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref1/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref1/terragrunt.hcl
@@ -1,0 +1,119 @@
+terraform {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-eks.git?ref=v19.15.2"
+}
+
+inputs = {
+  cluster_name    = "my-cluster"
+  cluster_version = "1.27"
+
+  cluster_endpoint_public_access = true
+
+  cluster_addons = {
+    coredns = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+    }
+  }
+
+  vpc_id                   = "vpc-1234556abcdef"
+  subnet_ids               = ["subnet-abcde012", "subnet-bcde012a", "subnet-fghi345a"]
+  control_plane_subnet_ids = ["subnet-xyzde987", "subnet-slkjf456", "subnet-qeiru789"]
+
+  # Self Managed Node Group(s)
+  self_managed_node_group_defaults = {
+    instance_type                          = "m6i.large"
+    update_launch_template_default_version = true
+    iam_role_additional_policies           = {
+      AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    }
+  }
+
+  self_managed_node_groups = {
+    one = {
+      name         = "mixed-1"
+      max_size     = 5
+      desired_size = 2
+
+      use_mixed_instances_policy = true
+      mixed_instances_policy     = {
+        override = [
+          {
+            instance_type     = "m5.large"
+            weighted_capacity = "1"
+          },
+          {
+            instance_type     = "m6i.large"
+            weighted_capacity = "2"
+          },
+        ]
+      }
+    }
+  }
+
+  # EKS Managed Node Group(s)
+  eks_managed_node_group_defaults = {
+    instance_types = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
+  }
+
+  eks_managed_node_groups = {
+    blue  = {}
+    green = {
+      min_size     = 1
+      max_size     = 10
+      desired_size = 1
+
+      instance_types = ["t3.large"]
+    }
+  }
+
+  # Fargate Profile(s)
+  fargate_profiles = {
+    default = {
+      name      = "default"
+      selectors = [
+        {
+          namespace = "default"
+        }
+      ]
+    }
+  }
+
+  # aws-auth configmap
+  manage_aws_auth_configmap = true
+
+  aws_auth_roles = [
+    {
+      rolearn  = "arn:aws:iam::66666666666:role/role1"
+      username = "role1"
+      groups   = ["system:masters"]
+    },
+  ]
+
+  aws_auth_users = [
+    {
+      userarn  = "arn:aws:iam::66666666666:user/user1"
+      username = "user1"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::66666666666:user/user2"
+      username = "user2"
+      groups   = ["system:masters"]
+    },
+  ]
+
+  aws_auth_accounts = [
+    "777777777777",
+    "888888888888",
+  ]
+
+  tags = {
+    Environment = "dev"
+    Terraform   = "true"
+  }
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref2/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref2/terragrunt.hcl
@@ -1,0 +1,119 @@
+terraform {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-eks.git"
+}
+
+inputs = {
+  cluster_name    = "my-cluster"
+  cluster_version = "1.27"
+
+  cluster_endpoint_public_access = true
+
+  cluster_addons = {
+    coredns = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent = true
+    }
+  }
+
+  vpc_id                   = "vpc-1234556abcdef"
+  subnet_ids               = ["subnet-abcde012", "subnet-bcde012a", "subnet-fghi345a"]
+  control_plane_subnet_ids = ["subnet-xyzde987", "subnet-slkjf456", "subnet-qeiru789"]
+
+  # Self Managed Node Group(s)
+  self_managed_node_group_defaults = {
+    instance_type                          = "m6i.large"
+    update_launch_template_default_version = true
+    iam_role_additional_policies           = {
+      AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    }
+  }
+
+  self_managed_node_groups = {
+    one = {
+      name         = "mixed-1"
+      max_size     = 5
+      desired_size = 2
+
+      use_mixed_instances_policy = true
+      mixed_instances_policy     = {
+        override = [
+          {
+            instance_type     = "m5.large"
+            weighted_capacity = "1"
+          },
+          {
+            instance_type     = "m6i.large"
+            weighted_capacity = "2"
+          },
+        ]
+      }
+    }
+  }
+
+  # EKS Managed Node Group(s)
+  eks_managed_node_group_defaults = {
+    instance_types = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
+  }
+
+  eks_managed_node_groups = {
+    blue  = {}
+    green = {
+      min_size     = 1
+      max_size     = 10
+      desired_size = 1
+
+      instance_types = ["t3.large"]
+    }
+  }
+
+  # Fargate Profile(s)
+  fargate_profiles = {
+    default = {
+      name      = "default"
+      selectors = [
+        {
+          namespace = "default"
+        }
+      ]
+    }
+  }
+
+  # aws-auth configmap
+  manage_aws_auth_configmap = true
+
+  aws_auth_roles = [
+    {
+      rolearn  = "arn:aws:iam::66666666666:role/role1"
+      username = "role1"
+      groups   = ["system:masters"]
+    },
+  ]
+
+  aws_auth_users = [
+    {
+      userarn  = "arn:aws:iam::66666666666:user/user1"
+      username = "user1"
+      groups   = ["system:masters"]
+    },
+    {
+      userarn  = "arn:aws:iam::66666666666:user/user2"
+      username = "user2"
+      groups   = ["system:masters"]
+    },
+  ]
+
+  aws_auth_accounts = [
+    "777777777777",
+    "888888888888",
+  ]
+
+  tags = {
+    Environment = "dev"
+    Terraform   = "true"
+  }
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref1-2/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref1-2/terragrunt.hcl
@@ -1,0 +1,12 @@
+terraform {
+  source = "git::https://github.com/infracost/infracost.git//examples/terragrunt/modules/example?ref=74725d6e91aa91d7283642b7ed3316d12f271212"
+}
+
+inputs = {
+  instance_type = "m5.4xlarge"
+  root_block_device_volume_size = 100
+  block_device_volume_size = 1000
+  block_device_iops = 800
+
+  hello_world_function_memory_size = 1024
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref1/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref1/terragrunt.hcl
@@ -1,0 +1,12 @@
+terraform {
+  source = "git::https://github.com/infracost/infracost.git//examples/terragrunt/modules/example?ref=74725d6e91aa91d7283642b7ed3316d12f271212"
+}
+
+inputs = {
+  instance_type = "m5.16xlarge"
+  root_block_device_volume_size = 100
+  block_device_volume_size = 1000
+  block_device_iops = 800
+
+  hello_world_function_memory_size = 1024
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref3/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref3/terragrunt.hcl
@@ -1,0 +1,12 @@
+terraform {
+  source = "git::https://github.com/infracost/infracost.git//examples/terragrunt/modules/example?ref=1f94a2fd07b3e29deea4706b5d2fdc68c1d02aad"
+}
+
+inputs = {
+  instance_type = "m5.8xlarge"
+  root_block_device_volume_size = 100
+  block_device_volume_size = 1000
+  block_device_iops = 800
+
+  hello_world_function_memory_size = 1024
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
@@ -1,0 +1,112 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref1
+Module path: submod-ref1
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ ├─ Ephemeral storage                                   Monthly cost depends on usage: $0.0000000309 per GB-seconds   
+ └─ Duration (first 6B)                                 Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ Project total                                                                                                $560.64 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref2
+Module path: submod-ref2
+
+Errors:
+  Working dir cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/modules/instance from source git::https://github.com/infracost/infracost.git?ref=74725d6e91aa91d7283642b7ed3316d12f271212 does not exist
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/submod-ref3
+Module path: submod-ref3
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ ├─ Ephemeral storage                                   Monthly cost depends on usage: $0.0000000309 per GB-seconds   
+ └─ Duration (first 6B)                                 Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ Project total                                                                                                $560.64 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref1
+Module path: ref1
+
+Errors:
+  1 error occurred:
+	* error downloading 'https://github.com/terraform-aws-modules/terraform-aws-eks.git?ref=19.15.2':
+    /opt/homebrew/bin/git exited with 1:
+      error:
+        pathspec '19.15.2' did not match any file(s) known to git
+
+
+
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref2
+Module path: ref2
+
+ Name                                                                         Monthly Qty  Unit                    Monthly Cost 
+                                                                                                                                
+ aws_cloudwatch_log_group.this[0]                                                                                               
+ ├─ Data ingested                                                       Monthly cost depends on usage: $0.50 per GB             
+ ├─ Archival Storage                                                    Monthly cost depends on usage: $0.03 per GB             
+ └─ Insights queries data scanned                                       Monthly cost depends on usage: $0.005 per GB            
+                                                                                                                                
+ aws_eks_cluster.this[0]                                                                                                        
+ └─ EKS cluster                                                                       730  hours                         $73.00 
+                                                                                                                                
+ module.eks_managed_node_group["blue"].aws_eks_node_group.this[0]                                                               
+ └─ module.eks_managed_node_group["blue"].aws_launch_template.this[0]                                                           
+    ├─ Instance usage (Linux/UNIX, on-demand, m6i.large)                              730  hours                         $70.08 
+    └─ EC2 detailed monitoring                                                          7  metrics                        $2.10 
+                                                                                                                                
+ module.eks_managed_node_group["green"].aws_eks_node_group.this[0]                                                              
+ └─ module.eks_managed_node_group["green"].aws_launch_template.this[0]                                                          
+    ├─ Instance usage (Linux/UNIX, on-demand, t3.large)                               730  hours                         $60.74 
+    └─ EC2 detailed monitoring                                                          7  metrics                        $2.10 
+                                                                                                                                
+ module.fargate_profile["default"].aws_eks_fargate_profile.this[0]                                                              
+ ├─ Per GB per hour                                                                     1  GB                             $3.24 
+ └─ Per vCPU per hour                                                                   1  CPU                           $29.55 
+                                                                                                                                
+ module.kms.aws_kms_key.this[0]                                                                                                 
+ ├─ Customer master key                                                                 1  months                         $1.00 
+ ├─ Requests                                                            Monthly cost depends on usage: $0.03 per 10k requests   
+ ├─ ECC GenerateDataKeyPair requests                                    Monthly cost depends on usage: $0.10 per 10k requests   
+ └─ RSA GenerateDataKeyPair requests                                    Monthly cost depends on usage: $0.10 per 10k requests   
+                                                                                                                                
+ module.self_managed_node_group["one"].aws_autoscaling_group.this[0]                                                            
+ └─ module.self_managed_node_group["one"].aws_launch_template.this[0]                                                           
+    ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                               730  hours                         $70.08 
+    ├─ Instance usage (Linux/UNIX, spot, m5.large)                                    730  hours                         $33.87 
+    └─ EC2 detailed monitoring                                                         14  metrics                        $4.20 
+                                                                                                                                
+ Project total                                                                                                          $349.96 
+
+ OVERALL TOTAL                                                                                                        $1,471.24 
+──────────────────────────────────
+56 cloud resources were detected:
+∙ 11 were estimated, 8 of which include usage-based costs, see https://infracost.io/usage-file
+∙ 45 were free, rerun with --show-skipped to see details
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...with_remote_source/submod-ref1 ┃ $561         ┃
+┃ infracost/infracost/cmd/infraco...with_remote_source/submod-ref2 ┃ $0.00        ┃
+┃ infracost/infracost/cmd/infraco...with_remote_source/submod-ref3 ┃ $561         ┃
+┃ infracost/infracost/cmd/infraco...agrunt_with_remote_source/ref1 ┃ $0.00        ┃
+┃ infracost/infracost/cmd/infraco...agrunt_with_remote_source/ref2 ┃ $350         ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+
+Err:
+

--- a/go.mod
+++ b/go.mod
@@ -266,4 +266,4 @@ replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
-replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20230627084705-f27e16c7e6bd
+replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20230808085620-a0a234c63878

--- a/go.sum
+++ b/go.sum
@@ -831,8 +831,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/infracost/terragrunt v0.47.1-0.20230627084705-f27e16c7e6bd h1:TQm106xMJQcZeYp1FzPdGMTAYer1UeVC5ovXIQcU1kg=
-github.com/infracost/terragrunt v0.47.1-0.20230627084705-f27e16c7e6bd/go.mod h1:UUPeQZP+swqZpL5XCTtf8LT/ozO84uocbJ41FuoF6eE=
+github.com/infracost/terragrunt v0.47.1-0.20230808085620-a0a234c63878 h1:R6LNCL0t0HMlkeY9t+3PhiSQVMBtqtWWO7mrbQUKF5c=
+github.com/infracost/terragrunt v0.47.1-0.20230808085620-a0a234c63878/go.mod h1:UUPeQZP+swqZpL5XCTtf8LT/ozO84uocbJ41FuoF6eE=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -21,11 +21,9 @@ import (
 	"github.com/gruntwork-io/terragrunt/options"
 	tgoptions "github.com/gruntwork-io/terragrunt/options"
 	"github.com/gruntwork-io/terragrunt/util"
-	"github.com/hashicorp/go-getter"
 	hcl2 "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
-	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -37,10 +35,13 @@ import (
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/hcl"
 	"github.com/infracost/infracost/internal/schema"
+	infSync "github.com/infracost/infracost/internal/sync"
 	"github.com/infracost/infracost/internal/ui"
 )
 
-const terragruntSourceVersionFile = ".terragrunt-source-version"
+// terragruntSourceLock is the global lock which works across TerragrunHCLProviders to provide
+// concurrency safe downloading.
+var terragruntSourceLock = infSync.KeyMutex{}
 
 type panicError struct {
 	msg string
@@ -543,7 +544,22 @@ func (p *TerragruntHCLProvider) runTerragrunt(opts *tgoptions.TerragruntOptions)
 		return
 	}
 	if sourceURL != "" {
-		updatedTerragruntOptions, err := p.downloadTerraformSource(sourceURL, opts, terragruntConfig)
+		source, err := tfsource.NewTerraformSource(sourceURL, opts.DownloadDir, opts.WorkingDir, opts.Logger)
+		if err != nil {
+			info.error = err
+			return
+		}
+
+		// make the source download directory absolute so that we lock on a consistent key.
+		dir := source.DownloadDir
+		if v, err := filepath.Abs(dir); err == nil {
+			dir = v
+		}
+
+		unlock := terragruntSourceLock.Lock(dir)
+		updatedTerragruntOptions, err := tgcli.DownloadTerraformSource(sourceURL, opts, terragruntConfig)
+		unlock()
+
 		if err != nil {
 			info.error = err
 			return
@@ -931,263 +947,6 @@ func generateTypeFromValuesMap(valMap map[string]cty.Value) cty.Type {
 		outType[k] = v.Type()
 	}
 	return cty.Object(outType)
-}
-
-// 1. Download the given source URL, which should use Terraform's module source syntax, into a temporary folder
-// 2. Check if module directory exists in temporary folder
-// 3. Copy the contents of terragruntOptions.WorkingDir into the temporary folder.
-// 4. Set terragruntOptions.WorkingDir to the temporary folder.
-//
-// See the NewTerraformSource method for how we determine the temporary folder so we can reuse it across multiple
-// runs of Terragrunt to avoid downloading everything from scratch every time.
-// Copied from github.com/gruntwork-io/terragrunt
-func (p *TerragruntHCLProvider) downloadTerraformSource(source string, terragruntOptions *tgoptions.TerragruntOptions, terragruntConfig *tgconfig.TerragruntConfig) (*tgoptions.TerragruntOptions, error) {
-	terraformSource, err := tfsource.NewTerraformSource(source, terragruntOptions.DownloadDir, terragruntOptions.WorkingDir, terragruntOptions.Logger)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := p.downloadTerraformSourceIfNecessary(terraformSource, terragruntOptions, terragruntConfig); err != nil {
-		return nil, err
-	}
-
-	if _, ok := p.sourceCache[terraformSource.CanonicalSourceURL.String()]; !ok {
-		terragruntOptions.Logger.Debugf("Adding %s to the source cache", terraformSource.CanonicalSourceURL.String())
-		p.sourceCache[terraformSource.CanonicalSourceURL.String()] = terraformSource.DownloadDir
-	}
-
-	terragruntOptions.Logger.Debugf("Copying files from %s into %s", terragruntOptions.WorkingDir, terraformSource.WorkingDir)
-	var includeInCopy []string
-	if terragruntConfig.Terraform != nil && terragruntConfig.Terraform.IncludeInCopy != nil {
-		includeInCopy = *terragruntConfig.Terraform.IncludeInCopy
-	}
-	if err := util.CopyFolderContents(terragruntOptions.WorkingDir, terraformSource.WorkingDir, tgcli.MODULE_MANIFEST_NAME, includeInCopy); err != nil {
-		return nil, err
-	}
-
-	updatedTerragruntOptions := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
-
-	terragruntOptions.Logger.Debugf("Setting working directory to %s", terraformSource.WorkingDir)
-	updatedTerragruntOptions.WorkingDir = terraformSource.WorkingDir
-
-	return updatedTerragruntOptions, nil
-}
-
-// copyLocalSource copies the contents of a previously downloaded source folder into the destination folder
-func (p *TerragruntHCLProvider) copyLocalSource(prevDest string, dest string, terragruntOptions *tgoptions.TerragruntOptions) error {
-	err := os.MkdirAll(dest, os.ModePerm)
-	if err != nil {
-		return fmt.Errorf("failed to create directory '%s': %w", dest, err)
-	}
-
-	// Skip dotfiles and, but keep:
-	// 1. Terraform lock files - these are normally committed to source control
-	// 2. .terragrunt-source-version files - these are used to determine if the source has changed
-	// 3. .infracost dir - this contains any cached third party modules. We can remove this when we move this directory to the root path
-	opt := copy.Options{
-		Skip: func(src string) (bool, error) {
-			base := filepath.Base(src)
-			if base == util.TerraformLockFile || base == terragruntSourceVersionFile || base == config.InfracostDir {
-				return false, nil
-			}
-
-			return strings.HasPrefix(base, "."), nil
-		},
-		OnSymlink: func(src string) copy.SymlinkAction {
-			return copy.Shallow
-		},
-	}
-
-	err = copy.Copy(prevDest, dest, opt)
-	if err != nil {
-		return fmt.Errorf("failed to copy source from '%s' to '%s': %w", prevDest, dest, err)
-	}
-
-	return nil
-}
-
-// Download the specified TerraformSource if the latest code hasn't already been downloaded.
-// Copied from github.com/gruntwork-io/terragrunt
-func (p *TerragruntHCLProvider) downloadTerraformSourceIfNecessary(terraformSource *tfsource.TerraformSource, terragruntOptions *tgoptions.TerragruntOptions, terragruntConfig *tgconfig.TerragruntConfig) error {
-	alreadyLatest, err := p.alreadyHaveLatestCode(terraformSource, terragruntOptions)
-	if err != nil {
-		return err
-	}
-
-	if alreadyLatest {
-		if err := p.validateWorkingDir(terraformSource); err != nil {
-			return err
-		}
-		terragruntOptions.Logger.Debugf("Terraform files in %s are up to date. Will not download again.", terraformSource.WorkingDir)
-		return nil
-	}
-
-	var previousVersion = ""
-	// read previous source version
-	// https://github.com/gruntwork-io/terragrunt/issues/1921
-	if util.FileExists(terraformSource.VersionFile) {
-		previousVersion, err = p.readVersionFile(terraformSource)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Check if the directory has already been downloaded during this run and is in the source cache
-	// If so, we can just copy the files from the previous download to avoid downloading again
-	if prevDownloadDir, ok := p.sourceCache[terraformSource.CanonicalSourceURL.String()]; ok {
-		terragruntOptions.Logger.Debugf("Source files have already been downloading. Copying files from %s into %s", prevDownloadDir, terraformSource.DownloadDir)
-		err := p.copyLocalSource(prevDownloadDir, terraformSource.DownloadDir, terragruntOptions)
-		if err != nil {
-			terragruntOptions.Logger.Debugf("Failed to copy local source from %s to %s: %v. Will try to redownload", prevDownloadDir, terraformSource.DownloadDir, err)
-		} else {
-			terragruntOptions.Logger.Debugf("Successfully copied files from %s to %s. Will not download again", prevDownloadDir, terraformSource.DownloadDir)
-			return nil
-		}
-	}
-
-	// When downloading source, we need to process any hooks waiting on `init-from-module`. Therefore, we clone the
-	// options struct, set the command to the value the hooks are expecting, and run the download action surrounded by
-	// before and after hooks (if any).
-	// terragruntOptionsForDownload := terragruntOptions.Clone(terragruntOptions.TerragruntConfigPath)
-	// terragruntOptionsForDownload.TerraformCommand = tgcli.CMD_INIT_FROM_MODULE
-	// downloadErr := runActionWithHooks("download source", terragruntOptionsForDownload, terragruntConfig, func() error {
-	//	return downloadSource(terraformSource, terragruntOptions, terragruntConfig)
-	// })
-	downloadErr := p.downloadSource(terraformSource, terragruntOptions, terragruntConfig)
-
-	if downloadErr != nil {
-		return downloadErr
-	}
-
-	if err := terraformSource.WriteVersionFile(); err != nil {
-		return err
-	}
-
-	if err := p.validateWorkingDir(terraformSource); err != nil {
-		return err
-	}
-
-	currentVersion, err := terraformSource.EncodeSourceVersion()
-	if err != nil {
-		return fmt.Errorf("could not encode source version: %w", err)
-	}
-	// if source versions are different, create file to run init
-	// https://github.com/gruntwork-io/terragrunt/issues/1921
-	if previousVersion != currentVersion {
-		initFile := util.JoinPath(terraformSource.WorkingDir, ".terragrunt-init-required")
-		f, createErr := os.Create(initFile)
-		if createErr != nil {
-			return createErr
-		}
-		defer f.Close()
-	}
-
-	return nil
-}
-
-// Download the code from the Canonical Source URL into the Download Folder using the go-getter library
-// Copied from github.com/gruntwork-io/terragrunt
-func (p *TerragruntHCLProvider) downloadSource(terraformSource *tfsource.TerraformSource, terragruntOptions *tgoptions.TerragruntOptions, terragruntConfig *tgconfig.TerragruntConfig) error {
-	terragruntOptions.Logger.Debugf("Downloading Terraform configurations from %s into %s", terraformSource.CanonicalSourceURL, terraformSource.DownloadDir)
-
-	if err := getter.GetAny(terraformSource.DownloadDir, terraformSource.CanonicalSourceURL.String(), p.updateGetters(terragruntConfig)); err != nil {
-		return tgerrors.WithStackTrace(err)
-	}
-
-	return nil
-}
-
-// updateGetters returns the customized go-getter interfaces that Terragrunt relies on. Specifically:
-//   - Local file path getter is updated to copy the files instead of creating symlinks, which is what go-getter defaults
-//     to.
-//   - Include the customized getter for fetching sources from the Terraform Registry.
-//
-// This creates a closure that returns a function so that we have access to the terragrunt configuration, which is
-// necessary for customizing the behavior of the file getter.
-// Copied from github.com/gruntwork-io/terragrunt
-func (p *TerragruntHCLProvider) updateGetters(terragruntConfig *tgconfig.TerragruntConfig) func(*getter.Client) error {
-	return func(client *getter.Client) error {
-		// We copy all the default getters from the go-getter library, but replace the "file" getter. We shallow clone the
-		// getter map here rather than using getter.Getters directly because (a) we shouldn't change the original,
-		// globally-shared getter.Getters map and (b) Terragrunt may run this code from many goroutines concurrently during
-		// xxx-all calls, so creating a new map each time ensures we don't a "concurrent map writes" error.
-		client.Getters = map[string]getter.Getter{}
-		for getterName, getterValue := range getter.Getters {
-			if getterName == "file" {
-				var includeInCopy []string
-				if terragruntConfig.Terraform != nil && terragruntConfig.Terraform.IncludeInCopy != nil {
-					includeInCopy = *terragruntConfig.Terraform.IncludeInCopy
-				}
-				client.Getters[getterName] = &tgcli.FileCopyGetter{IncludeInCopy: includeInCopy}
-			} else {
-				client.Getters[getterName] = getterValue
-			}
-		}
-
-		// Load in custom getters that are only supported in Terragrunt
-		client.Getters["tfr"] = &TerraformRegistryGetter{}
-
-		return nil
-	}
-}
-
-// Check if working terraformSource.WorkingDir exists and is directory
-// Copied from github.com/gruntwork-io/terragrunt
-func (p *TerragruntHCLProvider) validateWorkingDir(terraformSource *tfsource.TerraformSource) error {
-	workingLocalDir := strings.ReplaceAll(terraformSource.WorkingDir, terraformSource.DownloadDir+filepath.FromSlash("/"), "")
-	if util.IsFile(terraformSource.WorkingDir) {
-		return tgcli.WorkingDirNotDir{Dir: workingLocalDir, Source: terraformSource.CanonicalSourceURL.String()}
-	}
-	if !util.IsDir(terraformSource.WorkingDir) {
-		return tgcli.WorkingDirNotFound{Dir: workingLocalDir, Source: terraformSource.CanonicalSourceURL.String()}
-	}
-
-	return nil
-}
-
-// Returns true if the specified TerraformSource, of the exact same version, has already been downloaded into the
-// DownloadFolder. This helps avoid downloading the same code multiple times. Note that if the TerraformSource points
-// to a local file path, we assume the user is doing local development and always return false to ensure the latest
-// code is downloaded (or rather, copied) every single time. See the ProcessTerraformSource method for more info.
-// Copied from github.com/gruntwork-io/terragrunt
-func (p *TerragruntHCLProvider) alreadyHaveLatestCode(terraformSource *tfsource.TerraformSource, terragruntOptions *tgoptions.TerragruntOptions) (bool, error) {
-	if tfsource.IsLocalSource(terraformSource.CanonicalSourceURL) ||
-		!util.FileExists(terraformSource.DownloadDir) ||
-		!util.FileExists(terraformSource.WorkingDir) ||
-		!util.FileExists(terraformSource.VersionFile) {
-
-		return false, nil
-	}
-
-	tfFiles, err := filepath.Glob(fmt.Sprintf("%s/*.tf", terraformSource.WorkingDir))
-	if err != nil {
-		return false, tgerrors.WithStackTrace(err)
-	}
-
-	if len(tfFiles) == 0 {
-		terragruntOptions.Logger.Debugf("Working dir %s exists but contains no Terraform files, so assuming code needs to be downloaded again.", terraformSource.WorkingDir)
-		return false, nil
-	}
-
-	currentVersion, err := terraformSource.EncodeSourceVersion()
-	if err != nil {
-		return false, fmt.Errorf("could not encode source version: %w", err)
-	}
-
-	previousVersion, err := p.readVersionFile(terraformSource)
-	if err != nil {
-		return false, err
-	}
-
-	return previousVersion == currentVersion, nil
-}
-
-// Return the version number stored in the DownloadDir. This version number can be used to check if the Terraform code
-// that has already been downloaded is the same as the version the user is currently requesting. The version number is
-// calculated using the encodeSourceVersion method.
-// Copied from github.com/gruntwork-io/terragrunt
-func (p *TerragruntHCLProvider) readVersionFile(terraformSource *tfsource.TerraformSource) (string, error) {
-	return util.ReadFileAsString(terraformSource.VersionFile)
 }
 
 type terragruntDependency struct {


### PR DESCRIPTION


Resolves issue where modules using refs where being downloaded to same directory. We now encode the ref/query into the directory hash: https://github.com/infracost/terragrunt/pull/4/commits/a0a234c6387888404e78489071bc78cde25abd06 so the directories are unique. The source lock is updated to use the download directory that terragrunt checks to ensure that goroutines are synced with the downloading logic.