### PR TITLE
refactor: force https module get logic

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,10 +22,10 @@ jobs:
         run: make tf_fmt_check
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.4.0
+        uses: golangci/golangci-lint-action@v3.7.0
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: they always use the latest patch version.
-          version: v1.51.2
+          version: latest
+          skip-pkg-cache: true
           args: --timeout 5m
 
       - name: Install Terragrunt v0.31.8

--- a/internal/hcl/modules/fetch.go
+++ b/internal/hcl/modules/fetch.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,8 @@ import (
 	getter "github.com/hashicorp/go-getter"
 	"github.com/otiai10/copy"
 	"github.com/rs/zerolog"
+
+	"github.com/infracost/infracost/internal/logging"
 )
 
 // PackageFetcher downloads modules from a remote source to the given destination
@@ -75,15 +78,20 @@ func (r *PackageFetcher) fetch(moduleAddr string, dest string) error {
 	// I'm not sure if we really need it, but added it just in case/
 	decompressors["tar.tbz2"] = new(getter.TarBzip2Decompressor)
 
+	getters := make(map[string]getter.Getter, len(getter.Getters))
+	for k, g := range getter.Getters {
+		getters[k] = g
+	}
+
+	getters["git"] = &CustomGitGetter{new(getter.GitGetter)}
+
 	client := getter.Client{
 		Src:           moduleAddr,
 		Dst:           dest,
 		Pwd:           dest,
 		Mode:          getter.ClientModeDir,
 		Decompressors: decompressors,
-		// We don't need to specify any of the Getters, since Terraform uses the same as the default Getter values,
-		// but if we do need to at some point we can specify them here:
-		// Getters: getters,
+		Getters:       getters,
 	}
 
 	r.cache.Store(moduleAddr, dest)
@@ -94,4 +102,79 @@ func (r *PackageFetcher) fetch(moduleAddr string, dest string) error {
 	}
 
 	return nil
+}
+
+// CustomGitGetter extends the standard GitGetter transforming SSH sources to
+// HTTPs first before attempting a Get. This means that we can attempt to use any
+// Git credentials on the host machine to resolve the Get before falling back to
+// SSH.
+type CustomGitGetter struct {
+	*getter.GitGetter
+}
+
+// Get overrides the standard Get method transforming SSH urls to their HTTPS
+// equivalent. Get then tries to get the new url into the dst, falling back to
+// the original SSH url if an HTTPS get fails.
+func (g *CustomGitGetter) Get(dst string, u *url.URL) error {
+	if u.Scheme != "ssh" {
+		return g.GitGetter.Get(dst, u)
+	}
+
+	httpsURL, err := TransformSSHToHttps(u)
+	if err != nil {
+		logging.Logger.Debug().Err(err).Msgf("failed to transform %s to https", u)
+		return g.GitGetter.Get(dst, u)
+	}
+
+	err = g.GitGetter.Get(dst, httpsURL)
+	if err != nil {
+		logging.Logger.Debug().Err(err).Msgf("failed to get transformed ssh url %s, retrying with ssh", httpsURL)
+		return g.GitGetter.Get(dst, u)
+	}
+
+	return nil
+}
+
+// IsGitSSHSource returns if the url u is a valid git ssh source. Param u is
+// expected to be an url that has been transformed by a go-getter Detect pass,
+// removing shorthand and aliased for various sources.
+func IsGitSSHSource(u *url.URL) bool {
+	if u == nil {
+		return false
+	}
+
+	if u.Scheme == "ssh" || u.Scheme == "git::ssh" {
+		return true
+	}
+
+	return false
+}
+
+// TransformSSHToHttps transforms a Terraform module source url to an HTTPS
+// equivalent. This only handles source urls prefixed with ssh:: or git::ssh. The
+// shorthand ssh source referenced here:
+// https://developer.hashicorp.com/terraform/language/modules/sources#github e.g.
+// "git@github.com:hashicorp/example.git" in not handled by this method as we
+// expect the source to already be Detected to the valid longhand equivalent
+// before calling this function. This can be achieved by calling
+// getter.Detect(src) before calling TransformSSHToHttps.
+func TransformSSHToHttps(u *url.URL) (*url.URL, error) {
+	if !IsGitSSHSource(u) {
+		return u, nil
+	}
+
+	hostname := u.Host
+	path := strings.TrimPrefix(u.Path, "/")
+
+	// SSH URLs might contain ':' after the host (like 'git@hostname:user/repo.git')
+	// We need to replace the first ':' with a '/'
+	if idx := strings.Index(path, ":"); idx != -1 {
+		path = path[:idx] + "/" + path[idx+1:]
+	}
+
+	return &url.URL{
+		Scheme: "https",
+		Host:   hostname,
+		Path:   path,
+	}, nil
 }

