### PR TITLE
fix: cty panic when variable type definition is not an object

### DIFF
--- a/cmd/infracost/testdata/breakdown_with_optional_variables/breakdown_with_optional_variables.golden
+++ b/cmd/infracost/testdata/breakdown_with_optional_variables/breakdown_with_optional_variables.golden
@@ -20,15 +20,21 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_optional_vari
  aws_eip.test3[1]                                            
  └─ IP address (if unused)          730  hours         $3.65 
                                                              
- OVERALL TOTAL                                        $21.90 
+ aws_eip.test4[0]                                            
+ └─ IP address (if unused)          730  hours         $3.65 
+                                                             
+ aws_eip.test4[1]                                            
+ └─ IP address (if unused)          730  hours         $3.65 
+                                                             
+ OVERALL TOTAL                                        $29.20 
 ──────────────────────────────────
-6 cloud resources were detected:
-∙ 6 were estimated
+8 cloud resources were detected:
+∙ 8 were estimated
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...akdown_with_optional_variables ┃ $22          ┃
+┃ infracost/infracost/cmd/infraco...akdown_with_optional_variables ┃ $29          ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_with_optional_variables/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_optional_variables/main.tf
@@ -25,6 +25,18 @@ variable "var2" {
   }
 }
 
+variable "var3" {
+  type = list(object({
+    attr1 = string
+    attr2 = optional(string)
+    attr3 = optional(string, "value3")
+  }))
+
+  default = [{
+    attr1 = "value1"
+  }]
+}
+
 resource "aws_eip" "test1" {
   count = var.var1.attr1 == "value1" ? 2 : 1
 }
@@ -35,5 +47,9 @@ resource "aws_eip" "test2" {
 
 resource "aws_eip" "test3" {
   count = var.var1.attr3 == "value3" ? 2 : 1
+}
+
+resource "aws_eip" "test4" {
+  count = var.var3[0].attr3 == "value3" ? 2 : 1
 }
 

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -648,7 +648,7 @@ func (e *Evaluator) convertType(b *Block, val cty.Value, attrType *Attribute) (c
 	// with optional types that have default values e.g., optional(string, "foo")
 	// are fully resolved.
 	if def != nil {
-		val = mergeObjects(cty.ObjectVal(def.DefaultValues), val)
+		val = def.Apply(val)
 	}
 	return convert.Convert(val, ty)
 }


### PR DESCRIPTION
Switches `convertType` logic to use `Defaults.Apply` which handles other complex types other than objects. This means types like `list(object(...` or `map(...` are properly converted.