### PR TITLE
feat: pricing client cache

### DIFF
--- a/cmd/infracost/comment_azure_repos.go
+++ b/cmd/infracost/comment_azure_repos.go
@@ -95,7 +95,7 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 					return err
 				}
 
-				pricingClient := apiclient.NewPricingAPIClient(ctx)
+				pricingClient := apiclient.GetPricingAPIClient(ctx)
 				err = pricingClient.AddEvent("infracost-comment", ctx.EventEnv())
 				if err != nil {
 					logging.Logger.WithError(err).Error("could not report infracost-comment event")

--- a/cmd/infracost/comment_bitbucket.go
+++ b/cmd/infracost/comment_bitbucket.go
@@ -113,7 +113,7 @@ func commentBitbucketCmd(ctx *config.RunContext) *cobra.Command {
 					return err
 				}
 
-				pricingClient := apiclient.NewPricingAPIClient(ctx)
+				pricingClient := apiclient.GetPricingAPIClient(ctx)
 				err = pricingClient.AddEvent("infracost-comment", ctx.EventEnv())
 				if err != nil {
 					logging.Logger.WithError(err).Error("could not report infracost-comment event")

--- a/cmd/infracost/comment_github.go
+++ b/cmd/infracost/comment_github.go
@@ -137,7 +137,7 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 					return err
 				}
 
-				pricingClient := apiclient.NewPricingAPIClient(ctx)
+				pricingClient := apiclient.GetPricingAPIClient(ctx)
 				err = pricingClient.AddEvent("infracost-comment", ctx.EventEnv())
 				if err != nil {
 					logging.Logger.WithError(err).Error("could not report infracost-comment event")

--- a/cmd/infracost/comment_gitlab.go
+++ b/cmd/infracost/comment_gitlab.go
@@ -109,7 +109,7 @@ func commentGitLabCmd(ctx *config.RunContext) *cobra.Command {
 					return err
 				}
 
-				pricingClient := apiclient.NewPricingAPIClient(ctx)
+				pricingClient := apiclient.GetPricingAPIClient(ctx)
 				err = pricingClient.AddEvent("infracost-comment", ctx.EventEnv())
 				if err != nil {
 					logging.Logger.WithError(err).Error("could not report infracost-comment event")

--- a/cmd/infracost/diff.go
+++ b/cmd/infracost/diff.go
@@ -108,7 +108,7 @@ func runCompare(cmd *cobra.Command, ctx *config.RunContext, current output.Root)
 		return err
 	}
 
-	pricingClient := apiclient.NewPricingAPIClient(ctx)
+	pricingClient := apiclient.GetPricingAPIClient(ctx)
 	err = pricingClient.AddEvent("infracost-run", ctx.EventEnv())
 	if err != nil {
 		logging.Logger.WithError(err).Error("could not report infracost-run event")

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -91,6 +91,10 @@ func Run(modifyCtx func(*config.RunContext), args *[]string) {
 	}
 
 	appErr = rootCmd.Execute()
+	err = apiclient.GetPricingAPIClient(ctx).FlushCache()
+	if err != nil {
+		logging.Logger.WithError(err).Debug("could not flush pricing API cache to filesystem")
+	}
 }
 
 type debugWriter struct {

--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -39,6 +39,10 @@ func main() {
 	}
 
 	Run(nil, nil)
+	err := apiclient.GetPricingAPIClient(nil).FlushCache()
+	if err != nil {
+		logging.Logger.WithError(err).Debug("could not flush pricing API cache to filesystem")
+	}
 }
 
 // Run starts the Infracost application with the configured cobra cmds.
@@ -91,10 +95,6 @@ func Run(modifyCtx func(*config.RunContext), args *[]string) {
 	}
 
 	appErr = rootCmd.Execute()
-	err = apiclient.GetPricingAPIClient(ctx).FlushCache()
-	if err != nil {
-		logging.Logger.WithError(err).Debug("could not flush pricing API cache to filesystem")
-	}
 }
 
 type debugWriter struct {

--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -156,7 +156,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 				return err
 			}
 
-			pricingClient := apiclient.NewPricingAPIClient(ctx)
+			pricingClient := apiclient.GetPricingAPIClient(ctx)
 			err = pricingClient.AddEvent("infracost-output", ctx.EventEnv())
 			if err != nil {
 				log.Errorf("Error reporting event: %s", err)

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -163,7 +163,7 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 
 	env := buildRunEnv(runCtx, projectContexts, r)
 
-	pricingClient := apiclient.NewPricingAPIClient(runCtx)
+	pricingClient := apiclient.GetPricingAPIClient(runCtx)
 	err = pricingClient.AddEvent("infracost-run", env)
 	if err != nil {
 		log.Errorf("Error reporting event: %s", err)

--- a/cmd/infracost/upload.go
+++ b/cmd/infracost/upload.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
@@ -68,7 +69,7 @@ See https://infracost.io/docs/features/cli_commands/#upload-runs`,
 				cmd.Println("Share this cost estimate: ", ui.LinkString(root.ShareURL))
 			}
 
-			pricingClient := apiclient.NewPricingAPIClient(ctx)
+			pricingClient := apiclient.GetPricingAPIClient(ctx)
 			err = pricingClient.AddEvent("infracost-upload", ctx.EventEnv())
 			if err != nil {
 				logging.Logger.WithError(err).Warn("could not report `infracost-upload` event")

--- a/go.mod
+++ b/go.mod
@@ -190,6 +190,8 @@ require (
 	github.com/lib/pq v1.10.5 // indirect
 	github.com/lithammer/fuzzysearch v1.1.8 // indirect
 	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326 // indirect
+	github.com/mitchellh/hashstructure v1.1.0 // indirect
+	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/opencontainers/runc v1.1.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.6 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform v0.15.3 // indirect
 	github.com/hashicorp/terraform-registry-address v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -963,6 +963,10 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
+github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
+github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=

--- a/go.sum
+++ b/go.sum
@@ -783,6 +783,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.6 h1:3xi/Cafd1NaoEnS/yDssIiuVeDVywU0QdFGl3aQaQHM=
+github.com/hashicorp/golang-lru/v2 v2.0.6/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault h1:UiJeEzCWAYdVaJr8Xo4lBkTozlW1+1yxVUnpbS1xVEk=

--- a/internal/apiclient/errors.go
+++ b/internal/apiclient/errors.go
@@ -35,6 +35,6 @@ func ReportCLIError(ctx *config.RunContext, cliErr error, replacePath bool) erro
 	d["error"] = errMsg
 	d["stacktrace"] = stacktrace
 
-	c := NewPricingAPIClient(ctx)
+	c := GetPricingAPIClient(ctx)
 	return c.AddEvent("infracost-error", d)
 }

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -3,12 +3,17 @@ package apiclient
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/gob"
 	"fmt"
 	"math"
 	"net/http"
 	"os"
+	"path/filepath"
+	"sync"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/mitchellh/hashstructure/v2"
 
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/logging"
@@ -22,12 +27,19 @@ var (
 	excludedEnv = map[string]struct{}{
 		"repoMetadata": {},
 	}
+	pricingClient *PricingAPIClient
+	pricingMu     = &sync.Mutex{}
 )
 
 type PricingAPIClient struct {
 	APIClient
 	Currency       string
 	EventsDisabled bool
+
+	mu          *sync.RWMutex
+	cache       *map[uint64]gjson.Result
+	objectLimit int
+	cacheFile   string
 }
 
 type PriceQueryKey struct {
@@ -38,6 +50,8 @@ type PriceQueryKey struct {
 type PriceQueryResult struct {
 	PriceQueryKey
 	Result gjson.Result
+
+	filled bool
 }
 
 type BatchRequest struct {
@@ -45,7 +59,18 @@ type BatchRequest struct {
 	queries []GraphQLQuery
 }
 
-func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
+// GetPricingAPIClient initializes and returns an instance of PricingAPIClient
+// using the given RunContext configuration. If an instance of PricingAPIClient
+// has already been created, it will return the existing instance. This is done
+// to ensure that the client cache is global across the application.
+func GetPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
+	pricingMu.Lock()
+	defer pricingMu.Unlock()
+
+	if pricingClient != nil {
+		return pricingClient
+	}
+
 	currency := ctx.Config.Currency
 	if currency == "" {
 		currency = "USD"
@@ -83,7 +108,7 @@ func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 	client.Logger = &LeveledLogger{Logger: logging.Logger.WithField("library", "retryablehttp")}
 	client.HTTPClient.Transport.(*http.Transport).TLSClientConfig = &tlsConfig
 
-	return &PricingAPIClient{
+	c := &PricingAPIClient{
 		APIClient: APIClient{
 			httpClient: client.StandardClient(),
 			endpoint:   ctx.Config.PricingAPIEndpoint,
@@ -93,6 +118,82 @@ func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 		Currency:       currency,
 		EventsDisabled: ctx.Config.EventsDisabled,
 	}
+
+	initCache(ctx, c)
+	pricingClient = c
+	return c
+}
+
+func initCache(ctx *config.RunContext, c *PricingAPIClient) {
+	if ctx.Config.PricingCacheDisabled {
+		return
+	}
+
+	cacheFile := filepath.Join(ctx.Config.CachePath(), config.InfracostDir, "pricing.gob")
+	c.cacheFile = cacheFile
+	cache := loadCacheFromFile(cacheFile)
+	c.cache = &cache
+
+	c.mu = &sync.RWMutex{}
+	c.objectLimit = 200
+	if ctx.Config.PricingCacheObjectSize > 0 {
+		c.objectLimit = ctx.Config.PricingCacheObjectSize
+	}
+}
+
+func loadCacheFromFile(cacheFile string) map[uint64]gjson.Result {
+	cache := make(map[uint64]gjson.Result)
+	info, err := os.Stat(cacheFile)
+	if err != nil {
+		return cache
+	}
+
+	// if the cache is older than a day don't use it
+	if info.ModTime().Before(time.Now().AddDate(0, 0, -1)) {
+		return cache
+	}
+
+	f, err := os.Open(cacheFile)
+	if err != nil {
+		logging.Logger.WithError(err).Debugf("could not load cache file %s", cacheFile)
+		return cache
+	}
+
+	var storedCache map[uint64]string
+	err = gob.NewDecoder(f).Decode(&storedCache)
+	if err != nil {
+		logging.Logger.WithError(err).Debugf("failed to decode cache file %s", cacheFile)
+		return cache
+	}
+
+	for k, raw := range storedCache {
+		cache[k] = gjson.Parse(raw)
+	}
+
+	return cache
+}
+
+// FlushCache writes the in memory cache to the filesystem. This allows the cache
+// to be persisted between runs. FlushCache should only be called once, at
+// program termination.
+func (c *PricingAPIClient) FlushCache() error {
+	if c.cache == nil {
+		return nil
+	}
+
+	// we store the cache as a string instead of the gjson.Result so the size is
+	// smaller on the filesystem and gob encoding doesn't have to work as hard.
+	storedCache := map[uint64]string{}
+	for k, result := range *c.cache {
+		storedCache[k] = result.Raw
+	}
+
+	f, err := os.OpenFile(c.cacheFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	return gob.NewEncoder(f).Encode(storedCache)
 }
 
 func (c *PricingAPIClient) AddEvent(name string, env map[string]interface{}) error {
@@ -137,7 +238,7 @@ func (c *PricingAPIClient) buildQuery(product *schema.ProductFilter, price *sche
 	return GraphQLQuery{query, v}
 }
 
-// Batch all the queries for these resources so we can use less GraphQL requests
+// BatchRequests batches all the queries for these resources so we can use less GraphQL requests
 // Use PriceQueryKeys to keep track of which query maps to which sub-resource and price component.
 func (c *PricingAPIClient) BatchRequests(resources []*schema.Resource, batchSize int) []BatchRequest {
 	reqs := make([]BatchRequest, 0)
@@ -169,26 +270,123 @@ func (c *PricingAPIClient) BatchRequests(resources []*schema.Resource, batchSize
 	return reqs
 }
 
+type pricingQuery struct {
+	hash  uint64
+	query GraphQLQuery
+
+	result gjson.Result
+}
+
+// PerformRequest sends a batch request to the Pricing API endpoint to fetch
+// pricing details for the provided queries. It optimizes the API call by
+// checking a local cache for previous results. If the results of a given query
+// are cached, they are used directly; otherwise, a request to the API is made.
 func (c *PricingAPIClient) PerformRequest(req BatchRequest) ([]PriceQueryResult, error) {
 	log.Debugf("Getting pricing details for %d cost components from %s", len(req.queries), c.endpoint)
+	res := make([]PriceQueryResult, len(req.keys))
+	for i, key := range req.keys {
+		res[i].PriceQueryKey = key
+	}
 
-	results, err := c.doQueries(req.queries)
+	queries := make([]pricingQuery, len(req.queries))
+	for i, query := range req.queries {
+		key, err := hashstructure.Hash(query, hashstructure.FormatV2, nil)
+		if err != nil {
+			logging.Logger.WithError(err).Debugf("failed to hash query %s will use nil hash", query)
+		}
+
+		queries[i] = pricingQuery{
+			hash:  key,
+			query: query,
+		}
+	}
+
+	// first filter any queries that have been stored in the cache. We don't need to
+	// send requests for these as we already have the results in memory.
+	var serverQueries []pricingQuery
+	if c.cache != nil {
+		for i, query := range queries {
+			c.mu.RLock()
+			v, ok := (*c.cache)[query.hash]
+			c.mu.RUnlock()
+			if ok {
+				res[i] = PriceQueryResult{
+					PriceQueryKey: req.keys[i],
+					Result:        v,
+					filled:        true,
+				}
+			} else {
+				serverQueries = append(serverQueries, query)
+			}
+		}
+	}
+
+	// now we deduplicate the queries, ensuring that a request for a price only happens once.
+	var deduplicatedServerQueries []pricingQuery
+	seenQueries := map[uint64]bool{}
+	for _, query := range serverQueries {
+		if seenQueries[query.hash] {
+			continue
+		}
+
+		deduplicatedServerQueries = append(deduplicatedServerQueries, query)
+		seenQueries[query.hash] = true
+	}
+
+	// send the deduplicated queries to the pricing API to fetch live prices.
+	rawQueries := make([]GraphQLQuery, len(deduplicatedServerQueries))
+	for i, query := range deduplicatedServerQueries {
+		rawQueries[i] = query.query
+	}
+	resultsFromServer, err := c.doQueries(rawQueries)
 	if err != nil {
 		return []PriceQueryResult{}, err
 	}
 
-	return c.zipQueryResults(req.keys, results), nil
-}
+	// if the cache is enabled lets store each pricing result returned in the cache.
+	if *c.cache != nil {
+		for i, query := range deduplicatedServerQueries {
+			c.mu.RLock()
+			keyLength := len(*c.cache)
+			c.mu.RUnlock()
+			if keyLength >= c.objectLimit {
+				logging.Logger.Debugf("cache is at object limit of %d, will not add any additional keys to the cache", keyLength)
+				continue
+			}
 
-func (c *PricingAPIClient) zipQueryResults(k []PriceQueryKey, r []gjson.Result) []PriceQueryResult {
-	res := make([]PriceQueryResult, 0, len(k))
-
-	for i, k := range k {
-		res = append(res, PriceQueryResult{
-			PriceQueryKey: k,
-			Result:        r[i],
-		})
+			if len(resultsFromServer)-1 >= i {
+				c.mu.Lock()
+				(*c.cache)[query.hash] = resultsFromServer[i]
+				c.mu.Unlock()
+			}
+		}
 	}
 
-	return res
+	// now lets match the results from the server to their initial deduplicated queries.
+	for i, result := range resultsFromServer {
+		deduplicatedServerQueries[i].result = result
+	}
+
+	// Then we match deduplicated server queries to the initial list using the unique
+	// query hash to tie a query to it's deduped query.
+	resultMap := make(map[uint64]gjson.Result, len(deduplicatedServerQueries))
+	for _, query := range deduplicatedServerQueries {
+		resultMap[query.hash] = query.result
+	}
+
+	for i, query := range serverQueries {
+		serverQueries[i].result = resultMap[query.hash]
+	}
+
+	// finally let's use the server queries to fill any results that haven't been
+	// already populated from the cache.
+	var x int
+	for i, re := range res {
+		if !re.filled {
+			res[i].Result = serverQueries[x].result
+			x++
+		}
+	}
+
+	return res, nil
 }

--- a/internal/apiclient/pricing_test.go
+++ b/internal/apiclient/pricing_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/mitchellh/hashstructure/v2"
@@ -114,7 +115,7 @@ func TestPricingAPIClient_PerformRequest(t *testing.T) {
 	q := c.buildQuery(cachedProduct, nil)
 	k, err := hashstructure.Hash(q, hashstructure.FormatV2, nil)
 	assert.NoError(t, err)
-	(*c.cache)[k] = gjson.Parse(`{"data":{"products":[{"prices":[{"priceHash":"cached-ee3dd7e4624338037ca6fea0933a662f","USD":"0.1250000000"}]}]}`)
+	c.cache.Add(k, cacheValue{Result: gjson.Parse(`{"data":{"products":[{"prices":[{"priceHash":"cached-ee3dd7e4624338037ca6fea0933a662f","USD":"0.1250000000"}]}]}`), ExpiresAt: time.Now().Add(time.Hour)})
 
 	batches := c.BatchRequests(resources, 100)
 	result, err := c.PerformRequest(batches[0])

--- a/internal/apiclient/pricing_test.go
+++ b/internal/apiclient/pricing_test.go
@@ -1,0 +1,215 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/vcs"
+)
+
+func TestPricingAPIClient_PerformRequest(t *testing.T) {
+	client := retryablehttp.NewClient()
+	conf := config.DefaultConfig()
+	i := 0
+	requestMap := map[int]string{}
+	responseMap := map[int][]byte{
+		0: []byte(`
+[
+	{"data":{"products":[{"prices":[{"priceHash":"99450513de8c131ee2151e1b319d8143-ee3dd7e4624338037ca6fea0933a662f","USD":"0.1250000000"}]}]}},
+	{"data":{"products":[{"prices":[{"priceHash":"d5c5e1fb9b8ded55c336f6ae87aa2c3b-9c483347596633f8cf3ab7fdd5502b78","USD":"0.0650000000"}]}]}}
+]
+`),
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		requestMap[i] = string(bodyBytes)
+
+		if len(responseMap)-1 < i {
+			t.Errorf("received unexpected request to pricing API at index: %d body: %s", i, bodyBytes)
+			_, err := w.Write([]byte{})
+			assert.NoError(t, err)
+			return
+		}
+
+		_, err := w.Write(responseMap[i])
+		assert.NoError(t, err)
+		i++
+	}))
+
+	conf.PricingAPIEndpoint = ts.URL
+	ctx := &config.RunContext{
+		Config:        conf,
+		State:         nil,
+		VCSMetadata:   vcs.Metadata{},
+		CMD:           "",
+		ContextValues: nil,
+		ModuleMutex:   nil,
+		StartTime:     0,
+		OutWriter:     nil,
+		ErrWriter:     nil,
+		Exit:          nil,
+	}
+
+	c := &PricingAPIClient{
+		APIClient: APIClient{
+			httpClient: client.StandardClient(),
+			endpoint:   ctx.Config.PricingAPIEndpoint,
+			apiKey:     ctx.Config.APIKey,
+			uuid:       ctx.UUID(),
+		},
+		Currency: "USD",
+	}
+	initCache(ctx, c)
+
+	cachedProduct := &schema.ProductFilter{
+		VendorName: strPtr("aws"),
+		Service:    strPtr("some service"),
+	}
+
+	resources := []*schema.Resource{
+		{
+			Name: "test",
+			CostComponents: []*schema.CostComponent{
+				{
+					ProductFilter: cachedProduct,
+					PriceFilter: &schema.PriceFilter{
+						PurchaseOption: strPtr("something else"),
+					},
+				},
+				{
+					ProductFilter: &schema.ProductFilter{
+						VendorName: strPtr("aws"),
+						Service:    strPtr("some service 2"),
+					},
+				},
+			},
+		},
+		{
+			Name: "test2",
+			CostComponents: []*schema.CostComponent{
+				{
+					ProductFilter: cachedProduct,
+				},
+				{
+					ProductFilter: &schema.ProductFilter{
+						VendorName: strPtr("aws"),
+						Service:    strPtr("some service 2"),
+					},
+				},
+			},
+		},
+	}
+	q := c.buildQuery(cachedProduct, nil)
+	k, err := hashstructure.Hash(q, hashstructure.FormatV2, nil)
+	assert.NoError(t, err)
+	(*c.cache)[k] = gjson.Parse(`{"data":{"products":[{"prices":[{"priceHash":"cached-ee3dd7e4624338037ca6fea0933a662f","USD":"0.1250000000"}]}]}`)
+
+	batches := c.BatchRequests(resources, 100)
+	result, err := c.PerformRequest(batches[0])
+
+	assert.Len(t, requestMap, 1, "invalid number of requests made to pricing API")
+	assert.JSONEq(
+		t,
+		`
+[
+  {
+    "query": "query($productFilter: ProductFilter!, $priceFilter: PriceFilter) {products(filter: $productFilter) {prices(filter: $priceFilter) {priceHashUSD}}}",
+    "variables": {
+      "priceFilter": {
+        "purchaseOption": "something else"
+      },
+      "productFilter": {
+        "vendorName": "aws",
+        "service": "some service"
+      }
+    }
+  },
+  {
+    "query": "query($productFilter: ProductFilter!, $priceFilter: PriceFilter) {products(filter: $productFilter) {prices(filter: $priceFilter) {priceHashUSD}}}",
+    "variables": {
+      "priceFilter": null,
+      "productFilter": {
+        "vendorName": "aws",
+        "service": "some service 2"
+      }
+    }
+  }
+]
+`,
+		strings.ReplaceAll(strings.ReplaceAll(requestMap[0], `\t`, ""), `\n`, ""),
+	)
+	assert.NoError(t, err)
+	assertResults(t, result)
+
+	// try the request again to ensure we cache everything now
+	result, err = c.PerformRequest(batches[0])
+	assert.NoError(t, err)
+	assertResults(t, result)
+}
+
+func assertResults(t *testing.T, result []PriceQueryResult) {
+	require.Len(t, result, 4)
+	assertResultEqual(
+		t,
+		result[0],
+		"test",
+		`{"vendorName":"aws","service":"some service"}`,
+		`{"purchaseOption":"something else"}`,
+		`{"data":{"products":[{"prices":[{"priceHash":"99450513de8c131ee2151e1b319d8143-ee3dd7e4624338037ca6fea0933a662f","USD":"0.1250000000"}]}]}}`,
+	)
+	assertResultEqual(
+		t,
+		result[1],
+		"test",
+		`{"vendorName":"aws","service":"some service 2"}`,
+		`null`,
+		`{"data":{"products":[{"prices":[{"priceHash":"d5c5e1fb9b8ded55c336f6ae87aa2c3b-9c483347596633f8cf3ab7fdd5502b78","USD":"0.0650000000"}]}]}}`,
+	)
+	assertResultEqual(
+		t,
+		result[2],
+		"test2",
+		`{"vendorName":"aws","service":"some service"}`,
+		`null`,
+		`{"data":{"products":[{"prices":[{"priceHash":"cached-ee3dd7e4624338037ca6fea0933a662f","USD":"0.1250000000"}]}]}`,
+	)
+	assertResultEqual(
+		t,
+		result[3],
+		"test2",
+		`{"vendorName":"aws","service":"some service 2"}`,
+		`null`,
+		`{"data":{"products":[{"prices":[{"priceHash":"d5c5e1fb9b8ded55c336f6ae87aa2c3b-9c483347596633f8cf3ab7fdd5502b78","USD":"0.0650000000"}]}]}}`,
+	)
+}
+
+func assertResultEqual(t *testing.T, queryResult PriceQueryResult, name string, expProductFilter string, expPriceFilter string, result string) {
+	t.Helper()
+
+	assert.Equal(t, name, queryResult.Resource.Name)
+	productFilter := queryResult.CostComponent.ProductFilter
+	b, _ := json.Marshal(productFilter)
+	assert.JSONEq(t, expProductFilter, string(b))
+
+	priceFilter := queryResult.CostComponent.PriceFilter
+	b, _ = json.Marshal(priceFilter)
+	assert.JSONEq(t, expPriceFilter, string(b))
+
+	assert.Equal(t, result, queryResult.Result.Raw)
+}
+
+func strPtr(str string) *string {
+	return &str
+}

--- a/internal/comment/handler.go
+++ b/internal/comment/handler.go
@@ -117,7 +117,7 @@ func (h *CommentHandler) CommentWithBehavior(ctx context.Context, behavior, body
 			break
 		}
 
-		logging.Logger.WithError(err).Debugf("received an error trying to post comment pausing %d seconds then will retry", backoff.Seconds())
+		logging.Logger.WithError(err).Debugf("received an error trying to post comment pausing %2f seconds then will retry", backoff.Seconds())
 		time.Sleep(backoff)
 		backoff *= 2
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,8 @@ type Config struct {
 
 	APIKey                    string `envconfig:"API_KEY"`
 	PricingAPIEndpoint        string `yaml:"pricing_api_endpoint,omitempty" envconfig:"PRICING_API_ENDPOINT"`
+	PricingCacheDisabled      bool   `yaml:"pricing_cache_disabled" envconfig:"PRICING_CACHE_DISABLED"`
+	PricingCacheObjectSize    int    `yaml:"pricing_cache_object_size" envconfig:"PRICING_CACHE_OBJECT_SIZE"`
 	DefaultPricingAPIEndpoint string `yaml:"default_pricing_api_endpoint,omitempty" envconfig:"DEFAULT_PRICING_API_ENDPOINT"`
 	DashboardAPIEndpoint      string `yaml:"dashboard_api_endpoint,omitempty" envconfig:"DASHBOARD_API_ENDPOINT"`
 	DashboardEndpoint         string `yaml:"dashboard_endpoint,omitempty" envconfig:"DASHBOARD_ENDPOINT"`

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -17,7 +17,7 @@ var batchSize = 5
 func PopulatePrices(ctx *config.RunContext, project *schema.Project) error {
 	resources := project.AllResources()
 
-	c := apiclient.NewPricingAPIClient(ctx)
+	c := apiclient.GetPricingAPIClient(ctx)
 
 	err := GetPricesConcurrent(ctx, c, resources)
 	if err != nil {

--- a/internal/scan/terraform.go
+++ b/internal/scan/terraform.go
@@ -34,7 +34,7 @@ type TerraformPlanScanner struct {
 // NewTerraformPlanScanner returns an initialised TerraformPlanScanner.
 func NewTerraformPlanScanner(ctx *config.RunContext, logger *log.Entry, getPrices GetPricesFunc) *TerraformPlanScanner {
 	return &TerraformPlanScanner{
-		pricingAPIClient: apiclient.NewPricingAPIClient(ctx),
+		pricingAPIClient: apiclient.GetPricingAPIClient(ctx),
 		policyAPIClient:  apiclient.NewPolicyClient(ctx.Config, logger),
 		logger:           logger,
 		ctx:              ctx,


### PR DESCRIPTION
Introduces an persisent and in memory query cache for the pricing api. As part of this change the PricingApiClient is now shared across the application codebase so that we maintain a consistent cache used across goroutines. Furthermore, we now dedupe pricing api queries sent to the pricing API, further reducing request size made by the CLI.

Caching functionality can be controlled by the new configuration parameters:

* `INFRACOST_PRICING_CACHE_DISABLED` which, if set to true, completely removes caching functionality
* `INFRACOST_PRICING_CACHE_OBJECT_SIZE` which can control the size of the cache. This is useful for memory requirements.