--- a/internal/hcl/modules/fetch_test.go
+++ b/internal/hcl/modules/fetch_test.go
@@ -1,0 +1,26 @@
+package modules
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformSSHToHTTPS(t *testing.T) {
+	testCases := []struct {
+		sshURL   *url.URL
+		expected string
+	}{
+		{&url.URL{Scheme: "ssh", User: url.User("git"), Path: "user/repo.git", Host: "github.com"}, "https://github.com/user/repo.git"},
+		{&url.URL{Scheme: "https", Path: "user/repo.git", Host: "github.com"}, "https://github.com/user/repo.git"},
+		{&url.URL{Scheme: "git::ssh", User: url.User("git"), Path: "user/repo.git", Host: "github.com"}, "https://github.com/user/repo.git"},
+	}
+
+	for _, tc := range testCases {
+		transformed, err := TransformSSHToHttps(tc.sshURL)
+		assert.NoError(t, err)
+
+		assert.Equal(t, tc.expected, transformed.String())
+	}
+}

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -24,6 +25,7 @@ import (
 	tgoptions "github.com/gruntwork-io/terragrunt/options"
 	tfsource "github.com/gruntwork-io/terragrunt/terraform"
 	"github.com/gruntwork-io/terragrunt/util"
+	"github.com/hashicorp/go-getter"
 	hcl2 "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -38,6 +40,7 @@ import (
 	"github.com/infracost/infracost/internal/clierror"
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/hcl"
+	"github.com/infracost/infracost/internal/hcl/modules"
 	"github.com/infracost/infracost/internal/schema"
 	infSync "github.com/infracost/infracost/internal/sync"
 	"github.com/infracost/infracost/internal/ui"
@@ -664,14 +667,43 @@ func downloadSourceOnce(sourceURL string, opts *tgoptions.TerragruntOptions, ter
 		return source.WorkingDir, nil
 	}
 
-	_, err = tgcliterraform.DownloadTerraformSource(sourceURL, opts, terragruntConfig)
-	if err != nil {
-		return "", err
+	// first attempt to force an HTTPS download of the source, this is only applicable to
+	// SSH sources. We do this to try and make use of any git credentials stored on a
+	// host machine, rather than requiring an SSH key is added.
+	failedHttpsDownload := !forceHttpsDownload(sourceURL, opts, terragruntConfig)
+	if failedHttpsDownload {
+		_, err = tgcliterraform.DownloadTerraformSource(sourceURL, opts, terragruntConfig)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	terragruntDownloadedDirs.Store(dir, true)
 
 	return source.WorkingDir, nil
+}
+
+func forceHttpsDownload(sourceURL string, opts *tgoptions.TerragruntOptions, terragruntConfig *tgconfig.TerragruntConfig) bool {
+	newSource, err := getter.Detect(sourceURL, opts.WorkingDir, getter.Detectors)
+	if err != nil {
+		return false
+	}
+	u, err := url.Parse(newSource)
+	if err != nil {
+		return false
+	}
+
+	if !modules.IsGitSSHSource(u) {
+		return false
+	}
+
+	newUrl, err := modules.TransformSSHToHttps(u)
+	if err != nil {
+		return false
+	}
+
+	_, err = tgcliterraform.DownloadTerraformSource(newUrl.String(), opts, terragruntConfig)
+	return err == nil
 }
 
 func generateConfig(terragruntConfig *tgconfig.TerragruntConfig, opts *options.TerragruntOptions, workingDir string) error {


### PR DESCRIPTION
Changes Terraform and Terragrunt getter logic to force a https `Get` before attempting a ssh `Get`. The Terraform logic now uses a custom `GitGetter` which transforms the URL before `Get`. The Terragrunt provider cannot use this as the `Getters` are hidden below in the lib, so we try and transform the `sourceUrl` before Download.