### PR TITLE
Fix circular dependency issue when an alias provider is used

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -973,6 +973,19 @@ func TestBreakdownWithDeepMergeModule(t *testing.T) {
 	)
 }
 
+func TestBreakdownWithNestedProviderAliases(t *testing.T) {
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path",
+			path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		nil,
+	)
+}
+
 func TestBreakdownWithMultipleProviders(t *testing.T) {
 	GoldenFileCommandTest(
 		t,

--- a/cmd/infracost/testdata/breakdown_with_nested_provider_aliases/account_lookup/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_nested_provider_aliases/account_lookup/main.tf
@@ -1,0 +1,10 @@
+module "region_data" {
+  source = "../region_lookup"
+}
+
+output "data" {
+  value = {
+    "role"        = "arn:aws:iam::12345:role/role"
+    "region_name" = module.region_data.full_name
+  }
+}

--- a/cmd/infracost/testdata/breakdown_with_nested_provider_aliases/breakdown_with_nested_provider_aliases.golden
+++ b/cmd/infracost/testdata/breakdown_with_nested_provider_aliases/breakdown_with_nested_provider_aliases.golden
@@ -1,0 +1,22 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_nested_provider_aliases
+
+ Name                                                 Monthly Qty  Unit   Monthly Cost 
+                                                                                       
+ aws_instance.web                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours         $9.64 
+ └─ root_block_device                                                                  
+    └─ Storage (general purpose SSD, gp2)                       8  GB            $0.93 
+                                                                                       
+ OVERALL TOTAL                                                                  $10.56 
+──────────────────────────────────
+1 cloud resource was detected:
+∙ 1 was estimated, it includes usage-based costs, see https://infracost.io/usage-file
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...n_with_nested_provider_aliases ┃ $11          ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_nested_provider_aliases/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_nested_provider_aliases/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  alias  = "lookup"
+  region = "eu-west-2"
+}
+
+module "account_lookup" {
+  source = "./account_lookup"
+  providers = {
+    aws = aws.lookup
+  }
+}
+
+provider "aws" {
+  region = module.account_lookup.data.region_name
+  assume_role {
+    role_arn = module.account_lookup.data.role
+  }
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-0c55b159cbfafe1f0"
+  instance_type = "t2.micro"
+}

--- a/cmd/infracost/testdata/breakdown_with_nested_provider_aliases/region_lookup/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_nested_provider_aliases/region_lookup/main.tf
@@ -1,0 +1,5 @@
+data "aws_region" "current" {}
+
+output "full_name" {
+  value = data.aws_region.current.name
+}

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -149,19 +149,10 @@ func (attr *Attribute) ProvidersValue() cty.Value {
 
 		for _, item := range origExpr.Items {
 			if origKeyExpr, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr); ok {
-				buf := bytes.Buffer{}
-				for _, tr := range origKeyExpr.AsTraversal() {
-					switch step := tr.(type) {
-					case hcl.TraverseRoot:
-						buf.WriteString(step.Name)
-					case hcl.TraverseAttr:
-						buf.WriteString(".")
-						buf.WriteString(step.Name)
-					}
-				}
+				key := traversalAsString(origKeyExpr.AsTraversal())
 
 				literalKey := &hclsyntax.LiteralValueExpr{
-					Val: cty.StringVal(buf.String()),
+					Val: cty.StringVal(key),
 				}
 
 				newExpr.Items = append(newExpr.Items, hclsyntax.ObjectConsItem{
@@ -177,6 +168,34 @@ func (attr *Attribute) ProvidersValue() cty.Value {
 	}
 
 	return attr.Value()
+}
+
+// DecodeProviders decodes the providers block into a map of provider names to provider aliases.
+// This is used by the graph evaluator to make sure the correct edges are created when providers are
+// inherited from parent modules.
+func (attr *Attribute) DecodeProviders() map[string]string {
+	providers := make(map[string]string)
+
+	if origExpr, ok := attr.HCLAttr.Expr.(*hclsyntax.ObjectConsExpr); ok {
+		for _, item := range origExpr.Items {
+			keyExpr, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
+			if !ok {
+				continue
+			}
+
+			valExpr, ok := item.ValueExpr.(*hclsyntax.ScopeTraversalExpr)
+			if !ok {
+				continue
+			}
+
+			key := traversalAsString(keyExpr.AsTraversal())
+			val := traversalAsString(valExpr.AsTraversal())
+
+			providers[key] = val
+		}
+	}
+
+	return providers
 }
 
 // HasChanged returns if the Attribute Value has changed since Value was last called.
@@ -1018,7 +1037,24 @@ func (attr *Attribute) referencesFromExpression(expression hcl.Expression) []*Re
 		}
 		return refs
 	case *hclsyntax.ObjectConsKeyExpr:
-		refs = append(refs, attr.referencesFromExpression(t.Wrapped)...)
+		// If the traversal is of length one it is treated as a string by Terraform.
+		// Otherwise it could be a reference. For example:
+		//
+		// providers = {
+		//   aws = aws.alias
+		// }
+		//
+		// In this case the traversal of the key expression would be of length 1 and
+		// we would treat it as a string.
+		//
+		// TODO: Although this helps, I think we still need some way of totally ignoring keys for
+		// the providers attribute of module calls since they can contain a '.' and therefore have
+		// a traversal, but are a special case that should be treated as strings.
+		wrapped, ok := t.Wrapped.(*hclsyntax.ScopeTraversalExpr)
+		if ok && len(wrapped.Traversal) > 1 {
+			refs = append(refs, attr.referencesFromExpression(t.Wrapped)...)
+		}
+
 		return refs
 	case *hclsyntax.SplatExpr:
 		refs = append(refs, attr.referencesFromExpression(t.Source)...)
@@ -1260,6 +1296,20 @@ func toRelativeTraversal(traversal hcl.Traversal) hcl.Traversal {
 	}
 
 	return ret
+}
+
+func traversalAsString(traversal hcl.Traversal) string {
+	buf := bytes.Buffer{}
+	for _, tr := range traversal {
+		switch step := tr.(type) {
+		case hcl.TraverseRoot:
+			buf.WriteString(step.Name)
+		case hcl.TraverseAttr:
+			buf.WriteString(".")
+			buf.WriteString(step.Name)
+		}
+	}
+	return buf.String()
 }
 
 func shouldSkipRef(block *Block, attr *Attribute, key string) bool {


### PR DESCRIPTION
A circular dependency was possible in the graph evaluator. We were adding edges for every data and resource vertex to their provider. For cases where the provider was aliased in the parent module and then implicitly passed to a child module, instead of adding an edge to the aliased provider, we were adding an edge to the root provider.

This fixes that by decoding the providers blocks before creating the edges so we can keep track of all aliased providers and add the correct edges.