### PR TITLE
Fix cost components/golden tests

### DIFF
--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
@@ -142,13 +142,20 @@ WRN 'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_G
 WRN 'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API.
 WRN 'Multiple products found' are safe to ignore for 'Compute (provisioned, HS_Gen5_2)' due to limitations in the Azure API.
 WRN 'Multiple products found' are safe to ignore for 'Compute (provisioned, HS_Gen5_2)' due to limitations in the Azure API.
+WRN 'Multiple products found' are safe to ignore for 'Compute (serverless, GP_S_Gen5_2)' due to limitations in the Azure API.
+WRN 'Multiple products found' are safe to ignore for 'Compute (serverless, GP_S_Gen5_4)' due to limitations in the Azure API.
+WRN 'Multiple products found' are safe to ignore for 'Compute (serverless, GP_S_Gen5_4)' due to limitations in the Azure API.
 WRN Multiple products with prices found for azurerm_mssql_database.backup_default Compute (provisioned, GP_Gen5_4), using the first product
 WRN Multiple products with prices found for azurerm_mssql_database.backup_geo Compute (provisioned, GP_Gen5_4), using the first product
 WRN Multiple products with prices found for azurerm_mssql_database.backup_local Compute (provisioned, GP_Gen5_4), using the first product
 WRN Multiple products with prices found for azurerm_mssql_database.backup_zone Compute (provisioned, GP_Gen5_4), using the first product
+WRN Multiple products with prices found for azurerm_mssql_database.blank_sku Compute (serverless, GP_S_Gen5_2), using the first product
 WRN Multiple products with prices found for azurerm_mssql_database.business_critical_gen Compute (provisioned, BC_Gen5_8), using the first product
 WRN Multiple products with prices found for azurerm_mssql_database.business_critical_m Compute (provisioned, BC_M_8), using the first product
 WRN Multiple products with prices found for azurerm_mssql_database.general_purpose_gen Compute (provisioned, GP_Gen5_4), using the first product
 WRN Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_without_license Compute (provisioned, GP_Gen5_4), using the first product
 WRN Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_zone Compute (provisioned, GP_Gen5_4), using the first product
 WRN Multiple products with prices found for azurerm_mssql_database.general_purpose_gen_zone Zone redundancy (provisioned, GP_Gen5_4), using the first product
+WRN Multiple products with prices found for azurerm_mssql_database.serverless Compute (serverless, GP_S_Gen5_4), using the first product
+WRN Multiple products with prices found for azurerm_mssql_database.serverless_zone Compute (serverless, GP_S_Gen5_4), using the first product
+WRN Multiple products with prices found for azurerm_mssql_database.serverless_zone Zone redundancy (serverless, GP_S_Gen5_4), using the first product

--- a/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/sql_database_test/sql_database_test.golden
@@ -86,8 +86,10 @@ WRN 'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_G
 WRN 'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_2)' due to limitations in the Azure API.
 WRN 'Multiple products found' are safe to ignore for 'Compute (provisioned, GP_Gen5_4)' due to limitations in the Azure API.
 WRN 'Multiple products found' are safe to ignore for 'Compute (provisioned, HS_Gen5_2)' due to limitations in the Azure API.
+WRN 'Multiple products found' are safe to ignore for 'Compute (serverless, GP_S_Gen5_4)' due to limitations in the Azure API.
 WRN Multiple products with prices found for azurerm_sql_database.backup Compute (provisioned, GP_Gen5_4), using the first product
 WRN Multiple products with prices found for azurerm_sql_database.default_sql_database Compute (provisioned, GP_Gen5_2), using the first product
+WRN Multiple products with prices found for azurerm_sql_database.serverless Compute (serverless, GP_S_Gen5_4), using the first product
 WRN Multiple products with prices found for azurerm_sql_database.sql_database_with_edition_critical Compute (provisioned, BC_Gen5_2), using the first product
 WRN Multiple products with prices found for azurerm_sql_database.sql_database_with_edition_gen Compute (provisioned, GP_Gen5_2), using the first product
 WRN Multiple products with prices found for azurerm_sql_database.sql_database_with_max_size Compute (provisioned, GP_Gen5_2), using the first product

--- a/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/storage_account_test/storage_account_test.golden
@@ -1,462 +1,400 @@
 
