### PR TITLE
feat(azure): add support for Azure DNS Private Resolver (endpoints and ruleset)

### DIFF
--- a/internal/providers/terraform/azure/private_dns_resolver_dns_forwarding_ruleset.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_dns_forwarding_ruleset.go
@@ -7,17 +7,17 @@ import (
 	"github.com/infracost/infracost/internal/schema"
 )
 
-func getPrivateDnsResolverOutboundEndpointRegistryItem() *schema.RegistryItem {
+func getPrivateDnsResolverDnsForwardingRulesetRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
-		Name:      "azurerm_private_dns_resolver_outbound_endpoint",
-		CoreRFunc: newPrivateDnsResolverOutboundEndpoint,
+		Name:      "azurerm_private_dns_resolver_dns_forwarding_ruleset",
+		CoreRFunc: newPrivateDnsResolverDnsForwardingRuleset,
 		ReferenceAttributes: []string{
 			"resource_group_name",
 		},
 	}
 }
 
-func newPrivateDnsResolverOutboundEndpoint(d *schema.ResourceData) schema.CoreResource {
+func newPrivateDnsResolverDnsForwardingRuleset(d *schema.ResourceData) schema.CoreResource {
 	region := lookupRegion(d, []string{"resource_group_name"})
 
 	if strings.HasPrefix(strings.ToLower(region), "usgov") {
@@ -30,7 +30,7 @@ func newPrivateDnsResolverOutboundEndpoint(d *schema.ResourceData) schema.CoreRe
 		region = "Zone 1"
 	}
 
-	return &azure.PrivateDnsResolverOutboundEndpoint{
+	return &azure.PrivateDnsResolverDnsForwardingRuleset{
 		Address: d.Address,
 		Region:  region,
 	}

--- a/internal/providers/terraform/azure/private_dns_resolver_dns_forwarding_ruleset_test.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_dns_forwarding_ruleset_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestPrivateDnsResolverDnsForwardingRuleset(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "private_dns_resolver_dns_forwarding_ruleset_test")
+}

--- a/internal/providers/terraform/azure/private_dns_resolver_inbound_endpoint.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_inbound_endpoint.go
@@ -1,0 +1,37 @@
+package azure
+
+import (
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getPrivateDnsResolverInboundEndpointRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "azurerm_private_dns_resolver_inbound_endpoint",
+		CoreRFunc: newPrivateDnsResolverInboundEndpoint,
+		ReferenceAttributes: []string{
+			"resource_group_name",
+		},
+	}
+}
+
+func newPrivateDnsResolverInboundEndpoint(d *schema.ResourceData) schema.CoreResource {
+	region := lookupRegion(d, []string{"resource_group_name"})
+
+	if strings.HasPrefix(strings.ToLower(region), "usgov") {
+		region = "US Gov Zone 1"
+	} else if strings.HasPrefix(strings.ToLower(region), "germany") {
+		region = "DE Zone 1"
+	} else if strings.HasPrefix(strings.ToLower(region), "china") {
+		region = "Zone 1 (China)"
+	} else {
+		region = "Zone 1"
+	}
+
+	return &azure.PrivateDnsResolverInboundEndpoint{
+		Address: d.Address,
+		Region:  region,
+	}
+}

--- a/internal/providers/terraform/azure/private_dns_resolver_inbound_endpoint.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_inbound_endpoint.go
@@ -12,7 +12,7 @@ func getPrivateDnsResolverInboundEndpointRegistryItem() *schema.RegistryItem {
 		Name:      "azurerm_private_dns_resolver_inbound_endpoint",
 		CoreRFunc: newPrivateDnsResolverInboundEndpoint,
 		ReferenceAttributes: []string{
-			"location",
+			"resource_group_name",
 		},
 	}
 }

--- a/internal/providers/terraform/azure/private_dns_resolver_inbound_endpoint_test.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_inbound_endpoint_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestPrivateDnsResolverInboundEndpoint(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "private_dns_resolver_inbound_endpoint_test")
+}

--- a/internal/providers/terraform/azure/private_dns_resolver_outbound_endpoint.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_outbound_endpoint.go
@@ -7,17 +7,17 @@ import (
 	"github.com/infracost/infracost/internal/schema"
 )
 
