### PR TITLE
fix: add timeout for hcpapi requests

### DIFF
--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -116,7 +116,7 @@ func GetPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 	client := retryablehttp.NewClient()
 	client.Logger = &LeveledLogger{Logger: logging.Logger.WithField("library", "retryablehttp")}
 	client.HTTPClient.Transport.(*http.Transport).TLSClientConfig = &tlsConfig
-	client.HTTPClient.Timeout = time.Minute
+	client.HTTPClient.Timeout = time.Second * 30
 
 	c := &PricingAPIClient{
 		APIClient: APIClient{

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -116,6 +116,7 @@ func GetPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 	client := retryablehttp.NewClient()
 	client.Logger = &LeveledLogger{Logger: logging.Logger.WithField("library", "retryablehttp")}
 	client.HTTPClient.Transport.(*http.Transport).TLSClientConfig = &tlsConfig
+	client.HTTPClient.Timeout = time.Minute
 
 	c := &PricingAPIClient{
 		APIClient: APIClient{


### PR DESCRIPTION
@aliscott I'm not sure what you were thinking for the timeout.  I looked at cloudwatch for the max TargetResponseTime from the HCPAPI ELBs and 60s covers all outliers, but it does seem ridicuously high.