### PR TITLE
refactor: change naming for autodetect fields

### DIFF
--- a/cmd/infracost/generate.go
+++ b/cmd/infracost/generate.go
@@ -86,8 +86,8 @@ func (g *generateConfigCommand) run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to unmarshal autodetect section: %w", err)
 		}
 
-		locatorConfig.ExcludedDirs = partialConfig.Autodetect.ExcludedDirs
-		locatorConfig.IncludedDirs = partialConfig.Autodetect.IncludedDirs
+		locatorConfig.ExcludedDirs = partialConfig.Autodetect.ExcludeDirs
+		locatorConfig.IncludedDirs = partialConfig.Autodetect.IncludeDirs
 		locatorConfig.EnvNames = partialConfig.Autodetect.EnvNames
 
 		_, _ = reader.Seek(0, io.SeekStart)

--- a/cmd/infracost/testdata/generate/excluded_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/excluded_dirs/expected.golden
@@ -1,6 +1,6 @@
 version: 0.1
 autodetect:
-  excluded_dirs:
+  exclude_dirs:
     - apps/foo
 
 projects:

--- a/cmd/infracost/testdata/generate/excluded_dirs/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/excluded_dirs/infracost.yml.tmpl
@@ -1,6 +1,6 @@
 version: 0.1
 autodetect:
-  excluded_dirs:
+  exclude_dirs:
     - apps/foo
 
 projects:

--- a/cmd/infracost/testdata/generate/include_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/include_dirs/expected.golden
@@ -1,6 +1,6 @@
 version: 0.1
 autodetect:
-  included_dirs:
+  include_dirs:
     - apps/bat
     - apps/baz
     - apps/wildcard/**

--- a/cmd/infracost/testdata/generate/include_dirs/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/include_dirs/infracost.yml.tmpl
@@ -1,6 +1,6 @@
 version: 0.1
 autodetect:
-  included_dirs:
+  include_dirs:
     - apps/bat
     - apps/baz
     - apps/wildcard/**

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,11 +23,11 @@ type AutodetectConfig struct {
 	// EnvNames is the list of environment names that we should use to group
 	// terraform var files.
 	EnvNames []string `yaml:"env_names,omitempty" ignored:"true"`
-	// ExcludedDirs is a list of directories that the autodetect should ignore.
-	ExcludedDirs []string `yaml:"excluded_dirs,omitempty" ignored:"true"`
-	// IncludedDirs is a list of directories that the autodetect should append
+	// ExcludeDirs is a list of directories that the autodetect should ignore.
+	ExcludeDirs []string `yaml:"exclude_dirs,omitempty" ignored:"true"`
+	// IncludeDirs is a list of directories that the autodetect should append
 	// to the already detected directories.
-	IncludedDirs []string `yaml:"included_dirs,omitempty" ignored:"true"`
+	IncludeDirs []string `yaml:"include_dirs,omitempty" ignored:"true"`
 }
 
 // Project defines a specific terraform project config. This can be used

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -138,8 +138,8 @@ func NewHCLProvider(ctx *config.ProjectContext, config *HCLProviderConfig, opts 
 	runCtx := ctx.RunContext
 	locatorConfig := &hcl.ProjectLocatorConfig{
 		SkipAutoDetection: config.SkipAutoDetection,
-		ExcludedDirs:      append(ctx.ProjectConfig.ExcludePaths, ctx.RunContext.Config.Autodetect.ExcludedDirs...),
-		IncludedDirs:      ctx.RunContext.Config.Autodetect.IncludedDirs,
+		ExcludedDirs:      append(ctx.ProjectConfig.ExcludePaths, ctx.RunContext.Config.Autodetect.ExcludeDirs...),
+		IncludedDirs:      ctx.RunContext.Config.Autodetect.IncludeDirs,
 		EnvNames:          ctx.RunContext.Config.Autodetect.EnvNames,
 		ChangedObjects:    runCtx.VCSMetadata.Commit.ChangedObjects,
 		UseAllPaths:       ctx.ProjectConfig.IncludeAllPaths,


### PR DESCRIPTION
renames included and excluded to be present tense so that they are more compatible with cmd line flags in the future.