### PR TITLE
fix: correct markdown spacing for Bitbucket IC-559

### DIFF
--- a/cmd/infracost/testdata/comment_bitbucket_commit/comment_bitbucket_commit.golden
+++ b/cmd/infracost/testdata/comment_bitbucket_commit/comment_bitbucket_commit.golden
@@ -7,6 +7,7 @@
 | **Project** | **Cost change** | **New monthly cost** |
 | ----------- | --------------: | -------------------- |
 | infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json | +$41 (+100%) | $81 |
+
 ### Cost details ###
 
 ```

--- a/cmd/infracost/testdata/comment_bitbucket_pull_request/comment_bitbucket_pull_request.golden
+++ b/cmd/infracost/testdata/comment_bitbucket_pull_request/comment_bitbucket_pull_request.golden
@@ -7,6 +7,7 @@
 | **Project** | **Cost change** | **New monthly cost** |
 | ----------- | --------------: | -------------------- |
 | infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json | +$41 (+100%) | $81 |
+
 ### Cost details ###
 
 ```

--- a/cmd/infracost/testdata/output_format_bitbucket_comment_with_project_names/output_format_bitbucket_comment_with_project_names.golden
+++ b/cmd/infracost/testdata/output_format_bitbucket_comment_with_project_names/output_format_bitbucket_comment_with_project_names.golden
@@ -12,6 +12,7 @@
 | my terragrunt prod project |  | -$561 (-43%) | $748 |
 | my terragrunt workspace | prod | -$561 (-43%) | $748 |
 | my workspace project |  | -$561 (-43%) | $743 |
+
 ### Cost details ###
 
 ```

--- a/internal/output/templates/markdown.tmpl
+++ b/internal/output/templates/markdown.tmpl
@@ -63,6 +63,7 @@
 {{- end }}
 
 {{- if displayOutput  }}
+
 ### Cost details ###
 
 ```


### PR DESCRIPTION
fixes #2799

Adds spacing between markdown table and header in the markdown.tmpl. This resolves issue where the header was being appeded as a table row.