### PR TITLE
feat: add auto-detect cousin support

### DIFF
--- a/cmd/infracost/testdata/generate/cousin/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin/expected.golden
@@ -1,0 +1,33 @@
+version: 0.1
+
+projects:
+  - path: infra/components/foo
+    name: infra-components-foo-dev
+    terraform_var_files:
+      - ../../variables/envs/dev/dev.tfvars
+    terraform_workspace: default
+  - path: infra/components/foo
+    name: infra-components-foo-prod
+    terraform_var_files:
+      - ../../variables/envs/prod/prod.tfvars
+    terraform_workspace: default
+  - path: infra/nested/components/baz
+    name: infra-nested-components-baz-dev
+    terraform_var_files:
+      - ../../variables/envs/defaults.tfvars
+      - ../../../variables/envs/dev/dev.tfvars
+      - ../../variables/envs/dev/dev.tfvars
+    terraform_workspace: default
+  - path: infra/nested/components/baz
+    name: infra-nested-components-baz-prod
+    terraform_var_files:
+      - ../../variables/envs/defaults.tfvars
+      - ../../../variables/envs/prod/prod.tfvars
+    terraform_workspace: default
+  - path: infra/nested/components/baz
+    name: infra-nested-components-baz-stag
+    terraform_var_files:
+      - ../../variables/envs/defaults.tfvars
+      - ../../variables/envs/stag/stag.tfvars
+    terraform_workspace: default
+

--- a/cmd/infracost/testdata/generate/cousin/tree.txt
+++ b/cmd/infracost/testdata/generate/cousin/tree.txt
@@ -1,0 +1,22 @@
+.
+└── infra
+    ├── components
+    │   └── foo
+    │       └── main.tf
+    ├── variables
+    │   └── envs
+    │       ├── dev
+    │       │   └── dev.tfvars
+    │       └── prod
+    │           └── prod.tfvars
+    └── nested
+        ├── components
+        │   └── baz
+        │       └── main.tf
+        └── variables
+            └── envs
+                ├── stag
+                │   └── stag.tfvars
+                ├── dev
+                │   └── dev.tfvars
+                └── defaults.tfvars

--- a/cmd/infracost/testdata/generate/cousin_flat/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin_flat/expected.golden
@@ -1,0 +1,16 @@
+version: 0.1
+
+projects:
+  - path: .
+    name: main-dev
+    terraform_var_files:
+      - variables/envs/defaults.tfvars
+      - variables/envs/dev/dev.tfvars
+    terraform_workspace: default
+  - path: .
+    name: main-prod
+    terraform_var_files:
+      - variables/envs/defaults.tfvars
+      - variables/envs/prod/prod.tfvars
+    terraform_workspace: default
+

