### PR TITLE
refactor: use different mocking logic for graph evaluator IC-608

### DIFF
--- a/internal/hcl/attribute_test.go
+++ b/internal/hcl/attribute_test.go
@@ -113,6 +113,8 @@ func TestAttribute_AsString(t *testing.T) {
 }
 
 func TestAttributeValueWithIncompleteContextAndConditionalShouldNotPanic(t *testing.T) {
+	t.Setenv("INFRACOST_GRAPH_EVALUATOR", "true")
+
 	p := hclparse.NewParser()
 	f, diags := p.ParseHCL([]byte(`
 locals {
@@ -172,7 +174,7 @@ locals {
 	}
 
 	v := attr.Value()
-	assert.Equal(t, cty.DynamicVal, v)
+	assert.Equal(t, cty.StringVal("transformed_tags-mock"), v)
 
 	b, err := io.ReadAll(buf)
 	require.NoError(t, err)

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -762,11 +762,19 @@ func (e *Evaluator) evaluateVariable(b *Block, inputVars map[string]cty.Value) (
 
 	attrType := attributes["type"]
 	if override, exists := inputVars[b.Label()]; exists {
-		return e.convertType(b, override, attrType)
+		val, err := e.convertType(b, override, attrType)
+		if err == nil {
+			return val, nil
+		}
+
+		return override, nil
 	}
 
 	if def, exists := attributes["default"]; exists {
-		return e.convertType(b, def.Value(), attrType)
+		val, err := e.convertType(b, def.Value(), attrType)
+		if err == nil {
+			return val, nil
+		}
 	}
 
 	c, err := e.convertType(b, cty.DynamicVal, attrType)

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -290,6 +290,7 @@ func LoadParsers(ctx *config.ProjectContext, initialPath string, loader *modules
 		pl := NewProjectLocator(logger, locatorConfig)
 		rootPaths = pl.FindRootModules(initialPath)
 	}
+
 	if len(rootPaths) == 0 && len(locatorConfig.ChangedObjects) > 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
This PR changes the mocking logic in the graph evaluator to an expression based approach. Now instead of changing the global Context we instead traverse any expression that is found with a Diagnostic. We walk this expression tree until we hit an expression that is a candidate for mocking. These are:

* hclsyntax.AnonSymbolExpr:
* hclsyntax.LiteralValueExpr
* hclsyntax.ScopeTraversalExpr:

and occasionally hclsyntax.FunctionCallExpr

These are Expressions that likely correspond to "incomplete" values that infracost cannot build. E.g. hclsyntax.ScopeTraversalExpr directly relates to a "missing attribute" or "invalid attribute" diagnostics that are 95% of the cases that we handle. These come about through lack of complete information because attributes/blocks which are populated from the cloud, e.g. data blocks.

Whilst this method works for the normal evaluator, i've only enabled it for the graph evaluator at the moment as this new functionality creates occasional issues with count/for_each attributes that rely on values not already populated in the context - e.g. for_each attributes that rely on module outputs.