### PR TITLE
fix(google): update `google_sql_database_instance` resource to work with new tiers

### DIFF
--- a/internal/providers/terraform/google/sql_database_instance.go
+++ b/internal/providers/terraform/google/sql_database_instance.go
@@ -19,6 +19,7 @@ func NewSQLDatabaseInstance(d *schema.ResourceData, u *schema.UsageData) *schema
 		Address:              d.Address,
 		DatabaseVersion:      d.Get("database_version").String(),
 		Tier:                 d.Get("settings.0.tier").String(),
+		Edition:              d.Get("settings.0.edition").String(),
 		Region:               d.Get("region").String(),
 		ReplicaConfiguration: d.Get("replica_configuration").String(),
 		AvailabilityType:     d.Get("settings.0.availability_type").String(),

--- a/internal/providers/terraform/google/sql_database_instance_test.go
+++ b/internal/providers/terraform/google/sql_database_instance_test.go
@@ -7,10 +7,9 @@ import (
 )
 
 func TestNewSQLInstance(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "sql_database_instance_test")
+	tftest.GoldenFileResourceTestsWithOpts(t, "sql_database_instance_test", &tftest.GoldenFileOptions{CaptureLogs: true})
 }

--- a/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
@@ -1,93 +1,1118 @@
 
- Name                                                        Monthly Qty  Unit            Monthly Cost 
-                                                                                                       
- google_sql_database_instance.HA_custom_postgres                                                       
- ├─ vCPUs (regional)                                              11,680  hours                $964.77 
- ├─ Memory (regional)                                             43,800  GB                   $613.20 
- ├─ Storage (SSD, regional)                                           10  GB                     $3.40 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.HA_small_mysql                                                           
- ├─ SQL instance (db-g1-small, regional)                             730  hours                 $51.10 
- ├─ Storage (SSD, regional)                                          100  GB                    $34.00 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.custom_postgres                                                          
- ├─ vCPUs (zonal)                                                  1,460  hours                 $60.30 
- ├─ Memory (zonal)                                                 9,490  GB                    $66.43 
- ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.micro_mysql_HDD_storage                                                  
- ├─ SQL instance (db-f1-micro, zonal)                                730  hours                  $7.67 
- ├─ Storage (HDD, zonal)                                              10  GB                     $0.90 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.micro_mysql_SSD_storage                                                  
- ├─ SQL instance (db-f1-micro, zonal)                                730  hours                  $7.67 
- ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.mysql_highmem                                                            
- ├─ SQL instance (db-n1-highmem-8, zonal)                            730  hours                $514.07 
- ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.mysql_standard                                                           
- ├─ SQL instance (db-n1-standard-32, zonal)                          730  hours              $1,578.26 
- ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.mysql_standard_no_public_ip                                              
- ├─ vCPUs (zonal)                                                 11,680  hours                $482.38 
- ├─ Memory (zonal)                                                43,800  GB                   $306.60 
- ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
- └─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
-                                                                                                       
- google_sql_database_instance.small_mysql                                                              
- ├─ SQL instance (db-g1-small, zonal)                                730  hours                 $25.55 
- ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.sql_server                                                               
- ├─ vCPUs (zonal)                                                 11,680  hours                $482.38 
- ├─ Memory (zonal)                                                43,800  GB                   $306.60 
- ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.usage                                                                    
- ├─ SQL instance (db-g1-small, zonal)                                730  hours                 $25.55 
- ├─ Storage (SSD, zonal)                                              10  GB                     $1.70 
- ├─ Backups                                                        1,000  GB                    $80.00 
- └─ IP address (if unused)                                           730  hours                  $7.30 
-                                                                                                       
- google_sql_database_instance.with_replica                                                             
- ├─ vCPUs (regional)                                              11,680  hours                $964.77 
- ├─ Memory (regional)                                             43,800  GB                   $613.20 
- ├─ Storage (SSD, regional)                                          500  GB                   $170.00 
- ├─ Backups                                                Monthly cost depends on usage: $0.08 per GB 
- ├─ IP address (if unused)                                           730  hours                  $7.30 
- └─ Replica                                                                                            
-    ├─ vCPUs (zonal)                                              11,680  hours                $482.38 
-    ├─ Memory (zonal)                                             43,800  GB                   $306.60 
-    └─ Storage (SSD, zonal)                                          500  GB                    $85.00 
-                                                                                                       
- OVERALL TOTAL                                                                               $8,326.67 
+ Name                                                                                           Monthly Qty  Unit            Monthly Cost 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-1-3840.MYSQL_8_0.REGIONAL"]                                                          
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-1-3840.MYSQL_8_0.ZONAL"]                                                             
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-1-3840.POSTGRES_15.REGIONAL"]                                                        
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-1-3840.POSTGRES_15.ZONAL"]                                                           
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-1-3840.SQLSERVER_2019_WEB.REGIONAL"]                                                 
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-1-3840.SQLSERVER_2019_WEB.ZONAL"]                                                    
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-16-61440.MYSQL_8_0.REGIONAL"]                                                        
+ ├─ vCPUs (16, regional)                                                                             11,680  hours                $964.77 
+ ├─ Memory (60 GB, regional)                                                                             60  GB                   $613.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-16-61440.MYSQL_8_0.ZONAL"]                                                           
+ ├─ vCPUs (16, zonal)                                                                                11,680  hours                $482.38 
+ ├─ Memory (60 GB, zonal)                                                                                60  GB                   $306.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-16-61440.POSTGRES_15.REGIONAL"]                                                      
+ ├─ vCPUs (16, regional)                                                                             11,680  hours                $964.77 
+ ├─ Memory (60 GB, regional)                                                                             60  GB                   $613.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-16-61440.POSTGRES_15.ZONAL"]                                                         
+ ├─ vCPUs (16, zonal)                                                                                11,680  hours                $482.38 
+ ├─ Memory (60 GB, zonal)                                                                                60  GB                   $306.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-16-61440.SQLSERVER_2019_WEB.REGIONAL"]                                               
+ ├─ vCPUs (16, regional)                                                                             11,680  hours                $964.77 
+ ├─ Memory (60 GB, regional)                                                                             60  GB                   $613.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-16-61440.SQLSERVER_2019_WEB.ZONAL"]                                                  
+ ├─ vCPUs (16, zonal)                                                                                11,680  hours                $482.38 
+ ├─ Memory (60 GB, zonal)                                                                                60  GB                   $306.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-2-7680.MYSQL_8_0.REGIONAL"]                                                          
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (7.5 GB, regional)                                                                           7.5  GB                    $76.65 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-2-7680.MYSQL_8_0.ZONAL"]                                                             
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (7.5 GB, zonal)                                                                              7.5  GB                    $38.33 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-2-7680.POSTGRES_15.REGIONAL"]                                                        
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (7.5 GB, regional)                                                                           7.5  GB                    $76.65 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-2-7680.POSTGRES_15.ZONAL"]                                                           
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (7.5 GB, zonal)                                                                              7.5  GB                    $38.33 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-2-7680.SQLSERVER_2019_WEB.REGIONAL"]                                                 
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (7.5 GB, regional)                                                                           7.5  GB                    $76.65 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-2-7680.SQLSERVER_2019_WEB.ZONAL"]                                                    
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (7.5 GB, zonal)                                                                              7.5  GB                    $38.33 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-32-122880.MYSQL_8_0.REGIONAL"]                                                       
+ ├─ vCPUs (32, regional)                                                                             23,360  hours              $1,929.54 
+ ├─ Memory (120 GB, regional)                                                                           120  GB                 $1,226.40 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-32-122880.MYSQL_8_0.ZONAL"]                                                          
+ ├─ vCPUs (32, zonal)                                                                                23,360  hours                $964.77 
+ ├─ Memory (120 GB, zonal)                                                                              120  GB                   $613.20 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-32-122880.POSTGRES_15.REGIONAL"]                                                     
+ ├─ vCPUs (32, regional)                                                                             23,360  hours              $1,929.54 
+ ├─ Memory (120 GB, regional)                                                                           120  GB                 $1,226.40 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-32-122880.POSTGRES_15.ZONAL"]                                                        
+ ├─ vCPUs (32, zonal)                                                                                23,360  hours                $964.77 
+ ├─ Memory (120 GB, zonal)                                                                              120  GB                   $613.20 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-32-122880.SQLSERVER_2019_WEB.REGIONAL"]                                              
+ ├─ vCPUs (32, regional)                                                                             23,360  hours              $1,929.54 
+ ├─ Memory (120 GB, regional)                                                                           120  GB                 $1,226.40 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-32-122880.SQLSERVER_2019_WEB.ZONAL"]                                                 
+ ├─ vCPUs (32, zonal)                                                                                23,360  hours                $964.77 
+ ├─ Memory (120 GB, zonal)                                                                              120  GB                   $613.20 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-4-15360.MYSQL_8_0.REGIONAL"]                                                         
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (15 GB, regional)                                                                             15  GB                   $153.30 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-4-15360.MYSQL_8_0.ZONAL"]                                                            
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (15 GB, zonal)                                                                                15  GB                    $76.65 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-4-15360.POSTGRES_15.REGIONAL"]                                                       
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (15 GB, regional)                                                                             15  GB                   $153.30 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-4-15360.POSTGRES_15.ZONAL"]                                                          
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (15 GB, zonal)                                                                                15  GB                    $76.65 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-4-15360.SQLSERVER_2019_WEB.REGIONAL"]                                                
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (15 GB, regional)                                                                             15  GB                   $153.30 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-4-15360.SQLSERVER_2019_WEB.ZONAL"]                                                   
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (15 GB, zonal)                                                                                15  GB                    $76.65 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-64-245760.MYSQL_8_0.REGIONAL"]                                                       
+ ├─ vCPUs (64, regional)                                                                             46,720  hours              $3,859.07 
+ ├─ Memory (240 GB, regional)                                                                           240  GB                 $2,452.80 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-64-245760.MYSQL_8_0.ZONAL"]                                                          
+ ├─ vCPUs (64, zonal)                                                                                46,720  hours              $1,929.54 
+ ├─ Memory (240 GB, zonal)                                                                              240  GB                 $1,226.40 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-64-245760.POSTGRES_15.REGIONAL"]                                                     
+ ├─ vCPUs (64, regional)                                                                             46,720  hours              $3,859.07 
+ ├─ Memory (240 GB, regional)                                                                           240  GB                 $2,452.80 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-64-245760.POSTGRES_15.ZONAL"]                                                        
+ ├─ vCPUs (64, zonal)                                                                                46,720  hours              $1,929.54 
+ ├─ Memory (240 GB, zonal)                                                                              240  GB                 $1,226.40 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-64-245760.SQLSERVER_2019_WEB.REGIONAL"]                                              
+ ├─ vCPUs (64, regional)                                                                             46,720  hours              $3,859.07 
+ ├─ Memory (240 GB, regional)                                                                           240  GB                 $2,452.80 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-64-245760.SQLSERVER_2019_WEB.ZONAL"]                                                 
+ ├─ vCPUs (64, zonal)                                                                                46,720  hours              $1,929.54 
+ ├─ Memory (240 GB, zonal)                                                                              240  GB                 $1,226.40 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-8-30720.MYSQL_8_0.REGIONAL"]                                                         
+ ├─ vCPUs (8, regional)                                                                               5,840  hours                $482.38 
+ ├─ Memory (30 GB, regional)                                                                             30  GB                   $306.60 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-8-30720.MYSQL_8_0.ZONAL"]                                                            
+ ├─ vCPUs (8, zonal)                                                                                  5,840  hours                $241.19 
+ ├─ Memory (30 GB, zonal)                                                                                30  GB                   $153.30 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-8-30720.POSTGRES_15.REGIONAL"]                                                       
+ ├─ vCPUs (8, regional)                                                                               5,840  hours                $482.38 
+ ├─ Memory (30 GB, regional)                                                                             30  GB                   $306.60 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-8-30720.POSTGRES_15.ZONAL"]                                                          
+ ├─ vCPUs (8, zonal)                                                                                  5,840  hours                $241.19 
+ ├─ Memory (30 GB, zonal)                                                                                30  GB                   $153.30 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-8-30720.SQLSERVER_2019_WEB.REGIONAL"]                                                
+ ├─ vCPUs (8, regional)                                                                               5,840  hours                $482.38 
+ ├─ Memory (30 GB, regional)                                                                             30  GB                   $306.60 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-8-30720.SQLSERVER_2019_WEB.ZONAL"]                                                   
+ ├─ vCPUs (8, zonal)                                                                                  5,840  hours                $241.19 
+ ├─ Memory (30 GB, zonal)                                                                                30  GB                   $153.30 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-96-368640.MYSQL_8_0.REGIONAL"]                                                       
+ ├─ vCPUs (96, regional)                                                                             70,080  hours              $5,788.61 
+ ├─ Memory (360 GB, regional)                                                                           360  GB                 $3,679.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-96-368640.MYSQL_8_0.ZONAL"]                                                          
+ ├─ vCPUs (96, zonal)                                                                                70,080  hours              $2,894.30 
+ ├─ Memory (360 GB, zonal)                                                                              360  GB                 $1,839.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-96-368640.POSTGRES_15.REGIONAL"]                                                     
+ ├─ vCPUs (96, regional)                                                                             70,080  hours              $5,788.61 
+ ├─ Memory (360 GB, regional)                                                                           360  GB                 $3,679.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-96-368640.POSTGRES_15.ZONAL"]                                                        
+ ├─ vCPUs (96, zonal)                                                                                70,080  hours              $2,894.30 
+ ├─ Memory (360 GB, zonal)                                                                              360  GB                 $1,839.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-96-368640.SQLSERVER_2019_WEB.REGIONAL"]                                              
+ ├─ vCPUs (96, regional)                                                                             70,080  hours              $5,788.61 
+ ├─ Memory (360 GB, regional)                                                                           360  GB                 $3,679.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-custom-96-368640.SQLSERVER_2019_WEB.ZONAL"]                                                 
+ ├─ vCPUs (96, zonal)                                                                                70,080  hours              $2,894.30 
+ ├─ Memory (360 GB, zonal)                                                                              360  GB                 $1,839.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-f1-micro.MYSQL_8_0.REGIONAL"]                                                               
+ ├─ SQL instance (db-f1-micro, regional)                                                                730  hours                 $15.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-f1-micro.MYSQL_8_0.ZONAL"]                                                                  
+ ├─ SQL instance (db-f1-micro, zonal)                                                                   730  hours                  $7.67 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-f1-micro.POSTGRES_15.REGIONAL"]                                                             
+ ├─ SQL instance (db-f1-micro, regional)                                                                730  hours                 $15.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-f1-micro.POSTGRES_15.ZONAL"]                                                                
+ ├─ SQL instance (db-f1-micro, zonal)                                                                   730  hours                  $7.67 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-g1-small.MYSQL_8_0.REGIONAL"]                                                               
+ ├─ SQL instance (db-g1-small, regional)                                                                730  hours                 $51.10 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-g1-small.MYSQL_8_0.ZONAL"]                                                                  
+ ├─ SQL instance (db-g1-small, zonal)                                                                   730  hours                 $25.55 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-g1-small.POSTGRES_15.REGIONAL"]                                                             
+ ├─ SQL instance (db-g1-small, regional)                                                                730  hours                 $51.10 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-g1-small.POSTGRES_15.ZONAL"]                                                                
+ ├─ SQL instance (db-g1-small, zonal)                                                                   730  hours                 $25.55 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-16.MYSQL_8_0.REGIONAL"]                                                             
+ ├─ vCPUs (16, regional)                                                                             11,680  hours                $964.77 
+ ├─ Memory (104 GB, regional)                                                                           104  GB                 $1,062.88 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-16.MYSQL_8_0.ZONAL"]                                                                
+ ├─ vCPUs (16, zonal)                                                                                11,680  hours                $482.38 
+ ├─ Memory (104 GB, zonal)                                                                              104  GB                   $531.44 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-16.POSTGRES_15.REGIONAL"]                                                           
+ ├─ vCPUs (16, regional)                                                                             11,680  hours                $964.77 
+ ├─ Memory (104 GB, regional)                                                                           104  GB                 $1,062.88 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-16.POSTGRES_15.ZONAL"]                                                              
+ ├─ vCPUs (16, zonal)                                                                                11,680  hours                $482.38 
+ ├─ Memory (104 GB, zonal)                                                                              104  GB                   $531.44 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-16.SQLSERVER_2019_WEB.REGIONAL"]                                                    
+ ├─ vCPUs (16, regional)                                                                             11,680  hours                $964.77 
+ ├─ Memory (104 GB, regional)                                                                           104  GB                 $1,062.88 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-16.SQLSERVER_2019_WEB.ZONAL"]                                                       
+ ├─ vCPUs (16, zonal)                                                                                11,680  hours                $482.38 
+ ├─ Memory (104 GB, zonal)                                                                              104  GB                   $531.44 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-4.MYSQL_8_0.REGIONAL"]                                                              
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (26 GB, regional)                                                                             26  GB                   $265.72 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-4.MYSQL_8_0.ZONAL"]                                                                 
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (26 GB, zonal)                                                                                26  GB                   $132.86 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-4.POSTGRES_15.REGIONAL"]                                                            
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (26 GB, regional)                                                                             26  GB                   $265.72 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-4.POSTGRES_15.ZONAL"]                                                               
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (26 GB, zonal)                                                                                26  GB                   $132.86 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-4.SQLSERVER_2019_WEB.REGIONAL"]                                                     
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (26 GB, regional)                                                                             26  GB                   $265.72 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-4.SQLSERVER_2019_WEB.ZONAL"]                                                        
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (26 GB, zonal)                                                                                26  GB                   $132.86 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-8.MYSQL_8_0.REGIONAL"]                                                              
+ ├─ vCPUs (8, regional)                                                                               5,840  hours                $482.38 
+ ├─ Memory (52 GB, regional)                                                                             52  GB                   $531.44 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-8.MYSQL_8_0.ZONAL"]                                                                 
+ ├─ vCPUs (8, zonal)                                                                                  5,840  hours                $241.19 
+ ├─ Memory (52 GB, zonal)                                                                                52  GB                   $265.72 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-8.POSTGRES_15.REGIONAL"]                                                            
+ ├─ vCPUs (8, regional)                                                                               5,840  hours                $482.38 
+ ├─ Memory (52 GB, regional)                                                                             52  GB                   $531.44 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-8.POSTGRES_15.ZONAL"]                                                               
+ ├─ vCPUs (8, zonal)                                                                                  5,840  hours                $241.19 
+ ├─ Memory (52 GB, zonal)                                                                                52  GB                   $265.72 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-8.SQLSERVER_2019_WEB.REGIONAL"]                                                     
+ ├─ vCPUs (8, regional)                                                                               5,840  hours                $482.38 
+ ├─ Memory (52 GB, regional)                                                                             52  GB                   $531.44 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-highmem-8.SQLSERVER_2019_WEB.ZONAL"]                                                        
+ ├─ vCPUs (8, zonal)                                                                                  5,840  hours                $241.19 
+ ├─ Memory (52 GB, zonal)                                                                                52  GB                   $265.72 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-1.MYSQL_8_0.REGIONAL"]                                                          
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-1.MYSQL_8_0.ZONAL"]                                                             
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-1.POSTGRES_15.REGIONAL"]                                                        
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-1.POSTGRES_15.ZONAL"]                                                           
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-1.SQLSERVER_2019_WEB.REGIONAL"]                                                 
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-1.SQLSERVER_2019_WEB.ZONAL"]                                                    
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-2.MYSQL_8_0.REGIONAL"]                                                          
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-2.MYSQL_8_0.ZONAL"]                                                             
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-2.POSTGRES_15.REGIONAL"]                                                        
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-2.POSTGRES_15.ZONAL"]                                                           
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-2.SQLSERVER_2019_WEB.REGIONAL"]                                                 
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-2.SQLSERVER_2019_WEB.ZONAL"]                                                    
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-4.MYSQL_8_0.REGIONAL"]                                                          
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-4.MYSQL_8_0.ZONAL"]                                                             
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-4.POSTGRES_15.REGIONAL"]                                                        
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-4.POSTGRES_15.ZONAL"]                                                           
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-4.SQLSERVER_2019_WEB.REGIONAL"]                                                 
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-lightweight-4.SQLSERVER_2019_WEB.ZONAL"]                                                    
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-1.MYSQL_8_0.REGIONAL"]                                                          
+ ├─ SQL instance (db-n1-standard-1, regional)                                                           730  hours                 $98.62 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-1.MYSQL_8_0.ZONAL"]                                                             
+ ├─ SQL instance (db-n1-standard-1, zonal)                                                              730  hours                 $49.35 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-1.POSTGRES_15.REGIONAL"]                                                        
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-1.POSTGRES_15.ZONAL"]                                                           
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-1.SQLSERVER_2019_WEB.REGIONAL"]                                                 
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-1.SQLSERVER_2019_WEB.ZONAL"]                                                    
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-16.MYSQL_8_0.REGIONAL"]                                                         
+ ├─ SQL instance (db-n1-standard-16, regional)                                                          730  hours              $1,578.48 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-16.MYSQL_8_0.ZONAL"]                                                            
+ ├─ SQL instance (db-n1-standard-16, zonal)                                                             730  hours                $789.28 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-16.POSTGRES_15.REGIONAL"]                                                       
+ ├─ vCPUs (16, regional)                                                                             11,680  hours                $964.77 
+ ├─ Memory (60 GB, regional)                                                                             60  GB                   $613.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-16.POSTGRES_15.ZONAL"]                                                          
+ ├─ vCPUs (16, zonal)                                                                                11,680  hours                $482.38 
+ ├─ Memory (60 GB, zonal)                                                                                60  GB                   $306.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-16.SQLSERVER_2019_WEB.REGIONAL"]                                                
+ ├─ vCPUs (16, regional)                                                                             11,680  hours                $964.77 
+ ├─ Memory (60 GB, regional)                                                                             60  GB                   $613.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-16.SQLSERVER_2019_WEB.ZONAL"]                                                   
+ ├─ vCPUs (16, zonal)                                                                                11,680  hours                $482.38 
+ ├─ Memory (60 GB, zonal)                                                                                60  GB                   $306.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-2.MYSQL_8_0.REGIONAL"]                                                          
+ ├─ SQL instance (db-n1-standard-2, regional)                                                           730  hours                $197.25 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-2.MYSQL_8_0.ZONAL"]                                                             
+ ├─ SQL instance (db-n1-standard-2, zonal)                                                              730  hours                 $98.62 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-2.POSTGRES_15.REGIONAL"]                                                        
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (7.5 GB, regional)                                                                           7.5  GB                    $76.65 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-2.POSTGRES_15.ZONAL"]                                                           
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (7.5 GB, zonal)                                                                              7.5  GB                    $38.33 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-2.SQLSERVER_2019_WEB.REGIONAL"]                                                 
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (7.5 GB, regional)                                                                           7.5  GB                    $76.65 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-2.SQLSERVER_2019_WEB.ZONAL"]                                                    
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (7.5 GB, zonal)                                                                              7.5  GB                    $38.33 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-32.MYSQL_8_0.REGIONAL"]                                                         
+ ├─ SQL instance (db-n1-standard-32, regional)                                                          730  hours              $3,156.45 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-32.MYSQL_8_0.ZONAL"]                                                            
+ ├─ SQL instance (db-n1-standard-32, zonal)                                                             730  hours              $1,578.26 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-32.POSTGRES_15.REGIONAL"]                                                       
+ ├─ vCPUs (32, regional)                                                                             23,360  hours              $1,929.54 
+ ├─ Memory (120 GB, regional)                                                                           120  GB                 $1,226.40 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-32.POSTGRES_15.ZONAL"]                                                          
+ ├─ vCPUs (32, zonal)                                                                                23,360  hours                $964.77 
+ ├─ Memory (120 GB, zonal)                                                                              120  GB                   $613.20 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-32.SQLSERVER_2019_WEB.REGIONAL"]                                                
+ ├─ vCPUs (32, regional)                                                                             23,360  hours              $1,929.54 
+ ├─ Memory (120 GB, regional)                                                                           120  GB                 $1,226.40 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-32.SQLSERVER_2019_WEB.ZONAL"]                                                   
+ ├─ vCPUs (32, zonal)                                                                                23,360  hours                $964.77 
+ ├─ Memory (120 GB, zonal)                                                                              120  GB                   $613.20 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-4.MYSQL_8_0.REGIONAL"]                                                          
+ ├─ SQL instance (db-n1-standard-4, regional)                                                           730  hours                $394.49 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-4.MYSQL_8_0.ZONAL"]                                                             
+ ├─ SQL instance (db-n1-standard-4, zonal)                                                              730  hours                $197.25 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-4.POSTGRES_15.REGIONAL"]                                                        
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (15 GB, regional)                                                                             15  GB                   $153.30 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-4.POSTGRES_15.ZONAL"]                                                           
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (15 GB, zonal)                                                                                15  GB                    $76.65 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-4.SQLSERVER_2019_WEB.REGIONAL"]                                                 
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (15 GB, regional)                                                                             15  GB                   $153.30 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-4.SQLSERVER_2019_WEB.ZONAL"]                                                    
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (15 GB, zonal)                                                                                15  GB                    $76.65 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-64.MYSQL_8_0.REGIONAL"]                                                         
+ ├─ SQL instance (db-n1-standard-64, regional)                                                          730  hours              $6,312.89 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-64.MYSQL_8_0.ZONAL"]                                                            
+ ├─ SQL instance (db-n1-standard-64, zonal)                                                             730  hours              $3,156.45 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-64.POSTGRES_15.REGIONAL"]                                                       
+ ├─ vCPUs (64, regional)                                                                             46,720  hours              $3,859.07 
+ ├─ Memory (240 GB, regional)                                                                           240  GB                 $2,452.80 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-64.POSTGRES_15.ZONAL"]                                                          
+ ├─ vCPUs (64, zonal)                                                                                46,720  hours              $1,929.54 
+ ├─ Memory (240 GB, zonal)                                                                              240  GB                 $1,226.40 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-64.SQLSERVER_2019_WEB.REGIONAL"]                                                
+ ├─ vCPUs (64, regional)                                                                             46,720  hours              $3,859.07 
+ ├─ Memory (240 GB, regional)                                                                           240  GB                 $2,452.80 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-64.SQLSERVER_2019_WEB.ZONAL"]                                                   
+ ├─ vCPUs (64, zonal)                                                                                46,720  hours              $1,929.54 
+ ├─ Memory (240 GB, zonal)                                                                              240  GB                 $1,226.40 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-8.MYSQL_8_0.REGIONAL"]                                                          
+ ├─ SQL instance (db-n1-standard-8, regional)                                                           730  hours                $788.98 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-8.MYSQL_8_0.ZONAL"]                                                             
+ ├─ SQL instance (db-n1-standard-8, zonal)                                                              730  hours                $394.49 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-8.POSTGRES_15.REGIONAL"]                                                        
+ ├─ vCPUs (8, regional)                                                                               5,840  hours                $482.38 
+ ├─ Memory (30 GB, regional)                                                                             30  GB                   $306.60 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-8.POSTGRES_15.ZONAL"]                                                           
+ ├─ vCPUs (8, zonal)                                                                                  5,840  hours                $241.19 
+ ├─ Memory (30 GB, zonal)                                                                                30  GB                   $153.30 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-8.SQLSERVER_2019_WEB.REGIONAL"]                                                 
+ ├─ vCPUs (8, regional)                                                                               5,840  hours                $482.38 
+ ├─ Memory (30 GB, regional)                                                                             30  GB                   $306.60 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-8.SQLSERVER_2019_WEB.ZONAL"]                                                    
+ ├─ vCPUs (8, zonal)                                                                                  5,840  hours                $241.19 
+ ├─ Memory (30 GB, zonal)                                                                                30  GB                   $153.30 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-96.MYSQL_8_0.REGIONAL"]                                                         
+ ├─ SQL instance (db-n1-standard-96, regional)                                                          730  hours              $9,469.34 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-96.MYSQL_8_0.ZONAL"]                                                            
+ ├─ SQL instance (db-n1-standard-96, zonal)                                                             730  hours              $4,734.71 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-96.POSTGRES_15.REGIONAL"]                                                       
+ ├─ vCPUs (96, regional)                                                                             70,080  hours              $5,788.61 
+ ├─ Memory (360 GB, regional)                                                                           360  GB                 $3,679.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-96.POSTGRES_15.ZONAL"]                                                          
+ ├─ vCPUs (96, zonal)                                                                                70,080  hours              $2,894.30 
+ ├─ Memory (360 GB, zonal)                                                                              360  GB                 $1,839.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-96.SQLSERVER_2019_WEB.REGIONAL"]                                                
+ ├─ vCPUs (96, regional)                                                                             70,080  hours              $5,788.61 
+ ├─ Memory (360 GB, regional)                                                                           360  GB                 $3,679.20 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-n1-standard-96.SQLSERVER_2019_WEB.ZONAL"]                                                   
+ ├─ vCPUs (96, zonal)                                                                                70,080  hours              $2,894.30 
+ ├─ Memory (360 GB, zonal)                                                                              360  GB                 $1,839.60 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-1.MYSQL_8_0.REGIONAL"]                                                             
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-1.MYSQL_8_0.ZONAL"]                                                                
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-1.POSTGRES_15.REGIONAL"]                                                           
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-1.POSTGRES_15.ZONAL"]                                                              
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-1.SQLSERVER_2019_WEB.REGIONAL"]                                                    
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-1.SQLSERVER_2019_WEB.ZONAL"]                                                       
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-2.MYSQL_8_0.REGIONAL"]                                                             
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (7.5 GB, regional)                                                                           7.5  GB                    $76.65 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-2.MYSQL_8_0.ZONAL"]                                                                
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (7.5 GB, zonal)                                                                              7.5  GB                    $38.33 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-2.POSTGRES_15.REGIONAL"]                                                           
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (7.5 GB, regional)                                                                           7.5  GB                    $76.65 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-2.POSTGRES_15.ZONAL"]                                                              
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (7.5 GB, zonal)                                                                              7.5  GB                    $38.33 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-2.SQLSERVER_2019_WEB.REGIONAL"]                                                    
+ ├─ vCPUs (2, regional)                                                                               1,460  hours                $120.60 
+ ├─ Memory (7.5 GB, regional)                                                                           7.5  GB                    $76.65 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-2.SQLSERVER_2019_WEB.ZONAL"]                                                       
+ ├─ vCPUs (2, zonal)                                                                                  1,460  hours                 $60.30 
+ ├─ Memory (7.5 GB, zonal)                                                                              7.5  GB                    $38.33 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-4.MYSQL_8_0.REGIONAL"]                                                             
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (15 GB, regional)                                                                             15  GB                   $153.30 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-4.MYSQL_8_0.ZONAL"]                                                                
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (15 GB, zonal)                                                                                15  GB                    $76.65 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-4.POSTGRES_15.REGIONAL"]                                                           
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (15 GB, regional)                                                                             15  GB                   $153.30 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-4.POSTGRES_15.ZONAL"]                                                              
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (15 GB, zonal)                                                                                15  GB                    $76.65 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-4.SQLSERVER_2019_WEB.REGIONAL"]                                                    
+ ├─ vCPUs (4, regional)                                                                               2,920  hours                $241.19 
+ ├─ Memory (15 GB, regional)                                                                             15  GB                   $153.30 
+ ├─ Storage (SSD, regional)                                                                              10  GB                     $3.40 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.db_instance["db-standard-4.SQLSERVER_2019_WEB.ZONAL"]                                                       
+ ├─ vCPUs (4, zonal)                                                                                  2,920  hours                $120.60 
+ ├─ Memory (15 GB, zonal)                                                                                15  GB                    $76.65 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.no_public_ip                                                                                                
+ ├─ vCPUs (1, zonal)                                                                                    730  hours                 $30.15 
+ ├─ Memory (3.75 GB, zonal)                                                                            3.75  GB                    $19.16 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ └─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+                                                                                                                                          
+ google_sql_database_instance.usage                                                                                                       
+ ├─ SQL instance (db-g1-small, zonal)                                                                   730  hours                 $25.55 
+ ├─ Storage (SSD, zonal)                                                                                 10  GB                     $1.70 
+ ├─ Backups                                                                                           1,000  GB                    $80.00 
+ └─ IP address (if unused)                                                                              730  hours                  $7.30 
+                                                                                                                                          
+ google_sql_database_instance.with_replica                                                                                                
+ ├─ vCPUs (1, regional)                                                                                 730  hours                 $60.30 
+ ├─ Memory (3.75 GB, regional)                                                                         3.75  GB                    $38.33 
+ ├─ Storage (SSD, regional)                                                                             500  GB                   $170.00 
+ ├─ Backups                                                                                   Monthly cost depends on usage: $0.08 per GB 
+ ├─ IP address (if unused)                                                                              730  hours                  $7.30 
+ └─ Replica                                                                                                                               
+    ├─ vCPUs (1, zonal)                                                                                 730  hours                 $30.15 
+    ├─ Memory (3.75 GB, zonal)                                                                         3.75  GB                    $19.16 
+    └─ Storage (SSD, zonal)                                                                             500  GB                    $85.00 
+                                                                                                                                          
+ OVERALL TOTAL                                                                                                                $221,764.39 
 ──────────────────────────────────
