### PR TITLE
fix: return correct values from stubbed data blocks in submodules

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -996,3 +996,15 @@ func TestBreakdownWithFreeResourcesChecksum(t *testing.T) {
 			ctx.Config.TagPoliciesEnabled = true
 		})
 }
+
+func TestBreakdownWithDataBlocksInSubmod(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", dir,
+		}, nil)
+}

--- a/cmd/infracost/testdata/breakdown_with_data_blocks_in_submod/breakdown_with_data_blocks_in_submod.golden
+++ b/cmd/infracost/testdata/breakdown_with_data_blocks_in_submod/breakdown_with_data_blocks_in_submod.golden
@@ -1,0 +1,44 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_data_blocks_in_submod
+
+ Name                                                        Monthly Qty  Unit   Monthly Cost 
+                                                                                              
+ module.vpc.aws_eip.available["eu-central-1-ham-1a"]                                          
+ └─ IP address (if unused)                                           730  hours         $3.65 
+                                                                                              
+ module.vpc.aws_eip.available["eu-central-1-waw-1a"]                                          
+ └─ IP address (if unused)                                           730  hours         $3.65 
+                                                                                              
+ module.vpc.aws_eip.available["eu-central-1-wl1-ber-wlz-1"]                                   
+ └─ IP address (if unused)                                           730  hours         $3.65 
+                                                                                              
+ module.vpc.aws_eip.available["eu-central-1-wl1-dtm-wlz-1"]                                   
+ └─ IP address (if unused)                                           730  hours         $3.65 
+                                                                                              
+ module.vpc.aws_eip.available["eu-central-1-wl1-muc-wlz-1"]                                   
+ └─ IP address (if unused)                                           730  hours         $3.65 
+                                                                                              
+ module.vpc.aws_eip.available["eu-central-1a"]                                                
+ └─ IP address (if unused)                                           730  hours         $3.65 
+                                                                                              
+ module.vpc.aws_eip.available["eu-central-1b"]                                                
+ └─ IP address (if unused)                                           730  hours         $3.65 
+                                                                                              
+ module.vpc.aws_eip.available["eu-central-1c"]                                                
+ └─ IP address (if unused)                                           730  hours         $3.65 
+                                                                                              
+ module.vpc.aws_eip.current["eu-central-1"]                                                   
+ └─ IP address (if unused)                                           730  hours         $3.65 
+                                                                                              
+ OVERALL TOTAL                                                                         $32.85 
+──────────────────────────────────
+9 cloud resources were detected:
+∙ 9 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...own_with_data_blocks_in_submod ┃ $33          ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_data_blocks_in_submod/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_data_blocks_in_submod/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = "eu-central-1"
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+}

--- a/cmd/infracost/testdata/breakdown_with_data_blocks_in_submod/modules/vpc/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_data_blocks_in_submod/modules/vpc/main.tf
@@ -1,0 +1,13 @@
+data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_eip" "available" {
+  for_each = { for entry in data.aws_availability_zones.available.names : "${entry}" => entry }
+}
+
+resource "aws_eip" "current" {
+  for_each = { for entry in [data.aws_region.current] : "${entry.name}" => entry }
+}

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -1155,10 +1155,17 @@ var (
 	blockValueFuncs = map[string]BlockValueFunc{
 		"data.aws_availability_zones": awsAvailabilityZonesValues,
 		"data.google_compute_zones":   googleComputeZonesValues,
+		"data.aws_region":             awsCurrentRegion,
 		"data.aws_default_tags":       awsDefaultTagValues,
 		"resource.random_shuffle":     randomShuffleValues,
 	}
 )
+
+func awsCurrentRegion(b *Block) cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"name": cty.StringVal(getRegionFromProvider(b, "aws")),
+	})
+}
 
 func awsDefaultTagValues(b *Block) cty.Value {
 	defaultTags := getFromProvider(b, "aws", "default_tags")

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -379,6 +379,7 @@ func (p *Parser) ParseDirectory() (m *Module, err error) {
 		p.blockBuilder,
 		p.newSpinner,
 		p.logger,
+		nil,
 	)
 
 	root, err := evaluator.Run()


### PR DESCRIPTION
Resolves issue where data blocks such as `data.aws_availability_zones` was returning the default value in a submodule. This was because the provider context was not properly set when evaluating submodules. Also adds support for `data.aws_region` block.