### PR TITLE
Merge mock values

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1054,6 +1054,19 @@ func TestBreakdownWithPolicyDataUploadHCL(t *testing.T) {
 	testutil.AssertGoldenFile(t, path.Join("./testdata", testName, testName+"-upload.golden"), uploadWriter.Bytes())
 }
 
+func TestBreakdownWithMockedMerge(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path",
+			path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		nil,
+	)
+}
+
 func TestBreakdownWithPolicyDataUploadPlanJson(t *testing.T) {
 	ts, uploadWriter := GraphqlTestServerWithWriter(map[string]string{
 		"policyResourceAllowList": policyResourceAllowlistGraphQLResponse,

--- a/cmd/infracost/testdata/breakdown_with_mocked_merge/breakdown_with_mocked_merge.golden
+++ b/cmd/infracost/testdata/breakdown_with_mocked_merge/breakdown_with_mocked_merge.golden
@@ -1,0 +1,22 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_mocked_merge
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours       $560.64 
+ └─ root_block_device                                                                    
+    └─ Storage (general purpose SSD, gp2)                         8  GB            $0.80 
+                                                                                         
+ OVERALL TOTAL                                                                   $561.44 
+──────────────────────────────────
+1 cloud resource was detected:
+∙ 1 was estimated, it includes usage-based costs, see https://infracost.io/usage-file
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...ta/breakdown_with_mocked_merge ┃ $561         ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_mocked_merge/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_mocked_merge/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+locals {
+  value1 = data.terraform_remote_state.env
+
+  value2 = merge(
+    data.terraform_remote_state.env["test"],
+    {
+      instance_type = "m5.4xlarge"
+    }
+  )
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = local.value2["instance_type"]
+}

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -1011,7 +1011,7 @@ func ExpFunctions(baseDir string, logger zerolog.Logger) map[string]function.Fun
 		"matchkeys":        funcs.MatchkeysFunc,
 		"max":              stdlib.MaxFunc,
 		"md5":              funcs.Md5Func,
-		"merge":            stdlib.MergeFunc,
+		"merge":            funcs.MergeFunc,
 		"min":              stdlib.MinFunc,
 		"parseint":         stdlib.ParseIntFunc,
 		"pathexpand":       funcs.PathExpandFunc,

--- a/internal/hcl/funcs/general.go
+++ b/internal/hcl/funcs/general.go
@@ -1,0 +1,7 @@
+package funcs
+
+import "github.com/zclconf/go-cty/cty"
+
+func refineNonNull(b *cty.RefinementBuilder) *cty.RefinementBuilder {
+	return b.NotNull()
+}

--- a/internal/hcl/funcs/json.go
+++ b/internal/hcl/funcs/json.go
@@ -29,7 +29,7 @@ var JSONDecodeFunc = function.New(&function.Spec{
 		}
 
 		val := str.AsString()
-		if strings.HasPrefix(val, "mock") {
+		if strings.HasSuffix(val, "-mock") {
 			return cty.Object(map[string]cty.Type{
 				"foo": cty.String,
 			}), nil
@@ -39,7 +39,7 @@ var JSONDecodeFunc = function.New(&function.Spec{
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		val := args[0].AsString()
-		if strings.HasPrefix(val, "mock") {
+		if strings.HasSuffix(val, "-mock") {
 			return cty.ObjectVal(map[string]cty.Value{
 				"foo": cty.StringVal("bar"),
 			}), nil

--- a/internal/hcl/funcs/yaml.go
+++ b/internal/hcl/funcs/yaml.go
@@ -29,7 +29,7 @@ var YAMLDecodeFunc = function.New(&function.Spec{
 			return cty.NilType, function.NewArgErrorf(0, "YAML source code cannot be null")
 		}
 		val := args[0].AsString()
-		if strings.HasPrefix(val, "mock") {
+		if strings.HasSuffix(val, "-mock") {
 			return cty.Object(map[string]cty.Type{
 				"foo": cty.String,
 			}), nil
@@ -39,7 +39,7 @@ var YAMLDecodeFunc = function.New(&function.Spec{
 	},
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 		val := args[0].AsString()
-		if strings.HasPrefix(val, "mock") {
+		if strings.HasSuffix(val, "-mock") {
 			return cty.ObjectVal(map[string]cty.Value{
 				"foo": cty.StringVal("bar"),
 			}), nil

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -384,8 +384,8 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 		Functions: func(baseDir string) map[string]function.Function {
 			funcs := hcl.ExpFunctions(baseDir, p.logger)
 
-			funcs["run_cmd"] = mockSliceFuncStaticReturn(cty.StringVal("mock-run_cmd"))
-			funcs["sops_decrypt_file"] = mockSliceFuncStaticReturn(cty.StringVal("mock"))
+			funcs["run_cmd"] = mockSliceFuncStaticReturn(cty.StringVal("run_cmd-mock"))
+			funcs["sops_decrypt_file"] = mockSliceFuncStaticReturn(cty.StringVal("sops_decrypt_file-mock"))
 
 			return funcs
 		},


### PR DESCRIPTION
Ensure `merge` can handle values that have already been mocked but then are discovered to be objects, e.g:
```
locals {
  value1 = data.terraform_remote_state.env

  value2 = merge(
    data.terraform_remote_state.env["test"],
    {
      instance_type = "m5.4xlarge"
    }
  )
}
```