### PR TITLE
feat: add skip_auto_detection for autogenerated config files

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1171,3 +1171,19 @@ func TestBreakdownWithPolicyDataUploadTerragrunt(t *testing.T) {
 
 	testutil.AssertGoldenFile(t, path.Join("./testdata", testName, testName+"-upload.golden"), stripDynamicValues(uploadWriter.Bytes()))
 }
+
+func TestBreakdownConfigFileWithSkipAutoDetect(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--config-file", path.Join(dir, "infracost.yml"),
+		},
+		&GoldenFileOptions{
+			IsJSON: true,
+		},
+	)
+}

--- a/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/breakdown_config_file_with_skip_auto_detect.golden
+++ b/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/breakdown_config_file_with_skip_auto_detect.golden
@@ -1,0 +1,45 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infra
+Module path: infra
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.8xlarge)          730  hours     $1,121.28 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ Project total                                                                 $1,303.28 
+
+──────────────────────────────────
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infra/dev
+Module path: infra/dev
+
+ Name                                                   Monthly Qty  Unit   Monthly Cost 
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours       $560.64 
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                        50  GB            $5.00 
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB          $125.00 
+    └─ Provisioned IOPS                                         800  IOPS         $52.00 
+                                                                                         
+ Project total                                                                   $742.64 
+
+ OVERALL TOTAL                                                                 $2,045.92 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...le_with_skip_auto_detect/infra ┃ $1,303       ┃
+┃ infracost/infracost/cmd/infraco...ith_skip_auto_detect/infra/dev ┃ $743         ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infra/dev/main.tf
+++ b/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infra/dev/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infra/main.tf
+++ b/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infra/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.8xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infracost.yml
+++ b/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infracost.yml
@@ -2,6 +2,6 @@ version: 0.1
 
 projects:
   - path: "./testdata/breakdown_config_file_with_skip_auto_detect/infra"
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: "./testdata/breakdown_config_file_with_skip_auto_detect/infra/dev"
-    skip_auto_detection: true
+    skip_autodetect: true

--- a/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infracost.yml
+++ b/cmd/infracost/testdata/breakdown_config_file_with_skip_auto_detect/infracost.yml
@@ -1,0 +1,7 @@
+version: 0.1
+
+projects:
+  - path: "./testdata/breakdown_config_file_with_skip_auto_detect/infra"
+    skip_auto_detection: true
+  - path: "./testdata/breakdown_config_file_with_skip_auto_detect/infra/dev"
+    skip_auto_detection: true

--- a/cmd/infracost/testdata/generate/aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt/expected.golden
@@ -6,47 +6,47 @@ projects:
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt/expected.golden
@@ -6,47 +6,47 @@ projects:
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
@@ -8,7 +8,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
@@ -16,7 +16,7 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
@@ -24,7 +24,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
@@ -32,7 +32,7 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
@@ -40,7 +40,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
@@ -48,7 +48,7 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
@@ -56,7 +56,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
@@ -64,5 +64,5 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
@@ -8,7 +8,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
@@ -16,7 +16,7 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
@@ -24,7 +24,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
@@ -32,7 +32,7 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
@@ -40,7 +40,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
@@ -48,7 +48,7 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
@@ -56,7 +56,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
@@ -64,5 +64,5 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/child/expected.golden
+++ b/cmd/infracost/testdata/generate/child/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - envs/default.tfvars
       - envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - envs/default.tfvars
       - envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - envs/default.tfvars
       - envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - envs/default.tfvars
       - envs/staging.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/child/expected.golden
+++ b/cmd/infracost/testdata/generate/child/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - envs/default.tfvars
       - envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - envs/default.tfvars
       - envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - envs/default.tfvars
       - envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - envs/default.tfvars
       - envs/staging.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/cousin/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin/expected.golden
@@ -5,29 +5,29 @@ projects:
     name: infra-components-foo-dev
     terraform_var_files:
       - ../../variables/envs/dev/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/components/foo
     name: infra-components-foo-prod
     terraform_var_files:
       - ../../variables/envs/prod/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-dev
     terraform_var_files:
       - ../../variables/envs/defaults.tfvars
       - ../../../variables/envs/dev/dev.tfvars
       - ../../variables/envs/dev/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-prod
     terraform_var_files:
       - ../../variables/envs/defaults.tfvars
       - ../../../variables/envs/prod/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-stag
     terraform_var_files:
       - ../../variables/envs/defaults.tfvars
       - ../../variables/envs/stag/stag.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/cousin/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin/expected.golden