-func getPrivateDnsResolverInboundEndpointRegistryItem() *schema.RegistryItem {
+func getPrivateDnsResolverOutboundEndpointRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
-		Name:      "azurerm_private_dns_resolver_inbound_endpoint",
-		CoreRFunc: newPrivateDnsResolverInboundEndpoint,
+		Name:      "azurerm_private_dns_resolver_outbound_endpoint",
+		CoreRFunc: newPrivateDnsResolverOutboundEndpoint,
 		ReferenceAttributes: []string{
 			"location",
 		},
 	}
 }
 
-func newPrivateDnsResolverInboundEndpoint(d *schema.ResourceData) schema.CoreResource {
+func newPrivateDnsResolverOutboundEndpoint(d *schema.ResourceData) schema.CoreResource {
 	region := lookupRegion(d, []string{"resource_group_name"})
 
 	if strings.HasPrefix(strings.ToLower(region), "usgov") {
@@ -30,7 +30,7 @@ func newPrivateDnsResolverInboundEndpoint(d *schema.ResourceData) schema.CoreRes
 		region = "Zone 1"
 	}
 
-	return &azure.PrivateDnsResolverInboundEndpoint{
+	return &azure.PrivateDnsResolverOutboundEndpoint{
 		Address: d.Address,
 		Region:  region,
 	}

--- a/internal/providers/terraform/azure/private_dns_resolver_outbound_endpoint_test.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_outbound_endpoint_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestPrivateDnsResolverOutboundEndpoint(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "private_dns_resolver_outbound_endpoint_test")
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -156,6 +156,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getLogicAppStandardRegistryItem(),
 	getImageRegistryItem(),
 	getSnapshotRegistryItem(),
+	getPrivateDnsResolverInboundEndpointRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -157,6 +157,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getImageRegistryItem(),
 	getSnapshotRegistryItem(),
 	getPrivateDnsResolverInboundEndpointRegistryItem(),
+	getPrivateDnsResolverOutboundEndpointRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -158,6 +158,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getSnapshotRegistryItem(),
 	getPrivateDnsResolverInboundEndpointRegistryItem(),
 	getPrivateDnsResolverOutboundEndpointRegistryItem(),
+	getPrivateDnsResolverDnsForwardingRulesetRegistryItem(),
 }
 
 // FreeResources grouped alphabetically
@@ -262,6 +263,7 @@ var FreeResources = []string{
 
 	// Azure DNS
 	"azurerm_private_dns_zone_virtual_network_link",
+	"azurerm_private_dns_resolver",
 
 	// Azure Data Factory
 	"azurerm_data_factory_custom_dataset",

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_dns_forwarding_ruleset_test/private_dns_resolver_dns_forwarding_ruleset_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_dns_forwarding_ruleset_test/private_dns_resolver_dns_forwarding_ruleset_test.golden
@@ -1,0 +1,24 @@
+
+ Name                                                         Monthly Qty  Unit    Monthly Cost 
+                                                                                                
+ azurerm_private_dns_resolver_dns_forwarding_ruleset.example                                    
+ └─ Forwarding ruleset                                                  1  months         $2.50 
+                                                                                                
+ azurerm_private_dns_resolver_outbound_endpoint.example                                         
+ └─ Outbound endpoint                                                   1  months       $180.00 
+                                                                                                
+ OVERALL TOTAL                                                                          $182.50 
+──────────────────────────────────
+6 cloud resources were detected:
+∙ 2 were estimated
+∙ 4 were free:
+  ∙ 1 x azurerm_private_dns_resolver
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                            ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ TestPrivateDnsResolverDnsForwardingRuleset         ┃ $183         ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_dns_forwarding_ruleset_test/private_dns_resolver_dns_forwarding_ruleset_test.tf
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_dns_forwarding_ruleset_test/private_dns_resolver_dns_forwarding_ruleset_test.tf
@@ -1,0 +1,46 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "internal" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_private_dns_resolver" "example" {
+  name                = "pdnsr-example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  virtual_network_id  = azurerm_virtual_network.example.id
+}
+
+resource "azurerm_private_dns_resolver_outbound_endpoint" "example" {
+  name                    = "droe-example"
+  location                = azurerm_resource_group.example.location
+  subnet_id               = azurerm_subnet.internal.id
+  private_dns_resolver_id = azurerm_private_dns_resolver.example.id
+}
+
+
+resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "example" {
+  name                                       = "drdfr-example"
+  resource_group_name                        = azurerm_resource_group.example.name
+  location                                   = azurerm_resource_group.example.location
+  private_dns_resolver_outbound_endpoint_ids = [azurerm_private_dns_resolver_outbound_endpoint.example.id]
+}
+

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_dns_forwarding_ruleset_test/private_dns_resolver_dns_forwarding_ruleset_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_dns_forwarding_ruleset_test/private_dns_resolver_dns_forwarding_ruleset_test.usage.yml
@@ -1,0 +1,2 @@
+version: 0.1
+resource_usage:

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_inbound_endpoint_test/private_dns_resolver_inbound_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_inbound_endpoint_test/private_dns_resolver_inbound_endpoint_test.golden
@@ -8,12 +8,11 @@
 ──────────────────────────────────
 5 cloud resources were detected:
 ∙ 1 was estimated
-∙ 3 were free:
+∙ 4 were free:
+  ∙ 1 x azurerm_private_dns_resolver
   ∙ 1 x azurerm_resource_group
   ∙ 1 x azurerm_subnet
   ∙ 1 x azurerm_virtual_network
-∙ 1 is not supported yet, see https://infracost.io/requested-resources:
-  ∙ 1 x azurerm_private_dns_resolver
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_inbound_endpoint_test/private_dns_resolver_inbound_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_inbound_endpoint_test/private_dns_resolver_inbound_endpoint_test.golden
@@ -1,0 +1,22 @@
+
+ Name                                                   Monthly Qty  Unit    Monthly Cost 
+                                                                                          
+ azurerm_private_dns_resolver_inbound_endpoint.example                                    
+ └─ Inbound endpoint                                              1  months       $180.00 
+                                                                                          
+ OVERALL TOTAL                                                                    $180.00 
+──────────────────────────────────
+5 cloud resources were detected:
+∙ 1 was estimated
+∙ 3 were free:
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network
+∙ 1 is not supported yet, see https://infracost.io/requested-resources:
+  ∙ 1 x azurerm_private_dns_resolver
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                            ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ TestPrivateDnsResolverInboundEndpoint              ┃ $180         ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_inbound_endpoint_test/private_dns_resolver_inbound_endpoint_test.tf
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_inbound_endpoint_test/private_dns_resolver_inbound_endpoint_test.tf
@@ -1,0 +1,43 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "internal" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_private_dns_resolver" "example" {
+  name                = "pdnsr-example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  virtual_network_id  = azurerm_virtual_network.example.id
+}
+
+resource "azurerm_private_dns_resolver_inbound_endpoint" "example" {
+  name     = "drie-example"
+  location = azurerm_resource_group.example.location
+
+  private_dns_resolver_id = azurerm_private_dns_resolver.example.id
+
+  ip_configurations {
+    private_ip_allocation_method = "Dynamic"
+    subnet_id                    = azurerm_subnet.internal.id
+  }
+}
+

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_inbound_endpoint_test/private_dns_resolver_inbound_endpoint_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_inbound_endpoint_test/private_dns_resolver_inbound_endpoint_test.usage.yml
@@ -1,0 +1,2 @@
+version: 0.1
+resource_usage:

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_outbound_endpoint_test/private_dns_resolver_outbound_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_outbound_endpoint_test/private_dns_resolver_outbound_endpoint_test.golden
@@ -8,12 +8,11 @@
 ──────────────────────────────────
 5 cloud resources were detected:
 ∙ 1 was estimated
-∙ 3 were free:
+∙ 4 were free:
+  ∙ 1 x azurerm_private_dns_resolver
   ∙ 1 x azurerm_resource_group
   ∙ 1 x azurerm_subnet
   ∙ 1 x azurerm_virtual_network
-∙ 1 is not supported yet, see https://infracost.io/requested-resources:
-  ∙ 1 x azurerm_private_dns_resolver
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_outbound_endpoint_test/private_dns_resolver_outbound_endpoint_test.golden
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_outbound_endpoint_test/private_dns_resolver_outbound_endpoint_test.golden
@@ -1,0 +1,22 @@
+
+ Name                                                    Monthly Qty  Unit    Monthly Cost 
+                                                                                           
+ azurerm_private_dns_resolver_outbound_endpoint.example                                    
+ └─ Outbound endpoint                                              1  months       $180.00 
+                                                                                           
+ OVERALL TOTAL                                                                     $180.00 
+──────────────────────────────────
+5 cloud resources were detected:
+∙ 1 was estimated
+∙ 3 were free:
+  ∙ 1 x azurerm_resource_group
+  ∙ 1 x azurerm_subnet
+  ∙ 1 x azurerm_virtual_network
+∙ 1 is not supported yet, see https://infracost.io/requested-resources:
+  ∙ 1 x azurerm_private_dns_resolver
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                            ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ TestPrivateDnsResolverOutboundEndpoint             ┃ $180         ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_outbound_endpoint_test/private_dns_resolver_outbound_endpoint_test.tf
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_outbound_endpoint_test/private_dns_resolver_outbound_endpoint_test.tf
@@ -1,0 +1,38 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "internal" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_private_dns_resolver" "example" {
+  name                = "pdnsr-example"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  virtual_network_id  = azurerm_virtual_network.example.id
+}
+
+resource "azurerm_private_dns_resolver_outbound_endpoint" "example" {
+  name                    = "droe-example"
+  location                = azurerm_resource_group.example.location
+  subnet_id               = azurerm_subnet.internal.id
+  private_dns_resolver_id = azurerm_private_dns_resolver.example.id
+}
+