- Name                                                                       Monthly Qty  Unit             Monthly Cost 
-                                                                                                                       
- azurerm_storage_account.blob["BlobStorage.Premium.LRS.Cool"]                                                          
- ├─ Capacity                                                                  2,000,000  GB                $390,000.00 
- ├─ Write operations                                                                200  10k operations          $4.56 
- ├─ List and create container operations                                            200  10k operations         $13.00 
- ├─ Read operations                                                                  20  10k operations          $0.04 
- └─ All other operations                                                            200  10k operations          $0.36 
-                                                                                                                       
- azurerm_storage_account.blob["BlobStorage.Premium.LRS.Hot"]                                                           
- ├─ Capacity                                                                  2,000,000  GB                $390,000.00 
- ├─ Write operations                                                                200  10k operations          $4.56 
- ├─ List and create container operations                                            200  10k operations         $13.00 
- ├─ Read operations                                                                  20  10k operations          $0.04 
- └─ All other operations                                                            200  10k operations          $0.36 
-                                                                                                                       
- azurerm_storage_account.blob["BlobStorage.Premium.ZRS.Cool"]                                                          
- ├─ Capacity                                                                  2,000,000  GB                $518,000.00 
- ├─ Write operations                                                                200  10k operations          $6.06 
- ├─ List and create container operations                                            200  10k operations         $17.20 
- ├─ Read operations                                                                  20  10k operations          $0.05 
- └─ All other operations                                                            200  10k operations          $0.48 
-                                                                                                                       
- azurerm_storage_account.blob["BlobStorage.Premium.ZRS.Hot"]                                                           
- ├─ Capacity                                                                  2,000,000  GB                $518,000.00 
- ├─ Write operations                                                                200  10k operations          $6.06 
- ├─ List and create container operations                                            200  10k operations         $17.20 
- ├─ Read operations                                                                  20  10k operations          $0.05 
- └─ All other operations                                                            200  10k operations          $0.48 
-                                                                                                                       
- azurerm_storage_account.blob["BlobStorage.Standard.GRS.Cool"]                                                         
- ├─ Capacity                                                                  2,000,000  GB                 $46,000.00 
- ├─ Write operations                                                                200  10k operations         $40.00 
- ├─ List and create container operations                                            200  10k operations         $22.00 
- ├─ Read operations                                                                  20  10k operations          $0.20 
- ├─ All other operations                                                            200  10k operations          $0.88 
- ├─ Data retrieval                                                                2,000  GB                     $20.00 
- └─ Blob index                                                                       20  10k tags                $1.38 
-                                                                                                                       
- azurerm_storage_account.blob["BlobStorage.Standard.GRS.Hot"]                                                          
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $2,344.96 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $22,511.62 
- ├─ Capacity (over 500TB)                                                     1,436,800  GB                 $60,541.00 
- ├─ Write operations                                                                200  10k operations         $22.00 
- ├─ List and create container operations                                            200  10k operations         $22.00 
- ├─ Read operations                                                                  20  10k operations          $0.09 
- ├─ All other operations                                                            200  10k operations          $0.88 
- └─ Blob index                                                                       20  10k tags                $1.38 
-                                                                                                                       
- azurerm_storage_account.blob["BlobStorage.Standard.LRS.Cool"]                                                         
- ├─ Capacity                                                                  2,000,000  GB                 $23,000.00 
- ├─ Write operations                                                                200  10k operations         $20.00 
- ├─ List and create container operations                                            200  10k operations         $11.00 
- ├─ Read operations                                                                  20  10k operations          $0.20 
- ├─ All other operations                                                            200  10k operations          $0.88 
- ├─ Data retrieval                                                                2,000  GB                     $20.00 
- └─ Blob index                                                                       20  10k tags                $0.78 
-                                                                                                                       
- azurerm_storage_account.blob["BlobStorage.Standard.LRS.Hot"]                                                          
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $1,064.96 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $10,223.62 
- ├─ Capacity (over 500TB)                                                     1,436,800  GB                 $27,494.60 
- ├─ Write operations                                                                200  10k operations         $11.00 
- ├─ List and create container operations                                            200  10k operations         $11.00 
- ├─ Read operations                                                                  20  10k operations          $0.09 
- ├─ All other operations                                                            200  10k operations          $0.88 
- └─ Blob index                                                                       20  10k tags                $0.78 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Premium.LRS.Cool"]                                                
- ├─ Capacity                                                                  1,000,000  GB                $195,000.00 
- ├─ Write operations                                                                100  10k operations          $2.28 
- ├─ List and create container operations                                            100  10k operations          $6.50 
- ├─ Read operations                                                                  10  10k operations          $0.02 
- └─ All other operations                                                            100  10k operations          $0.18 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Premium.LRS.Hot"]                                                 
- ├─ Capacity                                                                  1,000,000  GB                $195,000.00 
- ├─ Write operations                                                                100  10k operations          $2.28 
- ├─ List and create container operations                                            100  10k operations          $6.50 
- ├─ Read operations                                                                  10  10k operations          $0.02 
- └─ All other operations                                                            100  10k operations          $0.18 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Premium.ZRS.Cool"]                                                
- ├─ Capacity                                                                  1,000,000  GB                $259,000.00 
- ├─ Write operations                                                                100  10k operations          $3.03 
- ├─ List and create container operations                                            100  10k operations          $8.60 
- ├─ Read operations                                                                  10  10k operations          $0.02 
- └─ All other operations                                                            100  10k operations          $0.24 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Premium.ZRS.Hot"]                                                 
- ├─ Capacity                                                                  1,000,000  GB                $259,000.00 
- ├─ Write operations                                                                100  10k operations          $3.03 
- ├─ List and create container operations                                            100  10k operations          $8.60 
- ├─ Read operations                                                                  10  10k operations          $0.02 
- └─ All other operations                                                            100  10k operations          $0.24 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Standard.GRS.Cool"]                                               
- ├─ Capacity                                                                  1,000,000  GB                 $23,000.00 
- ├─ Write operations                                                                100  10k operations         $20.00 
- ├─ List and create container operations                                            100  10k operations         $11.00 
- ├─ Read operations                                                                  10  10k operations          $0.10 
- ├─ All other operations                                                            100  10k operations          $0.44 
- ├─ Data retrieval                                                                1,000  GB                     $10.00 
- ├─ Data write                                                                    1,000  GB                      $5.00 
- └─ Blob index                                                                       10  10k tags                $0.69 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Standard.GRS.Hot"]                                                
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $2,344.96 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $22,511.62 
- ├─ Capacity (over 500TB)                                                       436,800  GB                 $18,405.00 
- ├─ Write operations                                                                100  10k operations         $11.00 
- ├─ List and create container operations                                            100  10k operations         $11.00 
- ├─ Read operations                                                                  10  10k operations          $0.04 
- ├─ All other operations                                                            100  10k operations          $0.44 
- └─ Blob index                                                                       10  10k tags                $0.69 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Standard.LRS.Cool"]                                               
- ├─ Capacity                                                                  1,000,000  GB                 $11,500.00 
- ├─ Write operations                                                                100  10k operations         $10.00 
- ├─ List and create container operations                                            100  10k operations          $5.50 
- ├─ Read operations                                                                  10  10k operations          $0.10 
- ├─ All other operations                                                            100  10k operations          $0.44 
- ├─ Data retrieval                                                                1,000  GB                     $10.00 
- ├─ Data write                                                                    1,000  GB                      $2.50 
- └─ Blob index                                                                       10  10k tags                $0.39 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Standard.LRS.Hot"]                                                
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $1,064.96 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $10,223.62 
- ├─ Capacity (over 500TB)                                                       436,800  GB                  $8,358.60 
- ├─ Write operations                                                                100  10k operations          $5.50 
- ├─ List and create container operations                                            100  10k operations          $5.50 
- ├─ Read operations                                                                  10  10k operations          $0.04 
- ├─ All other operations                                                            100  10k operations          $0.44 
- └─ Blob index                                                                       10  10k tags                $0.39 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Standard.RAGRS.Cool"]                                             
- ├─ Capacity                                                                  1,000,000  GB                 $28,800.00 
- ├─ Write operations                                                                100  10k operations         $20.00 
- ├─ List and create container operations                                            100  10k operations         $11.00 
- ├─ Read operations                                                                  10  10k operations          $0.10 
- ├─ All other operations                                                            100  10k operations          $0.44 
- ├─ Data retrieval                                                                1,000  GB                     $10.00 
- ├─ Data write                                                                    1,000  GB                      $5.00 
- └─ Blob index                                                                       10  10k tags                $0.69 
-                                                                                                                       
- azurerm_storage_account.blockblob["BlockBlobStorage.Standard.RAGRS.Hot"]                                              
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $2,447.36 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $23,494.66 
- ├─ Capacity (over 500TB)                                                       436,800  GB                 $19,208.72 
- ├─ Write operations                                                                100  10k operations         $11.00 
- ├─ List and create container operations                                            100  10k operations         $11.00 
- ├─ Read operations                                                                  10  10k operations          $0.04 
- ├─ All other operations                                                            100  10k operations          $0.44 
- └─ Blob index                                                                       10  10k tags                $0.69 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Premium.LRS.Cool"]                                                          
- ├─ Data at rest                                                                 50,000  GB                  $8,800.00 
- └─ Snapshots                                                                    50,000  GB                  $7,500.00 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Premium.LRS.Hot"]                                                           
- ├─ Data at rest                                                                 50,000  GB                  $8,800.00 
- └─ Snapshots                                                                    50,000  GB                  $7,500.00 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Premium.ZRS.Cool"]                                                          
- ├─ Data at rest                                                                 50,000  GB                 $11,000.00 
- └─ Snapshots                                                                    50,000  GB                  $9,350.00 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Premium.ZRS.Hot"]                                                           
- ├─ Data at rest                                                                 50,000  GB                 $11,000.00 
- └─ Snapshots                                                                    50,000  GB                  $9,350.00 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Standard.GRS.Cool"]                                                         
- ├─ Data at rest                                                                 50,000  GB                  $2,505.00 
- ├─ Snapshots                                                                    50,000  GB                  $2,505.00 
- ├─ Metadata at rest                                                             50,000  GB                  $3,275.00 
- ├─ Write operations                                                                600  10k operations        $156.00 
- ├─ List operations                                                                 500  10k operations         $71.50 
- ├─ Read operations                                                                  50  10k operations          $0.65 
- ├─ All other operations                                                            500  10k operations          $2.86 
- ├─ Data retrieval                                                                5,000  GB                     $50.00 
- └─ Early deletion                                                                5,000  GB                    $250.50 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Standard.GRS.Hot"]                                                          
- ├─ Data at rest                                                                 50,000  GB                  $3,160.00 
- ├─ Snapshots                                                                    50,000  GB                  $3,160.00 
- ├─ Metadata at rest                                                             50,000  GB                  $3,275.00 
- ├─ Write operations                                                                600  10k operations         $85.80 
- ├─ List operations                                                                 500  10k operations         $71.50 
- ├─ Read operations                                                                  50  10k operations          $0.29 
- └─ All other operations                                                            500  10k operations          $2.86 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Standard.LRS.Cool"]                                                         
- ├─ Data at rest                                                                 50,000  GB                  $1,140.00 
- ├─ Snapshots                                                                    50,000  GB                  $1,140.00 
- ├─ Metadata at rest                                                             50,000  GB                  $1,485.00 
- ├─ Write operations                                                                600  10k operations         $78.00 
- ├─ List operations                                                                 500  10k operations         $35.75 
- ├─ Read operations                                                                  50  10k operations          $0.65 
- ├─ All other operations                                                            500  10k operations          $2.86 
- ├─ Data retrieval                                                                5,000  GB                     $50.00 
- └─ Early deletion                                                                5,000  GB                    $114.00 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Standard.LRS.Hot"]                                                          
- ├─ Data at rest                                                                 50,000  GB                  $1,435.00 
- ├─ Snapshots                                                                    50,000  GB                  $1,435.00 
- ├─ Metadata at rest                                                             50,000  GB                  $1,485.00 
- ├─ Write operations                                                                600  10k operations         $42.90 
- ├─ List operations                                                                 500  10k operations         $35.75 
- ├─ Read operations                                                                  50  10k operations          $0.29 
- └─ All other operations                                                            500  10k operations          $2.86 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Standard.ZRS.Cool"]                                                         
- ├─ Data at rest                                                                 50,000  GB                  $1,425.00 
- ├─ Snapshots                                                                    50,000  GB                  $1,425.00 
- ├─ Metadata at rest                                                             50,000  GB                  $1,855.00 
- ├─ Write operations                                                                600  10k operations         $78.00 
- ├─ List operations                                                                 500  10k operations         $44.70 
- ├─ Read operations                                                                  50  10k operations          $0.65 
- ├─ All other operations                                                            500  10k operations          $2.86 
- ├─ Data retrieval                                                                5,000  GB                     $50.00 
- └─ Early deletion                                                                5,000  GB                    $142.50 
-                                                                                                                       
- azurerm_storage_account.file["FileStorage.Standard.ZRS.Hot"]                                                          
- ├─ Data at rest                                                                 50,000  GB                  $1,800.00 
- ├─ Snapshots                                                                    50,000  GB                  $1,800.00 
- ├─ Metadata at rest                                                             50,000  GB                  $1,855.00 
- ├─ Write operations                                                                600  10k operations         $53.64 
- ├─ List operations                                                                 500  10k operations         $44.70 
- ├─ Read operations                                                                  50  10k operations          $0.29 
- └─ All other operations                                                            500  10k operations          $2.86 
-                                                                                                                       
- azurerm_storage_account.nfsv3["BlockBlobStorage.Premium.LRS.Cool"]                                                    
- ├─ Capacity                                                                  6,000,000  GB              $1,170,000.00 
- ├─ Write operations                                                                600  10k operations         $13.68 
- ├─ List and create container operations                                            600  10k operations         $39.00 
- ├─ Read operations                                                                  60  10k operations          $0.11 
- └─ All other operations                                                            600  10k operations          $1.09 
-                                                                                                                       
- azurerm_storage_account.nfsv3["BlockBlobStorage.Premium.LRS.Hot"]                                                     
- ├─ Capacity                                                                  6,000,000  GB              $1,170,000.00 
- ├─ Write operations                                                                600  10k operations         $13.68 
- ├─ List and create container operations                                            600  10k operations         $39.00 
- ├─ Read operations                                                                  60  10k operations          $0.11 
- └─ All other operations                                                            600  10k operations          $1.09 
-                                                                                                                       
- azurerm_storage_account.nfsv3["BlockBlobStorage.Premium.ZRS.Cool"]                                                    
- ├─ Capacity                                                                  6,000,000  GB              $1,554,000.00 
- ├─ Write operations                                                                600  10k operations         $18.18 
- ├─ List and create container operations                                            600  10k operations         $51.60 
- ├─ Read operations                                                                  60  10k operations          $0.15 
- └─ All other operations                                                            600  10k operations          $1.45 
-                                                                                                                       
- azurerm_storage_account.nfsv3["BlockBlobStorage.Premium.ZRS.Hot"]                                                     
- ├─ Capacity                                                                  6,000,000  GB              $1,554,000.00 
- ├─ Write operations                                                                600  10k operations         $18.18 
- ├─ List and create container operations                                            600  10k operations         $51.60 
- ├─ Read operations                                                                  60  10k operations          $0.15 
- └─ All other operations                                                            600  10k operations          $1.45 
-                                                                                                                       
- azurerm_storage_account.nfsv3["StorageV2.Standard.GRS.Cool"]                                                          
- ├─ Capacity                                                                  6,000,000  GB                $138,000.00 
- ├─ Iterative write operations                                                    6,700  100 operations      $1,742.00 
- ├─ Write operations                                                                600  10k operations        $156.00 
- ├─ Iterative read operations                                                        66  10k operations          $9.44 
- ├─ Read operations                                                                  60  10k operations          $0.78 
- ├─ All other operations                                                            600  10k operations          $3.60 
- ├─ Data retrieval                                                                6,000  GB                     $60.00 
- └─ Early deletion                                                                6,000  GB                    $198.00 
-                                                                                                                       
- azurerm_storage_account.nfsv3["StorageV2.Standard.GRS.Hot"]                                                           
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $2,355.20 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $22,528.00 
- ├─ Capacity (over 500TB)                                                     5,436,800  GB                $228,889.28 
- ├─ Iterative write operations                                                    6,700  100 operations        $958.10 
- ├─ Write operations                                                                600  10k operations         $85.80 
- ├─ Iterative read operations                                                        66  10k operations          $9.44 
- ├─ Read operations                                                                  60  10k operations          $0.36 
- └─ All other operations                                                            600  10k operations          $3.60 
-                                                                                                                       
- azurerm_storage_account.nfsv3["StorageV2.Standard.LRS.Cool"]                                                          
- ├─ Capacity                                                                  6,000,000  GB                 $69,000.00 
- ├─ Iterative write operations                                                    6,700  100 operations        $871.00 
- ├─ Write operations                                                                600  10k operations         $78.00 
- ├─ Iterative read operations                                                        66  10k operations          $4.75 
- ├─ Read operations                                                                  60  10k operations          $0.78 
- ├─ All other operations                                                            600  10k operations          $3.60 
- ├─ Data retrieval                                                                6,000  GB                     $60.00 
- └─ Early deletion                                                                6,000  GB                     $90.00 
-                                                                                                                       
- azurerm_storage_account.nfsv3["StorageV2.Standard.LRS.Hot"]                                                           
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $1,075.20 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $10,240.00 
- ├─ Capacity (over 500TB)                                                     5,436,800  GB                $103,842.88 
- ├─ Iterative write operations                                                    6,700  100 operations        $482.40 
- ├─ Write operations                                                                600  10k operations         $43.20 
- ├─ Iterative read operations                                                        66  10k operations          $4.75 
- ├─ Read operations                                                                  60  10k operations          $0.36 
- └─ All other operations                                                            600  10k operations          $3.60 
-                                                                                                                       
- azurerm_storage_account.storagev1["Storage.Standard.GRS"]                                                             
- ├─ Capacity                                                                  3,000,000  GB                $144,000.00 
- ├─ Write operations                                                                300  10k operations          $0.11 
- ├─ List and create container operations                                            300  10k operations          $0.11 
- ├─ Read operations                                                                  30  10k operations          $0.01 
- └─ All other operations                                                            300  10k operations          $0.11 
-                                                                                                                       
- azurerm_storage_account.storagev1["Storage.Standard.LRS"]                                                             
- ├─ Capacity                                                                  3,000,000  GB                 $72,000.00 
- ├─ Write operations                                                                300  10k operations          $0.11 
- ├─ List and create container operations                                            300  10k operations          $0.11 
- ├─ Read operations                                                                  30  10k operations          $0.01 
- └─ All other operations                                                            300  10k operations          $0.11 
-                                                                                                                       
- azurerm_storage_account.storagev1["Storage.Standard.RAGRS"]                                                           
- ├─ Capacity                                                                  3,000,000  GB                $183,000.00 
- ├─ Write operations                                                                300  10k operations          $0.11 
- ├─ List and create container operations                                            300  10k operations          $0.11 
- ├─ Read operations                                                                  30  10k operations          $0.01 
- └─ All other operations                                                            300  10k operations          $0.11 
-                                                                                                                       
- azurerm_storage_account.storagev1["Storage.Standard.ZRS"]                                                             
- ├─ Capacity                                                                  3,000,000  GB                 $90,000.00 
- ├─ Write operations                                                                300  10k operations          $0.11 
- ├─ List and create container operations                                            300  10k operations          $0.11 
- ├─ Read operations                                                                  30  10k operations          $0.01 
- └─ All other operations                                                            300  10k operations          $0.11 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Premium.LRS.Cool"]                                                       
- ├─ Capacity                                                                  4,000,000  GB                $780,000.00 
- ├─ Write operations                                                                400  10k operations          $9.12 
- ├─ List and create container operations                                            400  10k operations         $26.00 
- ├─ Read operations                                                                  40  10k operations          $0.07 
- └─ All other operations                                                            400  10k operations          $0.73 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Premium.LRS.Hot"]                                                        
- ├─ Capacity                                                                  4,000,000  GB                $780,000.00 
- ├─ Write operations                                                                400  10k operations          $9.12 
- ├─ List and create container operations                                            400  10k operations         $26.00 
- ├─ Read operations                                                                  40  10k operations          $0.07 
- └─ All other operations                                                            400  10k operations          $0.73 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Premium.ZRS.Cool"]                                                       
- ├─ Capacity                                                                  4,000,000  GB              $1,036,000.00 
- ├─ Write operations                                                                400  10k operations         $12.12 
- ├─ List and create container operations                                            400  10k operations         $34.40 
- ├─ Read operations                                                                  40  10k operations          $0.10 
- └─ All other operations                                                            400  10k operations          $0.97 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Premium.ZRS.Hot"]                                                        
- ├─ Capacity                                                                  4,000,000  GB              $1,036,000.00 
- ├─ Write operations                                                                400  10k operations         $12.12 
- ├─ List and create container operations                                            400  10k operations         $34.40 
- ├─ Read operations                                                                  40  10k operations          $0.10 
- └─ All other operations                                                            400  10k operations          $0.97 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.GRS.Cool"]                                                      
- ├─ Capacity                                                                  4,000,000  GB                 $92,000.00 
- ├─ Write operations                                                                400  10k operations         $80.00 
- ├─ List and create container operations                                            400  10k operations         $44.00 
- ├─ Read operations                                                                  40  10k operations          $0.40 
- ├─ All other operations                                                            400  10k operations          $1.76 
- ├─ Data retrieval                                                                4,000  GB                     $40.00 
- ├─ Blob index                                                                       40  10k tags                $2.76 
- └─ Early deletion                                                                4,000  GB                    $133.60 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.GRS.Hot"]                                                       
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $2,344.96 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $22,511.62 
- ├─ Capacity (over 500TB)                                                     3,436,800  GB                $144,813.00 
- ├─ Write operations                                                                400  10k operations         $44.00 
- ├─ List and create container operations                                            400  10k operations         $44.00 
- ├─ Read operations                                                                  40  10k operations          $0.18 
- ├─ All other operations                                                            400  10k operations          $1.76 
- └─ Blob index                                                                       40  10k tags                $2.76 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.GZRS.Cool"]                                                     
- ├─ Read operations                                                                  40  10k operations          $0.40 
- ├─ All other operations                                                            400  10k operations          $1.76 
- └─ Data retrieval                                                                4,000  GB                     $40.00 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.GZRS.Hot"]                                                      
- ├─ Read operations                                                                  40  10k operations          $0.18 
- └─ All other operations                                                            400  10k operations          $1.76 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.LRS.Cool"]                                                      
- ├─ Capacity                                                                  4,000,000  GB                 $46,000.00 
- ├─ Write operations                                                                400  10k operations         $40.00 
- ├─ List and create container operations                                            400  10k operations         $22.00 
- ├─ Read operations                                                                  40  10k operations          $0.40 
- ├─ All other operations                                                            400  10k operations          $1.76 
- ├─ Data retrieval                                                                4,000  GB                     $40.00 
- ├─ Blob index                                                                       40  10k tags                $1.56 
- └─ Early deletion                                                                4,000  GB                     $60.80 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.LRS.Hot"]                                                       
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $1,064.96 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $10,223.62 
- ├─ Capacity (over 500TB)                                                     3,436,800  GB                 $65,766.60 
- ├─ Write operations                                                                400  10k operations         $22.00 
- ├─ List and create container operations                                            400  10k operations         $22.00 
- ├─ Read operations                                                                  40  10k operations          $0.18 
- ├─ All other operations                                                            400  10k operations          $1.76 
- └─ Blob index                                                                       40  10k tags                $1.56 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.RAGRS.Cool"]                                                    
- ├─ Capacity                                                                  4,000,000  GB                $115,200.00 
- ├─ Write operations                                                                400  10k operations         $80.00 
- ├─ List and create container operations                                            400  10k operations         $44.00 
- ├─ Read operations                                                                  40  10k operations          $0.40 
- ├─ All other operations                                                            400  10k operations          $1.76 
- ├─ Data retrieval                                                                4,000  GB                     $40.00 
- ├─ Blob index                                                                       40  10k tags                $2.76 
- └─ Early deletion                                                                4,000  GB                    $140.00 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.RAGRS.Hot"]                                                     
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $2,447.36 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $23,494.66 
- ├─ Capacity (over 500TB)                                                     3,436,800  GB                $151,136.72 
- ├─ Write operations                                                                400  10k operations         $44.00 
- ├─ List and create container operations                                            400  10k operations         $44.00 
- ├─ Read operations                                                                  40  10k operations          $0.18 
- ├─ All other operations                                                            400  10k operations          $1.76 
- └─ Blob index                                                                       40  10k tags                $2.76 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.RAGZRS.Cool"]                                                   
- ├─ Read operations                                                                  40  10k operations          $0.40 
- ├─ All other operations                                                            400  10k operations          $1.76 
- └─ Data retrieval                                                                4,000  GB                     $40.00 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.RAGZRS.Hot"]                                                    
- ├─ List and create container operations                                            400  10k operations         $27.14 
- ├─ Read operations                                                                  40  10k operations          $0.18 
- └─ All other operations                                                            400  10k operations          $1.76 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.ZRS.Cool"]                                                      
- ├─ Capacity                                                                  4,000,000  GB                 $57,600.00 
- ├─ Write operations                                                                400  10k operations         $40.00 
- ├─ List and create container operations                                            400  10k operations         $27.50 
- ├─ Read operations                                                                  40  10k operations          $0.40 
- ├─ All other operations                                                            400  10k operations          $1.76 
- ├─ Data retrieval                                                                4,000  GB                     $40.00 
- ├─ Blob index                                                                       40  10k tags                $1.56 
- └─ Early deletion                                                                4,000  GB                     $76.00 
-                                                                                                                       
- azurerm_storage_account.storagev2["StorageV2.Standard.ZRS.Hot"]                                                       
- ├─ Capacity (first 50TB)                                                        51,200  GB                  $1,331.20 
- ├─ Capacity (next 450TB)                                                       512,000  GB                 $12,779.52 
- ├─ Capacity (over 500TB)                                                     3,436,800  GB                 $82,208.26 
- ├─ List and create container operations                                            400  10k operations         $27.50 
- ├─ Read operations                                                                  40  10k operations          $0.18 
- ├─ All other operations                                                            400  10k operations          $1.76 
- └─ Blob index                                                                       40  10k tags                $1.56 
-                                                                                                                       
- OVERALL TOTAL                                                                                          $14,182,475.61 
+ Name                                                                            Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                                     
+ azurerm_storage_account.blob["BlobStorage.Premium.LRS.Cool"]                                                                        
+ ├─ Capacity                                                                       2,000,000  GB                         $390,000.00 
+ ├─ Write operations                                                                     200  10k operations                   $4.56 
+ ├─ List and create container operations                                                 200  10k operations                  $13.00 
+ ├─ Read operations                                                                       20  10k operations                   $0.04 
+ └─ All other operations                                                                 200  10k operations                   $0.36 
+                                                                                                                                     
+ azurerm_storage_account.blob["BlobStorage.Premium.LRS.Hot"]                                                                         
+ ├─ Capacity                                                                       2,000,000  GB                         $390,000.00 
+ ├─ Write operations                                                                     200  10k operations                   $4.56 
+ ├─ List and create container operations                                                 200  10k operations                  $13.00 
+ ├─ Read operations                                                                       20  10k operations                   $0.04 
+ └─ All other operations                                                                 200  10k operations                   $0.36 
+                                                                                                                                     
+ azurerm_storage_account.blob["BlobStorage.Premium.ZRS.Cool"]                                                                        
+ ├─ Capacity                                                                       2,000,000  GB                         $518,000.00 
+ ├─ Write operations                                                                     200  10k operations                   $6.06 
+ ├─ List and create container operations                                                 200  10k operations                  $17.20 
+ ├─ Read operations                                                                       20  10k operations                   $0.05 
+ └─ All other operations                                                                 200  10k operations                   $0.48 
+                                                                                                                                     
+ azurerm_storage_account.blob["BlobStorage.Premium.ZRS.Hot"]                                                                         
+ ├─ Capacity                                                                       2,000,000  GB                         $518,000.00 
+ ├─ Write operations                                                                     200  10k operations                   $6.06 
+ ├─ List and create container operations                                                 200  10k operations                  $17.20 
+ ├─ Read operations                                                                       20  10k operations                   $0.05 
+ └─ All other operations                                                                 200  10k operations                   $0.48 
+                                                                                                                                     
+ azurerm_storage_account.blob["BlobStorage.Standard.GRS.Cool"]                                                                       
+ ├─ Capacity                                                                       2,000,000  GB                          $46,000.00 
+ ├─ Write operations                                                                     200  10k operations                  $40.00 
+ ├─ List and create container operations                                                 200  10k operations                  $22.00 
+ ├─ Read operations                                                                       20  10k operations                   $0.20 
+ ├─ All other operations                                                                 200  10k operations                   $0.88 
+ ├─ Data retrieval                                                                     2,000  GB                              $20.00 
+ └─ Blob index                                                                            20  10k tags                         $1.38 
+                                                                                                                                     
+ azurerm_storage_account.blob["BlobStorage.Standard.GRS.Hot"]                                                                        
+ ├─ Capacity (first 50TB)                                                             51,200  GB                           $2,344.96 
+ ├─ Capacity (next 450TB)                                                            512,000  GB                          $22,511.62 
+ ├─ Capacity (over 500TB)                                                          1,436,800  GB                          $60,541.00 
+ ├─ Write operations                                                                     200  10k operations                  $22.00 
+ ├─ List and create container operations                                                 200  10k operations                  $22.00 
+ ├─ Read operations                                                                       20  10k operations                   $0.09 
+ ├─ All other operations                                                                 200  10k operations                   $0.88 
+ └─ Blob index                                                                            20  10k tags                         $1.38 
+                                                                                                                                     
+ azurerm_storage_account.blob["BlobStorage.Standard.LRS.Cool"]                                                                       
+ ├─ Capacity                                                                       2,000,000  GB                          $23,000.00 
+ ├─ Write operations                                                                     200  10k operations                  $20.00 
+ ├─ List and create container operations                                                 200  10k operations                  $11.00 
+ ├─ Read operations                                                                       20  10k operations                   $0.20 
+ ├─ All other operations                                                                 200  10k operations                   $0.88 
+ ├─ Data retrieval                                                                     2,000  GB                              $20.00 
+ └─ Blob index                                                                            20  10k tags                         $0.78 
+                                                                                                                                     
+ azurerm_storage_account.blob["BlobStorage.Standard.LRS.Hot"]                                                                        
+ ├─ Capacity (first 50TB)                                                             51,200  GB                           $1,064.96 
+ ├─ Capacity (next 450TB)                                                            512,000  GB                          $10,223.62 
+ ├─ Capacity (over 500TB)                                                          1,436,800  GB                          $27,494.60 
+ ├─ Write operations                                                                     200  10k operations                  $11.00 
+ ├─ List and create container operations                                                 200  10k operations                  $11.00 
+ ├─ Read operations                                                                       20  10k operations                   $0.09 
+ ├─ All other operations                                                                 200  10k operations                   $0.88 
+ └─ Blob index                                                                            20  10k tags                         $0.78 
+                                                                                                                                     
+ azurerm_storage_account.blockblob["BlockBlobStorage.Premium.LRS"]                                                                   
+ ├─ Capacity                                                                       1,000,000  GB                         $195,000.00 
+ ├─ Write operations                                                                     100  10k operations                   $2.28 
+ ├─ List and create container operations                                                 100  10k operations                   $6.50 
+ ├─ Read operations                                                                       10  10k operations                   $0.02 
+ └─ All other operations                                                                 100  10k operations                   $0.18 
+                                                                                                                                     
+ azurerm_storage_account.blockblob["BlockBlobStorage.Premium.ZRS"]                                                                   
+ ├─ Capacity                                                                       1,000,000  GB                         $259,000.00 
+ ├─ Write operations                                                                     100  10k operations                   $3.03 
+ ├─ List and create container operations                                                 100  10k operations                   $8.60 
+ ├─ Read operations                                                                       10  10k operations                   $0.02 
+ └─ All other operations                                                                 100  10k operations                   $0.24 
+                                                                                                                                     
+ azurerm_storage_account.blockblob["BlockBlobStorage.Standard.GRS"]                                                                  
+ ├─ Capacity (first 50TB)                                                             51,200  GB                           $2,344.96 
+ ├─ Capacity (next 450TB)                                                            512,000  GB                          $22,511.62 
+ ├─ Capacity (over 500TB)                                                            436,800  GB                          $18,405.00 
+ ├─ Write operations                                                                     100  10k operations                  $11.00 
+ ├─ List and create container operations                                                 100  10k operations                  $11.00 
+ ├─ Read operations                                                                       10  10k operations                   $0.04 
+ ├─ All other operations                                                                 100  10k operations                   $0.44 
+ └─ Blob index                                                                            10  10k tags                         $0.69 
+                                                                                                                                     
+ azurerm_storage_account.blockblob["BlockBlobStorage.Standard.LRS"]                                                                  
+ ├─ Capacity (first 50TB)                                                             51,200  GB                           $1,064.96 
+ ├─ Capacity (next 450TB)                                                            512,000  GB                          $10,223.62 
+ ├─ Capacity (over 500TB)                                                            436,800  GB                           $8,358.60 
+ ├─ Write operations                                                                     100  10k operations                   $5.50 
+ ├─ List and create container operations                                                 100  10k operations                   $5.50 
+ ├─ Read operations                                                                       10  10k operations                   $0.04 
+ ├─ All other operations                                                                 100  10k operations                   $0.44 
+ └─ Blob index                                                                            10  10k tags                         $0.39 
+                                                                                                                                     
+ azurerm_storage_account.blockblob["BlockBlobStorage.Standard.RAGRS"]                                                                
+ ├─ Capacity (first 50TB)                                                             51,200  GB                           $2,447.36 
+ ├─ Capacity (next 450TB)                                                            512,000  GB                          $23,494.66 
+ ├─ Capacity (over 500TB)                                                            436,800  GB                          $19,208.72 
+ ├─ Write operations                                                                     100  10k operations                  $11.00 
+ ├─ List and create container operations                                                 100  10k operations                  $11.00 
+ ├─ Read operations                                                                       10  10k operations                   $0.04 
+ ├─ All other operations                                                                 100  10k operations                   $0.44 
+ └─ Blob index                                                                            10  10k tags                         $0.69 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Premium.LRS.Cool"]                                                                        
+ ├─ Data at rest                                                                      50,000  GB                           $8,800.00 
+ └─ Snapshots                                                                         50,000  GB                           $7,500.00 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Premium.LRS.Hot"]                                                                         
+ ├─ Data at rest                                                                      50,000  GB                           $8,800.00 
+ └─ Snapshots                                                                         50,000  GB                           $7,500.00 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Premium.ZRS.Cool"]                                                                        
+ ├─ Data at rest                                                                      50,000  GB                          $11,000.00 
+ └─ Snapshots                                                                         50,000  GB                           $9,350.00 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Premium.ZRS.Hot"]                                                                         
+ ├─ Data at rest                                                                      50,000  GB                          $11,000.00 
+ └─ Snapshots                                                                         50,000  GB                           $9,350.00 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Standard.GRS.Cool"]                                                                       
+ ├─ Data at rest                                                                      50,000  GB                           $2,505.00 
+ ├─ Snapshots                                                                         50,000  GB                           $2,505.00 
+ ├─ Metadata at rest                                                                  50,000  GB                           $3,275.00 
+ ├─ Write operations                                                                     600  10k operations                 $156.00 
+ ├─ List operations                                                                      500  10k operations                  $71.50 
+ ├─ Read operations                                                                       50  10k operations                   $0.65 
+ ├─ All other operations                                                                 500  10k operations                   $2.86 
+ ├─ Data retrieval                                                                     5,000  GB                              $50.00 
+ └─ Early deletion                                                                     5,000  GB                             $250.50 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Standard.GRS.Hot"]                                                                        
+ ├─ Data at rest                                                                      50,000  GB                           $3,160.00 
+ ├─ Snapshots                                                                         50,000  GB                           $3,160.00 
+ ├─ Metadata at rest                                                                  50,000  GB                           $3,275.00 
+ ├─ Write operations                                                                     600  10k operations                  $85.80 
+ ├─ List operations                                                                      500  10k operations                  $71.50 
+ ├─ Read operations                                                                       50  10k operations                   $0.29 
+ └─ All other operations                                                                 500  10k operations                   $2.86 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Standard.LRS.Cool"]                                                                       
+ ├─ Data at rest                                                                      50,000  GB                           $1,140.00 
+ ├─ Snapshots                                                                         50,000  GB                           $1,140.00 
+ ├─ Metadata at rest                                                                  50,000  GB                           $1,485.00 
+ ├─ Write operations                                                                     600  10k operations                  $78.00 
+ ├─ List operations                                                                      500  10k operations                  $35.75 
+ ├─ Read operations                                                                       50  10k operations                   $0.65 
+ ├─ All other operations                                                                 500  10k operations                   $2.86 
+ ├─ Data retrieval                                                                     5,000  GB                              $50.00 
+ └─ Early deletion                                                                     5,000  GB                             $114.00 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Standard.LRS.Hot"]                                                                        
+ ├─ Data at rest                                                                      50,000  GB                           $1,435.00 
+ ├─ Snapshots                                                                         50,000  GB                           $1,435.00 
+ ├─ Metadata at rest                                                                  50,000  GB                           $1,485.00 
+ ├─ Write operations                                                                     600  10k operations                  $42.90 
+ ├─ List operations                                                                      500  10k operations                  $35.75 
+ ├─ Read operations                                                                       50  10k operations                   $0.29 
+ └─ All other operations                                                                 500  10k operations                   $2.86 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Standard.ZRS.Cool"]                                                                       
+ ├─ Data at rest                                                                      50,000  GB                           $1,425.00 
+ ├─ Snapshots                                                                         50,000  GB                           $1,425.00 
+ ├─ Metadata at rest                                                                  50,000  GB                           $1,855.00 
+ ├─ Write operations                                                                     600  10k operations                  $78.00 
+ ├─ List operations                                                                      500  10k operations                  $44.70 
+ ├─ Read operations                                                                       50  10k operations                   $0.65 
+ ├─ All other operations                                                                 500  10k operations                   $2.86 
+ ├─ Data retrieval                                                                     5,000  GB                              $50.00 
+ └─ Early deletion                                                                     5,000  GB                             $142.50 
+                                                                                                                                     
+ azurerm_storage_account.file["FileStorage.Standard.ZRS.Hot"]                                                                        
+ ├─ Data at rest                                                                      50,000  GB                           $1,800.00 
+ ├─ Snapshots                                                                         50,000  GB                           $1,800.00 
+ ├─ Metadata at rest                                                                  50,000  GB                           $1,855.00 
+ ├─ Write operations                                                                     600  10k operations                  $53.64 
+ ├─ List operations                                                                      500  10k operations                  $44.70 
+ ├─ Read operations                                                                       50  10k operations                   $0.29 
+ └─ All other operations                                                                 500  10k operations                   $2.86 
+                                                                                                                                     
+ azurerm_storage_account.nfsv3_blockblob["BlockBlobStorage.Premium.LRS"]                                                             
+ ├─ Capacity                                                              Monthly cost depends on usage: $0.20 per GB                
+ ├─ Write operations                                                      Monthly cost depends on usage: $0.0228 per 10k operations  
+ ├─ List and create container operations                                  Monthly cost depends on usage: $0.065 per 10k operations   
+ ├─ Read operations                                                       Monthly cost depends on usage: $0.00182 per 10k operations 
+ └─ All other operations                                                  Monthly cost depends on usage: $0.00182 per 10k operations 
+                                                                                                                                     
+ azurerm_storage_account.nfsv3_blockblob["BlockBlobStorage.Premium.ZRS"]                                                             
+ ├─ Capacity                                                              Monthly cost depends on usage: $0.26 per GB                
+ ├─ Write operations                                                      Monthly cost depends on usage: $0.0303 per 10k operations  
+ ├─ List and create container operations                                  Monthly cost depends on usage: $0.086 per 10k operations   
+ ├─ Read operations                                                       Monthly cost depends on usage: $0.00242 per 10k operations 
+ └─ All other operations                                                  Monthly cost depends on usage: $0.00242 per 10k operations 
+                                                                                                                                     
+ azurerm_storage_account.nfsv3_storagev2["StorageV2.Standard.GRS.Cool"]                                                              
+ ├─ Capacity                                                              Monthly cost depends on usage: $0.023 per GB               
+ ├─ Iterative write operations                                            Monthly cost depends on usage: $0.26 per 100 operations    
+ ├─ Write operations                                                      Monthly cost depends on usage: $0.26 per 10k operations    
+ ├─ Iterative read operations                                             Monthly cost depends on usage: $0.14 per 10k operations    
+ ├─ Read operations                                                       Monthly cost depends on usage: $0.013 per 10k operations   
+ ├─ All other operations                                                  Monthly cost depends on usage: $0.006 per 10k operations   
+ ├─ Data retrieval                                                        Monthly cost depends on usage: $0.01 per GB                
+ └─ Early deletion                                                        Monthly cost depends on usage: $0.033 per GB               
+                                                                                                                                     
+ azurerm_storage_account.nfsv3_storagev2["StorageV2.Standard.GRS.Hot"]                                                               
+ ├─ Capacity                                                              Monthly cost depends on usage: $0.046 per GB               
+ ├─ Iterative write operations                                            Monthly cost depends on usage: $0.14 per 100 operations    
+ ├─ Write operations                                                      Monthly cost depends on usage: $0.14 per 10k operations    
+ ├─ Iterative read operations                                             Monthly cost depends on usage: $0.14 per 10k operations    
+ ├─ Read operations                                                       Monthly cost depends on usage: $0.006 per 10k operations   
+ └─ All other operations                                                  Monthly cost depends on usage: $0.006 per 10k operations   
+                                                                                                                                     
+ azurerm_storage_account.nfsv3_storagev2["StorageV2.Standard.LRS.Cool"]                                                              
+ ├─ Capacity                                                              Monthly cost depends on usage: $0.0115 per GB              
+ ├─ Iterative write operations                                            Monthly cost depends on usage: $0.13 per 100 operations    
+ ├─ Write operations                                                      Monthly cost depends on usage: $0.13 per 10k operations    
+ ├─ Iterative read operations                                             Monthly cost depends on usage: $0.072 per 10k operations   
+ ├─ Read operations                                                       Monthly cost depends on usage: $0.013 per 10k operations   
+ ├─ All other operations                                                  Monthly cost depends on usage: $0.006 per 10k operations   
+ ├─ Data retrieval                                                        Monthly cost depends on usage: $0.01 per GB                
+ └─ Early deletion                                                        Monthly cost depends on usage: $0.015 per GB               
+                                                                                                                                     
+ azurerm_storage_account.nfsv3_storagev2["StorageV2.Standard.LRS.Hot"]                                                               
+ ├─ Capacity                                                              Monthly cost depends on usage: $0.021 per GB               
+ ├─ Iterative write operations                                            Monthly cost depends on usage: $0.072 per 100 operations   
+ ├─ Write operations                                                      Monthly cost depends on usage: $0.072 per 10k operations   
+ ├─ Iterative read operations                                             Monthly cost depends on usage: $0.072 per 10k operations   
+ ├─ Read operations                                                       Monthly cost depends on usage: $0.006 per 10k operations   
+ └─ All other operations                                                  Monthly cost depends on usage: $0.006 per 10k operations   
+                                                                                                                                     
+ azurerm_storage_account.storagev1["Storage.Standard.GRS"]                                                                           
+ ├─ Capacity                                                                       3,000,000  GB                         $144,000.00 
+ ├─ Write operations                                                                     300  10k operations                   $0.11 
+ ├─ List and create container operations                                                 300  10k operations                   $0.11 
+ ├─ Read operations                                                                       30  10k operations                   $0.01 
+ └─ All other operations                                                                 300  10k operations                   $0.11 
+                                                                                                                                     
+ azurerm_storage_account.storagev1["Storage.Standard.LRS"]                                                                           
+ ├─ Capacity                                                                       3,000,000  GB                          $72,000.00 
+ ├─ Write operations                                                                     300  10k operations                   $0.11 
+ ├─ List and create container operations                                                 300  10k operations                   $0.11 
+ ├─ Read operations                                                                       30  10k operations                   $0.01 
+ └─ All other operations                                                                 300  10k operations                   $0.11 
+                                                                                                                                     
+ azurerm_storage_account.storagev1["Storage.Standard.RAGRS"]                                                                         
+ ├─ Capacity                                                                       3,000,000  GB                         $183,000.00 
+ ├─ Write operations                                                                     300  10k operations                   $0.11 
+ ├─ List and create container operations                                                 300  10k operations                   $0.11 
+ ├─ Read operations                                                                       30  10k operations                   $0.01 
+ └─ All other operations                                                                 300  10k operations                   $0.11 
+                                                                                                                                     
+ azurerm_storage_account.storagev1["Storage.Standard.ZRS"]                                                                           
+ ├─ Capacity                                                                       3,000,000  GB                          $90,000.00 
+ ├─ Write operations                                                                     300  10k operations                   $0.11 
+ ├─ List and create container operations                                                 300  10k operations                   $0.11 
+ ├─ Read operations                                                                       30  10k operations                   $0.01 
+ └─ All other operations                                                                 300  10k operations                   $0.11 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Premium.LRS.Cool"]                                                                     
+ ├─ Capacity                                                                       4,000,000  GB                         $780,000.00 
+ ├─ Write operations                                                                     400  10k operations                   $9.12 
+ ├─ List and create container operations                                                 400  10k operations                  $26.00 
+ ├─ Read operations                                                                       40  10k operations                   $0.07 
+ └─ All other operations                                                                 400  10k operations                   $0.73 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Premium.LRS.Hot"]                                                                      
+ ├─ Capacity                                                                       4,000,000  GB                         $780,000.00 
+ ├─ Write operations                                                                     400  10k operations                   $9.12 
+ ├─ List and create container operations                                                 400  10k operations                  $26.00 
+ ├─ Read operations                                                                       40  10k operations                   $0.07 
+ └─ All other operations                                                                 400  10k operations                   $0.73 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Premium.ZRS.Cool"]                                                                     
+ ├─ Capacity                                                                       4,000,000  GB                       $1,036,000.00 
+ ├─ Write operations                                                                     400  10k operations                  $12.12 
+ ├─ List and create container operations                                                 400  10k operations                  $34.40 
+ ├─ Read operations                                                                       40  10k operations                   $0.10 
+ └─ All other operations                                                                 400  10k operations                   $0.97 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Premium.ZRS.Hot"]                                                                      
+ ├─ Capacity                                                                       4,000,000  GB                       $1,036,000.00 
+ ├─ Write operations                                                                     400  10k operations                  $12.12 
+ ├─ List and create container operations                                                 400  10k operations                  $34.40 
+ ├─ Read operations                                                                       40  10k operations                   $0.10 
+ └─ All other operations                                                                 400  10k operations                   $0.97 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.GRS.Cool"]                                                                    
+ ├─ Capacity                                                                       4,000,000  GB                          $92,000.00 
+ ├─ Write operations                                                                     400  10k operations                  $80.00 
+ ├─ List and create container operations                                                 400  10k operations                  $44.00 
+ ├─ Read operations                                                                       40  10k operations                   $0.40 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ ├─ Data retrieval                                                                     4,000  GB                              $40.00 
+ ├─ Blob index                                                                            40  10k tags                         $2.76 
+ └─ Early deletion                                                                     4,000  GB                             $133.60 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.GRS.Hot"]                                                                     
+ ├─ Capacity (first 50TB)                                                             51,200  GB                           $2,344.96 
+ ├─ Capacity (next 450TB)                                                            512,000  GB                          $22,511.62 
+ ├─ Capacity (over 500TB)                                                          3,436,800  GB                         $144,813.00 
+ ├─ Write operations                                                                     400  10k operations                  $44.00 
+ ├─ List and create container operations                                                 400  10k operations                  $44.00 
+ ├─ Read operations                                                                       40  10k operations                   $0.18 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ └─ Blob index                                                                            40  10k tags                         $2.76 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.GZRS.Cool"]                                                                   
+ ├─ Read operations                                                                       40  10k operations                   $0.40 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ └─ Data retrieval                                                                     4,000  GB                              $40.00 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.GZRS.Hot"]                                                                    
+ ├─ Read operations                                                                       40  10k operations                   $0.18 
+ └─ All other operations                                                                 400  10k operations                   $1.76 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.LRS.Cool"]                                                                    
+ ├─ Capacity                                                                       4,000,000  GB                          $46,000.00 
+ ├─ Write operations                                                                     400  10k operations                  $40.00 
+ ├─ List and create container operations                                                 400  10k operations                  $22.00 
+ ├─ Read operations                                                                       40  10k operations                   $0.40 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ ├─ Data retrieval                                                                     4,000  GB                              $40.00 
+ ├─ Blob index                                                                            40  10k tags                         $1.56 
+ └─ Early deletion                                                                     4,000  GB                              $60.80 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.LRS.Hot"]                                                                     
+ ├─ Capacity (first 50TB)                                                             51,200  GB                           $1,064.96 
+ ├─ Capacity (next 450TB)                                                            512,000  GB                          $10,223.62 
+ ├─ Capacity (over 500TB)                                                          3,436,800  GB                          $65,766.60 
+ ├─ Write operations                                                                     400  10k operations                  $22.00 
+ ├─ List and create container operations                                                 400  10k operations                  $22.00 
+ ├─ Read operations                                                                       40  10k operations                   $0.18 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ └─ Blob index                                                                            40  10k tags                         $1.56 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.RAGRS.Cool"]                                                                  
+ ├─ Capacity                                                                       4,000,000  GB                         $115,200.00 
+ ├─ Write operations                                                                     400  10k operations                  $80.00 
+ ├─ List and create container operations                                                 400  10k operations                  $44.00 
+ ├─ Read operations                                                                       40  10k operations                   $0.40 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ ├─ Data retrieval                                                                     4,000  GB                              $40.00 
+ ├─ Blob index                                                                            40  10k tags                         $2.76 
+ └─ Early deletion                                                                     4,000  GB                             $140.00 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.RAGRS.Hot"]                                                                   
+ ├─ Capacity (first 50TB)                                                             51,200  GB                           $2,447.36 
+ ├─ Capacity (next 450TB)                                                            512,000  GB                          $23,494.66 
+ ├─ Capacity (over 500TB)                                                          3,436,800  GB                         $151,136.72 
+ ├─ Write operations                                                                     400  10k operations                  $44.00 
+ ├─ List and create container operations                                                 400  10k operations                  $44.00 
+ ├─ Read operations                                                                       40  10k operations                   $0.18 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ └─ Blob index                                                                            40  10k tags                         $2.76 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.RAGZRS.Cool"]                                                                 
+ ├─ Read operations                                                                       40  10k operations                   $0.40 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ └─ Data retrieval                                                                     4,000  GB                              $40.00 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.RAGZRS.Hot"]                                                                  
+ ├─ List and create container operations                                                 400  10k operations                  $27.14 
+ ├─ Read operations                                                                       40  10k operations                   $0.18 
+ └─ All other operations                                                                 400  10k operations                   $1.76 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.ZRS.Cool"]                                                                    
+ ├─ Capacity                                                                       4,000,000  GB                          $57,600.00 
+ ├─ Write operations                                                                     400  10k operations                  $40.00 
+ ├─ List and create container operations                                                 400  10k operations                  $27.50 
+ ├─ Read operations                                                                       40  10k operations                   $0.40 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ ├─ Data retrieval                                                                     4,000  GB                              $40.00 
+ ├─ Blob index                                                                            40  10k tags                         $1.56 
+ └─ Early deletion                                                                     4,000  GB                              $76.00 
+                                                                                                                                     
+ azurerm_storage_account.storagev2["StorageV2.Standard.ZRS.Hot"]                                                                     
+ ├─ Capacity (first 50TB)                                                             51,200  GB                           $1,331.20 
+ ├─ Capacity (next 450TB)                                                            512,000  GB                          $12,779.52 
+ ├─ Capacity (over 500TB)                                                          3,436,800  GB                          $82,208.26 
+ ├─ List and create container operations                                                 400  10k operations                  $27.50 
+ ├─ Read operations                                                                       40  10k operations                   $0.18 
+ ├─ All other operations                                                                 400  10k operations                   $1.76 
+ └─ Blob index                                                                            40  10k tags                         $1.56 
+                                                                                                                                     
+ OVERALL TOTAL                                                                                                         $7,635,980.70 
 ──────────────────────────────────
