### PR TITLE
fix: show details section when there are unsupported resources IC-562

### DIFF
--- a/cmd/infracost/comment_github_test.go
+++ b/cmd/infracost/comment_github_test.go
@@ -44,6 +44,12 @@ func TestCommentGitHubShowChangedProjects(t *testing.T) {
 		nil)
 }
 
+func TestCommentGitHubNoDiff(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(),
+		[]string{"comment", "github", "--github-token", "abc", "--repo", "test/test", "--commit", "5", "--path", "./testdata/no_diff.json", "--dry-run"},
+		nil)
+}
+
 func TestCommentGitHubWithMissingAdditionalCommentPath(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(),
 		[]string{

--- a/cmd/infracost/testdata/comment_git_hub_no_diff/comment_git_hub_no_diff.golden
+++ b/cmd/infracost/testdata/comment_git_hub_no_diff/comment_git_hub_no_diff.golden
@@ -1,0 +1,17 @@
+
+<h3>Infracost report</h3>
+<h4>💰 Monthly cost will not change</h4>
+<details>
+<summary>Cost details</summary>
+
+```
+──────────────────────────────────
+
+189 cloud resources were detected:
+∙ 31 were estimated, 23 of which include usage-based costs, see https://infracost.io/usage-file
+∙ 152 were free, rerun with --show-skipped to see details
+∙ 6 are not supported yet, rerun with --show-skipped to see details
+```
+</details>
+
+Comment not posted to GitHub (--dry-run was specified)

--- a/cmd/infracost/testdata/no_diff.json
+++ b/cmd/infracost/testdata/no_diff.json
@@ -1,0 +1,129 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "test",
+    "vcsCommitSha": "1234",
+    "vcsCommitAuthorName": "hugo",
+    "vcsCommitAuthorEmail": "hugo@test.com",
+    "vcsCommitTimestamp": "2021-10-11T22:41:00.144866-04:00",
+    "vcsCommitMessage": "mymessage",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost.git"
+  },
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "test",
+      "metadata": {
+        "path": "test",
+        "type": "terraform_dir",
+        "terraformModulePath": "test",
+        "vcsSubPath": "test",
+        "vcsCodeChanged": true,
+        "providers": [
+          {
+            "name": "aws",
+            "filename": "test.tf",
+            "startLine": 18,
+            "endLine": 24
+          }
+        ]
+      },
+      "pastBreakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "breakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 5,
+        "totalSupportedResources": 0,
+        "totalUnsupportedResources": 3,
+        "totalUsageBasedResources": 0,
+        "totalNoPriceResources": 2,
+        "unsupportedResourceCounts": {
+          "aws_appstream_fleet": 1,
+          "aws_appstream_fleet_stack_association": 1,
+          "aws_appstream_stack": 1
+        },
+        "noPriceResourceCounts": {
+          "aws_ssm_parameter": 2
+        }
+      }
+    }
+  ],
+  "totalHourlyCost": "1.7438128767123286806",
+  "totalMonthlyCost": "1272.9834",
+  "pastTotalHourlyCost": "1.7438128767123286806",
+  "pastTotalMonthlyCost": "1272.9834",
+  "diffTotalHourlyCost": "0",
+  "diffTotalMonthlyCost": "0",
+  "timeGenerated": "2023-12-28T09:45:58.122974746Z",
+  "summary": {
+    "totalDetectedResources": 189,
+    "totalSupportedResources": 31,
+    "totalUnsupportedResources": 6,
+    "totalUsageBasedResources": 23,
+    "totalNoPriceResources": 152,
+    "unsupportedResourceCounts": {
+      "aws_ami_from_instance": 1,
+      "aws_appstream_fleet": 1,
+      "aws_appstream_fleet_stack_association": 1,
+      "aws_appstream_stack": 1,
+      "aws_lightsail_instance_public_ports": 1,
+      "aws_route53_vpc_association_authorization": 1
+    },
+    "noPriceResourceCounts": {
+      "aws_backup_plan": 2,
+      "aws_backup_selection": 2,
+      "aws_cloudwatch_event_rule": 1,
+      "aws_cloudwatch_event_target": 1,
+      "aws_db_subnet_group": 2,
+      "aws_dx_gateway_association_proposal": 2,
+      "aws_eip": 2,
+      "aws_iam_group": 1,
+      "aws_iam_group_membership": 1,
+      "aws_iam_group_policy_attachment": 1,
+      "aws_iam_instance_profile": 4,
+      "aws_iam_policy": 9,
+      "aws_iam_role": 9,
+      "aws_iam_role_policy_attachment": 5,
+      "aws_iam_user": 1,
+      "aws_internet_gateway": 2,
+      "aws_key_pair": 1,
+      "aws_kms_alias": 1,
+      "aws_lambda_permission": 1,
+      "aws_lightsail_static_ip": 1,
+      "aws_lightsail_static_ip_attachment": 1,
+      "aws_network_interface": 2,
+      "aws_route": 15,
+      "aws_route53_resolver_rule": 2,
+      "aws_route53_resolver_rule_association": 4,
+      "aws_route53_zone_association": 2,
+      "aws_route_table": 6,
+      "aws_route_table_association": 18,
+      "aws_s3_bucket_acl": 1,
+      "aws_s3_bucket_object": 4,
+      "aws_s3_bucket_public_access_block": 2,
+      "aws_s3_bucket_server_side_encryption_configuration": 1,
+      "aws_s3_bucket_versioning": 1,
+      "aws_secretsmanager_secret_version": 1,
+      "aws_security_group": 11,
+      "aws_ssm_parameter": 2,
+      "aws_subnet": 18,
+      "aws_vpc": 2,
+      "aws_vpc_endpoint": 4,
+      "aws_vpn_gateway": 2,
+      "aws_vpn_gateway_route_propagation": 4
+    }
+  }
+}

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -154,7 +154,7 @@ func showProject(p Project, opts Options, showError bool) bool {
 		return true
 	}
 
