### PR TITLE
refactor(output): remove redundant nil check

### DIFF
--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -787,10 +787,8 @@ func outputResource(r *schema.Resource) Resource {
 
 func newResource(r *schema.Resource, comps []CostComponent, actualCosts []ActualCosts, subresources []Resource) Resource {
 	metadata := make(map[string]interface{})
-	if r.Metadata != nil {
-		for k, v := range r.Metadata {
-			metadata[k] = v.Value()
-		}
+	for k, v := range r.Metadata {
+		metadata[k] = v.Value()
 	}
 
 	return Resource{


### PR DESCRIPTION
From the Go docs:

> "If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/Cw_wnqYzemu