### PR TITLE
fix(azure): allow CosmosDB Accounts to be referenced by name

### DIFF
--- a/internal/providers/terraform/azure/cosmosdb_account.go
+++ b/internal/providers/terraform/azure/cosmosdb_account.go
@@ -1,0 +1,18 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+)
+
+// This is a free resource but needs it's own custom registry item to specify the custom ID lookup function.
+func getCosmosDBAccountRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:    "azurerm_cosmosdb_account",
+		NoPrice: true,
+		Notes:   []string{"Free resource."},
+
+		CustomRefIDFunc: func(d *schema.ResourceData) []string {
+			return []string{d.Get("name").String()}
+		},
+	}
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -25,6 +25,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	GetAzureRMBastionHostRegistryItem(),
 	GetAzureRMCDNEndpointRegistryItem(),
 	getContainerRegistryRegistryItem(),
+	getCosmosDBAccountRegistryItem(),
 	GetAzureRMCosmosdbCassandraKeyspaceRegistryItem(),
 	GetAzureRMCosmosdbCassandraTableRegistryItem(),
 	GetAzureRMCosmosdbGremlinDatabaseRegistryItem(),
@@ -260,7 +261,6 @@ var FreeResources = []string{
 	"azurerm_consumption_budget_subscription",
 
 	// Azure CosmosDB
-	"azurerm_cosmosdb_account",
 	"azurerm_cosmosdb_notebook_workspace",
 	"azurerm_cosmosdb_sql_stored_procedure",
 	"azurerm_cosmosdb_sql_trigger",

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.tf
@@ -118,3 +118,10 @@ resource "azurerm_cosmosdb_sql_database" "serverless" {
   resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
   account_name        = azurerm_cosmosdb_account.example.name
 }
+
+resource "azurerm_cosmosdb_sql_database" "account_by_name" {
+  name                = "tfex-cosmos-account-by-name"
+  resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
+  account_name        = "tfex-cosmosdb-account"
+  throughput          = 500
+}


### PR DESCRIPTION
This fixes some `account_name` not found issues for CosmosDB resources