### PR TITLE
fix: wrong comment on usage example file for aws_rds_cluster

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -326,8 +326,8 @@ resource_usage:
   aws_rds_cluster.my_cluster:
     capacity_units_per_hr: 50          # Number of aurora capacity units per hour. Only used when engine_mode is "serverless"
     storage_gb: 200                    # Storage amount in GB allocated to the aurora cluster.
-    write_requests_per_sec: 100        # Total number of reads per second for the cluster.
-    read_requests_per_sec: 100         # Total number of writes per second for the cluster.
+    write_requests_per_sec: 100        # Total number of writes per second for the cluster.
+    read_requests_per_sec: 100         # Total number of reads per second for the cluster.
     backup_snapshot_size_gb: 200       # Individual storage size for backup snapshots, used in conjunction with resource parameter "backup_retention_period".
     average_statements_per_hr: 10000   # Number of statements generated per hour when backtrack is enabled. Only available for MySQl-compatible Aurora
     change_records_per_statement: 0.38 # Records changed per statement executed.


### PR DESCRIPTION
wrong comment on usage example file for aws_rds_cluster.write_requests_per_sec and aws_rds_cluster.read_requests_per_sec

this resolve #2885 