@@ -5,29 +5,29 @@ projects:
     name: infra-components-foo-dev
     terraform_var_files:
       - ../../variables/envs/dev/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/components/foo
     name: infra-components-foo-prod
     terraform_var_files:
       - ../../variables/envs/prod/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-dev
     terraform_var_files:
       - ../../variables/envs/defaults.tfvars
       - ../../../variables/envs/dev/dev.tfvars
       - ../../variables/envs/dev/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-prod
     terraform_var_files:
       - ../../variables/envs/defaults.tfvars
       - ../../../variables/envs/prod/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-stag
     terraform_var_files:
       - ../../variables/envs/defaults.tfvars
       - ../../variables/envs/stag/stag.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/cousin_flat/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin_flat/expected.golden
@@ -6,11 +6,11 @@ projects:
     terraform_var_files:
       - variables/envs/defaults.tfvars
       - variables/envs/dev/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: .
     name: main-prod
     terraform_var_files:
       - variables/envs/defaults.tfvars
       - variables/envs/prod/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/cousin_flat/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin_flat/expected.golden
@@ -6,11 +6,11 @@ projects:
     terraform_var_files:
       - variables/envs/defaults.tfvars
       - variables/envs/dev/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: .
     name: main-prod
     terraform_var_files:
       - variables/envs/defaults.tfvars
       - variables/envs/prod/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/env_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/env_dirs/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/dev/baz.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/components/baz
     name: infra-components-baz-stag
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/stag/bop.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/components/foo
     name: infra-components-foo-dev
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/dev/baz.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/components/foo
     name: infra-components-foo-stag
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/stag/bop.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/env_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/env_dirs/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/dev/baz.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/components/baz
     name: infra-components-baz-stag
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/stag/bop.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/components/foo
     name: infra-components-foo-dev
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/dev/baz.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/components/foo
     name: infra-components-foo-stag
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/stag/bop.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/grandchild/expected.golden
+++ b/cmd/infracost/testdata/generate/grandchild/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/staging.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/grandchild/expected.golden
+++ b/cmd/infracost/testdata/generate/grandchild/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/staging.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/grandparent/expected.golden
@@ -6,47 +6,47 @@ projects:
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/grandparent/expected.golden
@@ -6,47 +6,47 @@ projects:
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/great_aunt/expected.golden
@@ -6,47 +6,47 @@ projects:
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/great_aunt/expected.golden
@@ -6,47 +6,47 @@ projects:
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/multi_descendents/expected.golden
+++ b/cmd/infracost/testdata/generate/multi_descendents/expected.golden
@@ -6,47 +6,47 @@ projects:
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/staging.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us1
     name: apps-bar-us1-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/staging.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/multi_descendents/expected.golden
+++ b/cmd/infracost/testdata/generate/multi_descendents/expected.golden
@@ -6,47 +6,47 @@ projects:
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/staging.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us1
     name: apps-bar-us1-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/staging.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/parent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - ../default.tfvars
       - ../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../default.tfvars
       - ../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/parent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - ../default.tfvars
       - ../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../default.tfvars
       - ../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
@@ -8,7 +8,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -16,7 +16,7 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -24,7 +24,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -32,7 +32,7 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -40,7 +40,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -48,7 +48,7 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -56,7 +56,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -64,5 +64,5 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
@@ -8,7 +8,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -16,7 +16,7 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -24,7 +24,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -32,7 +32,7 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -40,7 +40,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -48,7 +48,7 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -56,7 +56,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -64,5 +64,5 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/root_paths/expected.golden
+++ b/cmd/infracost/testdata/generate/root_paths/expected.golden
@@ -5,17 +5,17 @@ projects:
     name: apps-bar
     terraform_var_files:
       - terraform.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - terraform.tfvars
       - dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - terraform.tfvars
       - prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/root_paths/expected.golden
+++ b/cmd/infracost/testdata/generate/root_paths/expected.golden
@@ -5,17 +5,17 @@ projects:
     name: apps-bar
     terraform_var_files:
       - terraform.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - terraform.tfvars
       - dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - terraform.tfvars
       - prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
+++ b/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
@@ -7,26 +7,26 @@ projects:
       - ../default.tfvars
       - ../dev-default.tfvars
       - dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
       - ../default.tfvars
       - ../staging-default.tfvars
       - staging.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../default.tfvars
       - ../dev-default.tfvars
       - dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod-default.tfvars
       - prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
