### PR TITLE
fix: module variables not evaluated properly

### DIFF
--- a/internal/hcl/graph_vertex_module_call.go
+++ b/internal/hcl/graph_vertex_module_call.go
@@ -98,7 +98,7 @@ func (v *VertexModuleCall) expand(e *Evaluator, b *Block, mutex *sync.Mutex) ([]
 	expanded = e.expandBlockForEaches(expanded)
 	expanded = e.expandBlockCounts(expanded)
 
-	unexpandedName := b.FullName()
+	unexpandedName := v.block.FullName()
 
 	for _, block := range expanded {
 		name := block.FullName()


### PR DESCRIPTION
This was causing a case where variables could not be evaluated properly if they were nested inside a module, that was inside another expanded module.

The moduleConfig would incorrectly store `module.parent[0].module.child` as the key instead of `module.parent.module.child`, since the `unexpandedName` was only making sure the child module part was unexpanded, not the full module address. This meant that the module was being skipped when evaluating the variable because at that stage we are looking up `module.parent.module.child` in the moduleConfig.

To fix this we use the block's original name to add the module to the moduleConfig since that should be fully unexpanded.