### PR TITLE
feat: bump action dependencies (use nodejs20 runtime)

### DIFF
--- a/.github/workflows/check-resources.yml
+++ b/.github/workflows/check-resources.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/check-resources.yml
+++ b/.github/workflows/check-resources.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check resources
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -19,8 +19,7 @@ jobs:
       security-events: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v5

--- a/.github/workflows/create-pr-assets.yml
+++ b/.github/workflows/create-pr-assets.yml
@@ -15,8 +15,7 @@ jobs:
           - target: darwin
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/create-pr-assets.yml
+++ b/.github/workflows/create-pr-assets.yml
@@ -23,25 +23,25 @@ jobs:
       - name: Build project
         run: make ${{ matrix.target }}
       - name: Upload amd64 build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.target != 'windows' }}
         with:
           name: ${{ matrix.target }}-amd64
           path: "build/infracost-${{ matrix.target }}-amd64"
       - name: Upload windows amd64 build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.target == 'windows' }}
         with:
           name: ${{ matrix.target }}-amd64
           path: "build/infracost.exe"
       - name: Upload arm64 build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.target != 'windows' }}
         with:
           name: ${{ matrix.target }}-arm64
           path: "build/infracost-${{ matrix.target }}-arm64"
       - name: Upload windows arm64 build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ matrix.target == 'windows' }}
         with:
           name: ${{ matrix.target }}-arm64

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Docker meta (CI)
         id: meta-ci
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: |
             ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -99,7 +99,7 @@ jobs:
     name: Update Fig autocomplete spec
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/create-test-image.yml
+++ b/.github/workflows/create-test-image.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build and Push Docker test image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -76,7 +76,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -93,7 +93,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -110,7 +110,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,7 +45,7 @@ jobs:
         run: make parser_benchmarks
 
       - name: Upload benchmark artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmarks
           path: |


### PR DESCRIPTION
- feat: bump actions/checkout to v4 (use nodejs20 runtime)
- feat: bump actions/upload-artifact to v4 (use nodejs20 runtime)
- feat: bump aws-actions/configure-aws-credentials to v4 (use nodejs20 runtime)
- feat: bump docker/login-action to v3 (use nodejs20 runtime)
- feat: bump docker/metadata-action to v5 (use nodejs20 runtime)
- feat: bump docker/setup-buildx-action to v3 (use nodejs20 runtime)

----

closes #2679
closes #2680
closes #2681
closes #2682 
closes #2683