--- a/internal/providers/terraform/azure/testdata/private_dns_resolver_outbound_endpoint_test/private_dns_resolver_outbound_endpoint_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/private_dns_resolver_outbound_endpoint_test/private_dns_resolver_outbound_endpoint_test.usage.yml
@@ -1,0 +1,2 @@
+version: 0.1
+resource_usage:

--- a/internal/resources/azure/private_dns_resolver_dns_forwarding_ruleset.go
+++ b/internal/resources/azure/private_dns_resolver_dns_forwarding_ruleset.go
@@ -6,13 +6,10 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// PrivateDnsResolverDnsForwardingRuleset struct represents <TODO: cloud service short description>.
+// PrivateDnsResolverDnsForwardingRuleset struct represents Azure DNS Private Resolver Forwarding Ruleset.
 //
-// <TODO: Add any important information about the resource and links to the
-// pricing pages or documentation that might be useful to developers in the future, e.g:>
-//
-// Resource information: https://azure.microsoft.com/<PATH/TO/RESOURCE>/
-// Pricing information: https://azure.microsoft.com/<PATH/TO/PRICING>/
+// Resource information: https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview
+// Pricing information: https://azure.microsoft.com/en-us/pricing/details/dns/
 type PrivateDnsResolverDnsForwardingRuleset struct {
 	Address string
 	Region  string

--- a/internal/resources/azure/private_dns_resolver_dns_forwarding_ruleset.go
+++ b/internal/resources/azure/private_dns_resolver_dns_forwarding_ruleset.go
@@ -1,0 +1,63 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// PrivateDnsResolverDnsForwardingRuleset struct represents <TODO: cloud service short description>.
+//
+// <TODO: Add any important information about the resource and links to the
+// pricing pages or documentation that might be useful to developers in the future, e.g:>
+//
+// Resource information: https://azure.microsoft.com/<PATH/TO/RESOURCE>/
+// Pricing information: https://azure.microsoft.com/<PATH/TO/PRICING>/
+type PrivateDnsResolverDnsForwardingRuleset struct {
+	Address string
+	Region  string
+}
+
+// CoreType returns the name of this resource type
+func (r *PrivateDnsResolverDnsForwardingRuleset) CoreType() string {
+	return "PrivateDnsResolverDnsForwardingRuleset"
+}
+
+// UsageSchema defines a list which represents the usage schema of PrivateDnsResolverDnsForwardingRuleset.
+func (r *PrivateDnsResolverDnsForwardingRuleset) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{}
+}
+
+// PopulateUsage parses the u schema.UsageData into the PrivateDnsResolverDnsForwardingRuleset.
+// It uses the `infracost_usage` struct tags to populate data into the PrivateDnsResolverDnsForwardingRuleset.
+func (r *PrivateDnsResolverDnsForwardingRuleset) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid PrivateDnsResolverDnsForwardingRuleset struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *PrivateDnsResolverDnsForwardingRuleset) BuildResource() *schema.Resource {
+	return &schema.Resource{
+		Name:        r.Address,
+		UsageSchema: r.UsageSchema(),
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:            "Forwarding ruleset",
+				Unit:            "months",
+				UnitMultiplier:  decimal.NewFromInt(1),
+				MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("azure"),
+					Region:        strPtr(r.Region),
+					Service:       strPtr("Azure DNS"),
+					ProductFamily: strPtr("Networking"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "skuName", Value: strPtr("Azure DNS Private Resolver")},
+						{Key: "meterName", Value: strPtr("Azure DNS Private Resolver DNS Forwarding Ruleset")},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/resources/azure/private_dns_resolver_inbound_endpoint.go
+++ b/internal/resources/azure/private_dns_resolver_inbound_endpoint.go
@@ -1,0 +1,59 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// PrivateDnsResolverInboundEndpoint struct represents a Azure DNS Private Resolver Endpoint.
+//
+// Resource information: https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview
+// Pricing information: https://azure.microsoft.com/en-us/pricing/details/dns/
+type PrivateDnsResolverInboundEndpoint struct {
+	Address string
+	Region  string
+}
+
+// CoreType returns the name of this resource type
+func (r *PrivateDnsResolverInboundEndpoint) CoreType() string {
+	return "PrivateDnsResolverInboundEndpoint"
+}
+
+// UsageSchema defines a list which represents the usage schema of PrivateDnsResolverInboundEndpoint.
+func (r *PrivateDnsResolverInboundEndpoint) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{}
+}
+
+// PopulateUsage parses the u schema.UsageData into the PrivateDnsResolverInboundEndpoint.
+// It uses the `infracost_usage` struct tags to populate data into the PrivateDnsResolverInboundEndpoint.
+func (r *PrivateDnsResolverInboundEndpoint) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid PrivateDnsResolverInboundEndpoint struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *PrivateDnsResolverInboundEndpoint) BuildResource() *schema.Resource {
+	return &schema.Resource{
+		Name:        r.Address,
+		UsageSchema: r.UsageSchema(),
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:            "Inbound endpoint",
+				Unit:            "months",
+				UnitMultiplier:  decimal.NewFromInt(1),
+				MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr("azure"),
+					Region:        strPtr(r.Region),
+					Service:       strPtr("Azure DNS"),
+					ProductFamily: strPtr("Networking"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "meterName", Value: strPtr("Azure DNS Private Resolver Inbound Endpoint")},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/resources/azure/private_dns_resolver_inbound_endpoint.go
+++ b/internal/resources/azure/private_dns_resolver_inbound_endpoint.go
@@ -50,6 +50,7 @@ func (r *PrivateDnsResolverInboundEndpoint) BuildResource() *schema.Resource {
 					Service:       strPtr("Azure DNS"),
 					ProductFamily: strPtr("Networking"),
 					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "skuName", Value: strPtr("Azure DNS Private Resolver")},
 						{Key: "meterName", Value: strPtr("Azure DNS Private Resolver Inbound Endpoint")},
 					},
 				},

