### PR TITLE
feat: match tfvar naming to project names

### DIFF
--- a/cmd/infracost/testdata/generate/aunt_filename_matches_project/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_filename_matches_project/expected.golden
@@ -1,0 +1,37 @@
+version: 0.1
+
+projects:
+  - path: infra/components/bar
+    name: infra-components-bar-dev
+    terraform_var_files:
+      - ../../variables/env/dev/defaults.tfvars
+      - ../../variables/env/dev/bar.tfvars
+    skip_autodetect: true
+  - path: infra/components/bar
+    name: infra-components-bar-prod
+    terraform_var_files:
+      - ../../variables/env/prod/defaults.tfvars
+      - ../../variables/env/prod/bar.tfvars
+    skip_autodetect: true
+  - path: infra/components/baz
+    name: infra-components-baz-dev
+    terraform_var_files:
+      - ../../variables/env/dev/defaults.tfvars
+    skip_autodetect: true
+  - path: infra/components/baz
+    name: infra-components-baz-prod
+    terraform_var_files:
+      - ../../variables/env/prod/defaults.tfvars
+    skip_autodetect: true
+  - path: infra/components/foo
+    name: infra-components-foo-dev
+    terraform_var_files:
+      - ../../variables/env/dev/defaults.tfvars
+    skip_autodetect: true
+  - path: infra/components/foo
+    name: infra-components-foo-prod
+    terraform_var_files:
+      - ../../variables/env/prod/foo.tfvars
+      - ../../variables/env/prod/defaults.tfvars
+    skip_autodetect: true
+

--- a/cmd/infracost/testdata/generate/aunt_filename_matches_project/tree.txt
+++ b/cmd/infracost/testdata/generate/aunt_filename_matches_project/tree.txt
@@ -1,0 +1,18 @@
+.
+└── infra
+    ├── components
+    │   ├── foo
+    │   │   └── main.tf
+    │   ├── bar
+    │   │   └── main.tf
+    │   └── baz
+    │       └── main.tf
+    └── variables
+        └── env
+            ├── prod
+            │   ├── defaults.tfvars
+            │   ├── foo.tfvars
+            │   └── bar.tfvars
+            └── dev
+                ├── defaults.tfvars
+                └── bar.tfvars

--- a/cmd/infracost/testdata/generate/aunt_filenames_with_env/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_filenames_with_env/expected.golden
@@ -1,0 +1,79 @@
+version: 0.1
+
+projects:
+  - path: components/age
+    name: components-age-dev
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-dev/age.tfvars
+      - ../../variables/cko-dev/dev.tfvars
+    skip_autodetect: true
+  - path: components/age
+    name: components-age-mgmt
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-mgmt/age.tfvars
+    skip_autodetect: true
+  - path: components/age
+    name: components-age-playground
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-playground/age.tfvars
+    skip_autodetect: true
+  - path: components/age
+    name: components-age-prod
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-prod/age.tfvars
+    skip_autodetect: true
+  - path: components/airflow
+    name: components-airflow-dev
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-dev/airflow.tfvars
+      - ../../variables/cko-dev/dev.tfvars
+    skip_autodetect: true
+  - path: components/airflow
+    name: components-airflow-mgmt
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-mgmt/airflow.tfvars
+    skip_autodetect: true
+  - path: components/airflow
+    name: components-airflow-playground
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-playground/airflow.tfvars
+    skip_autodetect: true
+  - path: components/airflow
+    name: components-airflow-prod
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-prod/airflow.tfvars
+    skip_autodetect: true
+  - path: components/apm-events
+    name: components-apm-events-dev
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-dev/apm-events.tfvars
+      - ../../variables/cko-dev/dev.tfvars
+    skip_autodetect: true
+  - path: components/apm-events
+    name: components-apm-events-mgmt
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-mgmt/apm-events.tfvars
+    skip_autodetect: true
+  - path: components/apm-events
+    name: components-apm-events-playground
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-playground/apm-events.tfvars
+    skip_autodetect: true
+  - path: components/apm-events
+    name: components-apm-events-prod
+    terraform_var_files:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-prod/apm-events.tfvars
+    skip_autodetect: true
+

