### PR TITLE
feat: add terragrunt auto-detect support

### DIFF
--- a/cmd/infracost/diff.go
+++ b/cmd/infracost/diff.go
@@ -129,7 +129,7 @@ func checkDiffConfig(cfg *config.Config) error {
 		}
 
 		projectType := providers.DetectProjectType(projectConfig.Path, projectConfig.TerraformForceCLI)
-		if (projectType == providers.ProjectTypeAutodetect || projectType == providers.ProjectTypeTerragruntDir) && cfg.CompareTo == "" {
+		if (projectType == providers.ProjectTypeAutodetect) && cfg.CompareTo == "" {
 			examplePath := "/code"
 			if projectConfig.Path != "" {
 				examplePath = projectConfig.Path

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -242,6 +242,7 @@ func (r *parallelRunner) run() ([]projectResult, error) {
 	for _, p := range r.runCtx.Config.Projects {
 		ctx := config.NewProjectContext(r.runCtx, p, map[string]interface{}{})
 		detected, err := providers.Detect(r.runCtx, p, r.prior == nil)
+
 		if err != nil {
 			m := fmt.Sprintf("%s\n\n", err)
 			m += fmt.Sprintf("Try adding a config-file to configure how Infracost should run. See %s for details and examples.", ui.LinkString("https://infracost.io/config-file"))

--- a/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/breakdown_terragrunt_diff_project_error.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/breakdown_terragrunt_diff_project_error.golden
@@ -8,9 +8,19 @@ Errors:
           no such file or directory
 
 ──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error
+Errors:
+  Error processing module at 'REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/foo/terragrunt.hcl'. How this module was found:
+    dependency of module at 'REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/example/dev'. Underlying error:
+      Error reading file at path REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/foo/terragrunt.hcl:
+        open REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/foo/terragrunt.hcl:
+          no such file or directory
+
+──────────────────────────────────
 
 No cloud resources were detected
 
 Err:
+
 
 

--- a/cmd/infracost/testdata/breakdown_terragrunt_get_env_with_whitelist/breakdown_terragrunt_get_env_with_whitelist.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_get_env_with_whitelist/breakdown_terragrunt_get_env_with_whitelist.golden
@@ -2,20 +2,43 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_get_env
 
 Errors:
   Error processing module at 'REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_get_env_with_whitelist/dev/terragrunt.hcl'. How this module was found:
-    Terragrunt config file found in a subdirectory of testdata/breakdown_terragrunt_get_env_with_whitelist. Underlying error:
+    Terragrunt config file found in a subdirectory of testdata/breakdown_terragrunt_get_env_with_whitelist/dev. Underlying error:
       REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_get_env_with_whitelist/dev/terragrunt.hcl:6,9-17:
         Error in function call; Call to function "get_env" failed:
           EnvVarNotFound:
             Required environment variable UNSAFE_VAR - not found.
 
- OVERALL TOTAL       $0.00 
 ──────────────────────────────────
-No cloud resources were detected
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_get_env_with_whitelist/prod
+Module path: prod
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost 
+                                                                                                                      
+ aws_instance.web_app                                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64 
+ ├─ root_block_device                                                                                                 
+ │  └─ Storage (general purpose SSD, gp2)                               100  GB                                $10.00 
+ └─ ebs_block_device[0]                                                                                               
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00 
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00 
+                                                                                                                      
+ aws_lambda_function.hello_world                                                                                      
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests          
+ ├─ Ephemeral storage                                   Monthly cost depends on usage: $0.0000000309 per GB-seconds   
+ └─ Duration (first 6B)                                 Monthly cost depends on usage: $0.0000166667 per GB-seconds   
+                                                                                                                      
+ Project total                                                                                                $747.64 
+
+ OVERALL TOTAL                                                                                                $747.64 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
 ┃ infracost/infracost/cmd/infraco...ragrunt_get_env_with_whitelist ┃ $0.00        ┃
+┃ infracost/infracost/cmd/infraco...nt_get_env_with_whitelist/prod ┃ $748         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
@@ -156,9 +156,10 @@ Module path: ref2
 
  OVERALL TOTAL                                                                                                        $5,290.62 
 ──────────────────────────────────
-114 cloud resources were detected:
+115 cloud resources were detected:
 ∙ 21 were estimated, 14 of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 93 were free, rerun with --show-skipped to see details
+∙ 1 is not supported yet, rerun with --show-skipped to see details
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃

--- a/cmd/infracost/testdata/generate/terragrunt/expected.golden
+++ b/cmd/infracost/testdata/generate/terragrunt/expected.golden
@@ -1,0 +1,7 @@
+version: 0.1
+
+projects:
+  - path: apps/bar
+  - path: apps/baz/bip
+  - path: apps/foo
+

--- a/cmd/infracost/testdata/generate/terragrunt/tree.txt
+++ b/cmd/infracost/testdata/generate/terragrunt/tree.txt
@@ -1,0 +1,11 @@
+.
+├── apps
+│   ├── bar
+│   │   └── terragrunt.hcl
+│   ├── foo
+│   │   └── terragrunt.hcl.json
+│   └── baz
+│       ├── terragrunt.hcl
+│       └── bip
+│           └── terragrunt.hcl.json
+└── terragrunt.hcl

--- a/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/expected.golden
+++ b/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/expected.golden
@@ -1,0 +1,17 @@
+version: 0.1
+
+projects:
+  - path: apps/bar
+  - path: apps/baz/bip
+  - path: apps/fez
+    name: apps-fez-dev
+    terraform_var_files:
+      - ../envs/dev.tfvars
+    skip_autodetect: true
+  - path: apps/fez
+    name: apps-fez-prod
+    terraform_var_files:
+      - ../envs/prod.tfvars
+    skip_autodetect: true
+  - path: apps/foo
+

--- a/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/infracost.yml.tmpl
@@ -1,0 +1,4 @@
+version: 0.1
+autodetect:
+  include_dirs:
+    - fez

--- a/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/tree.txt
+++ b/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/tree.txt
@@ -1,0 +1,17 @@
+.
+└── apps
+    ├── bar
+    │   └── terragrunt.hcl
+    ├── foo
+    │   └── terragrunt.hcl
+    ├── baz
+    │   ├── terragrunt.hcl
+    │   └── bip
+    │       └── terragrunt.hcl.json
+    ├── _module
+    │   └── main.tf
+    ├── fez
+    │   └── main.tf
+    └── envs
+        ├── prod.tfvars
+        └── dev.tfvars

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -256,6 +256,13 @@ func OptionWithSpinner(f ui.SpinnerFunc) Option {
 	}
 }
 
+type DetectedProject interface {
+	ProjectName() string
+	RelativePath() string
+	TerraformVarFiles() []string
+	YAML() string
+}
+
 // Parser is a tool for parsing terraform templates at a given file system location.
 type Parser struct {
 	repoPath              string

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -79,7 +79,7 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 		projectContext := config.NewProjectContext(ctx, project, nil)
 		if rootPath.IsTerragrunt {
 			projectContext.ContextValues.SetValue("project_type", "terragrunt_dir")
-			autoProviders = append(autoProviders, terraform.NewTerragruntHCLProvider(rootPath, projectContext, includePastResources))
+			autoProviders = append(autoProviders, terraform.NewTerragruntHCLProvider(rootPath, projectContext))
 		} else {
 			options := []hcl.Option{hcl.OptionWithSpinner(ctx.NewSpinner)}
 			projectContext.ContextValues.SetValue("project_type", "terraform_dir")

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -168,6 +168,22 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 	}, nil
 }
 
+func (p *HCLProvider) ProjectName() string {
+	return p.Parser.ProjectName()
+}
+
+func (p *HCLProvider) RelativePath() string {
+	return p.Parser.RelativePath()
+}
+
+func (p *HCLProvider) TerraformVarFiles() []string {
+	return p.Parser.TerraformVarFiles()
+}
+
+func (p *HCLProvider) YAML() string {
+	return p.Parser.YAML()
+}
+
 func (p *HCLProvider) Type() string        { return "terraform_dir" }
 func (p *HCLProvider) DisplayType() string { return "Terraform directory" }
 func (p *HCLProvider) AddMetadata(metadata *schema.ProjectMetadata) {

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -431,6 +431,10 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 
 			workingDirInfo := p.runTerragrunt(opts)
 			_, _ = terragruntOutputCache.Set(opts.TerragruntConfigPath, func() (cty.Value, error) {
+				if workingDirInfo == nil {
+					return cty.EmptyObjectVal, errors.New("nil outputs")
+				}
+
 				return workingDirInfo.evaluatedOutputs, nil
 			})
 			if workingDirInfo != nil {
@@ -931,6 +935,10 @@ func (p *TerragruntHCLProvider) fetchModuleOutputs(opts *tgoptions.TerragruntOpt
 					info := p.runTerragrunt(opts.Clone(dir))
 					if info != nil && info.error != nil {
 						return cty.NilVal, fmt.Errorf("could not evaluate dependency %s at dir %s err: %w", dep.Name, dir, err)
+					}
+
+					if info == nil {
+						return cty.EmptyObjectVal, nil
 					}
 
 					return info.evaluatedOutputs, nil

--- a/internal/testutil/generate.go
+++ b/internal/testutil/generate.go
@@ -71,6 +71,10 @@ func createFileWithContents(filePath string) error {
     }
   }
 }`
+	case "terragrunt.hcl.json":
+		content = `include {
+	path = find_in_parent_folders()		
+}`
 	default:
 		content = ""
 	}


### PR DESCRIPTION
Changes the ProjectLocator to support Terragrunt projects. For the time being I have not change the `TerragruntHCLProvider` to take into account that it has a 1-1 link with a Terragrunt project (e.g. no need to find stacks in the Provider). I didn't want to change to many things as this is quite a dramatic change to how we do things. I will follow up later with a refactor to remove unecessary code.