--- a/internal/resources/azure/private_dns_resolver_outbound_endpoint.go
+++ b/internal/resources/azure/private_dns_resolver_outbound_endpoint.go
@@ -50,6 +50,7 @@ func (r *PrivateDnsResolverOutboundEndpoint) BuildResource() *schema.Resource {
 					Service:       strPtr("Azure DNS"),
 					ProductFamily: strPtr("Networking"),
 					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "skuName", Value: strPtr("Azure DNS Private Resolver")},
 						{Key: "meterName", Value: strPtr("Azure DNS Private Resolver Outbound Endpoint")},
 					},
 				},

--- a/internal/resources/azure/private_dns_resolver_outbound_endpoint.go
+++ b/internal/resources/azure/private_dns_resolver_outbound_endpoint.go
@@ -6,41 +6,41 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// PrivateDnsResolverInboundEndpoint struct represents a Azure DNS Private Resolver Inbound Endpoint.
+// PrivateDnsResolverOutboundEndpoint struct represents a Azure DNS Private Resolver Outbound Endpoint.
 //
 // Resource information: https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview
 // Pricing information: https://azure.microsoft.com/en-us/pricing/details/dns/
-type PrivateDnsResolverInboundEndpoint struct {
+type PrivateDnsResolverOutboundEndpoint struct {
 	Address string
 	Region  string
 }
 
 // CoreType returns the name of this resource type
-func (r *PrivateDnsResolverInboundEndpoint) CoreType() string {
-	return "PrivateDnsResolverInboundEndpoint"
+func (r *PrivateDnsResolverOutboundEndpoint) CoreType() string {
+	return "PrivateDnsResolverOutboundEndpoint"
 }
 
-// UsageSchema defines a list which represents the usage schema of PrivateDnsResolverInboundEndpoint.
-func (r *PrivateDnsResolverInboundEndpoint) UsageSchema() []*schema.UsageItem {
+// UsageSchema defines a list which represents the usage schema of PrivateDnsResolverOutboundEndpoint.
+func (r *PrivateDnsResolverOutboundEndpoint) UsageSchema() []*schema.UsageItem {
 	return []*schema.UsageItem{}
 }
 
-// PopulateUsage parses the u schema.UsageData into the PrivateDnsResolverInboundEndpoint.
-// It uses the `infracost_usage` struct tags to populate data into the PrivateDnsResolverInboundEndpoint.
-func (r *PrivateDnsResolverInboundEndpoint) PopulateUsage(u *schema.UsageData) {
+// PopulateUsage parses the u schema.UsageData into the PrivateDnsResolverOutboundEndpoint.
+// It uses the `infracost_usage` struct tags to populate data into the PrivateDnsResolverOutboundEndpoint.
+func (r *PrivateDnsResolverOutboundEndpoint) PopulateUsage(u *schema.UsageData) {
 	resources.PopulateArgsWithUsage(r, u)
 }
 
-// BuildResource builds a schema.Resource from a valid PrivateDnsResolverInboundEndpoint struct.
+// BuildResource builds a schema.Resource from a valid PrivateDnsResolverOutboundEndpoint struct.
 // This method is called after the resource is initialised by an IaC provider.
 // See providers folder for more information.
-func (r *PrivateDnsResolverInboundEndpoint) BuildResource() *schema.Resource {
+func (r *PrivateDnsResolverOutboundEndpoint) BuildResource() *schema.Resource {
 	return &schema.Resource{
 		Name:        r.Address,
 		UsageSchema: r.UsageSchema(),
 		CostComponents: []*schema.CostComponent{
 			{
-				Name:            "Inbound endpoint",
+				Name:            "Outbound endpoint",
 				Unit:            "months",
 				UnitMultiplier:  decimal.NewFromInt(1),
 				MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
@@ -50,7 +50,7 @@ func (r *PrivateDnsResolverInboundEndpoint) BuildResource() *schema.Resource {
 					Service:       strPtr("Azure DNS"),
 					ProductFamily: strPtr("Networking"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "meterName", Value: strPtr("Azure DNS Private Resolver Inbound Endpoint")},
+						{Key: "meterName", Value: strPtr("Azure DNS Private Resolver Outbound Endpoint")},
 					},
 				},
 			},


### PR DESCRIPTION
## Objective:

Add support for :
* azurerm_private_dns_resolver_inbound_endpoint
* azurerm_private_dns_resolver_outbound_endpoint 
* azurerm_private_dns_resolver_dns_forwarding_ruleset
* azurerm_private_dns_resolver

Fixes #2778.

PR on the documentation : https://github.com/infracost/docs/pull/594

## Pricing details:

Price for a each endpoint (inbound or outbound): 180$/month
Price for a each ruleset : 2.50$/month

## Status:

- [x] Generated the resource files
- [x] Updated the internal/resources file
- [x] Updated the internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [x] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/594)

## Issues:

None