### PR TITLE
fix: support optional defaults

### DIFF
--- a/cmd/infracost/testdata/breakdown_with_optional_variables/breakdown_with_optional_variables.golden
+++ b/cmd/infracost/testdata/breakdown_with_optional_variables/breakdown_with_optional_variables.golden
@@ -14,15 +14,21 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_optional_vari
  aws_eip.test2[1]                                            
  └─ IP address (if unused)          730  hours         $3.65 
                                                              
- OVERALL TOTAL                                        $14.60 
+ aws_eip.test3[0]                                            
+ └─ IP address (if unused)          730  hours         $3.65 
+                                                             
+ aws_eip.test3[1]                                            
+ └─ IP address (if unused)          730  hours         $3.65 
+                                                             
+ OVERALL TOTAL                                        $21.90 
 ──────────────────────────────────
-4 cloud resources were detected:
-∙ 4 were estimated
+6 cloud resources were detected:
+∙ 6 were estimated
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...akdown_with_optional_variables ┃ $15          ┃
+┃ infracost/infracost/cmd/infraco...akdown_with_optional_variables ┃ $22          ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_with_optional_variables/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_optional_variables/main.tf
@@ -6,6 +6,7 @@ variable "var1" {
   type = object({
     attr1 = string
     attr2 = optional(string)
+    attr3 = optional(string, "value3")
   })
 
   default = {
@@ -31,3 +32,8 @@ resource "aws_eip" "test1" {
 resource "aws_eip" "test2" {
   count = var.var2.attr1 == "value2" ? 2 : 1
 }
+
+resource "aws_eip" "test3" {
+  count = var.var1.attr3 == "value3" ? 2 : 1
+}
+

--- a/internal/hcl/context.go
+++ b/internal/hcl/context.go
@@ -117,6 +117,10 @@ func mergeVars(src cty.Value, parts []string, value cty.Value) cty.Value {
 	return cty.ObjectVal(data)
 }
 
+// mergeObjects merges two cty.Value objects by recursively combining their
+// key-value pairs. When there are conflicting keys, the value from object `b`
+// takes precedence over object `a`, unless both values are valid cty objects, in
+// which case they are recursively merged.
 func mergeObjects(a cty.Value, b cty.Value) cty.Value {
 	output := make(map[string]cty.Value)
 


### PR DESCRIPTION
This change adds support for type definitions which contain optional defaults. For example:

```
variable "my_var" {
  type = object({
    attr1 = string
    attr2 = optional(string, "value2")
  })

  default = {
    attr1 = "value1"
  }
}
```

would resolve to:

```
my_var = {
  attr1 = "value1"
  attr2 = "value2"
}
```

This solves cost estimate inconsistencies various users experienced when using variables attributes that contained optional defaults.