-58 cloud resources were detected:
-∙ 56 were estimated
+51 cloud resources were detected:
+∙ 49 were estimated
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
 ∙ 1 is not supported yet, see https://infracost.io/requested-resources:
@@ -465,7 +403,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestAzureStorageAccountGoldenFile                  ┃ $14,182,476  ┃
+┃ TestAzureStorageAccountGoldenFile                  ┃ $7,635,981   ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
@@ -5,10 +5,10 @@
  └─ IP address (unused)                                             730  hours         $8.76 
                                                                                              
  google_compute_address.preemptible_static                                                   
- └─ IP address (preemptible VM)                                     730  hours         $1.46 
+ └─ IP address (preemptible VM)                                     730  hours         $1.83 
                                                                                              
  google_compute_address.standard_static                                                      
- └─ IP address (standard VM)                                        730  hours         $2.92 
+ └─ IP address (standard VM)                                        730  hours         $3.65 
                                                                                              
  google_compute_address.static                                                               
  └─ IP address (unused)                                             730  hours         $7.30 
@@ -31,7 +31,7 @@
  ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)                730  hours         $3.88 
  └─ Standard provisioned storage (pd-standard)                       10  GB            $0.40 
                                                                                              
- OVERALL TOTAL                                                                        $46.56 
+ OVERALL TOTAL                                                                        $47.66 
 ──────────────────────────────────
 12 cloud resources were detected:
 ∙ 9 were estimated, 3 of which include usage-based costs, see https://infracost.io/usage-file
