### PR TITLE
feat: add HCL graph tests

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1061,6 +1061,7 @@ func TestBreakdownWithDataBlocksInSubmod(t *testing.T) {
 }
 
 func TestBreakdownWithPolicyDataUploadHCL(t *testing.T) {
+	sep := []byte("===\n")
 	ts, uploadWriter := GraphqlTestServerWithWriter(map[string]string{
 		"policyResourceAllowList": policyResourceAllowlistGraphQLResponse,
 		"storePolicyResources":    storePolicyResourcesGraphQLResponse,
@@ -1083,10 +1084,14 @@ func TestBreakdownWithPolicyDataUploadHCL(t *testing.T) {
 		}, func(ctx *config.RunContext) {
 			ctx.Config.PolicyV2APIEndpoint = ts.URL
 			ctx.Config.PoliciesEnabled = true
+			uploadWriter.Write(sep)
 		},
 	)
 
-	testutil.AssertGoldenFile(t, path.Join("./testdata", testName, testName+"-upload.golden"), uploadWriter.Bytes())
+	pp := strings.Split(uploadWriter.String(), string(sep))
+	for _, p := range pp[1:] {
+		testutil.AssertGoldenFile(t, path.Join("./testdata", testName, testName+"-upload.golden"), []byte(p))
+	}
 }
 
 func TestBreakdownWithMockedMerge(t *testing.T) {
@@ -1116,6 +1121,7 @@ func TestBreakdownWithDynamicIterator(t *testing.T) {
 }
 
 func TestBreakdownWithPolicyDataUploadPlanJson(t *testing.T) {
+	sep := []byte("===\n")
 	ts, uploadWriter := GraphqlTestServerWithWriter(map[string]string{
 		"policyResourceAllowList": policyResourceAllowlistGraphQLResponse,
 		"storePolicyResources":    storePolicyResourcesGraphQLResponse,
@@ -1138,13 +1144,18 @@ func TestBreakdownWithPolicyDataUploadPlanJson(t *testing.T) {
 		}, func(ctx *config.RunContext) {
 			ctx.Config.PolicyV2APIEndpoint = ts.URL
 			ctx.Config.PoliciesEnabled = true
+			uploadWriter.Write(sep)
 		},
 	)
 
-	testutil.AssertGoldenFile(t, path.Join("./testdata", testName, testName+"-upload.golden"), uploadWriter.Bytes())
+	pp := strings.Split(uploadWriter.String(), string(sep))
+	for _, p := range pp[1:] {
+		testutil.AssertGoldenFile(t, path.Join("./testdata", testName, testName+"-upload.golden"), []byte(p))
+	}
 }
 
 func TestBreakdownWithPolicyDataUploadTerragrunt(t *testing.T) {
+	sep := []byte("===\n")
 	ts, uploadWriter := GraphqlTestServerWithWriter(map[string]string{
 		"policyResourceAllowList": policyResourceAllowlistGraphQLResponse,
 		"storePolicyResources":    storePolicyResourcesGraphQLResponse,
@@ -1167,10 +1178,14 @@ func TestBreakdownWithPolicyDataUploadTerragrunt(t *testing.T) {
 		}, func(ctx *config.RunContext) {
 			ctx.Config.PolicyV2APIEndpoint = ts.URL
 			ctx.Config.PoliciesEnabled = true
+			uploadWriter.Write(sep)
 		},
 	)
 
-	testutil.AssertGoldenFile(t, path.Join("./testdata", testName, testName+"-upload.golden"), stripDynamicValues(uploadWriter.Bytes()))
+	pp := strings.Split(uploadWriter.String(), string(sep))
+	for _, p := range pp[1:] {
+		testutil.AssertGoldenFile(t, path.Join("./testdata", testName, testName+"-upload.golden"), stripDynamicValues([]byte(p)))
+	}
 }
 
 func TestBreakdownConfigFileWithSkipAutoDetect(t *testing.T) {

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -54,8 +54,9 @@ func GoldenFileCommandTest(t *testing.T, testName string, args []string, testOpt
 	})
 
 	t.Run("HCL Graph", func(t *testing.T) {
-		t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
-
+		ctxOptions = append(ctxOptions, func(ctx *config.RunContext) {
+			ctx.Config.GraphEvaluator = true
+		})
 		goldenFileCommandTest(t, testName, args, testOptions, true, ctxOptions...)
 	})
 

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -38,8 +38,6 @@ type GoldenFileOptions = struct {
 	Env         map[string]string
 	// RunTerraformCLI sets the cmd test to also run the cmd with --terraform-force-cli set
 	RunTerraformCLI bool
-	// OnlyRunTerraformCLI sets the cmd test to only run cmd with --terraform-force-cli set and ignores the HCL parsing.
-	OnlyRunTerraformCLI bool
 }
 
 func DefaultOptions() *GoldenFileOptions {
@@ -51,13 +49,17 @@ func DefaultOptions() *GoldenFileOptions {
 }
 
 func GoldenFileCommandTest(t *testing.T, testName string, args []string, testOptions *GoldenFileOptions, ctxOptions ...func(ctx *config.RunContext)) {
-	if testOptions == nil || !testOptions.OnlyRunTerraformCLI {
-		t.Run("HCL", func(t *testing.T) {
-			goldenFileCommandTest(t, testName, args, testOptions, true, ctxOptions...)
-		})
-	}
+	t.Run("HCL", func(t *testing.T) {
+		goldenFileCommandTest(t, testName, args, testOptions, true, ctxOptions...)
+	})
 
-	if testOptions != nil && (testOptions.RunTerraformCLI || testOptions.OnlyRunTerraformCLI) {
+	t.Run("HCL Graph", func(t *testing.T) {
+		t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
+
+		goldenFileCommandTest(t, testName, args, testOptions, true, ctxOptions...)
+	})
+
+	if testOptions != nil && (testOptions.RunTerraformCLI) {
 		t.Run("CLI", func(t *testing.T) {
 			tfCLIArgs := make([]string, len(args)+2)
 			copy(tfCLIArgs, args)

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -387,8 +387,8 @@ var policyResourceAllowlistGraphQLResponse = `[
   }
 ]`
 
-var storePolicyResourcesGraphQLResponse = `[{"data": 
-	{"storePolicyResources": 
+var storePolicyResourcesGraphQLResponse = `[{"data":
+	{"storePolicyResources":
 		{ "sha": "someshastring" }
 	}
 }]

--- a/cmd/infracost/comment_github_test.go
+++ b/cmd/infracost/comment_github_test.go
@@ -188,7 +188,7 @@ func TestCommentGitHubWithTagPolicyChecks(t *testing.T) {
 }
 
 var ghZeroCommentsResponse = `{ "data": { "repository": { "pullRequest": { "comments": { "nodes": [], "pageInfo": { "endCursor": "abc", "hasNextPage": false }}}}}}`
-var ghOneMatchingCommentResponse = `{ "data": { "repository": { "pullRequest": { "comments": { "nodes": [ 
+var ghOneMatchingCommentResponse = `{ "data": { "repository": { "pullRequest": { "comments": { "nodes": [
             { "id": "123", "body": "infracomment body here, followed by tag: [//]: <> (infracost-comment)" }
           ], "pageInfo": { "endCursor": "abc", "hasNextPage": false }}}}}}`
 
@@ -198,9 +198,10 @@ func TestCommentGitHubSkipNoDiffWithoutInitialComment(t *testing.T) {
 		ghZeroCommentsResponse,
 	}
 
+	i := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, githubGraphQLresponses[0])
-		githubGraphQLresponses = githubGraphQLresponses[1:]
+		fmt.Fprintln(w, githubGraphQLresponses[i])
+		i = (i + 1) % len(githubGraphQLresponses)
 	}))
 	defer ts.Close()
 
@@ -225,9 +226,10 @@ func TestCommentGitHubSkipNoDiffWithInitialComment(t *testing.T) {
 		`{}`,
 	}
 
+	i := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, githubGraphQLresponses[0])
-		githubGraphQLresponses = githubGraphQLresponses[1:]
+		fmt.Fprintln(w, githubGraphQLresponses[i])
+		i = (i + 1) % len(githubGraphQLresponses)
 	}))
 	defer ts.Close()
 
@@ -250,9 +252,10 @@ func TestCommentGitHubNewAndHideSkipNoDiffWithoutInitialComment(t *testing.T) {
 		ghZeroCommentsResponse,
 	}
 
+	i := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, githubGraphQLresponses[0])
-		githubGraphQLresponses = githubGraphQLresponses[1:]
+		fmt.Fprintln(w, githubGraphQLresponses[i])
+		i = (i + 1) % len(githubGraphQLresponses)
 	}))
 	defer ts.Close()
 
@@ -278,9 +281,10 @@ func TestCommentGitHubNewAndHideSkipNoDiffWithInitialComment(t *testing.T) {
 		`{}`, // empty json as response to the post comment mutation
 	}
 
+	i := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, githubGraphQLresponses[0])
-		githubGraphQLresponses = githubGraphQLresponses[1:]
+		fmt.Fprintln(w, githubGraphQLresponses[i])
+		i = (i + 1) % len(githubGraphQLresponses)
 	}))
 	defer ts.Close()
 
@@ -304,9 +308,10 @@ func TestCommentGitHubDeleteAndNewSkipNoDiffWithoutInitialComment(t *testing.T) 
 		ghZeroCommentsResponse,
 	}
 
+	i := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, githubGraphQLresponses[0])
-		githubGraphQLresponses = githubGraphQLresponses[1:]
+		fmt.Fprintln(w, githubGraphQLresponses[i])
+		i = (i + 1) % len(githubGraphQLresponses)
 	}))
 	defer ts.Close()
 
@@ -332,9 +337,10 @@ func TestCommentGitHubDeleteAndNewSkipNoDiffWithInitialComment(t *testing.T) {
 		`{}`, // empty json as response to the post comment mutation
 	}
 
+	i := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, githubGraphQLresponses[0])
-		githubGraphQLresponses = githubGraphQLresponses[1:]
+		fmt.Fprintln(w, githubGraphQLresponses[i])
+		i = (i + 1) % len(githubGraphQLresponses)
 	}))
 	defer ts.Close()
 
@@ -395,7 +401,7 @@ func TestCommentGitHubGuardrailFailureWithComment(t *testing.T) {
 	ts := governanceTestEndpoint(governanceAddRunResponse{
 		GovernanceComment: `<details>
 <summary><strong>⚠️ Guardrails triggered</strong></summary>
-				
+
 > - <b>Warning</b>: Stand by your estimate
 </details>`,
 		GovernanceResults: []GovernanceResult{{
@@ -432,7 +438,7 @@ func TestCommentGitHubGuardrailFailureWithCommentAndBlock(t *testing.T) {
 		GovernanceComment: `<details>
 <summary><strong>❌ Guardrails triggered (needs action)</strong></summary>
 This change is blocked, either reduce the costs or wait for an admin to review and unblock it.
-				
+
 > - <b>Blocked</b>: Stand by your estimate
 </details>`,
 		GovernanceResults: []GovernanceResult{{
@@ -529,8 +535,10 @@ func ghTestEndpoint() *httptest.Server {
 		// show zero comments in the response for findComments
 		ghZeroCommentsResponse, "{}", "{}",
 	}
+
+	i := 0
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, githubGraphQLresponses[0])
-		githubGraphQLresponses = githubGraphQLresponses[1:]
+		fmt.Fprintln(w, githubGraphQLresponses[i])
+		i = (i + 1) % len(githubGraphQLresponses)
 	}))
 }

--- a/cmd/infracost/comment_test.go
+++ b/cmd/infracost/comment_test.go
@@ -28,7 +28,7 @@ func TestCommentBackoffRetry(t *testing.T) {
 
 		attempts += 1
 		assert.Equal(t, "/api/v3/repos/infracost/infracost/issues/8/comments", r.RequestURI)
-		if attempts < 2 {
+		if (attempts % 3) < 2 {
 			w.WriteHeader(400)
 			return
 		}
@@ -79,5 +79,5 @@ func TestCommentBackoffRetry(t *testing.T) {
 		"--repo", "infracost/infracost",
 	}, nil)
 
-	assert.Equal(t, 2, attempts)
+	assert.Equal(t, 2, attempts%3)
 }

--- a/cmd/infracost/testdata/comment_git_hub_guardrail_failure_with_comment/comment_git_hub_guardrail_failure_with_comment.golden
+++ b/cmd/infracost/testdata/comment_git_hub_guardrail_failure_with_comment/comment_git_hub_guardrail_failure_with_comment.golden
@@ -5,5 +5,5 @@ INF Estimate uploaded to Infracost Cloud
 INF 1 guardrail checked
 INF guardrail check failed: Stand by your estimate
 INF Creating new comment
-WRN >\n<summary><strong>⚠️ Guardrails triggered</strong></summary>\n\t\t\t\t\n> - <b>Warning</b>: Stand by your estimate\n</
+WRN >\n<summary><strong>⚠️ Guardrails triggered</strong></summary>\n\n> - <b>Warning</b>: Stand by your estimate\n</
 INF Created new comment: 

--- a/cmd/infracost/testdata/comment_git_hub_guardrail_failure_with_comment_and_block/comment_git_hub_guardrail_failure_with_comment_and_block.golden
+++ b/cmd/infracost/testdata/comment_git_hub_guardrail_failure_with_comment_and_block/comment_git_hub_guardrail_failure_with_comment_and_block.golden
@@ -12,5 +12,5 @@ INF Estimate uploaded to Infracost Cloud
 INF 1 guardrail checked
 INF guardrail check failed: Stand by your estimate
 INF Creating new comment
-WRN >\n<summary><strong>❌ Guardrails triggered (needs action)</strong></summary>\nThis change is blocked, either reduce the costs or wait for an admin to review and unblock it.\n\t\t\t\t\n> - <b>Blocked</b>: Stand by your estimate\n</
+WRN >\n<summary><strong>❌ Guardrails triggered (needs action)</strong></summary>\nThis change is blocked, either reduce the costs or wait for an admin to review and unblock it.\n\n> - <b>Blocked</b>: Stand by your estimate\n</
 INF Created new comment: 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,7 @@ type Config struct {
 	EnableCloud               *bool `yaml:"enable_cloud,omitempty" envconfig:"ENABLE_CLOUD"`
 	EnableCloudUpload         *bool `yaml:"enable_cloud_upload,omitempty" envconfig:"ENABLE_CLOUD_UPLOAD"`
 	DisableHCLParsing         bool  `yaml:"disable_hcl_parsing,omitempty" envconfig:"DISABLE_HCL_PARSING"`
+	GraphEvaluator            bool  `yaml:"graph_evaluator,omitempty" envconfig:"GRAPH_EVALUATOR"`
 
 	TLSInsecureSkipVerify *bool  `envconfig:"TLS_INSECURE_SKIP_VERIFY"`
 	TLSCACertFile         string `envconfig:"TLS_CA_CERT_FILE"`

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -2,7 +2,6 @@ package hcl
 
 import (
 	"fmt"
-	"os"
 	"runtime/debug"
 	"strings"
 
@@ -45,6 +44,8 @@ type Attribute struct {
 	// Verbose defines if the attribute should log verbose diagnostics messages to debug.
 	Verbose bool
 	Logger  zerolog.Logger
+	// isGraph is a flag that indicates if the attribute should be evaluated with the graph evaluation
+	isGraph bool
 	// newMock generates a mock value for the attribute if it's value is missing.
 	newMock       func(attr *Attribute) cty.Value
 	previousValue cty.Value
@@ -129,7 +130,7 @@ func (attr *Attribute) Value() cty.Value {
 
 	attr.Logger.Debug().Msg("fetching attribute value")
 	var val cty.Value
-	if os.Getenv("INFRACOST_GRAPH_EVALUATOR") == "true" {
+	if attr.isGraph {
 		val = attr.graphValue()
 	} else {
 		val = attr.value(0)
@@ -155,7 +156,7 @@ func (attr *Attribute) HasChanged() (change bool) {
 
 	previous := attr.previousValue
 	var current cty.Value
-	if os.Getenv("INFRACOST_GRAPH_EVALUATOR") == "true" {
+	if attr.isGraph {
 		current = attr.graphValue()
 	} else {
 		current = attr.value(0)

--- a/internal/hcl/attribute_test.go
+++ b/internal/hcl/attribute_test.go
@@ -113,8 +113,6 @@ func TestAttribute_AsString(t *testing.T) {
 }
 
 func TestAttributeValueWithIncompleteContextAndConditionalShouldNotPanic(t *testing.T) {
-	t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
-
 	p := hclparse.NewParser()
 	f, diags := p.ParseHCL([]byte(`
 locals {
@@ -150,7 +148,8 @@ locals {
 		Ctx: &Context{ctx: &hcl.EvalContext{
 			Variables: map[string]cty.Value{},
 		}},
-		Logger: discard,
+		Logger:  discard,
+		isGraph: true,
 	}
 
 	attr := Attribute{
@@ -171,6 +170,7 @@ locals {
 		},
 		Verbose: false,
 		Logger:  logger,
+		isGraph: true,
 	}
 
 	v := attr.Value()

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -281,8 +281,10 @@ type Block struct {
 	// parent is the parent block if this is a child block.
 	parent *Block
 	// verbose determines whether the block uses verbose debug logging.
-	verbose    bool
-	logger     zerolog.Logger
+	verbose bool
+	logger  zerolog.Logger
+	// isGraph is a flag that indicates if the attribute should be evaluated with the graph evaluation
+	isGraph    bool
 	newMock    func(attr *Attribute) cty.Value
 	attributes []*Attribute
 	reference  *Reference
@@ -298,6 +300,7 @@ type BlockBuilder struct {
 	SetAttributes []SetAttributesFunc
 	Logger        zerolog.Logger
 	HCLParser     *modules.SharedHCLParser
+	isGraph       bool
 }
 
 // NewBlock returns a Block with Context and child Blocks initialised.
@@ -319,6 +322,7 @@ func (b BlockBuilder) NewBlock(filename string, rootPath string, hclBlock *hcl.B
 			rootPath:    rootPath,
 			childBlocks: make(Blocks, len(body.Blocks)),
 			verbose:     isLoggingVerbose,
+			isGraph:     b.isGraph,
 			newMock:     b.MockFunc,
 			parent:      parent,
 		}
@@ -352,6 +356,7 @@ func (b BlockBuilder) NewBlock(filename string, rootPath string, hclBlock *hcl.B
 			moduleBlock: moduleBlock,
 			rootPath:    rootPath,
 			verbose:     isLoggingVerbose,
+			isGraph:     b.isGraph,
 			newMock:     b.MockFunc,
 		}
 		block.setLogger(b.Logger)
@@ -370,6 +375,7 @@ func (b BlockBuilder) NewBlock(filename string, rootPath string, hclBlock *hcl.B
 		rootPath:    rootPath,
 		childBlocks: make(Blocks, len(content.Blocks)),
 		verbose:     isLoggingVerbose,
+		isGraph:     b.isGraph,
 		newMock:     b.MockFunc,
 	}
 
@@ -858,6 +864,7 @@ func (b *Block) GetAttributes() []*Attribute {
 				Logger: b.logger.With().Str(
 					"attribute_name", k,
 				).Logger(),
+				isGraph: b.isGraph,
 			})
 			continue
 		}
@@ -870,6 +877,7 @@ func (b *Block) GetAttributes() []*Attribute {
 			Logger: b.logger.With().Str(
 				"attribute_name", hclAttributes[k].Name,
 			).Logger(),
+			isGraph: b.isGraph,
 		})
 	}
 
@@ -927,6 +935,7 @@ func (b *Block) syntheticAttribute(name string, val cty.Value) *Attribute {
 		Logger: b.logger.With().Str(
 			"attribute_name", name,
 		).Logger(),
+		isGraph: b.isGraph,
 	}
 }
 

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -425,6 +425,7 @@ func (g *Graph) loadBlocksForModule(evaluator *Evaluator) ([]*Block, error) {
 				evaluator.blockBuilder,
 				nil,
 				evaluator.logger,
+				evaluator.isGraph,
 			)
 
 			modBlocks, err := g.loadBlocksForModule(moduleEvaluator)

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -371,8 +371,8 @@ func (g *Graph) Run(evaluator *Evaluator) (*Module, error) {
 	g.ReduceTransitively()
 	g.Walk()
 
-	evaluator.module.Blocks = evaluator.filteredBlocks
 	evaluator.module = *evaluator.collectModules()
+	evaluator.module.Blocks = evaluator.filteredBlocks
 
 	return &evaluator.module, nil
 }

--- a/internal/hcl/graph_vertex_module_call.go
+++ b/internal/hcl/graph_vertex_module_call.go
@@ -127,6 +127,7 @@ func (v *VertexModuleCall) expand(e *Evaluator, b *Block, mutex *sync.Mutex) ([]
 			e.blockBuilder,
 			nil,
 			e.logger,
+			e.isGraph,
 		)
 
 		v.moduleConfigs.Add(unexpandedName, ModuleConfig{

--- a/internal/hcl/graph_vertex_module_exit.go
+++ b/internal/hcl/graph_vertex_module_exit.go
@@ -32,8 +32,8 @@ func (v *VertexModuleExit) Visit(mutex *sync.Mutex) error {
 
 	for _, moduleInstance := range moduleInstances {
 		e := moduleInstance.evaluator
-		e.module.Blocks = e.filteredBlocks
 		e.module = *e.collectModules()
+		e.module.Blocks = e.filteredBlocks
 
 		modCall := moduleInstance.moduleCall
 		if modCall == nil {

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -256,6 +256,14 @@ func OptionWithSpinner(f ui.SpinnerFunc) Option {
 	}
 }
 
+// OptionGraphEvaluator sets the Parser to use the experimental graph evaluator.
+func OptionGraphEvaluator() Option {
+	return func(p *Parser) {
+		p.isGraph = true
+		p.blockBuilder.isGraph = true
+	}
+}
+
 type DetectedProject interface {
 	ProjectName() string
 	RelativePath() string
@@ -277,6 +285,7 @@ type Parser struct {
 	newSpinner            ui.SpinnerFunc
 	remoteVariablesLoader *RemoteVariablesLoader
 	logger                zerolog.Logger
+	isGraph               bool
 	hasChanges            bool
 	moduleSuffix          string
 	envMatcher            *EnvFileMatcher
@@ -421,12 +430,13 @@ func (p *Parser) ParseDirectory() (m *Module, err error) {
 		p.blockBuilder,
 		p.newSpinner,
 		p.logger,
+		p.isGraph,
 	)
 
 	var root *Module
 
 	// Graph evaluation
-	if evaluator.isGraphEvaluator() {
+	if evaluator.isGraph {
 		// we use the base zerolog log here so that it's consistent with the spinner logs
 		log.Info().Msgf("Building project with experimental graph runner")
 

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -1636,8 +1636,6 @@ resource "baz" "bat" {
 }
 
 func Test_ObjectLiteralIsMockedCorrectly(t *testing.T) {
-	t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
-
 	path := createTestFileWithModule(`
 module "mod1" {
   source = "../module"
@@ -1666,11 +1664,13 @@ resource "aws_instance" "example" {
 
 	logger := newDiscardLogger()
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
+
 	parser := NewParser(
 		RootPath{Path: path},
 		CreateEnvFileMatcher([]string{}),
 		loader,
 		logger,
+		OptionGraphEvaluator(),
 	)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
@@ -1696,12 +1696,10 @@ resource "aws_instance" "example" {
 }
 
 func Test_ModuleTernaryWithMockedValue(t *testing.T) {
-	t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
-
 	path := createTestFileWithModule(`
 module "mod1" {
   source = "../mod"
-  count  = 1 
+  count  = 1
   var1   = "don't create"
 }
 
@@ -1726,6 +1724,7 @@ resource "aws_instance" "example" {
 		CreateEnvFileMatcher([]string{}),
 		loader,
 		logger,
+		OptionGraphEvaluator(),
 	)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
@@ -1743,8 +1742,6 @@ resource "aws_instance" "example" {
 }
 
 func Test_VariableLengthWhenMocked(t *testing.T) {
-	t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
-
 	path := createTestFile("main.tf", `
 variable "my_config" {
  type    = any
@@ -1765,6 +1762,7 @@ resource "aws_instance" "example" {
 		CreateEnvFileMatcher([]string{}),
 		loader,
 		logger,
+		OptionGraphEvaluator(),
 	)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -157,6 +157,10 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 		}
 	}
 
+	if ctx.RunContext.Config.GraphEvaluator {
+		options = append(options, hcl.OptionGraphEvaluator())
+	}
+
 	rootPath.Path = initialPath
 	return &HCLProvider{
 		policyClient:   policyClient,

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -161,6 +161,12 @@ func ResourceTestsForTerraformProject(t *testing.T, tfProject TerraformProject, 
 		resourceTestsForTfProject(t, "hcl", tfProject, usage, checks)
 	})
 
+	t.Run("HCL Graph", func(t *testing.T) {
+		t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
+
+		resourceTestsForTfProject(t, "hcl", tfProject, usage, checks)
+	})
+
 	t.Run("Terraform CLI", func(t *testing.T) {
 		resourceTestsForTfProject(t, "terraform", tfProject, usage, checks)
 	})
@@ -200,6 +206,12 @@ func GoldenFileResourceTests(t *testing.T, testName string) {
 
 func GoldenFileResourceTestsWithOpts(t *testing.T, testName string, options *GoldenFileOptions) {
 	t.Run("HCL", func(t *testing.T) {
+		goldenFileResourceTestWithOpts(t, "hcl", testName, options)
+	})
+
+	t.Run("HCL Graph", func(t *testing.T) {
+		t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
+
 		goldenFileResourceTestWithOpts(t, "hcl", testName, options)
 	})
 
@@ -338,6 +350,12 @@ func RunCostCalculations(runCtx *config.RunContext, projects []*schema.Project) 
 
 func GoldenFileUsageSyncTest(t *testing.T, testName string) {
 	t.Run("HCL", func(t *testing.T) {
+		goldenFileSyncTest(t, "hcl", testName)
+	})
+
+	t.Run("HCL Graph", func(t *testing.T) {
+		t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
+
 		goldenFileSyncTest(t, "hcl", testName)
 	})
 

--- a/internal/usage/usage_file_test.go
+++ b/internal/usage/usage_file_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestUsageFile(t *testing.T) {
-	t.Parallel()
-
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
@@ -22,8 +20,6 @@ func TestUsageFile(t *testing.T) {
 }
 
 func TestUsageFileNoUsage(t *testing.T) {
-	t.Parallel()
-
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
@@ -33,8 +29,6 @@ func TestUsageFileNoUsage(t *testing.T) {
 }
 
 func TestUsageFileEmpty(t *testing.T) {
-	t.Parallel()
-
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
@@ -57,9 +51,9 @@ resource_usage:
       k: 1
     array[0]:
       el: 2
-    empty_string: ""    
-    empty_array[0]: 
-    empty: 
+    empty_string: ""
+    empty_array[0]:
+    empty:
     nested:
       number: 0
       string: string


### PR DESCRIPTION
Adds coverage for HCL graph evaluator. Also removes the onlyRunCLI option for the test suite as this is not used.