### PR TITLE
fix: don't show a double output when uploading to Infracost Cloud

### DIFF
--- a/internal/apiclient/policy.go
+++ b/internal/apiclient/policy.go
@@ -137,38 +137,6 @@ func (c *PolicyAPIClient) CheckPolicies(ctx *config.RunContext, out output.Root)
 		return nil, fmt.Errorf("failed to unmarshal tag policies %w", err)
 	}
 
-	if len(policies.EvaluatePolicies.TagPolicies) > 0 {
-		checkedStr := "tag policy"
-		if len(policies.EvaluatePolicies.TagPolicies) > 1 {
-			checkedStr = "tag policies"
-		}
-		msg := fmt.Sprintf(`%d %s checked`, len(policies.EvaluatePolicies.TagPolicies), checkedStr)
-		if ctx.Config.IsLogging() {
-			logging.Logger.Info().Msg(msg)
-		} else {
-			_, err := fmt.Fprintf(ctx.ErrWriter, "%s\n", msg)
-			if err != nil {
-				return nil, fmt.Errorf("failed to write tag policies %w", err)
-			}
-		}
-	}
-
-	if len(policies.EvaluatePolicies.FinOpsPolicies) > 0 {
-		checkedStr := "finops policy"
-		if len(policies.EvaluatePolicies.FinOpsPolicies) > 1 {
-			checkedStr = "finops policies"
-		}
-		msg := fmt.Sprintf(`%d %s checked`, len(policies.EvaluatePolicies.FinOpsPolicies), checkedStr)
-		if ctx.Config.IsLogging() {
-			logging.Logger.Info().Msg(msg)
-		} else {
-			_, err := fmt.Fprintf(ctx.ErrWriter, "%s\n", msg)
-			if err != nil {
-				return nil, fmt.Errorf("failed to write fin ops policies %w", err)
-			}
-		}
-	}
-
 	return &PolicyOutput{policies.EvaluatePolicies.TagPolicies, policies.EvaluatePolicies.FinOpsPolicies}, nil
 }
 


### PR DESCRIPTION
Before we were showing:
```
1 tag policy checked
48 finops policies checked
Estimate uploaded to organization 'org1' in Infracost Cloud
1 tag policy checked
48 finops policies checked
```

Now we show:
```
Estimate uploaded to organization 'org1' in Infracost Cloud
1 tag policy checked
48 finops policies checked
```

It doesn't seem like we need to show the message when we call CheckPolicies anywhere from what I can tell