--- a/cmd/infracost/testdata/generate/cousin_flat/tree.txt
+++ b/cmd/infracost/testdata/generate/cousin_flat/tree.txt
@@ -1,0 +1,9 @@
+.
+├── main.tf
+└── variables
+    └── envs
+        ├── dev
+        │   └── dev.tfvars
+        ├── prod
+        │   └── prod.tfvars
+        └── defaults.tfvars

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -463,12 +463,12 @@ func (p *Parser) ProjectName() string {
 	r := p.RelativePath()
 	name := strings.TrimSuffix(r, "/")
 	name = strings.ReplaceAll(name, "/", "-")
-	if p.moduleSuffix != "" {
-		name = fmt.Sprintf("%s-%s", name, p.moduleSuffix)
+	if name == "." {
+		name = "main"
 	}
 
-	if name == "." {
-		return "main"
+	if p.moduleSuffix != "" {
+		name = fmt.Sprintf("%s-%s", name, p.moduleSuffix)
 	}
 
 	return name

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -36,6 +36,7 @@ var (
 		"live",
 		"sandbox",
 		"sbx",
+		"sbox",
 		"demo",
 		"integration",
 		"int",

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -16,7 +16,41 @@ import (
 )
 
 var (
-	defaultEnvVarNames = createEnvVarNamesRegex([]string{"prd", "prod", "production", "preprod", "staging", "stage", "stg", "development", "dev", "release", "testing", "test", "tst", "qa", "uat", "live", "sandbox", "demo", "integration", "int", "experimental", "experiments", "trial", "validation", "perf", "sec", "dr"})
+	defaultEnvVarNames = createEnvVarNamesRegex([]string{
+		"prd",
+		"prod",
+		"production",
+		"preprod",
+		"staging",
+		"stage",
+		"stg",
+		"stag",
+		"development",
+		"dev",
+		"release",
+		"testing",
+		"test",
+		"tst",
+		"qa",
+		"uat",
+		"live",
+		"sandbox",
+		"sbx",
+		"demo",
+		"integration",
+		"int",
+		"experimental",
+		"experiments",
+		"trial",
+		"validation",
+		"perf",
+		"sec",
+		"dr",
+		"load",
+		"management",
+		"mgmt",
+		"playground",
+	})
 
 	VarFileEnvPrefixRegxp = regexp.MustCompile(`^(\w+)[-_]`)
 	VarFileEnvSuffixRegxp = regexp.MustCompile(`[-_](\w+)$`)
@@ -328,31 +362,19 @@ func (t *TreeNode) UnusedParentVarFiles() []*VarFiles {
 	return append(varFiles, parent.UnusedParentVarFiles()...)
 }
 
-// UnusedAuntVarFiles returns a list of any aunt directories that contain var
-// files that have not been used by a project.
-func (t *TreeNode) UnusedAuntVarFiles() []*VarFiles {
-	// if we don't have a root path, we can't have an aunt.
-	if t.RootPath == nil {
-		return nil
-	}
-
+// FindTfvarsCommonParent returns the first parent directory that has a child
+// directory with a root Terraform project.
+func (t *TreeNode) FindTfvarsCommonParent() *TreeNode {
 	parent := t.Parent
-	if parent == nil {
-		return nil
-	}
-
-	// get the parent of the parent as this will be above the current node.
-	parent = t.Parent
-	var varFiles []*VarFiles
 
 	for {
 		if parent == nil {
-			return varFiles
+			return nil
 		}
 
-		for _, child := range parent.Children {
-			if child.TerraformVarFiles != nil && !child.TerraformVarFiles.Used && child.RootPath == nil {
-				varFiles = append(varFiles, child.TerraformVarFiles)
+		for _, child := range parent.ChildNodesExcluding(t) {
+			if child.RootPath != nil {
+				return parent
 			}
 		}
 
@@ -360,7 +382,26 @@ func (t *TreeNode) UnusedAuntVarFiles() []*VarFiles {
 	}
 }
 
-// ChildNodes returns a list of child nodes that are Terraform projects or
+// ChildNodesExcluding collects all the child nodes of the current node,
+// excluding the given root node.
+func (t *TreeNode) ChildNodesExcluding(root *TreeNode) []*TreeNode {
+	var children []*TreeNode
+	for _, child := range t.Children {
+		if child.shouldVisitNode() && child != root {
+			children = append(children, child)
+		}
+	}
+
+	for _, child := range t.Children {
+		if child != root {
+			children = append(children, child.ChildNodesExcluding(root)...)
+		}
+	}
+
+	return children
+}
+
+// ChildNodes returns the first set of child nodes that are Terraform projects or
 // directories that contain var files.
 func (t *TreeNode) ChildNodes() []*TreeNode {
 	var children []*TreeNode
@@ -578,14 +619,21 @@ func (t *TreeNode) AssociateAuntVarFiles() {
 	})
 
 	t.PostOrder(func(t *TreeNode) {
-		if t.RootPath == nil {
+		if t.TerraformVarFiles == nil || t.TerraformVarFiles.Used {
 			return
 		}
 
-		varFiles := t.UnusedAuntVarFiles()
-		for _, varFile := range varFiles {
-			t.RootPath.AddVarFiles(varFile.Path, varFile.Files)
+		commonParent := t.FindTfvarsCommonParent()
+		if commonParent == nil {
+			return
 		}
+
+		for _, node := range commonParent.ChildNodesExcluding(t) {
+			if node.RootPath != nil {
+				node.RootPath.AddVarFiles(t.TerraformVarFiles.Path, t.TerraformVarFiles.Files)
+			}
+		}
+
 	})
 }
 


### PR DESCRIPTION
Adds support for var files found in cousin directories, or put another way any var files found in sub directories of aunts. I have also added additional env names to the global list, to improve env var file detection.