@@ -41,5 +41,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestComputeAddress                                 ┃ $47          ┃
+┃ TestComputeAddress                                 ┃ $48          ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/google/testdata/compute_ha_vpn_gateway_test/compute_ha_vpn_gateway_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_ha_vpn_gateway_test/compute_ha_vpn_gateway_test.golden
@@ -3,15 +3,15 @@
                                                                                             
  google_compute_ha_vpn_gateway.my_compute_ha_vpn_gateway                                    
  └─ Network egress                                                                          
-    ├─ IPSec traffic within the same region                         250  GB           $2.50 
-    ├─ IPSec traffic within the US or Canada                        100  GB           $1.00 
+    ├─ IPSec traffic within the same region                         250  GB           $5.00 
+    ├─ IPSec traffic within the US or Canada                        100  GB           $2.00 
     ├─ IPSec traffic within Europe                                   70  GB           $1.40 
-    ├─ IPSec traffic within Asia                                     50  GB           $2.50 
-    ├─ IPSec traffic within South America                           100  GB           $8.00 
-    ├─ IPSec traffic to/from Indonesia and Oceania                   50  GB           $7.50 
+    ├─ IPSec traffic within Asia                                     50  GB           $4.00 
+    ├─ IPSec traffic within South America                           100  GB          $14.00 
+    ├─ IPSec traffic to/from Indonesia and Oceania                   50  GB           $5.00 
     └─ IPSec traffic between continents (excludes Oceania)          200  GB          $16.00 
                                                                                             