--- a/cmd/infracost/testdata/generate/aunt_filenames_with_env/tree.txt
+++ b/cmd/infracost/testdata/generate/aunt_filenames_with_env/tree.txt
@@ -1,0 +1,27 @@
+.
+├── components
+│   ├── age
+│   │   └── main.tf
+│   ├── airflow
+│   │   └── main.tf
+│   ├── apm-events
+│   │   └── main.tf
+└── variables
+    ├── cko-dev
+    │   ├── age.tfvars
+    │   ├── airflow.tfvars
+    │   ├── dev.tfvars
+    │   └── apm-events.tfvars
+    ├── cko-mgmt
+    │   ├── age.tfvars
+    │   ├── airflow.tfvars
+    │   └── apm-events.tfvars
+    ├── cko-playground
+    │   ├── age.tfvars
+    │   ├── airflow.tfvars
+    │   └── apm-events.tfvars
+    ├── cko-prod
+    │   ├── age.tfvars
+    │   ├── airflow.tfvars
+    │   └── apm-events.tfvars
+    └── default.tfvars

--- a/cmd/infracost/testdata/generate/env_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/env_dirs/expected.golden
@@ -5,7 +5,7 @@ projects:
     name: infra-components-baz-dev
     terraform_var_files:
       - ../../variables/defaults.tfvars
-      - ../../variables/dev/baz.tfvars
+      - ../../variables/dev/bla.tfvars
     skip_autodetect: true
   - path: infra/components/baz
     name: infra-components-baz-stag
@@ -17,7 +17,7 @@ projects:
     name: infra-components-foo-dev
     terraform_var_files:
       - ../../variables/defaults.tfvars
-      - ../../variables/dev/baz.tfvars
+      - ../../variables/dev/bla.tfvars
     skip_autodetect: true
   - path: infra/components/foo
     name: infra-components-foo-stag

--- a/cmd/infracost/testdata/generate/env_dirs/tree.txt
+++ b/cmd/infracost/testdata/generate/env_dirs/tree.txt
@@ -9,5 +9,5 @@
         ├── stag
         │   └── bop.tfvars
         ├── dev
-        │   └── baz.tfvars
+        │   └── bla.tfvars
         └── defaults.tfvars

--- a/cmd/infracost/testdata/generate/parent_filename_matches_project/expected.golden
+++ b/cmd/infracost/testdata/generate/parent_filename_matches_project/expected.golden
@@ -1,0 +1,23 @@
+version: 0.1
+
+projects:
+  - path: infra/components/bar
+    name: infra-components-bar
+    terraform_var_files:
+      - ../defaults.tfvars
+      - ../bar.tfvars
+    skip_autodetect: true
+  - path: infra/components/baz
+    name: infra-components-baz
+    terraform_var_files:
+      - ../../baz.tfvars
+      - ../defaults.tfvars
+    skip_autodetect: true
+  - path: infra/components/foo
+    name: infra-components-foo
+    terraform_var_files:
+      - ../../foo.tfvars
+      - ../foo.tfvars
+      - ../defaults.tfvars
+    skip_autodetect: true
+

--- a/cmd/infracost/testdata/generate/parent_filename_matches_project/tree.txt
+++ b/cmd/infracost/testdata/generate/parent_filename_matches_project/tree.txt
@@ -1,0 +1,14 @@
+.
+└── infra
+    ├── components
+    │   ├── foo
+    │   │   └── main.tf
+    │   ├── bar
+    │   │   └── main.tf
+    │   ├── baz
+    │   │   └── main.tf
+    │   ├── defaults.tfvars
+    │   ├── foo.tfvars
+    │   └── bar.tfvars
+    ├── baz.tfvars
+    └── foo.tfvars

--- a/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
+++ b/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
@@ -20,13 +20,17 @@ projects:
     terraform_var_files:
       - ../default.tfvars
       - ../dev-default.tfvars
-      - dev.tfvars
     skip_autodetect: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod-default.tfvars
-      - prod.tfvars
+    skip_autodetect: true
+  - path: apps/foo
+    name: apps-foo-staging
+    terraform_var_files:
+      - ../default.tfvars
+      - ../staging-default.tfvars
     skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/shared_env_var_files/tree.txt
+++ b/cmd/infracost/testdata/generate/shared_env_var_files/tree.txt
@@ -2,8 +2,6 @@
 └── apps
     ├── foo
     │   ├── main.tf
-    │   ├── dev.tfvars
-    │   └── prod.tfvars
     ├── bar
     │   ├── main.tf
     │   ├── staging.tfvars


### PR DESCRIPTION
Changes `ProjectLocator` functionality so that tfvars are scoped to a project by their name.