### PR TITLE
feat: add DetectedRootModules template variable IC-603 

### DIFF
--- a/cmd/infracost/testdata/generate/detected_root_modules/expected.golden
+++ b/cmd/infracost/testdata/generate/detected_root_modules/expected.golden
@@ -1,0 +1,23 @@
+version: 0.1
+projects:
+  - path: apps/bar
+    name: apps-bar-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+  - path: apps/bar
+    name: apps-bar-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
+  - path: apps/foo
+    name: apps-foo-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+  - path: apps/foo
+    name: apps-foo-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
+

--- a/cmd/infracost/testdata/generate/detected_root_modules/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/detected_root_modules/infracost.yml.tmpl
@@ -1,0 +1,12 @@
+version: 0.1
+projects:
+{{- range $mod := .DetectedRootModules }}
+  {{- range $project := $mod.Projects }}
+  - path: {{ $mod.Path }}
+    name: {{ $project.Name }}
+    terraform_var_files:
+    {{- range $varFile := $project.TerraformVarFiles }}
+      - {{ $varFile }}
+    {{- end }}
+  {{- end}}
+{{- end }}

--- a/cmd/infracost/testdata/generate/detected_root_modules/tree.txt
+++ b/cmd/infracost/testdata/generate/detected_root_modules/tree.txt
@@ -1,0 +1,9 @@
+.
+└── apps
+    ├── bar
+    │   └── main.tf
+    ├── foo
+    │   └── main.tf
+    ├── dev.tfvars
+    ├── prod.tfvars
+    └── default.tfvars

--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -25,11 +25,17 @@ type DetectedProject struct {
 	TerraformVarFiles []string
 }
 
+type DetectedRooModule struct {
+	Path     string
+	Projects []DetectedProject
+}
+
 // Variables hold the global variables that are passed into any template that the Parser evaluates.
 type Variables struct {
-	Branch           string
-	BaseBranch       string
-	DetectedProjects []DetectedProject
+	Branch              string
+	BaseBranch          string
+	DetectedProjects    []DetectedProject
+	DetectedRootModules []DetectedRooModule
 }
 
 // Parser is the representation of an initialized Infracost template parser.


### PR DESCRIPTION
Adds support for a DetectedRootModules variable which is a deduped list
of DetectedProjects by path. The variable contains a list of Projects for
each corresponding path to facilitate composability in the template.

depends on https://github.com/infracost/infracost/pull/2820