### PR TITLE
fix: env matching logic

### DIFF
--- a/internal/hcl/project_locator_test.go
+++ b/internal/hcl/project_locator_test.go
@@ -1,0 +1,99 @@
+package hcl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvFileMatcher_EnvName(t *testing.T) {
+	type fields struct {
+		envNames []string
+	}
+	type args struct {
+		file string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "directly matches env name",
+			fields: fields{
+				envNames: []string{"dev", "prod"},
+			},
+			args: args{
+				file: "dev.tfvars",
+			},
+			want: "dev",
+		},
+		{
+			name: "directly matches env which collides",
+			fields: fields{
+				envNames: []string{"dev", "dev-legacy", "prod"},
+			},
+			args: args{
+				file: "dev-legacy.tfvars",
+			},
+			want: "dev-legacy",
+		},
+		{
+			name: "returns filename when no match",
+			fields: fields{
+				envNames: []string{"dev", "prod"},
+			},
+			args: args{
+				file: "foo.tfvars",
+			},
+			want: "foo",
+		},
+		{
+			name: "returns prefix",
+			fields: fields{
+				envNames: []string{"dev", "prod"},
+			},
+			args: args{
+				file: "prod-defaults.tfvars",
+			},
+			want: "prod",
+		},
+		{
+			name: "returns longest prefix match",
+			fields: fields{
+				envNames: []string{"dev", "prod", "prod-legacy"},
+			},
+			args: args{
+				file: "prod-legacy-defaults.tfvars",
+			},
+			want: "prod-legacy",
+		},
+		{
+			name: "returns suffix",
+			fields: fields{
+				envNames: []string{"dev", "prod"},
+			},
+			args: args{
+				file: "defaults-prod.tfvars",
+			},
+			want: "prod",
+		},
+		{
+			name: "returns longest suffix match",
+			fields: fields{
+				envNames: []string{"dev", "prod", "legacy-prod"},
+			},
+			args: args{
+				file: "defaults-legacy-prod.tfvars",
+			},
+			want: "legacy-prod",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := CreateEnvFileMatcher(tt.fields.envNames)
+			assert.Equalf(t, tt.want, e.EnvName(tt.args.file), "EnvName(%v)", tt.args.file)
+		})
+	}
+}


### PR DESCRIPTION
Changes env matching logic to use a list and string matching based approach. This is done in favour of the old regxp based method so that we can better environment names that have other environment names as substrings. e.g. dev-legacy.