### PR TITLE
fix: Fall back to BUILD_SOURCEBRANCHNAME when detecting azure repos s…

### DIFF
--- a/internal/vcs/metadata.go
+++ b/internal/vcs/metadata.go
@@ -760,6 +760,9 @@ func (f *metadataFetcher) getAzureReposGithubMetadata(path string, gitDiffTarget
 // on a git log call that doesn't appear to be a Merge commit.
 func (f *metadataFetcher) transformAzureDevOpsMergeCommit(path string, m *Metadata) error {
 	m.Branch.Name = strings.TrimPrefix(getEnv("SYSTEM_PULLREQUEST_SOURCEBRANCH"), "refs/heads/")
+	if m.Branch.Name == "" {
+			m.Branch.Name = getEnv("BUILD_SOURCEBRANCHNAME")
+	}
 
 	matches := mergeCommitRegxp.FindStringSubmatch(m.Commit.Message)
 	if len(matches) <= 1 {

--- a/internal/vcs/metadata.go
+++ b/internal/vcs/metadata.go
@@ -761,7 +761,7 @@ func (f *metadataFetcher) getAzureReposGithubMetadata(path string, gitDiffTarget
 func (f *metadataFetcher) transformAzureDevOpsMergeCommit(path string, m *Metadata) error {
 	m.Branch.Name = strings.TrimPrefix(getEnv("SYSTEM_PULLREQUEST_SOURCEBRANCH"), "refs/heads/")
 	if m.Branch.Name == "" {
-			m.Branch.Name = getEnv("BUILD_SOURCEBRANCHNAME")
+		m.Branch.Name = getEnv("BUILD_SOURCEBRANCHNAME")
 	}
 
 	matches := mergeCommitRegxp.FindStringSubmatch(m.Commit.Message)


### PR DESCRIPTION
…ource branch

This is needed when running Infracost on default branches (as opposed to PRs)