+++ b/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
@@ -7,26 +7,26 @@ projects:
       - ../default.tfvars
       - ../dev-default.tfvars
       - dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
       - ../default.tfvars
       - ../staging-default.tfvars
       - staging.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../default.tfvars
       - ../dev-default.tfvars
       - dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod-default.tfvars
       - prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling/expected.golden
@@ -6,23 +6,23 @@ projects:
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
@@ -8,7 +8,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -16,7 +16,7 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -24,7 +24,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -32,7 +32,7 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -40,7 +40,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -48,7 +48,7 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -56,7 +56,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -64,5 +64,5 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
@@ -8,7 +8,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -16,7 +16,7 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -24,7 +24,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -32,7 +32,7 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -40,7 +40,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -48,7 +48,7 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -56,7 +56,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -64,5 +64,5 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
@@ -5,16 +5,16 @@ projects:
     name: apps-dev
     terraform_var_files:
       - envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps
     name: apps-prod
     terraform_var_files:
       - envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
@@ -5,16 +5,16 @@ projects:
     name: apps-dev
     terraform_var_files:
       - envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps
     name: apps-prod
     terraform_var_files:
       - envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
@@ -5,20 +5,20 @@ projects:
     name: apps-dev
     terraform_var_files:
       - envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps
     name: apps-prod
     terraform_var_files:
       - envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
@@ -5,20 +5,20 @@ projects:
     name: apps-dev
     terraform_var_files:
       - envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps
     name: apps-prod
     terraform_var_files:
       - envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
@@ -5,30 +5,30 @@ projects:
     name: apps-dev
     terraform_var_files:
       - ../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps
     name: apps-prod
     terraform_var_files:
       - ../envs/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:
       - ../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
       - ../envs/staging.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/dev.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - ../envs/staging.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
@@ -5,30 +5,30 @@ projects:
     name: apps-dev
     terraform_var_files:
       - ../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps
     name: apps-prod
     terraform_var_files:
       - ../envs/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:
       - ../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
       - ../envs/staging.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/dev.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - ../envs/staging.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/single_nested_project/expected.golden
+++ b/cmd/infracost/testdata/generate/single_nested_project/expected.golden
@@ -3,5 +3,5 @@ version: 0.1
 projects:
   - path: app/foo
     name: app-foo
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/single_nested_project/expected.golden
+++ b/cmd/infracost/testdata/generate/single_nested_project/expected.golden
@@ -3,5 +3,5 @@ version: 0.1
 projects:
   - path: app/foo
     name: app-foo
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/single_root_project/expected.golden
+++ b/cmd/infracost/testdata/generate/single_root_project/expected.golden
@@ -3,5 +3,5 @@ version: 0.1
 projects:
   - path: .
     name: main
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate/single_root_project/expected.golden
+++ b/cmd/infracost/testdata/generate/single_root_project/expected.golden
@@ -3,5 +3,5 @@ version: 0.1
 projects:
   - path: .
     name: main
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
+++ b/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
@@ -6,28 +6,28 @@ projects:
     terraform_var_files:
       - defaults.tfvars
       - env/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: app1
     name: app1-test
     terraform_var_files:
       - defaults.tfvars
       - env/test.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: app1/app3
     name: app1-app3-qa
     terraform_var_files:
       - qa.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: app2
     name: app2-prod
     terraform_var_files:
       - env/defaults.tfvars
       - env/prod.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
   - path: app2
     name: app2-staging
     terraform_var_files:
       - env/defaults.tfvars
       - env/staging.tfvars
-    terraform_workspace: default
+    skip_auto_detection: true
 

--- a/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
+++ b/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
@@ -6,28 +6,28 @@ projects:
     terraform_var_files:
       - defaults.tfvars
       - env/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: app1
     name: app1-test
     terraform_var_files:
       - defaults.tfvars
       - env/test.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: app1/app3
     name: app1-app3-qa
     terraform_var_files:
       - qa.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: app2
     name: app2-prod
     terraform_var_files:
       - env/defaults.tfvars
       - env/prod.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
   - path: app2
     name: app2-staging
     terraform_var_files:
       - env/defaults.tfvars
       - env/staging.tfvars
