### PR TITLE
refactor: change max search depth for auto-detect

### DIFF
--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -94,7 +94,7 @@ func (p *ProjectLocator) buildSkippedMatcher(fullPath string) func(string) bool 
 	}
 }
 
-func (p ProjectLocator) hasChanges(dir string) bool {
+func (p *ProjectLocator) hasChanges(dir string) bool {
 	if len(p.changedObjects) == 0 {
 		return false
 	}
@@ -172,10 +172,10 @@ func (p *ProjectLocator) FindRootModules(fullPath string) []RootPath {
 
 func (p *ProjectLocator) maxSearchDepth() int {
 	if p.useAllPaths {
-		return 10
+		return 14
 	}
 
-	return 5
+	return 7
 }
 
 func (p *ProjectLocator) walkPaths(fullPath string, level int) []string {


### PR DESCRIPTION
Changes auto-detect logic so that the max search depth is 14 for `use-all-paths` and `7` as default. This change is required to support better discovery of nested Terraform projects in user repositories.