### PR TITLE
fix: handle autodetect section with `--template` arg

### DIFF
--- a/cmd/infracost/testdata/generate/include_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/include_dirs/expected.golden
@@ -3,6 +3,7 @@ autodetect:
   included_dirs:
     - apps/bat
     - apps/baz
+    - apps/wildcard/**
 
 projects:
   - path: apps/bar
@@ -45,4 +46,24 @@ projects:
     terraform_var_files:
       - ../default.tfvars
       - ../prod.tfvars
+  - path: apps/wildcard/one
+    name: apps-wildcard-one-dev
+    terraform_var_files:
+      - ../../default.tfvars
+      - ../../dev.tfvars
+  - path: apps/wildcard/one
+    name: apps-wildcard-one-prod
+    terraform_var_files:
+      - ../../default.tfvars
+      - ../../prod.tfvars
+  - path: apps/wildcard/two
+    name: apps-wildcard-two-dev
+    terraform_var_files:
+      - ../../default.tfvars
+      - ../../dev.tfvars
+  - path: apps/wildcard/two
+    name: apps-wildcard-two-prod
+    terraform_var_files:
+      - ../../default.tfvars
+      - ../../prod.tfvars
 

--- a/cmd/infracost/testdata/generate/include_dirs/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/include_dirs/infracost.yml.tmpl
@@ -3,6 +3,7 @@ autodetect:
   included_dirs:
     - apps/bat
     - apps/baz
+    - apps/wildcard/**
 
 projects:
 {{- range $project := .DetectedProjects }}

--- a/cmd/infracost/testdata/generate/include_dirs/tree.txt
+++ b/cmd/infracost/testdata/generate/include_dirs/tree.txt
@@ -8,6 +8,11 @@
     │   └── foo.tf
     ├── bat
     │   └── bip.tf
+    ├── wildcard
+    │   ├── one
+    │   │   └── fip.tf
+    │   └── two
+    │       └── fip.tf
     ├── dev.tfvars
     ├── prod.tfvars
     └── default.tfvars


### PR DESCRIPTION
This PR adds support for the autodetect section when using the `--template` command line arg.