- OVERALL TOTAL                                                                       $38.90 
+ OVERALL TOTAL                                                                       $47.40 
 ──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated, it includes usage-based costs, see https://infracost.io/usage-file
@@ -21,5 +21,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestComputeHAVPNGateway                            ┃ $39          ┃
+┃ TestComputeHAVPNGateway                            ┃ $47          ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
@@ -2,24 +2,24 @@
  Name                                                              Monthly Qty  Unit   Monthly Cost 
                                                                                                     
  google_compute_instance.custom                                                                     
- ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 6 vCPUs)                730  hours       $101.71 
+ ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 6 vCPUs)                730  hours       $101.77 
  ├─ Custom Instance RAM (Linux/UNIX, on-demand, N1 20 GB)                  730  hours        $45.44 
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40 
                                                                                                     
  google_compute_instance.custom_ext                                                                 
- ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 2 vCPUs)                730  hours        $33.90 
+ ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 2 vCPUs)                730  hours        $33.92 
  ├─ Custom Instance RAM (Linux/UNIX, on-demand, N1 13 GB)                  730  hours        $29.53 
  ├─ Custom Instance Extended RAM (Linux/UNIX, on-demand, N1 2 GB)          730  hours         $9.76 
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40 
                                                                                                     
  google_compute_instance.custom_n1                                                                  
- ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 6 vCPUs)                730  hours       $101.71 
+ ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 6 vCPUs)                730  hours       $101.77 
  ├─ Custom Instance RAM (Linux/UNIX, on-demand, N1 20 GB)                  730  hours        $45.44 
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40 
                                                                                                     
  google_compute_instance.custom_n2                                                                  
- ├─ Custom instance CPU (Linux/UNIX, on-demand, N2 6 vCPUs)                730  hours       $116.24 
- ├─ Custom Instance RAM (Linux/UNIX, on-demand, N2 20 GB)                  730  hours        $51.93 
+ ├─ Custom instance CPU (Linux/UNIX, on-demand, N2 6 vCPUs)                730  hours       $116.30 
+ ├─ Custom Instance RAM (Linux/UNIX, on-demand, N2 20 GB)                  730  hours        $51.96 
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40 
                                                                                                     
  google_compute_instance.custom_n2d                                                                 
@@ -81,7 +81,7 @@
  ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)                       100  hours         $0.76 
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40 
                                                                                                     
- OVERALL TOTAL                                                                            $9,446.82 
+ OVERALL TOTAL                                                                            $9,447.04 
 ──────────────────────────────────
 18 cloud resources were detected:
 ∙ 17 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/compute_vpn_gateway_test/compute_vpn_gateway_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_vpn_gateway_test/compute_vpn_gateway_test.golden
