### PR TITLE
fix: complex unknown values provided as inputs

### DIFF
--- a/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_hcldeps_output/dev/terragrunt.hcl
@@ -18,11 +18,19 @@ terraform {
   source = "..//modules/example"
 }
 
+locals {
+  region = "wa"
+}
+
 inputs = {
   instance_type                 = dependency.test.outputs.aws_instance_type
   root_block_device_volume_size = 50
   block_device_volume_size      = 100
   block_device_iops             = dependency.test2.outputs.block_iops
+
+  bad  = dependency.test2.outputs.map_existing["test"][local.region].id
+  bad2 = get_env("NA")
+  bad3 = TF_VAR_foo_bar
 
   test_input = {
     input1  = dependency.test2.outputs.obj.foo
@@ -53,7 +61,9 @@ inputs = {
     input24 = dependency.test2.outputs.bad_map["test"]
     input25 = dependency.test2.outputs.bad_map["test"]["bar"].id
     input26 = [dependency.test2.outputs.map_existing["test"]["bar"].id]
-    input27 = <<EOF
+    input27 = [dependency.test2.outputs.map_existing["test"][local.region].id]
+    input28 = dependency.test2.outputs.map_existing["test"][local.region].id
+    input29 = <<EOF
     {
       "key": "${dependency.stag-dep.outputs.retrieved_secrets.0}",
       "key2": "${dependency.stag-dep.outputs.retrieved_secrets.1}"

--- a/go.mod
+++ b/go.mod
@@ -270,6 +270,7 @@ replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
-replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20231103101711-77c5e7d4d795
+//replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20231103101711-77c5e7d4d795
+replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20231211141424-6a52de9a284a
 
 replace github.com/heimdalr/dag => github.com/aliscott/dag v1.3.2-0.20231115114512-4ce18c825f94

--- a/go.sum
+++ b/go.sum
@@ -847,8 +847,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/infracost/terragrunt v0.47.1-0.20231103101711-77c5e7d4d795 h1:0lsLSsXeV47+IM9UuPM0tJgLCNPUFjfqtUyDJnjTrAI=
-github.com/infracost/terragrunt v0.47.1-0.20231103101711-77c5e7d4d795/go.mod h1:xmRpWI+M4KlZbMQp1pj20CdXlZf5eIkRND5ybNkdnus=
+github.com/infracost/terragrunt v0.47.1-0.20231211141424-6a52de9a284a h1:+3N8wKw04orEc9Gi0XoAPUf9pwRKBHfs/LAiqFGwEm0=
+github.com/infracost/terragrunt v0.47.1-0.20231211141424-6a52de9a284a/go.mod h1:xmRpWI+M4KlZbMQp1pj20CdXlZf5eIkRND5ybNkdnus=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
Bumps the version to the `infracost/terragrunt` dependency so it contains https://github.com/infracost/terragrunt/pull/11. This resolves the early exit from the TerragruntProvider when unknown inputs cannot be "mocked".

**Note:** updated sha currently points to the  https://github.com/infracost/terragrunt/pull/11 commit sha, once it is reviewed and merged I'll update it here to point to the new master sha