### PR TITLE
feat: add finops policy output to comment

### DIFF
--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -134,7 +134,7 @@ func buildCommentOutput(cmd *cobra.Command, ctx *config.RunContext, paths []stri
 	opts := output.Options{
 		DashboardEndpoint: ctx.Config.DashboardEndpoint,
 		NoColor:           ctx.Config.NoColor,
-		PolicyOutput:      output.NewPolicyOutput(policyChecks, tagPolicyCheck),
+		PolicyOutput:      output.NewPolicyOutput(policyChecks, tagPolicyCheck, finOpsPolicyCheck),
 		GuardrailCheck:    guardrailCheck,
 	}
 	opts.ShowAllProjects, _ = cmd.Flags().GetBool("show-all-projects")
@@ -265,4 +265,17 @@ func readPolicyOut(v map[string]interface{}, checks *output.PolicyCheck) {
 	}
 
 	checks.Passed = append(checks.Passed, msg)
+}
+
+func isErrorUnhandled(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	switch err.(type) {
+	case output.PolicyCheckFailures, output.GuardrailFailures, output.TagPolicyCheck, output.FinOpsPolicyCheck:
+		return false
+	}
+
+	return true
 }

--- a/cmd/infracost/comment_azure_repos.go
+++ b/cmd/infracost/comment_azure_repos.go
@@ -63,24 +63,13 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 
 			paths, _ := cmd.Flags().GetStringArray("path")
 
-			commentOut, err := buildCommentOutput(cmd, ctx, paths, output.MarkdownOptions{
+			commentOut, commentErr := buildCommentOutput(cmd, ctx, paths, output.MarkdownOptions{
 				WillUpdate:          prNumber != 0 && behavior == "update",
 				WillReplace:         prNumber != 0 && behavior == "delete-and-new",
 				IncludeFeedbackLink: !ctx.Config.IsSelfHosted(),
 			})
-			var policyFailure output.PolicyCheckFailures
-			var guardrailFailure output.GuardrailFailures
-			var tagPolicyFailure *output.TagPolicyCheck
-			if err != nil {
-				if v, ok := err.(output.PolicyCheckFailures); ok {
-					policyFailure = v
-				} else if v, ok := err.(output.GuardrailFailures); ok {
-					guardrailFailure = v
-				} else if v, ok := err.(output.TagPolicyCheck); ok {
-					tagPolicyFailure = &v
-				} else {
-					return err
-				}
+			if isErrorUnhandled(commentErr) {
+				return commentErr
 			}
 
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
@@ -115,17 +104,7 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 				cmd.Println("Comment not posted to Azure Repos (--dry-run was specified)")
 			}
 
-			if policyFailure != nil {
-				return policyFailure
-			}
-			if guardrailFailure != nil {
-				return guardrailFailure
-			}
-			if tagPolicyFailure != nil {
-				return tagPolicyFailure
-			}
-
-			return nil
+			return commentErr
 		},
 	}
 

--- a/cmd/infracost/comment_github.go
+++ b/cmd/infracost/comment_github.go
@@ -36,7 +36,7 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx.ContextValues.SetValue("platform", "github")
 
-			var err error
+			var commentErr error
 
 			apiURL, _ := cmd.Flags().GetString("github-api-url")
 			token, _ := cmd.Flags().GetString("github-token")
