### PR TITLE
refactor: add shared hcl parser

### DIFF
--- a/cmd/infracost/testdata/breakdown_multi_project_with_all_errors/breakdown_multi_project_with_all_errors.golden
+++ b/cmd/infracost/testdata/breakdown_multi_project_with_all_errors/breakdown_multi_project_with_all_errors.golden
@@ -3,9 +3,9 @@ Module path: dev
 
 Errors:
   Error loading Terraform modules:
-    failed to inspect module path testdata/breakdown_multi_project_with_all_errors/dev diag:
-      Invalid block definition:
-        Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
+    failed to parse file testdata/breakdown_multi_project_with_all_errors/dev/mod_with_error.tf diag:
+      testdata/breakdown_multi_project_with_all_errors/dev/mod_with_error.tf:1,9-10:
+        Invalid block definition; Either a quoted string block label or an opening brace ("{") is expected here., and 1 other diagnostic(s)
 
 ──────────────────────────────────
 Project: infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_with_all_errors/prod
@@ -13,9 +13,9 @@ Module path: prod
 
 Errors:
   Error loading Terraform modules:
-    failed to inspect module path testdata/breakdown_multi_project_with_all_errors/prod diag:
-      Invalid block definition:
-        Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
+    failed to parse file testdata/breakdown_multi_project_with_all_errors/prod/mod_with_error.tf diag:
+      testdata/breakdown_multi_project_with_all_errors/prod/mod_with_error.tf:1,9-10:
+        Invalid block definition; Either a quoted string block label or an opening brace ("{") is expected here., and 1 other diagnostic(s)
 
  OVERALL TOTAL       $0.00 
 ──────────────────────────────────

--- a/cmd/infracost/testdata/breakdown_multi_project_with_error/breakdown_multi_project_with_error.golden
+++ b/cmd/infracost/testdata/breakdown_multi_project_with_error/breakdown_multi_project_with_error.golden
@@ -3,9 +3,9 @@ Module path: dev
 
 Errors:
   Error loading Terraform modules:
-    failed to inspect module path testdata/breakdown_multi_project_with_error/dev diag:
-      Invalid block definition:
-        Either a quoted string block label or an opening brace ("{") is expected here. (and 1 other messages)
+    failed to parse file testdata/breakdown_multi_project_with_error/dev/mod_with_error.tf diag:
+      testdata/breakdown_multi_project_with_error/dev/mod_with_error.tf:1,9-10:
+        Invalid block definition; Either a quoted string block label or an opening brace ("{") is expected here., and 1 other diagnostic(s)
 
 ──────────────────────────────────
 Project: infracost/infracost/cmd/infracost/testdata/breakdown_multi_project_with_error/prod

