### PR TITLE
refactor: skip JSON parser for Graph evaluator

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -395,3 +395,8 @@ func loadDotEnv() error {
 
 	return nil
 }
+
+// UseGraphEvaluator checks if we should use the HCL Graph evaluator.
+func UseGraphEvaluator() bool {
+	return os.Getenv("INFRACOST_GRAPH_EVALUATOR") == "true"
+}

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -622,6 +622,7 @@ func (attr *Attribute) VerticesReferenced(b *Block) []VertexReference {
 			ModuleAddress: modAddr,
 			AttributeName: attr.Name(),
 			Key:           otherPart,
+			Type:          ref.blockType.Name(),
 		})
 	}
 

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function/stdlib"
 	"github.com/zclconf/go-cty/cty/gocty"
 
+	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/hcl/funcs"
 	"github.com/infracost/infracost/internal/hcl/modules"
 	"github.com/infracost/infracost/internal/logging"
@@ -162,10 +163,6 @@ func NewEvaluator(
 		newSpinner:     spinFunc,
 		logger:         l,
 	}
-}
-
-func (e *Evaluator) isGraphEvaluator() bool {
-	return os.Getenv("INFRACOST_GRAPH_EVALUATOR") == "true"
 }
 
 func (e *Evaluator) AddFilteredBlocks(blocks ...*Block) {
@@ -531,7 +528,7 @@ func (e *Evaluator) expandBlockForEaches(blocks Blocks) Blocks {
 			continue
 		}
 
-		if !e.isGraphEvaluator() && (block.IsCountExpanded() || !block.IsForEachReferencedExpanded(blocks) || !shouldExpandBlock(block)) {
+		if !config.UseGraphEvaluator() && (block.IsCountExpanded() || !block.IsForEachReferencedExpanded(blocks) || !shouldExpandBlock(block)) {
 			original := block.original.GetAttribute("for_each")
 			if !original.HasChanged() {
 				expanded = append(expanded, block)
@@ -703,7 +700,7 @@ func (e *Evaluator) expandBlockCounts(blocks Blocks) Blocks {
 			continue
 		}
 
-		if !e.isGraphEvaluator() && (block.IsCountExpanded() || !shouldExpandBlock(block)) {
+		if !config.UseGraphEvaluator() && (block.IsCountExpanded() || !shouldExpandBlock(block)) {
 			original := block.original.GetAttribute("count")
 			if !original.HasChanged() {
 				expanded = append(expanded, block)

--- a/internal/hcl/graph_vertex_data.go
+++ b/internal/hcl/graph_vertex_data.go
@@ -26,13 +26,13 @@ func (v *VertexData) References() []VertexReference {
 	return v.block.VerticesReferenced()
 }
 
-func (v *VertexData) Visit(mutex *sync.Mutex) error {
+func (v *VertexData) Visit(mutex *sync.Mutex) (interface{}, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	moduleInstances := v.moduleConfigs.Get(v.block.ModuleAddress())
 	if len(moduleInstances) == 0 {
-		return fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
+		return nil, fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
 	}
 
 	for _, moduleInstance := range moduleInstances {
@@ -40,23 +40,23 @@ func (v *VertexData) Visit(mutex *sync.Mutex) error {
 		blockInstance := e.module.Blocks.FindLocalName(v.block.LocalName())
 
 		if blockInstance == nil {
-			return fmt.Errorf("could not find block %q in module %q", v.block.FullName(), moduleInstance.name)
+			return nil, fmt.Errorf("could not find block %q in module %q", v.block.FullName(), moduleInstance.name)
 		}
 
 		err := v.evaluate(e, blockInstance)
 		if err != nil {
-			return fmt.Errorf("could not evaluate data block %q", v.ID())
+			return nil, fmt.Errorf("could not evaluate data block %q", v.ID())
 		}
 
 		expanded, err := v.expand(e, blockInstance)
 		if err != nil {
-			return fmt.Errorf("could not expand data block %q", v.ID())
+			return nil, fmt.Errorf("could not expand data block %q", v.ID())
 		}
 
 		e.AddFilteredBlocks(expanded...)
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (v *VertexData) evaluate(e *Evaluator, b *Block) error {

--- a/internal/hcl/graph_vertex_local.go
+++ b/internal/hcl/graph_vertex_local.go
@@ -26,13 +26,13 @@ func (v *VertexLocal) References() []VertexReference {
 	return v.attr.VerticesReferenced(v.block)
 }
 
-func (v *VertexLocal) Visit(mutex *sync.Mutex) error {
+func (v *VertexLocal) Visit(mutex *sync.Mutex) (interface{}, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	moduleInstances := v.moduleConfigs.Get(v.block.ModuleAddress())
 	if len(moduleInstances) == 0 {
-		return fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
+		return nil, fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
 	}
 
 	for _, moduleInstance := range moduleInstances {
@@ -51,12 +51,12 @@ func (v *VertexLocal) Visit(mutex *sync.Mutex) error {
 		}
 
 		if attrInstance == nil {
-			return fmt.Errorf("could not find attribute %q in module %q", v.ID(), moduleInstance.name)
+			return nil, fmt.Errorf("could not find attribute %q in module %q", v.ID(), moduleInstance.name)
 		}
 
 		key := fmt.Sprintf("local.%s", attrInstance.Name())
 		e.ctx.SetByDot(attrInstance.Value(), key)
 	}
 
-	return nil
+	return nil, nil
 }

--- a/internal/hcl/graph_vertex_module_call.go
+++ b/internal/hcl/graph_vertex_module_call.go
@@ -48,10 +48,10 @@ func (v *VertexModuleCall) References() []VertexReference {
 	return v.block.VerticesReferenced()
 }
 
-func (v *VertexModuleCall) Visit(mutex *sync.Mutex) error {
+func (v *VertexModuleCall) Visit(mutex *sync.Mutex) (interface{}, error) {
 	moduleInstances := v.moduleConfigs.Get(v.block.ModuleAddress())
 	if len(moduleInstances) == 0 {
-		return fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
+		return nil, fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
 	}
 
 	for _, moduleInstance := range moduleInstances {
@@ -59,23 +59,23 @@ func (v *VertexModuleCall) Visit(mutex *sync.Mutex) error {
 		blockInstance := e.module.Blocks.FindLocalName(v.block.LocalName())
 
 		if blockInstance == nil {
-			return fmt.Errorf("could not find block %q in module %q", v.ID(), moduleInstance.name)
+			return nil, fmt.Errorf("could not find block %q in module %q", v.ID(), moduleInstance.name)
 		}
 
 		err := v.evaluate(e, blockInstance, mutex)
 		if err != nil {
-			return fmt.Errorf("could not evaluate module %q", v.block.FullName())
+			return nil, fmt.Errorf("could not evaluate module %q", v.block.FullName())
 		}
 
 		expanded, err := v.expand(e, blockInstance, mutex)
 		if err != nil {
-			return fmt.Errorf("could not expand module %q", v.block.FullName())
+			return nil, fmt.Errorf("could not expand module %q", v.block.FullName())
 		}
 
 		e.AddFilteredBlocks(expanded...)
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (v *VertexModuleCall) evaluate(e *Evaluator, b *Block, mutex *sync.Mutex) error {

--- a/internal/hcl/graph_vertex_module_exit.go
+++ b/internal/hcl/graph_vertex_module_exit.go
@@ -24,7 +24,7 @@ func (v *VertexModuleExit) References() []VertexReference {
 	return []VertexReference{}
 }
 
-func (v *VertexModuleExit) Visit(mutex *sync.Mutex) error {
+func (v *VertexModuleExit) Visit(mutex *sync.Mutex) (interface{}, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
@@ -42,5 +42,5 @@ func (v *VertexModuleExit) Visit(mutex *sync.Mutex) error {
 		modCall.Module = &e.module
 	}
 
-	return nil
+	return nil, nil
 }

--- a/internal/hcl/graph_vertex_output.go
+++ b/internal/hcl/graph_vertex_output.go
@@ -28,13 +28,13 @@ func (v *VertexOutput) References() []VertexReference {
 	return v.block.VerticesReferenced()
 }
 
-func (v *VertexOutput) Visit(mutex *sync.Mutex) error {
+func (v *VertexOutput) Visit(mutex *sync.Mutex) (interface{}, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	moduleInstances := v.moduleConfigs.Get(v.block.ModuleAddress())
 	if len(moduleInstances) == 0 {
-		return fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
+		return nil, fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
 	}
 
 	for _, moduleInstance := range moduleInstances {
@@ -42,13 +42,13 @@ func (v *VertexOutput) Visit(mutex *sync.Mutex) error {
 		blockInstance := e.module.Blocks.FindLocalName(v.block.LocalName())
 
 		if blockInstance == nil {
-			return fmt.Errorf("could not find block %q in module %q", v.ID(), moduleInstance.name)
+			return nil, fmt.Errorf("could not find block %q in module %q", v.ID(), moduleInstance.name)
 		}
 
 		key := fmt.Sprintf("output.%s", blockInstance.Label())
 		val, err := e.evaluateOutput(blockInstance)
 		if err != nil {
-			return fmt.Errorf("could not evaluate output %s: %w", v.ID(), err)
+			return nil, fmt.Errorf("could not evaluate output %s: %w", v.ID(), err)
 		}
 
 		v.logger.Debug().Msgf("adding output %s to the evaluation context", v.ID())
@@ -75,5 +75,5 @@ func (v *VertexOutput) Visit(mutex *sync.Mutex) error {
 		e.AddFilteredBlocks(blockInstance)
 	}
 
-	return nil
+	return nil, nil
 }

--- a/internal/hcl/graph_vertex_provider.go
+++ b/internal/hcl/graph_vertex_provider.go
@@ -32,18 +32,18 @@ func (v *VertexProvider) References() []VertexReference {
 	return v.block.VerticesReferenced()
 }
 
-func (v *VertexProvider) Visit(mutex *sync.Mutex) error {
+func (v *VertexProvider) Visit(mutex *sync.Mutex) (interface{}, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	provider := v.block.Label()
 	if provider == "" {
-		return fmt.Errorf("provider block %s has no label", v.ID())
+		return nil, fmt.Errorf("provider block %s has no label", v.ID())
 	}
 
 	moduleInstances := v.moduleConfigs.Get(v.block.ModuleAddress())
 	if len(moduleInstances) == 0 {
-		return fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
+		return nil, fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
 	}
 
 	for _, moduleInstance := range moduleInstances {
@@ -60,7 +60,7 @@ func (v *VertexProvider) Visit(mutex *sync.Mutex) error {
 		}
 
 		if blockInstance == nil {
-			return fmt.Errorf("could not find block %q in module %q", v.ID(), moduleInstance.name)
+			return nil, fmt.Errorf("could not find block %q in module %q", v.ID(), moduleInstance.name)
 		}
 
 		var existingVals map[string]cty.Value
@@ -79,5 +79,5 @@ func (v *VertexProvider) Visit(mutex *sync.Mutex) error {
 		e.AddFilteredBlocks(blockInstance)
 	}
 
-	return nil
+	return nil, nil
 }

--- a/internal/hcl/graph_vertex_root.go
+++ b/internal/hcl/graph_vertex_root.go
@@ -16,6 +16,6 @@ func (v *VertexRoot) References() []VertexReference {
 	return []VertexReference{}
 }
 
-func (v *VertexRoot) Visit(mutex *sync.Mutex) error {
-	return nil
+func (v *VertexRoot) Visit(mutex *sync.Mutex) (interface{}, error) {
+	return nil, nil
 }

--- a/internal/hcl/graph_vertex_variable.go
+++ b/internal/hcl/graph_vertex_variable.go
@@ -26,13 +26,13 @@ func (v *VertexVariable) References() []VertexReference {
 	return v.block.VerticesReferenced()
 }
 
-func (v *VertexVariable) Visit(mutex *sync.Mutex) error {
+func (v *VertexVariable) Visit(mutex *sync.Mutex) (interface{}, error) {
 	mutex.Lock()
 	defer mutex.Unlock()
 
 	moduleInstances := v.moduleConfigs.Get(v.block.ModuleAddress())
 	if len(moduleInstances) == 0 {
-		return fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
+		return nil, fmt.Errorf("no module instances found for module address %q", v.block.ModuleAddress())
 	}
 
 	for _, moduleInstance := range moduleInstances {
@@ -40,7 +40,7 @@ func (v *VertexVariable) Visit(mutex *sync.Mutex) error {
 		blockInstance := e.module.Blocks.FindLocalName(v.block.LocalName())
 
 		if blockInstance == nil {
-			return fmt.Errorf("could not find block %q in module %q", v.ID(), moduleInstance.name)
+			return nil, fmt.Errorf("could not find block %q in module %q", v.ID(), moduleInstance.name)
 		}
 
 		// Re-evaluate the matching module input variables for this variable block
@@ -59,7 +59,7 @@ func (v *VertexVariable) Visit(mutex *sync.Mutex) error {
 
 		val, err := e.evaluateVariable(blockInstance, inputVars)
 		if err != nil {
-			return fmt.Errorf("could not evaluate variable %s: %w", v.ID(), err)
+			return nil, fmt.Errorf("could not evaluate variable %s: %w", v.ID(), err)
 		}
 
 		v.logger.Debug().Msgf("adding variable %s to the evaluation context", v.ID())
@@ -69,5 +69,5 @@ func (v *VertexVariable) Visit(mutex *sync.Mutex) error {
 		e.AddFilteredBlocks(blockInstance)
 	}
 
-	return nil
+	return nil, nil
 }


### PR DESCRIPTION
This changes the HCL Graph evaluator logic to build resources directly from the graph output. When the graph evaluator finishes visiting a node it is assumed that we have all the relevant data/values to build a schema resource. This means that we can essentially skip the marshalling to Plan JSON and instead just change the resources to their CoreResource counterparts.

TODO:

- [ ] provider metadata
- [ ] remote module calls
- [ ] make sure the resource tests cover the graph runner and are passing