-12 cloud resources were detected:
-∙ 12 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+161 cloud resources were detected:
+∙ 161 were estimated, 3 of which include usage-based costs, see https://infracost.io/usage-file
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestNewSQLInstance                                 ┃ $8,327       ┃
+┃ TestNewSQLInstance                                 ┃ $221,764     ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.golden
@@ -1108,11 +1108,16 @@
                                                                                                                                           
  OVERALL TOTAL                                                                                                                $221,764.39 
 ──────────────────────────────────
-161 cloud resources were detected:
+162 cloud resources were detected:
 ∙ 161 were estimated, 3 of which include usage-based costs, see https://infracost.io/usage-file
+∙ 1 is not supported yet, see https://infracost.io/requested-resources:
+  ∙ 1 x google_sql_database_instance
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
 ┃ TestNewSQLInstance                                 ┃ $221,764     ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+Logs:
+
+WRN edition ENTERPRISE_PLUS of google_sql_database_instance.enterprise_plus is not yet supported

--- a/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.tf
+++ b/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.tf
@@ -67,6 +67,17 @@ resource "google_sql_database_instance" "with_replica" {
   }
 }
 
+
+resource "google_sql_database_instance" "enterprise_plus" {
+  name             = "with-replica"
+  database_version = "MYSQL_8_0"
+  settings {
+    tier              = "db-standard-1"
+    availability_type = "REGIONAL"
+    edition           = "ENTERPRISE_PLUS"
+  }
+}
+
 resource "google_sql_database_instance" "usage" {
   name             = "usage"
   database_version = "MYSQL_8_0"

--- a/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.tf
+++ b/internal/providers/terraform/google/testdata/sql_database_instance_test/sql_database_instance_test.tf
@@ -4,98 +4,48 @@ provider "google" {
   region      = "us-central1"
 }
 
-resource "google_sql_database_instance" "sql_server" {
-  name             = "master-instance"
-  database_version = "SQLSERVER_2017_ENTERPRISE"
+locals {
+  legacy_tiers      = ["db-n1-standard-1", "db-n1-standard-2", "db-n1-standard-4", "db-n1-standard-8", "db-n1-standard-16", "db-n1-standard-32", "db-n1-standard-64", "db-n1-standard-96"]
+  custom_tiers      = ["db-custom-1-3840", "db-custom-2-7680", "db-custom-4-15360", "db-custom-8-30720", "db-custom-16-61440", "db-custom-32-122880", "db-custom-64-245760", "db-custom-96-368640"]
+  current_tiers     = ["db-f1-micro", "db-g1-small", "db-lightweight-1", "db-lightweight-2", "db-lightweight-4", "db-standard-1", "db-standard-2", "db-standard-4", "db-highmem-4", "db-highmem-8", "db-highmem-16"]
+  database_versions = ["MYSQL_8_0", "POSTGRES_15", "SQLSERVER_2019_WEB"]
+
+  availability_types = ["ZONAL", "REGIONAL"]
+
+  all_tiers = concat(local.legacy_tiers, local.custom_tiers, local.current_tiers)
+
+  // Skip SQL Server on db-f1-micro and db-g1-small since that's not valid
+  permutations = distinct(flatten([
+    for tier in local.all_tiers : [
+      for database_version in local.database_versions : [
+        for availability_type in local.availability_types : {
+          tier              = tier
+          database_version  = database_version
+          availability_type = availability_type
+        }
+      ] if !(contains(["db-f1-micro", "db-g1-small"], tier) && database_version == "SQLSERVER_2019_WEB")
+    ]
+  ]))
+}
+
+resource "google_sql_database_instance" "db_instance" {
+  for_each = { for entry in local.permutations : "${entry.tier}.${entry.database_version}.${entry.availability_type}" => entry }
+
+  name             = "db-instance-${each.value.tier}-${each.value.database_version}-${each.value.availability_type}"
+  database_version = each.value.database_version
+
   settings {
-    tier              = "db-custom-16-61440"
-    availability_type = "ZONAL"
+    tier              = each.value.tier
+    availability_type = each.value.availability_type
   }
 }
 
-resource "google_sql_database_instance" "custom_postgres" {
-  name             = "master-instance"
-  database_version = "POSTGRES_11"
-
-  settings {
-    tier = "db-custom-2-13312"
-  }
-}
-
-resource "google_sql_database_instance" "HA_custom_postgres" {
-  name             = "master-instance"
-  database_version = "POSTGRES_11"
-
-  settings {
-    tier              = "db-custom-16-61440"
-    availability_type = "REGIONAL"
-  }
-}
-
-resource "google_sql_database_instance" "HA_small_mysql" {
-  name             = "master-instance"
+resource "google_sql_database_instance" "no_public_ip" {
+  name             = "no-public-ip"
   database_version = "MYSQL_8_0"
 
   settings {
-    tier              = "db-g1-small"
-    availability_type = "REGIONAL"
-    disk_size         = "100"
-  }
-}
-
-resource "google_sql_database_instance" "small_mysql" {
-  name             = "master-instance"
-  database_version = "MYSQL_8_0"
-
-  settings {
-    tier              = "db-g1-small"
-    availability_type = "ZONAL"
-  }
-}
-
-resource "google_sql_database_instance" "micro_mysql_SSD_storage" {
-  name             = "master-instance"
-  database_version = "MYSQL_8_0"
-
-  settings {
-    tier              = "db-f1-micro"
-    availability_type = "ZONAL"
-  }
-}
-
-resource "google_sql_database_instance" "micro_mysql_HDD_storage" {
-  name             = "master-instance"
-  database_version = "MYSQL_8_0"
-
-  settings {
-    tier              = "db-f1-micro"
-    availability_type = "ZONAL"
-    disk_type         = "PD_HDD"
-  }
-}
-
-resource "google_sql_database_instance" "mysql_standard" {
-  name             = "master-instance"
-  database_version = "MYSQL_5_7"
-  settings {
-    tier = "db-n1-standard-32"
-  }
-}
-
-resource "google_sql_database_instance" "mysql_highmem" {
-  name             = "master-instance"
-  database_version = "MYSQL_5_7"
-  settings {
-    tier = "db-n1-highmem-8"
-  }
-}
-
-resource "google_sql_database_instance" "mysql_standard_no_public_ip" {
-  name             = "master-instance"
-  database_version = "SQLSERVER_2017_ENTERPRISE"
-
-  settings {
-    tier              = "db-custom-16-61440"
+    tier              = "db-standard-1"
     availability_type = "ZONAL"
 
     ip_configuration {
@@ -104,12 +54,11 @@ resource "google_sql_database_instance" "mysql_standard_no_public_ip" {
   }
 }
 
-
 resource "google_sql_database_instance" "with_replica" {
-  name             = "master-instance"
-  database_version = "POSTGRES_11"
+  name             = "with-replica"
+  database_version = "MYSQL_8_0"
   settings {
-    tier              = "db-custom-16-61440"
+    tier              = "db-standard-1"
     availability_type = "REGIONAL"
     disk_size         = 500
   }
@@ -119,7 +68,7 @@ resource "google_sql_database_instance" "with_replica" {
 }
 
 resource "google_sql_database_instance" "usage" {
-  name             = "master-instance"
+  name             = "usage"
   database_version = "MYSQL_8_0"
 
   settings {

--- a/internal/resources/google/sql_database_instance.go
+++ b/internal/resources/google/sql_database_instance.go
@@ -5,7 +5,6 @@ import (
 	"github.com/infracost/infracost/internal/schema"
 
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/shopspring/decimal"
@@ -28,6 +27,10 @@ type SQLDatabaseInstance struct {
 
 var SQLDatabaseInstanceUsageSchema = []*schema.UsageItem{{Key: "backup_storage_gb", ValueType: schema.Float64, DefaultValue: 0}}
 
+var lightweightRAM = decimal.NewFromInt(3840)
+var standardRAMRatio = decimal.NewFromInt(3840)
+var highmemRAMRatio = decimal.NewFromInt(6656)
+
 func (r *SQLDatabaseInstance) PopulateUsage(u *schema.UsageData) {
 	resources.PopulateArgsWithUsage(r, u)
 }
@@ -40,9 +43,9 @@ func (r *SQLDatabaseInstance) BuildResource() *schema.Resource {
 		replica = true
 	}
 
-	resource = r.sqlDatabaseInstanceCostComponents(false, r.Address)
+	resource = r.costComponents(false)
 	if replica {
-		resource.SubResources = append(resource.SubResources, r.sqlDatabaseInstanceCostComponents(true, "Replica"))
+		resource.SubResources = append(resource.SubResources, r.costComponents(true))
 	}
 
 	return resource
@@ -56,13 +59,8 @@ const (
 	SQLServer
 )
 
-func (r *SQLDatabaseInstance) dbType() SQLInstanceDBType {
-	return r.sqlInstanceDBVersionToDBType()
-}
-
-func (r *SQLDatabaseInstance) sqlDatabaseInstanceCostComponents(replica bool, name string) *schema.Resource {
+func (r *SQLDatabaseInstance) costComponents(replica bool) *schema.Resource {
 	var costComponents []*schema.CostComponent
-	tier := r.Tier
 
 	if r.AvailabilityType == "" || replica {
 		r.AvailabilityType = "ZONAL"
@@ -76,36 +74,15 @@ func (r *SQLDatabaseInstance) sqlDatabaseInstanceCostComponents(replica bool, na
 		r.DiskSize = 10
 	}
 
-	if r.sqlInstanceTierToResourceGroup() != "" && r.dbType() != SQLServer {
-		costComponents = append(costComponents, r.sharedSQLInstance())
-	} else if r.sqlInstanceTierToResourceGroup() == "" && strings.Contains(tier, "db-custom-") {
-		splittedTier := strings.Split(tier, "-")
-		cpu, err := strconv.ParseInt(splittedTier[2], 10, 32)
-		if err != nil {
-			log.Warn().Msgf("cpu of tier %s of %s is not parsable", tier, r.Address)
-			return nil
-		}
-		vCPU := decimalPtr(decimal.NewFromInt32(int32(cpu)))
-
-		costComponents = append(costComponents, r.cpuCostComponent(vCPU))
-
-		if len(splittedTier) < 4 {
-			log.Warn().Msgf("tier %s of %s has no ram data", tier, r.Address)
-			return nil
-		}
-		ram, err := strconv.ParseInt(splittedTier[3], 10, 32)
-		if err != nil {
-			log.Warn().Msgf("ram of tier %s of %s is not parsable", tier, r.Address)
-			return nil
-		}
-		memory := decimalPtr(decimal.NewFromInt32(int32(ram)).Div(decimal.NewFromInt(1024)))
-
-		costComponents = append(costComponents, r.memoryCostComponent(memory))
-	} else if strings.Contains(tier, "db-n1-") && r.dbType() == MySQL {
-		costComponents = append(costComponents, r.sharedSQLInstance())
+	if r.IsShared() {
+		costComponents = append(costComponents, r.sharedInstanceCostComponent())
+	} else if r.IsLegacy() && r.dbType() == MySQL {
+		costComponents = append(costComponents, r.legacyMySQLInstanceCostComponent())
+	} else {
+		costComponents = append(costComponents, r.instanceCostComponents()...)
 	}
 
-	costComponents = append(costComponents, r.sqlInstanceStorage())
+	costComponents = append(costComponents, r.storageCostComponent())
 
 	if !replica {
 		var backupGB *decimal.Decimal
@@ -119,67 +96,29 @@ func (r *SQLDatabaseInstance) sqlDatabaseInstanceCostComponents(replica bool, na
 		}
 	}
 
+	name := r.Address
+	if replica {
+		name = "Replica"
+	}
+
 	return &schema.Resource{
 		Name:           name,
 		CostComponents: costComponents,
 	}
 }
 
-func (r *SQLDatabaseInstance) memoryCostComponent(memory *decimal.Decimal) *schema.CostComponent {
-	availabilityType := r.availabilityTypeDescName()
-	dbTypeName := r.sqlInstanceTypeToDescriptionName()
-	description := fmt.Sprintf("/%s: %s - RAM/", dbTypeName, availabilityType)
-
-	return &schema.CostComponent{
-		Name:           fmt.Sprintf("Memory (%s)", strings.ToLower(availabilityType)),
-		Unit:           "GB",
-		UnitMultiplier: decimal.NewFromInt(1),
-		HourlyQuantity: memory,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("gcp"),
-			Region:        strPtr(r.Region),
-			Service:       strPtr("Cloud SQL"),
-			ProductFamily: strPtr("ApplicationServices"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "description", ValueRegex: strPtr(description)},
-			},
-		},
-	}
-}
-
-func (r *SQLDatabaseInstance) cpuCostComponent(vCPU *decimal.Decimal) *schema.CostComponent {
-	availabilityType := r.availabilityTypeDescName()
-	dbTypeName := r.sqlInstanceTypeToDescriptionName()
-	description := fmt.Sprintf("/%s: %s - vCPU/", dbTypeName, availabilityType)
-
-	return &schema.CostComponent{
-		Name:           fmt.Sprintf("vCPUs (%s)", strings.ToLower(availabilityType)),
-		Unit:           "hours",
-		UnitMultiplier: decimal.NewFromInt(1),
-		HourlyQuantity: vCPU,
-		ProductFilter: &schema.ProductFilter{
-			VendorName:    strPtr("gcp"),
-			Region:        strPtr(r.Region),
-			Service:       strPtr("Cloud SQL"),
-			ProductFamily: strPtr("ApplicationServices"),
-			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "description", ValueRegex: strPtr(description)},
-			},
-		},
-	}
-}
-
-func (r *SQLDatabaseInstance) sharedSQLInstance() *schema.CostComponent {
-	resourceGroup := r.sqlInstanceTierToResourceGroup()
-	descriptionRegex := "/" + r.sqlInstanceAvDBTypeToDescription()
-
-	var vCPU string
-	if strings.Contains(r.Tier, "db-n1-standard") || strings.Contains(r.Tier, "db-n1-highmem") {
-		vCPU = (strings.Split(r.Tier, "-")[3])
-		descriptionRegex += " - " + vCPU + "/"
+func (r *SQLDatabaseInstance) sharedInstanceCostComponent() *schema.CostComponent {
+	var resourceGroup string
+	if strings.EqualFold(r.Tier, "db-f1-micro") {
+		resourceGroup = "SQLGen2InstancesF1Micro"
+	} else if strings.EqualFold(r.Tier, "db-g1-small") {
+		resourceGroup = "SQLGen2InstancesG1Small"
 	} else {
-		descriptionRegex += "/"
+		log.Warn().Msgf("tier %s of %s is not supported", r.Tier, r.Address)
+		return nil
 	}
+
+	descriptionRegex := fmt.Sprintf("Cloud SQL for %s: %s", r.dbTypeDescName(), r.availabilityTypeDescName())
 
 	return &schema.CostComponent{
 		Name:           fmt.Sprintf("SQL instance (%s, %s)", r.Tier, strings.ToLower(r.AvailabilityType)),
@@ -192,42 +131,108 @@ func (r *SQLDatabaseInstance) sharedSQLInstance() *schema.CostComponent {
 			Service:    strPtr("Cloud SQL"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "resourceGroup", Value: strPtr(resourceGroup)},
-				{Key: "description", ValueRegex: strPtr(descriptionRegex)},
+				{Key: "description", ValueRegex: regexPtr(descriptionRegex)},
 			},
 		},
 	}
 }
 
-func (r *SQLDatabaseInstance) sqlInstanceDBVersionToDBType() SQLInstanceDBType {
-	if strings.Contains(r.DatabaseVersion, "POSTGRES") {
+func (r *SQLDatabaseInstance) legacyMySQLInstanceCostComponent() *schema.CostComponent {
+	var resourceGroup string
+	if r.IsStandard() {
+		resourceGroup = "SQLGen2InstancesN1Standard"
+	} else if r.IsHighMem() {
+		resourceGroup = "SQLGen2InstancesN1Highmem"
+	}
+
+	vCPUs, err := r.vCPUs()
+	if err != nil {
+		log.Warn().Msgf("vCPU of tier %s of %s is not parsable", r.Tier, r.Address)
+		return nil
+	}
+
+	descriptionRegex := fmt.Sprintf("Cloud SQL for %s: %s - %s vCPU", r.dbTypeDescName(), r.availabilityTypeDescName(), vCPUs)
+
+	return &schema.CostComponent{
+		Name:           fmt.Sprintf("SQL instance (%s, %s)", r.Tier, strings.ToLower(r.AvailabilityType)),
+		Unit:           "hours",
+		UnitMultiplier: decimal.NewFromInt(1),
+		HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+		ProductFilter: &schema.ProductFilter{
+			VendorName: strPtr("gcp"),
+			Region:     strPtr(r.Region),
+			Service:    strPtr("Cloud SQL"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "resourceGroup", Value: strPtr(resourceGroup)},
+				{Key: "description", ValueRegex: regexPtr(descriptionRegex)},
+			},
+		},
+	}
+}
+
+func (r *SQLDatabaseInstance) instanceCostComponents() []*schema.CostComponent {
+	cpuDescRegex := fmt.Sprintf("%s: %s - vCPU", r.dbTypeDescName(), r.availabilityTypeDescName())
+	memDescRegex := fmt.Sprintf("%s: %s - RAM", r.dbTypeDescName(), r.availabilityTypeDescName())
+
+	vCPUs, err := r.vCPUs()
+	if err != nil {
+		log.Warn().Msgf("vCPU of tier %s of %s is not parsable: %s", r.Tier, r.Address, err)
+		return nil
+	}
+
+	mem, err := r.memory()
+	if err != nil {
+		log.Warn().Msgf("memory of tier %s of %s is not parsable: %s", r.Tier, r.Address, err)
+		return nil
+	}
+
+	return []*schema.CostComponent{
+		{
+			Name:           fmt.Sprintf("vCPUs (%s, %s)", vCPUs, strings.ToLower(r.AvailabilityType)),
+			Unit:           "hours",
+			UnitMultiplier: decimal.NewFromInt(1),
+			HourlyQuantity: decimalPtr(vCPUs),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("gcp"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cloud SQL"),
+				ProductFamily: strPtr("ApplicationServices"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "description", ValueRegex: regexPtr(cpuDescRegex)},
+				},
+			},
+		},
+		{
+			Name:           fmt.Sprintf("Memory (%s GB, %s)", mem, strings.ToLower(r.AvailabilityType)),
+			Unit:           "GB",
+			UnitMultiplier: schema.HourToMonthUnitMultiplier,
+			HourlyQuantity: decimalPtr(mem),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("gcp"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cloud SQL"),
+				ProductFamily: strPtr("ApplicationServices"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "description", ValueRegex: regexPtr(memDescRegex)},
+				},
+			},
+		},
+	}
+}
+
+func (r *SQLDatabaseInstance) dbType() SQLInstanceDBType {
+	if strings.HasPrefix(strings.ToLower(r.DatabaseVersion), "postgres") {
 		return PostgreSQL
-	} else if strings.Contains(r.DatabaseVersion, "MYSQL") {
+	} else if strings.HasPrefix(strings.ToLower(r.DatabaseVersion), "mysql") {
 		return MySQL
-	} else if strings.Contains(r.DatabaseVersion, "SQLSERVER") {
+	} else if strings.HasPrefix(strings.ToLower(r.DatabaseVersion), "sqlserver") {
 		return SQLServer
 	} else {
 		return MySQL
 	}
 }
 
-func (r *SQLDatabaseInstance) sqlInstanceTierToResourceGroup() string {
-	data := map[string]string{
-		"db-f1-micro": "SQLGen2InstancesF1Micro",
-		"db-g1-small": "SQLGen2InstancesG1Small",
-	}
-
-	if data[r.Tier] != "" {
-		return data[r.Tier]
-	} else if strings.Contains(r.Tier, "db-n1-standard") {
-		return "SQLGen2InstancesN1Standard"
-	} else if strings.Contains(r.Tier, "db-n1-highmem") {
-		return "SQLGen2InstancesN1Highmem"
-	}
-
-	return ""
-}
-
-func (r *SQLDatabaseInstance) sqlInstanceTypeToDescriptionName() string {
+func (r *SQLDatabaseInstance) dbTypeDescName() string {
 	dbTypeNames := map[SQLInstanceDBType]string{
 		MySQL:      "MySQL",
 		PostgreSQL: "PostgreSQL",
@@ -255,16 +260,53 @@ func (r *SQLDatabaseInstance) diskTypeDescName() string {
 	return diskTypeDescs[r.DiskType]
 }
 
-func (r *SQLDatabaseInstance) sqlInstanceAvDBTypeToDescription() string {
-	dbTypeString := r.sqlInstanceTypeToDescriptionName()
-	availabilityTypeString := r.availabilityTypeDescName()
+func (r *SQLDatabaseInstance) vCPUs() (decimal.Decimal, error) {
+	p := strings.Split(r.Tier, "-")
 
-	description := fmt.Sprintf("%s: %s", dbTypeString, availabilityTypeString)
+	if len(p) < 3 {
+		return decimal.Decimal{}, fmt.Errorf("tier %s has no vCPU data", r.Tier)
+	}
 
-	return description
+	if r.IsCustom() {
+		return decimal.NewFromString(p[2])
+	}
+
+	return decimal.NewFromString(p[len(p)-1])
 }
 
-func (r *SQLDatabaseInstance) sqlInstanceStorage() *schema.CostComponent {
+func (r *SQLDatabaseInstance) memory() (decimal.Decimal, error) {
+	if r.IsCustom() {
+		p := strings.Split(r.Tier, "-")
+
+		if len(p) < 4 {
+			return decimal.Decimal{}, fmt.Errorf("tier %s has no RAM data", r.Tier)
+		}
+
+		v, err := decimal.NewFromString(p[len(p)-1])
+		if err != nil {
+			return decimal.Decimal{}, err
+		}
+
+		return v.Div(decimal.NewFromInt(1024)), nil
+	} else if r.IsStandard() || r.IsHighMem() {
+		vCPUs, err := r.vCPUs()
+		if err != nil {
+			return decimal.Decimal{}, err
+		}
+
+		if r.IsStandard() {
+			return vCPUs.Mul(standardRAMRatio).Div(decimal.NewFromInt(1024)), nil
+		} else if r.IsHighMem() {
+			return vCPUs.Mul(highmemRAMRatio).Div(decimal.NewFromInt(1024)), nil
+		}
+	} else if r.isLightweight() {
+		return lightweightRAM.Div(decimal.NewFromInt(1024)), nil
+	}
+
+	return decimal.Decimal{}, fmt.Errorf("tier %s has no RAM data", r.Tier)
+}
+
+func (r *SQLDatabaseInstance) storageCostComponent() *schema.CostComponent {
 	diskType := r.DiskType
 	diskTypeHumanReadableNames := map[string]string{
 		"PD_SSD": "SSD",
@@ -280,7 +322,7 @@ func (r *SQLDatabaseInstance) sqlInstanceStorage() *schema.CostComponent {
 		diskType = "PD_SSD"
 	}
 
-	cost := &schema.CostComponent{
+	return &schema.CostComponent{
 		Name:            fmt.Sprintf("Storage (%s, %s)", diskTypeHumanReadableNames[diskType], strings.ToLower(r.AvailabilityType)),
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
@@ -291,16 +333,14 @@ func (r *SQLDatabaseInstance) sqlInstanceStorage() *schema.CostComponent {
 			Service:    strPtr("Cloud SQL"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "resourceGroup", Value: strPtr(diskTypeAPIResourceGroup[diskType])},
-				{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("%s: %s - %s", r.sqlInstanceTypeToDescriptionName(), r.availabilityTypeDescName(), r.diskTypeDescName()))},
+				{Key: "description", ValueRegex: regexPtr(fmt.Sprintf("%s: %s - %s", r.dbTypeDescName(), r.availabilityTypeDescName(), r.diskTypeDescName()))},
 			},
 		},
 	}
-
-	return cost
 }
 
 func (r *SQLDatabaseInstance) backupCostComponent(quantity *decimal.Decimal) *schema.CostComponent {
-	cost := &schema.CostComponent{
+	return &schema.CostComponent{
 		Name:            "Backups",
 		Unit:            "GB",
 		UnitMultiplier:  decimal.NewFromInt(1),
@@ -315,8 +355,6 @@ func (r *SQLDatabaseInstance) backupCostComponent(quantity *decimal.Decimal) *sc
 			},
 		},
 	}
-
-	return cost
 }
 
 func (r *SQLDatabaseInstance) ipv4CostComponent() *schema.CostComponent {
@@ -335,4 +373,28 @@ func (r *SQLDatabaseInstance) ipv4CostComponent() *schema.CostComponent {
 			},
 		},
 	}
+}
+
+func (r *SQLDatabaseInstance) IsCustom() bool {
+	return strings.HasPrefix(strings.ToLower(r.Tier), "db-custom-")
+}
+
+func (r *SQLDatabaseInstance) IsShared() bool {
+	return strings.EqualFold(r.Tier, "db-f1-micro") || strings.EqualFold(r.Tier, "db-g1-small")
+}
+
+func (r *SQLDatabaseInstance) IsLegacy() bool {
+	return strings.HasPrefix(strings.ToLower(r.Tier), "db-n1-")
+}
+
+func (r *SQLDatabaseInstance) IsStandard() bool {
+	return strings.HasPrefix(strings.ToLower(r.Tier), "db-n1-standard") || strings.HasPrefix(strings.ToLower(r.Tier), "db-standard")
+}
+
+func (r *SQLDatabaseInstance) IsHighMem() bool {
+	return strings.HasPrefix(strings.ToLower(r.Tier), "db-n1-highmem") || strings.HasPrefix(strings.ToLower(r.Tier), "db-highmem")
+}
+
+func (r *SQLDatabaseInstance) isLightweight() bool {
+	return strings.HasPrefix(strings.ToLower(r.Tier), "db-lightweight")
 }

--- a/internal/resources/google/sql_database_instance.go
+++ b/internal/resources/google/sql_database_instance.go
@@ -18,6 +18,7 @@ type SQLDatabaseInstance struct {
 	UseIPV4              bool
 	ReplicaConfiguration string
 	Tier                 string
+	Edition              string
 	AvailabilityType     string
 	Region               string
 	DatabaseVersion      string
@@ -37,6 +38,11 @@ func (r *SQLDatabaseInstance) PopulateUsage(u *schema.UsageData) {
 
 func (r *SQLDatabaseInstance) BuildResource() *schema.Resource {
 	var resource *schema.Resource
+
+	if strings.EqualFold(r.Edition, "enterprise_plus") {
+		log.Warn().Msgf("edition %s of %s is not yet supported", r.Edition, r.Address)
+		return nil
+	}
 
 	replica := false
 	if r.ReplicaConfiguration != "" {


### PR DESCRIPTION
This also fixes the legacy tiers for PostgreSQL and MSSQL.

Google has introduced new tiers of the form `db-standard-1`. The legacy tiers are `db-n1-*`. The new tiers don't have a single price in the pricing API, so we map them to the equivalent CPU and memory prices, similar to how custom instances work.

There's still 2 unsupported issues with this resource that I will separate into separate issues:
1. SQL Server Licensing isn't supported
2. Enterprise Plus pricing isn't supported.