### PR TITLE
feat: add path_overrides autodetect configuration

### DIFF
--- a/cmd/infracost/generate.go
+++ b/cmd/infracost/generate.go
@@ -91,6 +91,7 @@ func (g *generateConfigCommand) run(cmd *cobra.Command, args []string) error {
 		ctx.Config.Autodetect.ExcludeDirs = partialConfig.Autodetect.ExcludeDirs
 		ctx.Config.Autodetect.IncludeDirs = partialConfig.Autodetect.IncludeDirs
 		ctx.Config.Autodetect.EnvNames = partialConfig.Autodetect.EnvNames
+		ctx.Config.Autodetect.PathOverrides = partialConfig.Autodetect.PathOverrides
 
 		_, _ = reader.Seek(0, io.SeekStart)
 		definedProjects = hasLineStartingWith(reader, "projects:")

--- a/cmd/infracost/testdata/generate/path_overrides/expected.golden
+++ b/cmd/infracost/testdata/generate/path_overrides/expected.golden
@@ -1,0 +1,35 @@
+version: 0.1
+
+projects:
+  - path: infra/components/bar
+    name: infra-components-bar-bip
+    terraform_var_files:
+      - ../../prod.tfvars
+      - ../../dev.tfvars
+      - ../../default.tfvars
+      - ../../bip.tfvars
+    skip_autodetect: true
+  - path: infra/components/blah
+    name: infra-components-blah-bat
+    terraform_var_files:
+      - ../../prod.tfvars
+      - ../../dev.tfvars
+      - ../../default.tfvars
+      - ../../network-bat.tfvars
+      - ../../bat.tfvars
+    skip_autodetect: true
+  - path: infra/components/blah
+    name: infra-components-blah-bip
+    terraform_var_files:
+      - ../../prod.tfvars
+      - ../../dev.tfvars
+      - ../../default.tfvars
+      - ../../bip.tfvars
+    skip_autodetect: true
+  - path: infra/components/foo
+    name: infra-components-foo-baz
+    terraform_var_files:
+      - ../../network-baz.tfvars
+      - ../../baz.tfvars
+    skip_autodetect: true
+

--- a/cmd/infracost/testdata/generate/path_overrides/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/path_overrides/infracost.yml.tmpl
@@ -1,0 +1,16 @@
+version: 0.1
+autodetect:
+  env_names:
+    - baz
+    - bat
+    - bip
+  path_overrides:
+    - path: "**/**"
+      exclude:
+        - baz
+    - path: infra/components/foo
+      only:
+        - baz
+    - path: infra/**/bar
+      exclude:
+        - bat

--- a/cmd/infracost/testdata/generate/path_overrides/tree.txt
+++ b/cmd/infracost/testdata/generate/path_overrides/tree.txt
@@ -1,0 +1,17 @@
+.
+└── infra
+    ├── components
+    │   ├── foo
+    │   │   └── main.tf
+    │   ├── blah
+    │   │   └── main.tf
+    │   └── bar
+    │       └── main.tf
+    ├── baz.tfvars
+    ├── bat.tfvars
+    ├── bip.tfvars
+    ├── network-baz.tfvars
+    ├── network-bat.tfvars
+    ├── dev.tfvars
+    ├── prod.tfvars
+    └── default.tfvars

--- a/go.mod
+++ b/go.mod
@@ -239,7 +239,7 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gobwas/glob v0.2.3
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,15 @@ type AutodetectConfig struct {
 	// IncludeDirs is a list of directories that the autodetect should append
 	// to the already detected directories.
 	IncludeDirs []string `yaml:"include_dirs,omitempty" ignored:"true"`
+	// PathOverrides defines paths that should be overridden with specific
+	// environment variable grouping.
+	PathOverrides []PathOverride `yaml:"path_overrides,omitempty" ignored:"true"`
+}
+
+type PathOverride struct {
+	Path    string   `yaml:"path"`
+	Exclude []string `yaml:"exclude"`
+	Only    []string `yaml:"only"`
 }
 
 // Project defines a specific terraform project config. This can be used

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -54,9 +54,19 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 		return []schema.Provider{h}, nil
 	}
 
+	pathOverrides := make([]hcl.PathOverrideConfig, len(ctx.Config.Autodetect.PathOverrides))
+	for i, override := range ctx.Config.Autodetect.PathOverrides {
+		pathOverrides[i] = hcl.PathOverrideConfig{
+			Path:    override.Path,
+			Only:    override.Only,
+			Exclude: override.Exclude,
+		}
+	}
+
 	locatorConfig := &hcl.ProjectLocatorConfig{
 		ExcludedDirs:      append(project.ExcludePaths, ctx.Config.Autodetect.ExcludeDirs...),
 		IncludedDirs:      ctx.Config.Autodetect.IncludeDirs,
+		PathOverrides:     pathOverrides,
 		EnvNames:          ctx.Config.Autodetect.EnvNames,
 		ChangedObjects:    ctx.VCSMetadata.Commit.ChangedObjects,
 		UseAllPaths:       project.IncludeAllPaths,


### PR DESCRIPTION
Adds the ability to configure which envs apply to different paths using a new `path_overrides` autodetect config key.

**Note**: I've had to include the github.com/gobwas/glob package as the builting `filepath.Match` function could not accomodate the glob syntax that we want to use for the `path` field.