-	if p.Diff == nil || len(p.Diff.Resources) == 0 { // has no diff
+	if p.Diff == nil || !p.Diff.HasResources() {
 		return false
 	}
 

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -200,6 +200,13 @@ func ToMarkdown(out Root, opts Options, markdownOpts MarkdownOptions) (MarkdownO
 				return false
 			}
 
+			// we always want to show the output if there are unsupported resources. This is
+			// because we want to show the unsupported resources in the output so that the
+			// user can see why the cost changes are different from expectations.
+			if out.HasUnsupportedResources() {
+				return true
+			}
+
 			var valid Projects
 			for _, project := range out.Projects {
 				if showProject(project, opts, true) {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -41,6 +41,21 @@ type Root struct {
 	IsCIRun              bool             `json:"-"`
 }
 
+// HasUnsupportedResources returns if the summary has any unsupported resources.
+// This is used to determine if the summary should be shown in different output
+// formats.
+func (r *Root) HasUnsupportedResources() bool {
+	if r.Summary == nil {
+		return false
+	}
+
+	if r.Summary.TotalUnsupportedResources == nil {
+		return false
+	}
+
+	return *r.Summary.TotalUnsupportedResources > 0
+}
+
 type Project struct {
 	Name          string                  `json:"name"`
 	Metadata      *schema.ProjectMetadata `json:"metadata"`
@@ -222,6 +237,12 @@ type Breakdown struct {
 	FreeResources    []Resource       `json:"freeResources,omitempty"`
 	TotalHourlyCost  *decimal.Decimal `json:"totalHourlyCost"`
 	TotalMonthlyCost *decimal.Decimal `json:"totalMonthlyCost"`
+}
+
+// HasResources returns true if the breakdown has any resources or free resources.
+// This is used to determine if the breakdown should be shown in the output.
+func (b *Breakdown) HasResources() bool {
+	return len(b.Resources) > 0 || len(b.FreeResources) > 0
 }
 
 type CostComponent struct {


### PR DESCRIPTION
Changes the markdown templates so that the `displayOutput` always shows if there are unsupported resources. This ensures we always show more information to the user even with 0 cost PRs. This means that users can understand why certain PRs, where cost changes are expected, are showing 0 costs.