@@ -79,16 +79,16 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 			if prNumber != 0 {
 				ctx.ContextValues.SetValue("targetType", "pull-request")
 
-				commentHandler, err = comment.NewGitHubPRHandler(ctx.Context(), repo, strconv.Itoa(prNumber), extra)
-				if err != nil {
-					return err
+				commentHandler, commentErr = comment.NewGitHubPRHandler(ctx.Context(), repo, strconv.Itoa(prNumber), extra)
+				if commentErr != nil {
+					return commentErr
 				}
 			} else if commit != "" {
 				ctx.ContextValues.SetValue("targetType", "commit")
 
-				commentHandler, err = comment.NewGitHubCommitHandler(ctx.Context(), repo, commit, extra)
-				if err != nil {
-					return err
+				commentHandler, commentErr = comment.NewGitHubCommitHandler(ctx.Context(), repo, commit, extra)
+				if commentErr != nil {
+					return commentErr
 				}
 			} else {
 				ui.PrintUsage(cmd)
@@ -104,25 +104,14 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 
 			paths, _ := cmd.Flags().GetStringArray("path")
 
-			commentOut, err := buildCommentOutput(cmd, ctx, paths, output.MarkdownOptions{
+			commentOut, commentErr := buildCommentOutput(cmd, ctx, paths, output.MarkdownOptions{
 				WillUpdate:          prNumber != 0 && behavior == "update",
 				WillReplace:         prNumber != 0 && behavior == "delete-and-new",
 				IncludeFeedbackLink: !ctx.Config.IsSelfHosted(),
 				MaxMessageSize:      output.GitHubMaxMessageSize,
 			})
-			var policyFailure output.PolicyCheckFailures
-			var guardrailFailure output.GuardrailFailures
-			var tagPolicyFailure *output.TagPolicyCheck
-			if err != nil {
-				if v, ok := err.(output.PolicyCheckFailures); ok {
-					policyFailure = v
-				} else if v, ok := err.(output.GuardrailFailures); ok {
-					guardrailFailure = v
-				} else if v, ok := err.(output.TagPolicyCheck); ok {
-					tagPolicyFailure = &v
-				} else {
-					return err
-				}
+			if isErrorUnhandled(commentErr) {
+				return commentErr
 			}
 
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
@@ -157,17 +146,9 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 				cmd.Println("Comment not posted to GitHub (--dry-run was specified)")
 			}
 
-			if policyFailure != nil {
+			if commentErr != nil {
 				cmd.Printf("\n")
-				return policyFailure
-			}
-			if guardrailFailure != nil {
-				cmd.Printf("\n")
-				return guardrailFailure
-			}
-			if tagPolicyFailure != nil {
-				cmd.Printf("\n")
-				return tagPolicyFailure
+				return commentErr
 			}
 
 			return nil

--- a/cmd/infracost/comment_gitlab.go
+++ b/cmd/infracost/comment_gitlab.go
@@ -77,24 +77,13 @@ func commentGitLabCmd(ctx *config.RunContext) *cobra.Command {
 
 			paths, _ := cmd.Flags().GetStringArray("path")
 
-			commentOut, err := buildCommentOutput(cmd, ctx, paths, output.MarkdownOptions{
+			commentOut, commentErr := buildCommentOutput(cmd, ctx, paths, output.MarkdownOptions{
 				WillUpdate:          mrNumber != 0 && behavior == "update",
 				WillReplace:         mrNumber != 0 && behavior == "delete-and-new",
 				IncludeFeedbackLink: !ctx.Config.IsSelfHosted(),
 			})
-			var policyFailure output.PolicyCheckFailures
-			var guardrailFailure output.GuardrailFailures
-			var tagPolicyFailure *output.TagPolicyCheck
-			if err != nil {
-				if v, ok := err.(output.PolicyCheckFailures); ok {
-					policyFailure = v
-				} else if v, ok := err.(output.GuardrailFailures); ok {
-					guardrailFailure = v
-				} else if v, ok := err.(output.TagPolicyCheck); ok {
-					tagPolicyFailure = &v
-				} else {
-					return err
-				}
+			if isErrorUnhandled(commentErr) {
+				return commentErr
 			}
 
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
@@ -129,17 +118,7 @@ func commentGitLabCmd(ctx *config.RunContext) *cobra.Command {
 				cmd.Println("Comment not posted to GitLab (--dry-run was specified)")
 			}
 
-			if policyFailure != nil {
-				return policyFailure
-			}
-			if guardrailFailure != nil {
-				return guardrailFailure
-			}
-			if tagPolicyFailure != nil {
-				return tagPolicyFailure
-			}
-
-			return nil
+			return commentErr
 		},
 	}
 

--- a/cmd/infracost/testdata/comment_bitbucket_with_fin_ops_policy_checks/comment_bitbucket_with_fin_ops_policy_checks.golden
+++ b/cmd/infracost/testdata/comment_bitbucket_with_fin_ops_policy_checks/comment_bitbucket_with_fin_ops_policy_checks.golden
@@ -1,4 +1,24 @@
 
+
+## Infracost estimate: **monthly cost will not change**
+## ❌ Policies failed (needs action) ##
+    
+### ❌ Failing FinOps Policy (needs action) ###
+    
+    
+This should show as a failure
+    
+
+> **module.hosted_cloud_pricing_api.aws_s3_bucket.cloud_pricing_api_db_data** at `dev/main.tf:14`
+>
+> * "attribute" currently set to "value": description
+>
+> in projects `my-prod-project`, `my-dev-project`
+
+This comment will be updated when the cost estimate changes.
+
+Comment not posted to Bitbucket (--dry-run was specified)
+
 Err:
 Error: FinOps policy check failed:
 

--- a/cmd/infracost/testdata/comment_git_hub_with_fin_ops_policy_checks/comment_git_hub_with_fin_ops_policy_checks.golden
+++ b/cmd/infracost/testdata/comment_git_hub_with_fin_ops_policy_checks/comment_git_hub_with_fin_ops_policy_checks.golden
@@ -1,4 +1,52 @@
 
+<p>💰 Infracost estimate: <b>monthly cost will not change</b></p>
+<table>
+  <thead>
+    <td>Project</td>
+    <td>Cost change</td>
+    <td>New monthly cost</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>infracost/infracost/internal/hc.../multi_project_with_module/dev</td>
+      <td>$0</td>
+      <td align="right">$566</td>
+    </tr>
+  </tbody>
+</table>
+<details>
+<summary><strong>Infracost output</strong></summary>
+
+```
+──────────────────────────────────
+
+3 cloud resources were detected:
+∙ 3 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+```
+</details>
+    <details>
+        <summary><strong>❌ Policies failed (needs action)</strong></summary>
+      <h4>❌ <b>Failing FinOps Policy</b> (needs action)</h4>
+    <table>
+        <tr>
+          <td>
+            <p>This should show as a failure</p>
+          </td>
+        </tr>
+        <tr><td>
+
+**module.hosted_cloud_pricing_api.aws_s3_bucket.cloud_pricing_api_db_data** at `dev/main.tf:14`
+* "attribute" currently set to "value": description
+  
+in projects `my-prod-project`, `my-dev-project`
+  
+</td></tr>
+    </table>
+    </details>
+
+Comment not posted to GitHub (--dry-run was specified)
+
+
 Err:
 Error: FinOps policy check failed:
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -412,7 +412,7 @@ func mergeViolations(violations, otherViolations []PolicyCheckViolations) []Poli
 
 // NewPolicyOutput normalizes a PolicyCheck and a TagPolicyCheck into a PolicyOutput suitable
 // for use in the output markdown template.
-func NewPolicyOutput(pc PolicyCheck, tpc TagPolicyCheck) PolicyOutput {
+func NewPolicyOutput(pc PolicyCheck, tpc TagPolicyCheck, fpc FinOpsPolicyCheck) PolicyOutput {
 	po := PolicyOutput{}
 
 	if pc.Enabled && len(pc.Failures) > 0 {
@@ -438,6 +438,20 @@ func NewPolicyOutput(pc PolicyCheck, tpc TagPolicyCheck) PolicyOutput {
 		po.Checks = append(po.Checks, newTagPolicyCheckOutput(tagPolicy))
 	}
 
+	for _, policy := range fpc.Failing {
+		po.HasFailures = true
+		po.Checks = append(po.Checks, newFinOpsPolicyCheckOutput(policy, finOpsOutputOps{failure: true}))
+	}
+
+	for _, policy := range fpc.Warning {
+		po.HasWarnings = true
+		po.Checks = append(po.Checks, newFinOpsPolicyCheckOutput(policy, finOpsOutputOps{warning: true}))
+	}
+
+	for _, policy := range fpc.Passing {
+		po.Checks = append(po.Checks, newFinOpsPolicyCheckOutput(policy, finOpsOutputOps{}))
+	}
+
 	if pc.Enabled && len(pc.Passed) > 0 {
 		po.Checks = append(po.Checks, PolicyCheckOutput{
 			Name:    "Cost policy passed",
@@ -448,7 +462,49 @@ func NewPolicyOutput(pc PolicyCheck, tpc TagPolicyCheck) PolicyOutput {
 	return po
 }
 
-var maxTagPolicyResourceDetails = 10
+type finOpsOutputOps struct {
+	warning bool
+	failure bool
+}
+
+func newFinOpsPolicyCheckOutput(policy FinOpsPolicy, ops finOpsOutputOps) PolicyCheckOutput {
+	resources := make([]PolicyCheckResourceDetails, len(policy.Resources))
+	for i, resource := range policy.Resources {
+		violations := make([]PolicyCheckViolations, len(resource.Issues))
+		for x, issue := range resource.Issues {
+			violations[x] = PolicyCheckViolations{
+				Details: []string{
+					fmt.Sprintf("%q currently set to %q: %s", issue.Attribute, issue.Value, issue.Description),
+				},
+				ProjectNames: resource.ProjectNames,
+			}
+		}
+		resources[i] = PolicyCheckResourceDetails{
+			Address:      resource.Address,
+			ResourceType: resource.ResourceType,
+			Path:         resource.Path,
+			Line:         resource.StartLine,
+			Violations:   violations,
+		}
+	}
+
+	tc := 0
+	if len(resources) > maxResourceDetails {
+		tc = len(resources) - maxResourceDetails
+		resources = resources[:maxResourceDetails]
+	}
+
+	return PolicyCheckOutput{
+		Name:            policy.Name,
+		Message:         policy.Message,
+		Failure:         ops.failure,
+		Warning:         ops.warning,
+		ResourceDetails: resources,
+		TruncatedCount:  tc,
+	}
+}
+
+var maxResourceDetails = 10
 
 func newTagPolicyCheckOutput(tp TagPolicy) PolicyCheckOutput {
 	// group resources by address so we can show a single block with all project/violation permutations.
@@ -492,10 +548,10 @@ func newTagPolicyCheckOutput(tp TagPolicy) PolicyCheckOutput {
 	}
 
 	tc := 0
-	if len(resourceDetails) > maxTagPolicyResourceDetails {
+	if len(resourceDetails) > maxResourceDetails {
 		// truncate the list of resources so we don't go over the size limit of comments
-		tc = len(resourceDetails) - maxTagPolicyResourceDetails
-		resourceDetails = resourceDetails[:maxTagPolicyResourceDetails]
+		tc = len(resourceDetails) - maxResourceDetails
+		resourceDetails = resourceDetails[:maxResourceDetails]
 	}
 
 	return PolicyCheckOutput{


### PR DESCRIPTION
* adds support for finops policies using old comment output
* refactors comment error handling so it's a bit easier to use

Note: this was not moved to the API as previously discussed as Ali wants the old style comment output until
phase 3. See: https://infracost.slack.com/archives/C025MSU0US3/p1695068299141909?thread_ts=1695040182.419469&cid=C025MSU0US3