### PR TITLE
feat: add fallback to include all paths functionality

### DIFF
--- a/cmd/infracost/testdata/generate/with_no_directories_with_providers/expected.golden
+++ b/cmd/infracost/testdata/generate/with_no_directories_with_providers/expected.golden
@@ -1,0 +1,13 @@
+version: 0.1
+
+projects:
+  - path: modules/bar
+    name: modules-bar
+    skip_autodetect: true
+  - path: modules/baz
+    name: modules-baz
+    skip_autodetect: true
+  - path: modules/foo
+    name: modules-foo
+    skip_autodetect: true
+

--- a/cmd/infracost/testdata/generate/with_no_directories_with_providers/tree.txt
+++ b/cmd/infracost/testdata/generate/with_no_directories_with_providers/tree.txt
@@ -1,0 +1,8 @@
+.
+└── modules
+    ├── foo
+    │   └── test.tf
+    ├── bar
+    │   └── test.tf
+    └── baz
+        └── test.tf

--- a/internal/config/run_context.go
+++ b/internal/config/run_context.go
@@ -142,6 +142,11 @@ var (
 	outputIndent = "  "
 )
 
+// IsAutoDetect returns true if the command is running with auto-detect functionality.
+func (r *RunContext) IsAutoDetect() bool {
+	return len(r.Config.Projects) <= 1 && r.Config.ConfigFilePath == ""
+}
+
 // NewSpinner returns an ui.Spinner built from the RunContext.
 func (r *RunContext) NewSpinner(msg string) *ui.Spinner {
 	return ui.NewSpinner(msg, ui.SpinnerOptions{

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -60,13 +60,14 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 	}
 
 	locatorConfig := &hcl.ProjectLocatorConfig{
-		ExcludedDirs:      append(project.ExcludePaths, ctx.Config.Autodetect.ExcludeDirs...),
-		IncludedDirs:      ctx.Config.Autodetect.IncludeDirs,
-		PathOverrides:     pathOverrides,
-		EnvNames:          ctx.Config.Autodetect.EnvNames,
-		ChangedObjects:    ctx.VCSMetadata.Commit.ChangedObjects,
-		UseAllPaths:       project.IncludeAllPaths,
-		SkipAutoDetection: project.SkipAutodetect,
+		ExcludedDirs:           append(project.ExcludePaths, ctx.Config.Autodetect.ExcludeDirs...),
+		IncludedDirs:           ctx.Config.Autodetect.IncludeDirs,
+		PathOverrides:          pathOverrides,
+		EnvNames:               ctx.Config.Autodetect.EnvNames,
+		ChangedObjects:         ctx.VCSMetadata.Commit.ChangedObjects,
+		UseAllPaths:            project.IncludeAllPaths,
+		SkipAutoDetection:      project.SkipAutodetect,
+		FallbackToIncludePaths: ctx.IsAutoDetect(),
 	}
 	pl := hcl.NewProjectLocator(logging.Logger, locatorConfig)
 	rootPaths := pl.FindRootModules(project.Path)


### PR DESCRIPTION
Changes autodetect functionality so that if no paths are detected from an initial provider/backend block project detection we fallback to include all paths. This is particularly usefull for module repositories which often do not contain provider/backend blocks.