@@ -3,15 +3,15 @@
                                                                                             
  google_compute_vpn_gateway.my_compute_vpn_gateway                                          
  └─ Network egress                                                                          
-    ├─ IPSec traffic within the same region                         250  GB           $2.50 
-    ├─ IPSec traffic within the US or Canada                        100  GB           $1.00 
+    ├─ IPSec traffic within the same region                         250  GB           $5.00 
+    ├─ IPSec traffic within the US or Canada                        100  GB           $2.00 
     ├─ IPSec traffic within Europe                                   70  GB           $1.40 
-    ├─ IPSec traffic within Asia                                     50  GB           $2.50 
-    ├─ IPSec traffic within South America                           100  GB           $8.00 
-    ├─ IPSec traffic to/from Indonesia and Oceania                   50  GB           $7.50 
+    ├─ IPSec traffic within Asia                                     50  GB           $4.00 
+    ├─ IPSec traffic within South America                           100  GB          $14.00 
+    ├─ IPSec traffic to/from Indonesia and Oceania                   50  GB           $5.00 
     └─ IPSec traffic between continents (excludes Oceania)          200  GB          $16.00 
                                                                                             
- OVERALL TOTAL                                                                       $38.90 
+ OVERALL TOTAL                                                                       $47.40 
 ──────────────────────────────────
 2 cloud resources were detected:
 ∙ 1 was estimated, it includes usage-based costs, see https://infracost.io/usage-file
@@ -21,5 +21,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestComputeVPNGateway                              ┃ $39          ┃
+┃ TestComputeVPNGateway                              ┃ $47          ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
@@ -92,7 +92,7 @@
  └─ Standard provisioned storage (pd-standard)                       1,200  GB           $48.00 
                                                                                                 
  google_container_node_pool.with_custom_instance                                                
- ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 6 vCPUs)          2,190  hours       $305.13 
+ ├─ Custom instance CPU (Linux/UNIX, on-demand, N1 6 vCPUs)          2,190  hours       $305.30 
  ├─ Custom Instance RAM (Linux/UNIX, on-demand, N1 20 GB)            2,190  hours       $136.31 
  └─ Standard provisioned storage (pd-standard)                         300  GB           $12.00 
                                                                                                 
@@ -122,7 +122,7 @@
  ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                2,920  hours        $97.84 
  └─ Standard provisioned storage (pd-standard)                         400  GB           $16.00 
                                                                                                 
- OVERALL TOTAL                                                                       $27,981.77 
+ OVERALL TOTAL                                                                       $27,981.93 
 ──────────────────────────────────
 25 cloud resources were detected:
 ∙ 25 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file

