### PR TITLE
feat: add autodetect configuration to config file IC-604

### DIFF
--- a/cmd/infracost/generate_test.go
+++ b/cmd/infracost/generate_test.go
@@ -91,12 +91,19 @@ func TestGenerateConfigAutoDetect(t *testing.T) {
 			testutil.CreateDirectoryStructure(tt, path.Join(dir, "tree.txt"), tempDir)
 
 			buf := bytes.NewBuffer([]byte{})
-			actual := GetCommandOutput(tt, []string{
+			args := []string{
 				"generate",
 				"config",
 				"--repo-path",
 				tempDir,
-			}, nil, func(ctx *config.RunContext) {
+			}
+
+			templatePath := path.Join(dir, "infracost.yml.tmpl")
+			if _, err := os.Stat(templatePath); err == nil {
+				args = append(args, "--template-path", templatePath)
+			}
+
+			actual := GetCommandOutput(tt, args, nil, func(ctx *config.RunContext) {
 				ctx.Config.SetLogWriter(buf)
 				ctx.Config.LogLevel = "debug"
 

--- a/cmd/infracost/testdata/generate/env_names/expected.golden
+++ b/cmd/infracost/testdata/generate/env_names/expected.golden
@@ -1,0 +1,36 @@
+version: 0.1
+autodetect:
+  env_names:
+    - baz
+    - bat
+
+projects:
+  - path: apps/bar
+    name: apps-bar-bat
+    terraform_var_files:
+      - ../prod.tfvars
+      - ../dev.tfvars
+      - ../default.tfvars
+      - ../bat.tfvars
+  - path: apps/bar
+    name: apps-bar-baz
+    terraform_var_files:
+      - ../prod.tfvars
+      - ../dev.tfvars
+      - ../default.tfvars
+      - ../baz.tfvars
+  - path: apps/foo
+    name: apps-foo-bat
+    terraform_var_files:
+      - ../prod.tfvars
+      - ../dev.tfvars
+      - ../default.tfvars
+      - ../bat.tfvars
+  - path: apps/foo
+    name: apps-foo-baz
+    terraform_var_files:
+      - ../prod.tfvars
+      - ../dev.tfvars
+      - ../default.tfvars
+      - ../baz.tfvars
+

--- a/cmd/infracost/testdata/generate/env_names/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/env_names/infracost.yml.tmpl
@@ -1,0 +1,15 @@
+version: 0.1
+autodetect:
+  env_names:
+    - baz
+    - bat
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+    terraform_var_files:
+    {{- range $varFile := $project.TerraformVarFiles }}
+      - {{ $varFile }}
+    {{- end }}
+{{- end }}

--- a/cmd/infracost/testdata/generate/env_names/tree.txt
+++ b/cmd/infracost/testdata/generate/env_names/tree.txt
@@ -1,0 +1,11 @@
+.
+└── apps
+    ├── bar
+    │   └── main.tf
+    ├── foo
+    │   └── main.tf
+    ├── baz.tfvars
+    ├── bat.tfvars
+    ├── dev.tfvars
+    ├── prod.tfvars
+    └── default.tfvars

--- a/cmd/infracost/testdata/generate/excluded_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/excluded_dirs/expected.golden
@@ -1,0 +1,17 @@
+version: 0.1
+autodetect:
+  excluded_dirs:
+    - apps/foo
+
+projects:
+  - path: apps/bar
+    name: apps-bar-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+  - path: apps/bar
+    name: apps-bar-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
+

--- a/cmd/infracost/testdata/generate/excluded_dirs/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/excluded_dirs/infracost.yml.tmpl
@@ -1,0 +1,14 @@
+version: 0.1
+autodetect:
+  excluded_dirs:
+    - apps/foo
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+    terraform_var_files:
+    {{- range $varFile := $project.TerraformVarFiles }}
+      - {{ $varFile }}
+    {{- end }}
+{{- end }}

--- a/cmd/infracost/testdata/generate/excluded_dirs/tree.txt
+++ b/cmd/infracost/testdata/generate/excluded_dirs/tree.txt
@@ -1,0 +1,13 @@
+.
+└── apps
+    ├── bar
+    │   └── main.tf
+    ├── foo
+    │   └── main.tf
+    ├── baz
+    │   └── foo.tf
+    ├── bat
+    │   └── bip.tf
+    ├── dev.tfvars
+    ├── prod.tfvars
+    └── default.tfvars

--- a/cmd/infracost/testdata/generate/include_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/include_dirs/expected.golden
@@ -1,0 +1,48 @@
+version: 0.1
+autodetect:
+  included_dirs:
+    - apps/bat
+    - apps/baz
+
+projects:
+  - path: apps/bar
+    name: apps-bar-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+  - path: apps/bar
+    name: apps-bar-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
+  - path: apps/bat
+    name: apps-bat-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+  - path: apps/bat
+    name: apps-bat-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
+  - path: apps/baz
+    name: apps-baz-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+  - path: apps/baz
+    name: apps-baz-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
+  - path: apps/foo
+    name: apps-foo-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+  - path: apps/foo
+    name: apps-foo-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
+

--- a/cmd/infracost/testdata/generate/include_dirs/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/include_dirs/infracost.yml.tmpl
@@ -1,0 +1,15 @@
+version: 0.1
+autodetect:
+  included_dirs:
+    - apps/bat
+    - apps/baz
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+    terraform_var_files:
+    {{- range $varFile := $project.TerraformVarFiles }}
+      - {{ $varFile }}
+    {{- end }}
+{{- end }}

--- a/cmd/infracost/testdata/generate/include_dirs/tree.txt
+++ b/cmd/infracost/testdata/generate/include_dirs/tree.txt
@@ -1,0 +1,13 @@
+.
+└── apps
+    ├── bar
+    │   └── main.tf
+    ├── foo
+    │   └── main.tf
+    ├── baz
+    │   └── foo.tf
+    ├── bat
+    │   └── bip.tf
+    ├── dev.tfvars
+    ├── prod.tfvars
+    └── default.tfvars

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,17 @@ import (
 
 const InfracostDir = ".infracost"
 
+type AutodetectConfig struct {
+	// EnvNames is the list of environment names that we should use to group
+	// terraform var files.
+	EnvNames []string `yaml:"env_names,omitempty" ignored:"true"`
+	// ExcludedDirs is a list of directories that the autodetect should ignore.
+	ExcludedDirs []string `yaml:"excluded_dirs,omitempty" ignored:"true"`
+	// IncludedDirs is a list of directories that the autodetect should append
+	// to the already detected directories.
+	IncludedDirs []string `yaml:"included_dirs,omitempty" ignored:"true"`
+}
+
 // Project defines a specific terraform project config. This can be used
 // specify per folder/project configurations so that users don't have
 // to provide flags every run. Fields are documented below. More info
@@ -71,7 +82,9 @@ type Config struct {
 	Credentials   Credentials
 	Configuration Configuration
 
-	Version         string `yaml:"version,omitempty" ignored:"true"`
+	Version    string           `yaml:"version,omitempty" ignored:"true"`
+	Autodetect AutodetectConfig `yaml:"autodetect,omitempty" ignored:"true"`
+
 	LogLevel        string `yaml:"log_level,omitempty" envconfig:"LOG_LEVEL"`
 	DebugReport     bool   `ignored:"true"`
 	NoColor         bool   `yaml:"no_color,omitempty" envconfig:"NO_COLOR"`
@@ -126,7 +139,7 @@ type Config struct {
 	// ConfigFilePath defines the raw value of the `--config-file` flag provided by the user
 	ConfigFilePath string
 
-	NoCache bool `yaml:"fields,omitempty" ignored:"true"`
+	NoCache bool `yaml:"no_cache,omitempty" ignored:"true"`
 
 	SkipErrLine bool
 

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -38,7 +38,7 @@ func OptionWithTFVarsPaths(paths []string, autoDetected bool) Option {
 		filenames := makePathsRelativeToInitial(paths, p.initialPath)
 		tfVarsPaths := p.tfvarsPaths
 		tfVarsPaths = append(tfVarsPaths, filenames...)
-		sortVarFilesByPrecedence(tfVarsPaths, autoDetected)
+		p.sortVarFilesByPrecedence(tfVarsPaths, autoDetected)
 
 		p.tfvarsPaths = tfVarsPaths
 	}
@@ -52,7 +52,7 @@ func OptionWithTFVarsPaths(paths []string, autoDetected bool) Option {
 // 2. terraform.tfvars.json
 // 3. *.auto.tfvars or *.auto.tfvars.json files, processed in lexical order of their filenames.
 // 4. all other terraform var files
-func sortVarFilesByPrecedence(paths []string, autoDetected bool) {
+func (p *Parser) sortVarFilesByPrecedence(paths []string, autoDetected bool) {
 	sort.Slice(paths, func(i, j int) bool {
 		countI := strings.Count(paths[i], string(filepath.Separator))
 		countJ := strings.Count(paths[j], string(filepath.Separator))
@@ -66,7 +66,7 @@ func sortVarFilesByPrecedence(paths []string, autoDetected bool) {
 			case strings.HasSuffix(path, ".auto.tfvars"), strings.HasSuffix(path, ".auto.tfvars.json"):
 				return 3
 			case autoDetected:
-				if IsGlobalVarFile(path) {
+				if p.projectLocator.IsGlobalVarFile(path) {
 					return 4
 				}
 
@@ -273,23 +273,16 @@ type Parser struct {
 	logger                zerolog.Logger
 	hasChanges            bool
 	moduleSuffix          string
+	projectLocator        *ProjectLocator
 }
 
 // LoadParsers inits a list of Parser with the provided option and initialPath. LoadParsers locates Terraform files
 // in the given initialPath and returns a Parser for each directory it locates a Terraform project within. If
 // the initialPath contains Terraform files at the top level parsers will be len 1.
 func LoadParsers(ctx *config.ProjectContext, initialPath string, loader *modules.ModuleLoader, locatorConfig *ProjectLocatorConfig, logger zerolog.Logger, options ...Option) ([]*Parser, error) {
-	var rootPaths []RootPath
-	if locatorConfig != nil && locatorConfig.SkipAutoDetection {
-		rootPaths = []RootPath{
-			{
-				Path: initialPath,
-			},
-		}
-	} else {
-		pl := NewProjectLocator(logger, locatorConfig)
-		rootPaths = pl.FindRootModules(initialPath)
-	}
+	pl := NewProjectLocator(logger, locatorConfig)
+	rootPaths := pl.FindRootModules(initialPath)
+
 	if len(rootPaths) == 0 && len(locatorConfig.ChangedObjects) > 0 {
 		return nil, nil
 	}
@@ -314,7 +307,7 @@ func LoadParsers(ctx *config.ProjectContext, initialPath string, loader *modules
 					continue
 				}
 
-				if IsGlobalVarFile(varFile) {
+				if pl.IsGlobalVarFile(varFile) {
 					autoVarFiles = append(autoVarFiles, varFile)
 					continue
 				}
@@ -356,7 +349,7 @@ func LoadParsers(ctx *config.ProjectContext, initialPath string, loader *modules
 				sort.Strings(rootPath.TerraformVarFiles)
 
 				for _, env := range varEnvs {
-					parsers = append(parsers, newParser(rootPath, loader, logger, append(
+					parsers = append(parsers, newParser(rootPath, pl, loader, logger, append(
 						options,
 						OptionWithTFVarsPaths(append(autoVarFiles, varFileGrouping[env]...), true),
 						OptionWithModuleSuffix(env),
@@ -371,7 +364,7 @@ func LoadParsers(ctx *config.ProjectContext, initialPath string, loader *modules
 				parserOpts = append(parserOpts, OptionWithTFVarsPaths(append(varFiles, autoVarFiles...), true))
 			}
 
-			parsers = append(parsers, newParser(rootPath, loader, logger, parserOpts...))
+			parsers = append(parsers, newParser(rootPath, pl, loader, logger, parserOpts...))
 		}
 
 		return parsers, nil
@@ -394,13 +387,13 @@ func LoadParsers(ctx *config.ProjectContext, initialPath string, loader *modules
 			options = append(options, OptionWithTFVarsPaths(autoVarFiles, false))
 		}
 
-		parsers[i] = newParser(rootPath, loader, logger, options...)
+		parsers[i] = newParser(rootPath, pl, loader, logger, options...)
 	}
 
 	return parsers, nil
 }
 
-func newParser(projectRoot RootPath, moduleLoader *modules.ModuleLoader, logger zerolog.Logger, options ...Option) *Parser {
+func newParser(projectRoot RootPath, pl *ProjectLocator, moduleLoader *modules.ModuleLoader, logger zerolog.Logger, options ...Option) *Parser {
 	parserLogger := logger.With().Str(
 		"parser_path", projectRoot.Path,
 	).Logger()
@@ -408,14 +401,15 @@ func newParser(projectRoot RootPath, moduleLoader *modules.ModuleLoader, logger 
 	hclParser := modules.NewSharedHCLParser()
 
 	p := &Parser{
-		repoPath:      projectRoot.RepoPath,
-		initialPath:   projectRoot.Path,
-		hasChanges:    projectRoot.HasChanges,
-		workspaceName: defaultTerraformWorkspaceName,
-		hclParser:     hclParser,
-		blockBuilder:  BlockBuilder{SetAttributes: []SetAttributesFunc{SetUUIDAttributes}, Logger: logger, HCLParser: hclParser},
-		logger:        parserLogger,
-		moduleLoader:  moduleLoader,
+		repoPath:       projectRoot.RepoPath,
+		initialPath:    projectRoot.Path,
+		hasChanges:     projectRoot.HasChanges,
+		workspaceName:  defaultTerraformWorkspaceName,
+		hclParser:      hclParser,
+		blockBuilder:   BlockBuilder{SetAttributes: []SetAttributesFunc{SetUUIDAttributes}, Logger: logger, HCLParser: hclParser},
+		logger:         parserLogger,
+		moduleLoader:   moduleLoader,
+		projectLocator: pl,
 	}
 
 	for _, option := range options {

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -147,7 +147,7 @@ output "loadbalancer"  {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -220,7 +220,7 @@ output "exp2" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -267,7 +267,7 @@ output "instances" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -306,7 +306,7 @@ resource "other_resource" "test" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -351,7 +351,7 @@ output "attr_not_exists" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -391,7 +391,7 @@ resource "other_resource" "test" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -443,7 +443,7 @@ output "serviceendpoint_principals" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -481,7 +481,7 @@ output "val" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -499,7 +499,7 @@ func Test_SetsHasChangesOnMod(t *testing.T) {
 	path := createTestFile("test.tf", `variable "foo" {}`)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path), HasChanges: true}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path), HasChanges: true}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -521,7 +521,7 @@ output "val" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -675,7 +675,7 @@ resource "aws_instance" "my_instance" {
 `)
 
 	logger := newDiscardLogger()
-	parser := newParser(RootPath{Path: filepath.Dir(path)}, modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := newParser(RootPath{Path: filepath.Dir(path)}, NewProjectLocator(logger, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 

--- a/internal/hcl/project_locator_test.go
+++ b/internal/hcl/project_locator_test.go
@@ -38,7 +38,7 @@ func TestProjectLocator_FindRootModules_WithMultiProject(t *testing.T) {
 
 func TestProjectLocator_FindRootModules_WithMultiProject_ExcludeDirs(t *testing.T) {
 	pl := NewProjectLocator(newDiscardLogger(), &ProjectLocatorConfig{
-		ExcludedSubDirs: []string{"dev"},
+		ExcludedDirs: []string{"dev"},
 	})
 	p := "./testdata/project_locator/multi_project_with_module"
 	mods := pl.FindRootModules(p)
@@ -91,7 +91,7 @@ func TestProjectLocator_FindRootModules_WithMultiProjectWithoutProviderBlocks(t 
 func TestProjectLocator_FindRootModules_WithMultiProjectWithoutProviderBlocks_ExludePaths(t *testing.T) {
 	pl := NewProjectLocator(newDiscardLogger(), &ProjectLocatorConfig{
 		UseAllPaths: true,
-		ExcludedSubDirs: []string{
+		ExcludedDirs: []string{
 			"modules/**",
 		},
 	})

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -138,7 +138,9 @@ func NewHCLProvider(ctx *config.ProjectContext, config *HCLProviderConfig, opts 
 	runCtx := ctx.RunContext
 	locatorConfig := &hcl.ProjectLocatorConfig{
 		SkipAutoDetection: config.SkipAutoDetection,
-		ExcludedSubDirs:   ctx.ProjectConfig.ExcludePaths,
+		ExcludedDirs:      append(ctx.ProjectConfig.ExcludePaths, ctx.RunContext.Config.Autodetect.ExcludedDirs...),
+		IncludedDirs:      ctx.RunContext.Config.Autodetect.IncludedDirs,
+		EnvNames:          ctx.RunContext.Config.Autodetect.EnvNames,
 		ChangedObjects:    runCtx.VCSMetadata.Commit.ChangedObjects,
 		UseAllPaths:       ctx.ProjectConfig.IncludeAllPaths,
 	}


### PR DESCRIPTION
Adds new autodetect section to configuration file which passes configuration down to the `ProjectLocator`. This adds the ability to:

* add projects which haven't been detected with - included_dirs
* exclude bad projects from the autodetection with - excluded_dirs
* change the naming conventions for the env var files with - env_names

The `generate` functionality has had to be changed to accomodate this new functionality. We now need to "partially" unmarshal the template before running autodetect. This is not supported natively by the goyml package so we need to seek the file to build a partial YAML that can be marshalled without errors.