--- a/cmd/infracost/testdata/diff_with_compare_to_with_current_and_past_project_error/diff_with_compare_to_with_current_and_past_project_error.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_current_and_past_project_error/diff_with_compare_to_with_current_and_past_project_error.golden
@@ -22,7 +22,7 @@
         "errors": [
           {
             "code": 2,
-            "message": "Error loading Terraform modules: failed to inspect module path testdata/diff_with_compare_to_with_current_and_past_project_error/dev diag: Invalid block definition: Either a quoted string block label or an opening brace (\"{\") is expected here. (and 1 other messages)",
+            "message": "Error loading Terraform modules: failed to parse file testdata/diff_with_compare_to_with_current_and_past_project_error/dev/mod_with_error.tf diag: testdata/diff_with_compare_to_with_current_and_past_project_error/dev/mod_with_error.tf:1,9-10: Invalid block definition; Either a quoted string block label or an opening brace (\"{\") is expected here., and 1 other diagnostic(s)",
             "data": null
           },
           {

--- a/cmd/infracost/testdata/diff_with_compare_to_with_current_project_error/diff_with_compare_to_with_current_project_error.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_current_project_error/diff_with_compare_to_with_current_project_error.golden
@@ -22,7 +22,7 @@
         "errors": [
           {
             "code": 2,
-            "message": "Error loading Terraform modules: failed to inspect module path testdata/diff_with_compare_to_with_current_project_error/dev diag: Invalid block definition: Either a quoted string block label or an opening brace (\"{\") is expected here. (and 1 other messages)",
+            "message": "Error loading Terraform modules: failed to parse file testdata/diff_with_compare_to_with_current_project_error/dev/mod_with_error.tf diag: testdata/diff_with_compare_to_with_current_project_error/dev/mod_with_error.tf:1,9-10: Invalid block definition; Either a quoted string block label or an opening brace (\"{\") is expected here., and 1 other diagnostic(s)",
             "data": null
           }
         ]

--- a/internal/hcl/block_test.go
+++ b/internal/hcl/block_test.go
@@ -16,7 +16,7 @@ func TestBlock_LocalName(t *testing.T) {
 		{
 			name: "resource Block with empty labels will return empty local name",
 			block: &Block{
-				hclBlock: &hcl.Block{
+				HCLBlock: &hcl.Block{
 					Type:   "resource",
 					Labels: nil,
 				},
@@ -27,7 +27,7 @@ func TestBlock_LocalName(t *testing.T) {
 		{
 			name: "resource Block with valid labels will return reference without resource type",
 			block: &Block{
-				hclBlock: &hcl.Block{
+				HCLBlock: &hcl.Block{
 					Type:   "resource",
 					Labels: []string{"my-resource", "my-name"},
 				},
@@ -38,7 +38,7 @@ func TestBlock_LocalName(t *testing.T) {
 		{
 			name: "data Block with valid labels will return reference with Block type",
 			block: &Block{
-				hclBlock: &hcl.Block{
+				HCLBlock: &hcl.Block{
 					Type:   "data",
 					Labels: []string{"my-block", "my-name"},
 				},

--- a/internal/hcl/modules/loader_test.go
+++ b/internal/hcl/modules/loader_test.go
@@ -30,7 +30,7 @@ func testLoaderE2E(t *testing.T, path string, expectedModules []*ManifestModule,
 
 	logger := zerolog.New(io.Discard)
 
-	moduleLoader := NewModuleLoader(path, &CredentialsSource{FetchToken: credentials.FindTerraformCloudToken}, opts.SourceMap, logger, &sync2.KeyMutex{})
+	moduleLoader := NewModuleLoader(path, NewSharedHCLParser(), &CredentialsSource{FetchToken: credentials.FindTerraformCloudToken}, opts.SourceMap, logger, &sync2.KeyMutex{})
 
 	manifest, err := moduleLoader.Load(path)
 	if !assert.NoError(t, err) {
@@ -244,7 +244,7 @@ func TestMultiProject(t *testing.T) {
 
 	logger := zerolog.New(io.Discard)
 
-	moduleLoader := NewModuleLoader(path, &CredentialsSource{FetchToken: credentials.FindTerraformCloudToken}, config.TerraformSourceMap{}, logger, &sync2.KeyMutex{})
+	moduleLoader := NewModuleLoader(path, NewSharedHCLParser(), &CredentialsSource{FetchToken: credentials.FindTerraformCloudToken}, config.TerraformSourceMap{}, logger, &sync2.KeyMutex{})
 
 	wg := &sync.WaitGroup{}
 	wg.Add(3)

--- a/internal/hcl/modules/parser.go
+++ b/internal/hcl/modules/parser.go
@@ -1,0 +1,34 @@
+package modules
+
+import (
+	"sync"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
+)
+
+type SharedHCLParser struct {
+	parser *hclparse.Parser
+	mu     *sync.Mutex
+}
+
+func NewSharedHCLParser() *SharedHCLParser {
+	return &SharedHCLParser{
+		parser: hclparse.NewParser(),
+		mu:     &sync.Mutex{},
+	}
+}
+
+func (p *SharedHCLParser) ParseHCLFile(filename string) (*hcl.File, hcl.Diagnostics) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.parser.ParseHCLFile(filename)
+}
+
+func (p *SharedHCLParser) ParseJSONFile(filename string) (*hcl.File, hcl.Diagnostics) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.parser.ParseJSONFile(filename)
+}

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/rs/zerolog"
 	"github.com/zclconf/go-cty/cty"
 
@@ -204,6 +203,7 @@ type Parser struct {
 	inputVars             map[string]cty.Value
 	workspaceName         string
 	moduleLoader          *modules.ModuleLoader
+	hclParser             *modules.SharedHCLParser
 	blockBuilder          BlockBuilder
 	newSpinner            ui.SpinnerFunc
 	remoteVariablesLoader *RemoteVariablesLoader
@@ -278,11 +278,14 @@ func newParser(projectRoot RootPath, moduleLoader *modules.ModuleLoader, logger 
 		"parser_path", projectRoot.Path,
 	).Logger()
 
+	hclParser := modules.NewSharedHCLParser()
+
 	p := &Parser{
 		initialPath:   projectRoot.Path,
 		hasChanges:    projectRoot.HasChanges,
 		workspaceName: defaultTerraformWorkspaceName,
-		blockBuilder:  BlockBuilder{SetAttributes: []SetAttributesFunc{SetUUIDAttributes}, Logger: logger},
+		hclParser:     hclParser,
+		blockBuilder:  BlockBuilder{SetAttributes: []SetAttributesFunc{SetUUIDAttributes}, Logger: logger, HCLParser: hclParser},
 		logger:        parserLogger,
 		moduleLoader:  moduleLoader,
 	}
@@ -341,7 +344,7 @@ func (p *Parser) ParseDirectory() (m *Module, err error) {
 
 	// load the initial root directory into a list of hcl files
 	// at this point these files have no schema associated with them.
-	files, err := loadDirectory(p.logger, p.initialPath, false)
+	files, err := loadDirectory(p.hclParser, p.logger, p.initialPath, false)
 	if err != nil {
 		return m, err
 	}
@@ -508,11 +511,9 @@ func (p *Parser) loadVarFile(filename string) (map[string]cty.Value, error) {
 
 	var parseFunc func(filename string) (*hcl.File, hcl.Diagnostics)
 
-	hclParser := hclparse.NewParser()
-
-	parseFunc = hclParser.ParseHCLFile
+	parseFunc = p.hclParser.ParseHCLFile
 	if strings.HasSuffix(filename, ".json") {
-		parseFunc = hclParser.ParseJSONFile
+		parseFunc = p.hclParser.ParseJSONFile
 	}
 
 	variableFile, diags := parseFunc(filename)
@@ -558,13 +559,13 @@ type file struct {
 	hclFile *hcl.File
 }
 
-func loadDirectory(logger zerolog.Logger, fullPath string, stopOnHCLError bool) ([]file, error) {
-	hclParser := hclparse.NewParser()
-
+func loadDirectory(hclParser *modules.SharedHCLParser, logger zerolog.Logger, fullPath string, stopOnHCLError bool) ([]file, error) {
 	fileInfos, err := os.ReadDir(fullPath)
 	if err != nil {
 		return nil, err
 	}
+
+	files := make([]file, 0)
 
 	for _, info := range fileInfos {
 		if info.IsDir() {
@@ -586,7 +587,7 @@ func loadDirectory(logger zerolog.Logger, fullPath string, stopOnHCLError bool) 
 		}
 
 		path := filepath.Join(fullPath, info.Name())
-		_, diag := parseFunc(path)
+		f, diag := parseFunc(path)
 		if diag != nil && diag.HasErrors() {
 			if stopOnHCLError {
 				return nil, diag
@@ -595,11 +596,8 @@ func loadDirectory(logger zerolog.Logger, fullPath string, stopOnHCLError bool) 
 			logger.Debug().Msgf("skipping file: %s hcl parsing err: %s", path, diag.Error())
 			continue
 		}
-	}
 
-	files := make([]file, 0, len(hclParser.Files()))
-	for filename, f := range hclParser.Files() {
-		files = append(files, file{hclFile: f, path: filename})
+		files = append(files, file{hclFile: f, path: path})
 	}
 
 	// sort files by path to ensure consistent ordering

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -53,7 +53,7 @@ data "cats_cat" "the-cats-mother" {
 `)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -147,7 +147,7 @@ output "loadbalancer"  {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -220,7 +220,7 @@ output "exp2" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -267,7 +267,7 @@ output "instances" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -306,7 +306,7 @@ resource "other_resource" "test" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -351,7 +351,7 @@ output "attr_not_exists" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -391,7 +391,7 @@ resource "other_resource" "test" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -443,7 +443,7 @@ output "serviceendpoint_principals" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -481,7 +481,7 @@ output "val" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -499,7 +499,7 @@ func Test_SetsHasChangesOnMod(t *testing.T) {
 	path := createTestFile("test.tf", `variable "foo" {}`)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path), HasChanges: true}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path), HasChanges: true}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -521,7 +521,7 @@ output "val" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -561,7 +561,7 @@ output "mod_result" {
 
 	logger := newDiscardLogger()
 	dir := filepath.Dir(path)
-	loader := modules.NewModuleLoader(dir, nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(dir, modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	rootModule, err := parsers[0].ParseDirectory()
@@ -621,7 +621,7 @@ output "mod_result" {
 	)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	rootModule, err := parsers[0].ParseDirectory()
@@ -675,7 +675,7 @@ resource "aws_instance" "my_instance" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -816,7 +816,7 @@ resource "test_resource_two" "test" {
 `)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -872,7 +872,7 @@ resource "test_resource_two" "test" {
 `)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -934,7 +934,7 @@ output "mod_result" {
 	)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -1082,7 +1082,7 @@ output "mod_result" {
 	)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -1164,7 +1164,7 @@ resource "dynamic" "resource" {
 	)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), path, loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -1225,7 +1225,7 @@ resource "azurerm_linux_function_app" "function" {
 	)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -1275,7 +1275,7 @@ resource "test_resource" "second" {
 `)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -1327,7 +1327,7 @@ data "google_compute_zones" "us" {
 `)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -1378,7 +1378,7 @@ data "aws_availability_zones" "ne" {
 `)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -1425,7 +1425,7 @@ resource "random_shuffle" "bad" {
 `)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}), filepath.Dir(path), loader, nil, logger)
 	require.NoError(t, err)
 	module, err := parsers[0].ParseDirectory()
@@ -1492,7 +1492,7 @@ locals {
 `)
 
 	logger := newDiscardLogger()
-	loader := modules.NewModuleLoader(filepath.Dir(path), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parsers, err := LoadParsers(
 		config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}),
 		filepath.Dir(path),
@@ -1517,7 +1517,7 @@ func BenchmarkParserEvaluate(b *testing.B) {
 		logger := newDiscardLogger()
 		dir := filepath.Dir("./testdata/benchmarks/heavy")
 		source, _ := modules.NewTerraformCredentialsSource(modules.BaseCredentialSet{})
-		loader := modules.NewModuleLoader(dir, source, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+		loader := modules.NewModuleLoader(dir, modules.NewSharedHCLParser(), source, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 		parsers, _ := LoadParsers(
 			config.NewProjectContext(config.EmptyRunContext(), &config.Project{}, logrus.Fields{}),
 			dir,

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -147,7 +147,7 @@ func NewHCLProvider(ctx *config.ProjectContext, config *HCLProviderConfig, opts 
 			initialPath = abs
 		}
 	}
-	loader := modules.NewModuleLoader(cachePath, credsSource, ctx.RunContext.Config.TerraformSourceMap, logger, ctx.RunContext.ModuleMutex)
+	loader := modules.NewModuleLoader(cachePath, modules.NewSharedHCLParser(), credsSource, ctx.RunContext.Config.TerraformSourceMap, logger, ctx.RunContext.ModuleMutex)
 	parsers, err := hcl.LoadParsers(
 		ctx,
 		initialPath,
@@ -517,7 +517,6 @@ func (p *HCLProvider) marshalModule(module *hcl.Module) ModuleOut {
 func (p *HCLProvider) getResourceOutput(block *hcl.Block) ResourceOutput {
 	jsonValues := marshalAttributeValues(block.Type(), block.Values())
 	p.marshalBlock(block, jsonValues)
-
 	planned := ResourceJSON{
 		Address:       block.FullName(),
 		Mode:          "managed",


### PR DESCRIPTION
Adds shared hcl parser which loads files and blocks from a global cache when used. I've reworked how the unique attributes work on the `Block` to make this work. We now generate these as separate `hcl.Attributes` which sit outside of the `hclsyntax.Body`. This means, in theory that we won't run into issue when using the shared `hclsyntax.Block` across projects/evaluator.