--- a/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.golden
+++ b/internal/providers/terraform/google/testdata/service_networking_connection_test/service_networking_connection_test.golden
@@ -3,25 +3,25 @@
                                                                                                        
  google_service_networking_connection.my_connection                                                    
  └─ Network egress                                                                                     
-    ├─ Traffic within the same region                      Monthly cost depends on usage: $0.01 per GB 
-    ├─ Traffic within the US or Canada                     Monthly cost depends on usage: $0.01 per GB 
+    ├─ Traffic within the same region                      Monthly cost depends on usage: $0.02 per GB 
+    ├─ Traffic within the US or Canada                     Monthly cost depends on usage: $0.02 per GB 
     ├─ Traffic within Europe                               Monthly cost depends on usage: $0.02 per GB 
-    ├─ Traffic within Asia                                 Monthly cost depends on usage: $0.05 per GB 
-    ├─ Traffic within South America                        Monthly cost depends on usage: $0.08 per GB 
-    ├─ Traffic to/from Indonesia and Oceania               Monthly cost depends on usage: $0.15 per GB 
+    ├─ Traffic within Asia                                 Monthly cost depends on usage: $0.08 per GB 
+    ├─ Traffic within South America                        Monthly cost depends on usage: $0.14 per GB 
+    ├─ Traffic to/from Indonesia and Oceania               Monthly cost depends on usage: $0.10 per GB 
     └─ Traffic between continents (excludes Oceania)       Monthly cost depends on usage: $0.08 per GB 
                                                                                                        
  google_service_networking_connection.my_usage_connection                                              
  └─ Network egress                                                                                     
-    ├─ Traffic within the same region                                250  GB                     $2.50 
-    ├─ Traffic within the US or Canada                               100  GB                     $1.00 
+    ├─ Traffic within the same region                                250  GB                     $5.00 
+    ├─ Traffic within the US or Canada                               100  GB                     $2.00 
     ├─ Traffic within Europe                                          70  GB                     $1.40 
-    ├─ Traffic within Asia                                            50  GB                     $2.50 
-    ├─ Traffic within South America                                  100  GB                     $8.00 
-    ├─ Traffic to/from Indonesia and Oceania                          50  GB                     $7.50 
+    ├─ Traffic within Asia                                            50  GB                     $4.00 
+    ├─ Traffic within South America                                  100  GB                    $14.00 
+    ├─ Traffic to/from Indonesia and Oceania                          50  GB                     $5.00 
     └─ Traffic between continents (excludes Oceania)                 200  GB                    $16.00 
                                                                                                        
- OVERALL TOTAL                                                                                  $38.90 
+ OVERALL TOTAL                                                                                  $47.40 
 ──────────────────────────────────
 4 cloud resources were detected:
 ∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
@@ -32,5 +32,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestServiceNetworkingConnectionGoldenFile          ┃ $39          ┃
+┃ TestServiceNetworkingConnectionGoldenFile          ┃ $47          ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -332,8 +332,8 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 		backupStorageDBEngine := "Any"
 		attrFilters := []*schema.AttributeFilter{
 			{Key: "databaseEngine", Value: strPtr(backupStorageDBEngine)},
-			{Key: "usagetype", ValueRegex: strPtr("/BackupUsage/i")},
-			{Key: "engineCode", ValueRegex: strPtr("/[0-9]+/")},
+			{Key: "usagetype", ValueRegex: regexPtr("RDS:ChargedBackupUsage$")},
+			{Key: "engineCode", ValueRegex: regexPtr("[0-9]+")},
 			{Key: "operation", Value: strPtr("")},
 		}
 
@@ -341,8 +341,8 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 			backupStorageDBEngine = databaseEngine
 			attrFilters = []*schema.AttributeFilter{
 				{Key: "databaseEngine", Value: strPtr(backupStorageDBEngine)},
-				{Key: "usagetype", ValueRegex: strPtr("/BackupUsage/i")},
-				{Key: "engineCode", ValueRegex: strPtr("/[0-9]+/")},
+				{Key: "usagetype", ValueRegex: regexPtr("Aurora:BackupUsage$")},
+				{Key: "engineCode", ValueRegex: regexPtr("[0-9]+")},
 			}
 		}
 

--- a/internal/resources/aws/rds_cluster.go
+++ b/internal/resources/aws/rds_cluster.go
@@ -6,7 +6,6 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
-	"fmt"
 	"strings"
 
 	"github.com/shopspring/decimal"
@@ -81,7 +80,7 @@ func (r *RDSCluster) BuildResource() *schema.Resource {
 				Service:       strPtr("AmazonRDS"),
 				ProductFamily: strPtr(databaseEngineMode),
 				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "databaseEngine", ValueRegex: strPtr(fmt.Sprintf("/%s/i", databaseEngine))},
+					{Key: "databaseEngine", ValueRegex: regexPtr(databaseEngine)},
 				},
 			},
 		})
@@ -128,8 +127,8 @@ func (r *RDSCluster) BuildResource() *schema.Resource {
 			Region:        strPtr(r.Region),
 			ProductFamily: strPtr("System Operation"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "databaseEngine", ValueRegex: strPtr(fmt.Sprintf("/%s/i", databaseEngine))},
-				{Key: "usagetype", ValueRegex: strPtr("/Aurora:SnapshotExportToS3/")},
+				{Key: "databaseEngine", ValueRegex: regexPtr(databaseEngine)},
+				{Key: "usagetype", ValueRegex: regexPtr("Aurora:SnapshotExportToS3$")},
 			},
 		},
 	})
@@ -165,8 +164,8 @@ func (r *RDSCluster) auroraStorageCostComponents(databaseEngineStorageType strin
 				Service:       strPtr("AmazonRDS"),
 				ProductFamily: strPtr("Database Storage"),
 				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "databaseEngine", ValueRegex: strPtr(fmt.Sprintf("/%s/i", databaseEngineStorageType))},
-					{Key: "usagetype", ValueRegex: strPtr("/Aurora:Storage/")},
+					{Key: "databaseEngine", ValueRegex: regexPtr(databaseEngineStorageType)},
+					{Key: "usagetype", ValueRegex: regexPtr("Aurora:StorageUsage$")},
 				},
 			},
 		},
@@ -181,8 +180,8 @@ func (r *RDSCluster) auroraStorageCostComponents(databaseEngineStorageType strin
 				Service:       strPtr("AmazonRDS"),
 				ProductFamily: strPtr("System Operation"),
 				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "databaseEngine", ValueRegex: strPtr(fmt.Sprintf("/%s/i", databaseEngineStorageType))},
-					{Key: "usagetype", ValueRegex: strPtr("/Aurora:Storage/")},
+					{Key: "databaseEngine", ValueRegex: regexPtr(databaseEngineStorageType)},
+					{Key: "usagetype", ValueRegex: regexPtr("Aurora:StorageIOUsage$")},
 				},
 			},
 		},
@@ -201,7 +200,8 @@ func (r *RDSCluster) auroraBackupStorageCostComponent(totalBackupStorageGB *deci
 			Service:       strPtr("AmazonRDS"),
 			ProductFamily: strPtr("Storage Snapshot"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "databaseEngine", ValueRegex: strPtr(fmt.Sprintf("/%s/i", databaseEngine))},
+				{Key: "databaseEngine", ValueRegex: regexPtr(databaseEngine)},
+				{Key: "usagetype", ValueRegex: regexPtr("Aurora:BackupUsage$")},
 			},
 		},
 	}
@@ -219,7 +219,7 @@ func (r *RDSCluster) auroraBacktrackCostComponent(backtrackChangeRecords *decima
 			Region:        strPtr(r.Region),
 			ProductFamily: strPtr("System Operation"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "usagetype", ValueRegex: strPtr("/Aurora:BacktrackUsage/")},
+				{Key: "usagetype", ValueRegex: regexPtr("Aurora:BacktrackUsage$")},
 			},
 		},
 	}

--- a/internal/resources/azure/sql_database.go
+++ b/internal/resources/azure/sql_database.go
@@ -225,9 +225,12 @@ func (r *SQLDatabase) serverlessComputeHoursCostComponents() []*schema.CostCompo
 		vCoreHours = decimalPtr(decimal.NewFromInt(*r.MonthlyVCoreHours))
 	}
 
+	name := fmt.Sprintf("Compute (serverless, %s)", r.SKU)
+	log.Warn().Msgf("'Multiple products found' are safe to ignore for '%s' due to limitations in the Azure API.", name)
+
 	costComponents := []*schema.CostComponent{
 		{
-			Name:            fmt.Sprintf("Compute (serverless, %s)", r.SKU),
+			Name:            name,
 			Unit:            "vCore-hours",
 			UnitMultiplier:  decimal.NewFromInt(1),
 			MonthlyQuantity: vCoreHours,

--- a/internal/resources/google/compute_address.go
+++ b/internal/resources/google/compute_address.go
@@ -70,7 +70,7 @@ func (r *ComputeAddress) standardVMComputeAddress() *schema.CostComponent {
 			},
 		},
 		PriceFilter: &schema.PriceFilter{
-			StartUsageAmount: strPtr("744"),
+			StartUsageAmount: strPtr("696"),
 		},
 	}
 }


### PR DESCRIPTION
1. Google introduced several pricing changes on 1 Feb, so this fixes up them.
2. Fix the Azure golden tests now that `access_tier` is validated as not allowed for block blob storage.
3. Fix AWS RDS cost component lookups