### PR TITLE
fix: support dynamic iterator attribute

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1082,6 +1082,19 @@ func TestBreakdownWithMockedMerge(t *testing.T) {
 	)
 }
 
+func TestBreakdownWithDynamicIterator(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path",
+			path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		nil,
+	)
+}
+
 func TestBreakdownWithPolicyDataUploadPlanJson(t *testing.T) {
 	ts, uploadWriter := GraphqlTestServerWithWriter(map[string]string{
 		"policyResourceAllowList": policyResourceAllowlistGraphQLResponse,

--- a/cmd/infracost/testdata/breakdown_with_dynamic_iterator/breakdown_with_dynamic_iterator.golden
+++ b/cmd/infracost/testdata/breakdown_with_dynamic_iterator/breakdown_with_dynamic_iterator.golden
@@ -1,0 +1,39 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_dynamic_iterator
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours       $560.64 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ ├─ ebs_block_device[0]                                                                  
+ │  ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+ │  └─ Provisioned IOPS                                         800  IOPS         $52.00 
+ └─ ebs_block_device[1]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                      500  GB           $62.50 
+    └─ Provisioned IOPS                                         400  IOPS         $26.00 
+                                                                                         
+ aws_instance.web_app2                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours       $560.64 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ ├─ ebs_block_device[0]                                                                  
+ │  ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+ │  └─ Provisioned IOPS                                         800  IOPS         $52.00 
+ └─ ebs_block_device[1]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                      500  GB           $62.50 
+    └─ Provisioned IOPS                                         400  IOPS         $26.00 
+                                                                                         
+ OVERALL TOTAL                                                                 $1,662.28 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...reakdown_with_dynamic_iterator ┃ $1,662       ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_dynamic_iterator/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_dynamic_iterator/main.tf
@@ -1,0 +1,77 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  dynamic "ebs_block_device" {
+    for_each = {
+      device1 = {
+        name = "device1"
+        options = {
+          volume_size = 1000
+          iops        = 800
+        }
+      }
+      device2 = {
+        name = "device2"
+        options = {
+          volume_size = 500
+          iops        = 400
+        }
+      }
+    }
+    iterator = device
+    content {
+      device_name = device.value.name
+      volume_type = "io1"
+      volume_size = device.value.options.volume_size
+      iops        = device.value.options.iops
+    }
+  }
+}
+
+resource "aws_instance" "web_app2" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  dynamic "ebs_block_device" {
+    for_each = {
+      device1 = {
+        name = "device1"
+        options = {
+          volume_size = 1000
+          iops        = 800
+        }
+      }
+      device2 = {
+        name = "device2"
+        options = {
+          volume_size = 500
+          iops        = 400
+        }
+      }
+    }
+    content {
+      device_name = ebs_block_device.value.name
+      volume_type = "io1"
+      volume_size = ebs_block_device.value.options.volume_size
+      iops        = ebs_block_device.value.options.iops
+    }
+  }
+}
+


### PR DESCRIPTION
This PR adds support for expanded Dynamic block child context support. Normally, in the context of a for_each expansion we set the child context to have a prefix of "each". This allows correct evaluation of attributes referencing "each.value." or "each.key.". However, dynamic blocks are special cases. Not only can they use "each" in the content block, but they also are able to refer to the dynamic block label, e.g:

```
 dynamic "setting" {
   for_each = var.settings
   content {
     namespace = setting.value.namespace.
     ...
   }
 }
```

additionally they have an "iterator" block:
https://developer.hashicorp.com/terraform/language/expressions/dynamic-blocks which allow the user to specify a different prefix for a for_each expansion. For example:

```
  dynamic "foo" {
   for_each = {
      ...
   }
   iterator = device
   content {
     name = device.value.name
     ...
   }
 }
```

To add support for this logic, we now set an iteratorName on the child Context in for each expansion if the block type is "dynamic".