-    skip_auto_detection: true
+    skip_autodetect: true
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,8 @@ type Project struct {
 	DependencyPaths []string `yaml:"dependency_paths,omitempty"`
 	// IncludeAllPaths tells autodetect to use all folders with valid project files.
 	IncludeAllPaths bool `yaml:"include_all_paths,omitempty" ignored:"true"`
+	// SkipAutoDetection tells autodetect to skip this project.
+	SkipAutoDetection bool `yaml:"skip_auto_detection,omitempty" ignored:"true"`
 	// Name is a user defined name for the project
 	Name string `yaml:"name,omitempty" ignored:"true"`
 	// TerraformVarFiles is any var files that are to be used with the project.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,8 +47,8 @@ type Project struct {
 	DependencyPaths []string `yaml:"dependency_paths,omitempty"`
 	// IncludeAllPaths tells autodetect to use all folders with valid project files.
 	IncludeAllPaths bool `yaml:"include_all_paths,omitempty" ignored:"true"`
-	// SkipAutoDetection tells autodetect to skip this project.
-	SkipAutoDetection bool `yaml:"skip_auto_detection,omitempty" ignored:"true"`
+	// SkipAutodetect tells autodetect to skip this project.
+	SkipAutodetect bool `yaml:"skip_autodetect,omitempty" ignored:"true"`
 	// Name is a user defined name for the project
 	Name string `yaml:"name,omitempty" ignored:"true"`
 	// TerraformVarFiles is any var files that are to be used with the project.

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -315,7 +315,7 @@ func (p *Parser) YAML() string {
 		}
 	}
 
-	str.WriteString(fmt.Sprintf("    terraform_workspace: %s\n", p.workspaceName))
+	str.WriteString("    skip_auto_detection: true\n")
 
 	if len(p.tfEnvVars) > 0 {
 		str.WriteString("  terraform_vars:\n")

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -315,7 +315,7 @@ func (p *Parser) YAML() string {
 		}
 	}
 
-	str.WriteString("    skip_auto_detection: true\n")
+	str.WriteString("    skip_autodetect: true\n")
 
 	if len(p.tfEnvVars) > 0 {
 		str.WriteString("  terraform_vars:\n")

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -55,11 +55,12 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 	}
 
 	locatorConfig := &hcl.ProjectLocatorConfig{
-		ExcludedDirs:   append(project.ExcludePaths, ctx.Config.Autodetect.ExcludeDirs...),
-		IncludedDirs:   ctx.Config.Autodetect.IncludeDirs,
-		EnvNames:       ctx.Config.Autodetect.EnvNames,
-		ChangedObjects: ctx.VCSMetadata.Commit.ChangedObjects,
-		UseAllPaths:    project.IncludeAllPaths,
+		ExcludedDirs:      append(project.ExcludePaths, ctx.Config.Autodetect.ExcludeDirs...),
+		IncludedDirs:      ctx.Config.Autodetect.IncludeDirs,
+		EnvNames:          ctx.Config.Autodetect.EnvNames,
+		ChangedObjects:    ctx.VCSMetadata.Commit.ChangedObjects,
+		UseAllPaths:       project.IncludeAllPaths,
+		SkipAutoDetection: project.SkipAutoDetection,
 	}
 	pl := hcl.NewProjectLocator(logging.Logger, locatorConfig)
 	rootPaths := pl.FindRootModules(project.Path)

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -60,7 +60,7 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 		EnvNames:          ctx.Config.Autodetect.EnvNames,
 		ChangedObjects:    ctx.VCSMetadata.Commit.ChangedObjects,
 		UseAllPaths:       project.IncludeAllPaths,
-		SkipAutoDetection: project.SkipAutoDetection,
+		SkipAutoDetection: project.SkipAutodetect,
 	}
 	pl := hcl.NewProjectLocator(logging.Logger, locatorConfig)
 	rootPaths := pl.FindRootModules(project.Path)

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -48,7 +48,7 @@
         "include_all_paths": {
           "type": "boolean"
         },
-        "skip_auto_detection": {
+        "skip_autodetect": {
           "type": "boolean"
         },
         "name": {

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -48,6 +48,9 @@
         "include_all_paths": {
           "type": "boolean"
         },
+        "skip_auto_detection": {
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },


### PR DESCRIPTION
Adds a new project config key `skip_auto_detection` that is added by default for autogenerated config files. This fixes issues with duplicate projects being shown when a Terraform project has a child directory with another Terraform project. I've used `skip_auto_detection` as the key as this means that the default value is false.

I've also removed the `terraform_workspace` output from the generated config as this is not required and is just noise.