### PR TITLE
fix: include `terraform.tfvars` as "auto" file

### DIFF
--- a/cmd/infracost/testdata/generate_config_auto_detect/generate_config_auto_detect.golden
+++ b/cmd/infracost/testdata/generate_config_auto_detect/generate_config_auto_detect.golden
@@ -18,9 +18,4 @@ projects:
       - terraform.tfvars
       - prod.tfvars
     terraform_workspace: default
-  - path: apps/foo
-    name: apps-foo-terraform
-    terraform_var_files:
-      - terraform.tfvars
-    terraform_workspace: default
 

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -236,7 +236,8 @@ func LoadParsers(ctx *config.ProjectContext, initialPath string, loader *modules
 			var varFiles []string
 			var autoVarFiles []string
 			for _, varFile := range rootPath.TerraformVarFiles {
-				if strings.HasSuffix(strings.TrimSuffix(varFile, ".json"), ".auto.tfvars") {
+				withoutJSONSuffix := strings.TrimSuffix(varFile, ".json")
+				if strings.HasSuffix(withoutJSONSuffix, ".auto.tfvars") || withoutJSONSuffix == "terraform.tfvars" {
 					autoVarFiles = append(autoVarFiles, varFile)
 					continue
 				}


### PR DESCRIPTION
Fixes project auto-detection so we do not treat `terraform.tfvars` as an environment var file, but instead, correctly mark them as auto-applied to the project.