### PR TITLE
perf: fix memory leaks

### DIFF
--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -182,6 +182,8 @@ func (p *DirProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, e
 		project := schema.NewProject(name, metadata)
 
 		parser := NewParser(p.ctx, p.includePastResources)
+
+		j, _ = StripSetupTerraformWrapper(j)
 		parsed, err := parser.parseJSON(j, usage)
 		if err != nil {
 			return projects, errors.Wrap(err, "Error parsing Terraform JSON")

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -143,8 +143,6 @@ type ParsedPlanConfiguration struct {
 func (p *Parser) parseJSON(j []byte, usage schema.UsageMap) (*ParsedPlanConfiguration, error) {
 	baseResources := p.loadUsageFileResources(usage)
 
-	j, _ = StripSetupTerraformWrapper(j)
-
 	if !gjson.ValidBytes(j) {
 		return &ParsedPlanConfiguration{
 			PastResources:    baseResources,

--- a/internal/providers/terraform/parser.go
+++ b/internal/providers/terraform/parser.go
@@ -230,7 +230,7 @@ func collectModulesSourceUrls(moduleCalls []gjson.Result) []string {
 	for source := range remoteUrls {
 		// Perf/memory leak: Copy gjson string slices that may be returned so we don't prevent
 		// the entire underlying parsed json from being garbage collected.
-		sourceCopy := string([]byte(source))
+		sourceCopy := strings.Clone(source)
 		urls = append(urls, sourceCopy)
 	}
 
@@ -254,8 +254,8 @@ func parseProviderConfig(providerConf gjson.Result) []schema.ProviderMetadata {
 		md := schema.ProviderMetadata{
 			// Perf/memory leak: Copy gjson string slices that may be returned so we don't prevent
 			// the entire underlying parsed json from being garbage collected.
-			Name:      string([]byte(conf.Get("name").String())),
-			Filename:  string([]byte(conf.Get("infracost_metadata.filename").String())),
+			Name:      strings.Clone(conf.Get("name").String()),
+			Filename:  strings.Clone(conf.Get("infracost_metadata.filename").String()),
 			StartLine: conf.Get("infracost_metadata.start_line").Int(),
 			EndLine:   conf.Get("infracost_metadata.end_line").Int(),
 		}
@@ -268,7 +268,7 @@ func parseProviderConfig(providerConf gjson.Result) []schema.ProviderMetadata {
 			for key, value := range defaultTags.Get("tags.constant_value").Map() {
 				// Perf/memory leak: Copy gjson string slices that may be returned so we don't prevent
 				// the entire underlying parsed json from being garbage collected.
-				md.DefaultTags[string([]byte(key))] = string([]byte(value.String()))
+				md.DefaultTags[strings.Clone(key)] = strings.Clone(value.String())
 			}
 		}
 
@@ -383,13 +383,13 @@ func (p *Parser) parseResourceData(isState bool, confLoader *ConfLoader, provide
 
 		// Perf/memory leak: Copy gjson string slices that may be returned so we don't prevent
 		// the entire underlying parsed json from being garbage collected.
-		v = schema.AddRawValue(v, "region", string([]byte(region)))
-		data := schema.NewResourceData(string([]byte(t)), string([]byte(provider)), string([]byte(addr)), nil, v)
+		v = schema.AddRawValue(v, "region", strings.Clone(region))
+		data := schema.NewResourceData(strings.Clone(t), strings.Clone(provider), strings.Clone(addr), nil, v)
 
 		// Perf/memory leak: Copy gjson string slices that may be returned so we don't prevent
 		// the entire underlying parsed json from being garbage collected.
 		data.Metadata = gjson.ParseBytes([]byte(r.Get("infracost_metadata").Raw)).Map()
-		resources[string([]byte(addr))] = data
+		resources[strings.Clone(addr)] = data
 	}
 
 	// Recursively add any resources for child modules

--- a/internal/providers/terraform/plan_json_provider.go
+++ b/internal/providers/terraform/plan_json_provider.go
@@ -89,6 +89,7 @@ func (p *PlanJSONProvider) LoadResourcesFromSrc(usage schema.UsageMap, j []byte,
 	project := schema.NewProject(name, metadata)
 	parser := NewParser(p.ctx, p.includePastResources)
 
+	j, _ = StripSetupTerraformWrapper(j)
 	parsedConf, err := parser.parseJSON(j, usage)
 	if err != nil {
 		return project, fmt.Errorf("Error parsing Terraform plan JSON file %w", err)

--- a/internal/providers/terraform/plan_provider.go
+++ b/internal/providers/terraform/plan_provider.go
@@ -63,6 +63,7 @@ func (p *PlanProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, 
 	project := schema.NewProject(name, metadata)
 	parser := NewParser(p.ctx, p.includePastResources)
 
+	j, _ = StripSetupTerraformWrapper(j)
 	parsedConf, err := parser.parseJSON(j, usage)
 	if err != nil {
 		return []*schema.Project{project}, errors.Wrap(err, "Error parsing Terraform JSON")

--- a/internal/providers/terraform/state_json_provider.go
+++ b/internal/providers/terraform/state_json_provider.go
@@ -60,6 +60,7 @@ func (p *StateJSONProvider) LoadResources(usage schema.UsageMap) ([]*schema.Proj
 	project := schema.NewProject(name, metadata)
 	parser := NewParser(p.ctx, p.includePastResources)
 
+	j, _ = StripSetupTerraformWrapper(j)
 	parsedConf, err := parser.parseJSON(j, usage)
 	if err != nil {
 		return []*schema.Project{project}, errors.Wrap(err, "Error parsing Terraform state JSON file")

--- a/internal/providers/terraform/terragrunt_provider.go
+++ b/internal/providers/terraform/terragrunt_provider.go
@@ -133,7 +133,8 @@ func (p *TerragruntProvider) LoadResources(usage schema.UsageMap) ([]*schema.Pro
 		project := schema.NewProject(name, metadata)
 
 		parser := NewParser(p.ctx, p.includePastResources)
-		parsedConf, err := parser.parseJSON(outs[i], usage)
+		j, _ := StripSetupTerraformWrapper(outs[i])
+		parsedConf, err := parser.parseJSON(j, usage)
 		if err != nil {
 			return projects, errors.Wrap(err, "Error parsing Terraform JSON")
 		}

--- a/internal/schema/resource_data.go
+++ b/internal/schema/resource_data.go
@@ -102,7 +102,10 @@ func (d *ResourceData) References(keys ...string) []*ResourceData {
 	return data
 }
 
-func (d *ResourceData) AddReference(key string, reference *ResourceData, reverseRefAttrs []string) {
+func (d *ResourceData) AddReference(k string, reference *ResourceData, reverseRefAttrs []string) {
+	// Perf/memory leak: Copy gjson string slices that may be returned so we don't prevent
+	// the entire underlying parsed json from being garbage collected.
+	key := string([]byte(k))
 	if _, ok := d.ReferencesMap[key]; !ok {
 		d.ReferencesMap[key] = make([]*ResourceData, 0)
 	}

--- a/internal/schema/resource_data.go
+++ b/internal/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"encoding/json"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/awslabs/goformation/v4/cloudformation"
 	"github.com/tidwall/gjson"
@@ -130,14 +130,14 @@ func (d *ResourceData) Set(key string, value interface{}) {
 func AddRawValue(r gjson.Result, key string, v interface{}) gjson.Result {
 	j := make(map[string]interface{})
 
-	_ = json.Unmarshal([]byte(r.Raw), &j) // TODO: unhandled error
+	_ = jsoniter.Unmarshal([]byte(r.Raw), &j) // TODO: unhandled error
 	if j == nil {
 		j = make(map[string]interface{})
 	}
 
 	j[key] = v
 
-	mj, _ := json.Marshal(j) // TODO: unhandled error
+	mj, _ := jsoniter.Marshal(j) // TODO: unhandled error
 
 	return gjson.ParseBytes(mj)
 }

--- a/internal/schema/resource_data.go
+++ b/internal/schema/resource_data.go
@@ -1,9 +1,8 @@
 package schema
 
 import (
+	"encoding/json"
 	"strings"
-
-	jsoniter "github.com/json-iterator/go"
 
 	"github.com/awslabs/goformation/v4/cloudformation"
 	"github.com/tidwall/gjson"
@@ -132,14 +131,14 @@ func (d *ResourceData) Set(key string, value interface{}) {
 func AddRawValue(r gjson.Result, key string, v interface{}) gjson.Result {
 	j := make(map[string]interface{})
 
-	_ = jsoniter.Unmarshal([]byte(r.Raw), &j) // TODO: unhandled error
+	_ = json.Unmarshal([]byte(r.Raw), &j) // TODO: unhandled error
 	if j == nil {
 		j = make(map[string]interface{})
 	}
 
 	j[key] = v
 
-	mj, _ := jsoniter.Marshal(j) // TODO: unhandled error
+	mj, _ := json.Marshal(j) // TODO: unhandled error
 
 	return gjson.ParseBytes(mj)
 }

--- a/internal/schema/resource_data.go
+++ b/internal/schema/resource_data.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"strings"
+
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/awslabs/goformation/v4/cloudformation"
@@ -105,7 +107,7 @@ func (d *ResourceData) References(keys ...string) []*ResourceData {
 func (d *ResourceData) AddReference(k string, reference *ResourceData, reverseRefAttrs []string) {
 	// Perf/memory leak: Copy gjson string slices that may be returned so we don't prevent
 	// the entire underlying parsed json from being garbage collected.
-	key := string([]byte(k))
+	key := strings.Clone(k)
 	if _, ok := d.ReferencesMap[key]; !ok {
 		d.ReferencesMap[key] = make([]*ResourceData, 0)
 	}


### PR DESCRIPTION
The main memory leak was from putting gjson result strings into output structs.  If you do something like:
```
json := `{"name":"woofy","age":12}`
gjsonResult := gjson.Parse(json).Get("name")
name := gjsonResult.String()
```
`name` is a slice of the `json` string, so `json` cannot be garbage collected until `name` is released.

Since our output structs live for the life of the program, none of the underlying json was ever released even though only use a small subset of the values in the output.
  
  
  