### PR TITLE
fix: don't exclude global var files from path_overrides

### DIFF
--- a/cmd/infracost/testdata/generate/path_overrides/expected.golden
+++ b/cmd/infracost/testdata/generate/path_overrides/expected.golden
@@ -4,16 +4,12 @@ projects:
   - path: infra/components/bar
     name: infra-components-bar-bip
     terraform_var_files:
-      - ../../prod.tfvars
-      - ../../dev.tfvars
       - ../../default.tfvars
       - ../../bip.tfvars
     skip_autodetect: true
   - path: infra/components/blah
     name: infra-components-blah-bat
     terraform_var_files:
-      - ../../prod.tfvars
-      - ../../dev.tfvars
       - ../../default.tfvars
       - ../../network-bat.tfvars
       - ../../bat.tfvars
@@ -21,15 +17,15 @@ projects:
   - path: infra/components/blah
     name: infra-components-blah-bip
     terraform_var_files:
-      - ../../prod.tfvars
-      - ../../dev.tfvars
       - ../../default.tfvars
       - ../../bip.tfvars
     skip_autodetect: true
   - path: infra/components/foo
     name: infra-components-foo-baz
     terraform_var_files:
+      - ../../default.tfvars
       - ../../network-baz.tfvars
       - ../../baz.tfvars
+      - var.auto.tfvars
     skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/path_overrides/tree.txt
+++ b/cmd/infracost/testdata/generate/path_overrides/tree.txt
@@ -2,6 +2,7 @@
 └── infra
     ├── components
     │   ├── foo
+    │   │   ├── var.auto.tfvars
     │   │   └── main.tf
     │   ├── blah
     │   │   └── main.tf
@@ -12,6 +13,4 @@
     ├── bip.tfvars
     ├── network-baz.tfvars
     ├── network-bat.tfvars
-    ├── dev.tfvars
-    ├── prod.tfvars
     └── default.tfvars

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -1037,7 +1037,7 @@ func (p *ProjectLocator) FindRootModules(fullPath string) []RootPath {
 // excludeEnvFromPaths filters car files from the paths based on the path overrides.
 func (p *ProjectLocator) excludeEnvFromPaths(paths []RootPath) {
 	// filter the "only" paths first. This is done as "only" rules take precedence
-	// over exclude rules. So if a env is defined in both only and exclude and
+	// over exclude rules. So if an env is defined in both only and exclude and
 	// matches the same path, the "only" rule is the only one to apply.
 	onlyPaths := map[string]struct{}{}
 	for _, override := range p.pathOverrides {
@@ -1045,8 +1045,8 @@ func (p *ProjectLocator) excludeEnvFromPaths(paths []RootPath) {
 			for i, path := range paths {
 				relPath := path.RelPath()
 				if override.glob.Match(relPath) {
-					var filtered RootPathVarFiles
-					for _, varFile := range path.TerraformVarFiles {
+					filtered := append(path.GlobalFiles(), path.AutoFiles()...)
+					for _, varFile := range path.EnvFiles() {
 						if _, ok := override.only[varFile.EnvName]; ok {
 							onlyPaths[relPath+varFile.EnvName] = struct{}{}
 							filtered = append(filtered, varFile)


### PR DESCRIPTION
changes "only" configuration logic to only filter on tfvar files that are defined as "env" tfvars.