### PR TITLE
fix: set correct block context when expanding dynamic blocks

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -427,7 +427,7 @@ func (e *Evaluator) expandDynamicBlock(b *Block) *Block {
 		// for each expanded dynamic block add the generated "content" as a
 		// new child block into the parent block.
 		expanded := e.expandBlockForEaches([]*Block{child})
-		for _, ex := range expanded {
+		for i, ex := range expanded {
 			content := ex.GetChildBlock("content")
 			if content == nil {
 				continue
@@ -439,7 +439,7 @@ func (e *Evaluator) expandDynamicBlock(b *Block) *Block {
 			content.SetType(blockName)
 
 			for attrName, attr := range content.AttributesAsMap() {
-				b.context.Root().SetByDot(attr.Value(), fmt.Sprintf("%s.%s.%s", b.Reference().String(), blockName, attrName))
+				b.context.Root().SetByDot(attr.Value(), fmt.Sprintf("%s.%s.%d.%s", b.Reference().String(), blockName, i, attrName))
 			}
 
 			newChildBlocks = append(newChildBlocks, content)


### PR DESCRIPTION
When the `Evaluator` expands dynamic blocks it sets the evaluated `content` on the module context. This means that any resources that depend on the dynamic blocks can use the correct context. Take the following example:

```hcl
variable "my_config" {
  default = [
    {"location": "eu1"},
    {"location": "eu2"}
  ]
}

resource "aws_instance" "dynamic" {
  dynamic "block" {
    for_each = var.my_config
    content {
      location = block.value.location
    }
  }
}

resource "aws_instance" "example" {
  tags = {
    one = aws_instance.dynamic.block[0].location
    two = aws_instance.dynamic.block[1].location
  }
}
```

In this example we see that `aws_instance.example` uses the `aws_instance.dynamic.block`
values in the tags block. Prior to this fix the `Evaluator` was using incorrect keys in
the `SetByDot` context function. This meant that the context looked as follows:

```
aws_instance:
   dynamic:
     block:
       location: eu2
```

instead of

```
aws_instance:
   dynamic:
     block:
       0:
         location: eu1
       1:
         location: eu2
```

This was because we weren't using the `expanded` keys in the `SetByDot`, so the context
was always being set to a single object with the values of the last expanded dynamic block.
This meant any resource/blocks trying to reference the dynamic block with an index (e.g.
`aws_instance.dynamic.block[1]` would evaluate to mocked values.

To resolve this we now use the expanded index in the `SetByDot` function, meaning that we
correctly create a nested object with the expected keys.