### PR TITLE
fix: avoid race conditions by only downloading tg sources once

### DIFF
--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -45,7 +45,7 @@ var terragruntSourceLock = infSync.KeyMutex{}
 
 // terragruntDownloadedDirs is used to ensure sources are only downloaded once. Use terragruntSourceLock
 // for concurrency safety.
-var terragruntDownloadedDirs = map[string]bool{}
+var terragruntDownloadedDirs = sync.Map{}
 
 type panicError struct {
 	msg string
@@ -645,7 +645,7 @@ func downloadSourceOnce(sourceURL string, opts *tgoptions.TerragruntOptions, ter
 	unlock := terragruntSourceLock.Lock(dir)
 	defer unlock()
 
-	if alreadyDownloaded := terragruntDownloadedDirs[dir]; alreadyDownloaded {
+	if _, alreadyDownloaded := terragruntDownloadedDirs.Load(dir); alreadyDownloaded {
 		return source.WorkingDir, nil
 	}
 
@@ -654,7 +654,7 @@ func downloadSourceOnce(sourceURL string, opts *tgoptions.TerragruntOptions, ter
 		return "", err
 	}
 
-	terragruntDownloadedDirs[dir] = true
+	terragruntDownloadedDirs.Store(dir, true)
 
 	return source.WorkingDir, nil
 }

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -43,8 +43,9 @@ import (
 // concurrency safe downloading.
 var terragruntSourceLock = infSync.KeyMutex{}
 
-// terragruntDownloadedDirs is used to ensure sources are only downloaded once. Use terragruntSourceLock
-// for concurrency safety.
+// terragruntDownloadedDirs is used to ensure sources are only downloaded once. This is needed
+// because the call to util.CopyFolderContents in tgcli.DownloadTerraformSource seems to be mucking
+// up the cache directory unnecessarily.  If that is fixed we can remove this.
 var terragruntDownloadedDirs = sync.Map{}
 
 type panicError struct {


### PR DESCRIPTION
@hugorut I think this is ok, but can you confirm that it's correct to only download the terragrunt sourceURL once?  