### PR TITLE
Azure Machine Learning Compute Instance and Cluster

### DIFF
--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -1046,6 +1046,13 @@ resource_usage:
   azurerm_lb.my_lb:
     monthly_data_processed_gb: 100 # Monthly inbound and outbound data processed in GB.
 
+  azurerm_machine_learning_compute_cluster.my_cluster:
+    instances: 10    # Number of instances in the cluster.
+    monthly_hrs: 730 # Monthly number of hours each instance runs for.
+
+  azurerm_machine_learning_compute_instance.my_instances:
+    monthly_hrs: 730 # Monthly number of hours the instance runs for.
+
   azurerm_managed_disk.my_disk:
     monthly_disk_operations: 2000000 # Number of disk operations (writes, reads, deletes) using a unit size of 256KiB.
 

--- a/internal/providers/terraform/azure/machine_learning_compute_cluster.go
+++ b/internal/providers/terraform/azure/machine_learning_compute_cluster.go
@@ -1,0 +1,26 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getMachineLearningComputeClusterRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "azurerm_machine_learning_compute_cluster",
+		CoreRFunc: newMachineLearningComputeCluster,
+		ReferenceAttributes: []string{
+			"resource_group_name",
+		},
+	}
+}
+
+func newMachineLearningComputeCluster(d *schema.ResourceData) schema.CoreResource {
+	region := lookupRegion(d, []string{"resource_group_name"})
+	return &azure.MachineLearningComputeCluster{
+		Address:      d.Address,
+		Region:       region,
+		InstanceType: d.Get("vm_size").String(),
+		MinNodeCount: d.Get("scale_settings.0.min_node_count").Int(),
+	}
+}

--- a/internal/providers/terraform/azure/machine_learning_compute_cluster_test.go
+++ b/internal/providers/terraform/azure/machine_learning_compute_cluster_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestMachineLearningComputeCluster(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "machine_learning_compute_cluster_test")
+}

--- a/internal/providers/terraform/azure/machine_learning_compute_instance.go
+++ b/internal/providers/terraform/azure/machine_learning_compute_instance.go
@@ -1,0 +1,25 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getMachineLearningComputeInstanceRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "azurerm_machine_learning_compute_instance",
+		CoreRFunc: newMachineLearningComputeInstance,
+		ReferenceAttributes: []string{
+			"resource_group_name",
+		},
+	}
+}
+
+func newMachineLearningComputeInstance(d *schema.ResourceData) schema.CoreResource {
+	region := lookupRegion(d, []string{"resource_group_name"})
+	return &azure.MachineLearningComputeInstance{
+		Address:      d.Address,
+		Region:       region,
+		InstanceType: d.Get("virtual_machine_size").String(),
+	}
+}

--- a/internal/providers/terraform/azure/machine_learning_compute_instance_test.go
+++ b/internal/providers/terraform/azure/machine_learning_compute_instance_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestMachineLearningComputeInstance(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "machine_learning_compute_instance_test")
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -160,6 +160,8 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getPrivateDnsResolverInboundEndpointRegistryItem(),
 	getPrivateDnsResolverOutboundEndpointRegistryItem(),
 	getPrivateDnsResolverDnsForwardingRulesetRegistryItem(),
+	getMachineLearningComputeInstanceRegistryItem(),
+	getMachineLearningComputeClusterRegistryItem(),
 }
 
 // FreeResources grouped alphabetically
@@ -419,6 +421,9 @@ var FreeResources = []string{
 	"azurerm_logic_app_trigger_http_request",
 	"azurerm_logic_app_trigger_recurrence",
 	"azurerm_logic_app_workflow",
+
+	// Azure Machine Learning
+	"azurerm_machine_learning_workspace",
 
 	// Azure Management
 	"azurerm_management_group",

--- a/internal/providers/terraform/azure/testdata/machine_learning_compute_cluster_test/machine_learning_compute_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/machine_learning_compute_cluster_test/machine_learning_compute_cluster_test.golden
@@ -1,0 +1,240 @@
+
+ Name                                                                                  Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D16s_v3.1"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_D16s_v3)                                    730  hours                          $700.80 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D16s_v3.16"]                                                                   
+ └─ Instance usage (Linux, pay as you go, Standard_D16s_v3)                                 11,680  hours                       $11,212.80 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D16s_v3.4"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_D16s_v3)                                  2,920  hours                        $2,803.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D16s_v3.8"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_D16s_v3)                                  5,840  hours                        $5,606.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D2s_v3.1"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                                     730  hours                           $87.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D2s_v3.16"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                                  11,680  hours                        $1,401.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D2s_v3.4"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                                   2,920  hours                          $350.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D2s_v3.8"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                                   5,840  hours                          $700.80 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D4s_v3.1"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_D4s_v3)                                     730  hours                          $175.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D4s_v3.16"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_D4s_v3)                                  11,680  hours                        $2,803.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D4s_v3.4"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_D4s_v3)                                   2,920  hours                          $700.80 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D4s_v3.8"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_D4s_v3)                                   5,840  hours                        $1,401.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D8s_v3.1"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_D8s_v3)                                     730  hours                          $350.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D8s_v3.16"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_D8s_v3)                                  11,680  hours                        $5,606.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D8s_v3.4"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_D8s_v3)                                   2,920  hours                        $1,401.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_D8s_v3.8"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_D8s_v3)                                   5,840  hours                        $2,803.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_DS12_v2.1"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_DS12_v2)                                    730  hours                          $276.67 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_DS12_v2.16"]                                                                   
+ └─ Instance usage (Linux, pay as you go, Standard_DS12_v2)                                 11,680  hours                        $4,426.72 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_DS12_v2.4"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_DS12_v2)                                  2,920  hours                        $1,106.68 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_DS12_v2.8"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_DS12_v2)                                  5,840  hours                        $2,213.36 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E16s_v3.1"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_E16s_v3)                                    730  hours                          $934.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E16s_v3.16"]                                                                   
+ └─ Instance usage (Linux, pay as you go, Standard_E16s_v3)                                 11,680  hours                       $14,950.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E16s_v3.4"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_E16s_v3)                                  2,920  hours                        $3,737.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E16s_v3.8"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_E16s_v3)                                  5,840  hours                        $7,475.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E4s_v3.1"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_E4s_v3)                                     730  hours                          $233.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E4s_v3.16"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_E4s_v3)                                  11,680  hours                        $3,737.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E4s_v3.4"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_E4s_v3)                                   2,920  hours                          $934.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E4s_v3.8"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_E4s_v3)                                   5,840  hours                        $1,868.80 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E8s_v3.1"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_E8s_v3)                                     730  hours                          $467.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E8s_v3.16"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_E8s_v3)                                  11,680  hours                        $7,475.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E8s_v3.4"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_E8s_v3)                                   2,920  hours                        $1,868.80 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_E8s_v3.8"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_E8s_v3)                                   5,840  hours                        $3,737.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F16s_v2.1"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_F16s_v2)                                    730  hours                          $566.48 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F16s_v2.16"]                                                                   
+ └─ Instance usage (Linux, pay as you go, Standard_F16s_v2)                                 11,680  hours                        $9,063.68 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F16s_v2.4"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_F16s_v2)                                  2,920  hours                        $2,265.92 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F16s_v2.8"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_F16s_v2)                                  5,840  hours                        $4,531.84 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F4s_v2.1"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_F4s_v2)                                     730  hours                          $141.62 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F4s_v2.16"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_F4s_v2)                                  11,680  hours                        $2,265.92 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F4s_v2.4"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_F4s_v2)                                   2,920  hours                          $566.48 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F4s_v2.8"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_F4s_v2)                                   5,840  hours                        $1,132.96 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F8s_v2.1"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_F8s_v2)                                     730  hours                          $283.24 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F8s_v2.16"]                                                                    
+ └─ Instance usage (Linux, pay as you go, Standard_F8s_v2)                                  11,680  hours                        $4,531.84 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F8s_v2.4"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_F8s_v2)                                   2,920  hours                        $1,132.96 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_F8s_v2.8"]                                                                     
+ └─ Instance usage (Linux, pay as you go, Standard_F8s_v2)                                   5,840  hours                        $2,265.92 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC12.1"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NC12)                                       730  hours                        $1,703.09 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC12.16"]                                                                      
+ └─ Instance usage (Linux, pay as you go, Standard_NC12)                                    11,680  hours                       $27,249.44 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC12.4"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NC12)                                     2,920  hours                        $6,812.36 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC12.8"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NC12)                                     5,840  hours                       $13,624.72 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC24.1"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NC24)                                       730  hours                        $3,406.18 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC24.16"]                                                                      
+ └─ Instance usage (Linux, pay as you go, Standard_NC24)                                    11,680  hours                       $54,498.88 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC24.4"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NC24)                                     2,920  hours                       $13,624.72 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC24.8"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NC24)                                     5,840  hours                       $27,249.44 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC6.1"]                                                                        
+ └─ Instance usage (Linux, pay as you go, Standard_NC6)                                        730  hours                          $851.18 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC6.16"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NC6)                                     11,680  hours                       $13,618.88 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC6.4"]                                                                        
+ └─ Instance usage (Linux, pay as you go, Standard_NC6)                                      2,920  hours                        $3,404.72 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NC6.8"]                                                                        
+ └─ Instance usage (Linux, pay as you go, Standard_NC6)                                      5,840  hours                        $6,809.44 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV12.1"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NV12)                                       730  hours                        $1,992.90 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV12.16"]                                                                      
+ └─ Instance usage (Linux, pay as you go, Standard_NV12)                                    11,680  hours                       $31,886.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV12.4"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NV12)                                     2,920  hours                        $7,971.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV12.8"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NV12)                                     5,840  hours                       $15,943.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV24.1"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NV24)                                       730  hours                        $3,985.80 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV24.16"]                                                                      
+ └─ Instance usage (Linux, pay as you go, Standard_NV24)                                    11,680  hours                       $63,772.80 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV24.4"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NV24)                                     2,920  hours                       $15,943.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV24.8"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NV24)                                     5,840  hours                       $31,886.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV6.1"]                                                                        
+ └─ Instance usage (Linux, pay as you go, Standard_NV6)                                        730  hours                          $996.45 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV6.16"]                                                                       
+ └─ Instance usage (Linux, pay as you go, Standard_NV6)                                     11,680  hours                       $15,943.20 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV6.4"]                                                                        
+ └─ Instance usage (Linux, pay as you go, Standard_NV6)                                      2,920  hours                        $3,985.80 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.example["Standard_NV6.8"]                                                                        
+ └─ Instance usage (Linux, pay as you go, Standard_NV6)                                      5,840  hours                        $7,971.60 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.with_instances                                                                                   
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                                   7,300  hours                          $876.00 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.with_instances_and_monthly_hrs                                                                   
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                                      20  hours                            $2.40 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.with_monthly_hrs                                                                                 
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                                     200  hours                           $24.00 
+                                                                                                                                           
+ azurerm_machine_learning_compute_cluster.with_monthly_hrs_zero_min_node_count                                                             
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                                     100  hours                           $12.00 
+                                                                                                                                           
+ azurerm_storage_account.example                                                                                                           
+ ├─ Capacity                                                                    Monthly cost depends on usage: $0.0392 per GB              
+ ├─ Write operations                                                            Monthly cost depends on usage: $0.11 per 10k operations    
+ ├─ List and create container operations                                        Monthly cost depends on usage: $0.11 per 10k operations    
+ ├─ Read operations                                                             Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ All other operations                                                        Monthly cost depends on usage: $0.0043 per 10k operations  
+ └─ Blob index                                                                  Monthly cost depends on usage: $0.075 per 10k tags         
+                                                                                                                                           
+ OVERALL TOTAL                                                                                                                 $498,345.89 
+──────────────────────────────────
+92 cloud resources were detected:
+∙ 90 were estimated, 5 of which include usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free:
+  ∙ 1 x azurerm_machine_learning_workspace
+  ∙ 1 x azurerm_resource_group
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                            ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ TestMachineLearningComputeCluster                  ┃ $498,346     ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/machine_learning_compute_cluster_test/machine_learning_compute_cluster_test.tf
+++ b/internal/providers/terraform/azure/testdata/machine_learning_compute_cluster_test/machine_learning_compute_cluster_test.tf
@@ -1,0 +1,142 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+locals {
+  vm_sizes = [
+    "Standard_D2s_v3",
+    "Standard_D4s_v3",
+    "Standard_D8s_v3",
+    "Standard_D16s_v3",
+    "Standard_DS12_v2",
+    "Standard_F4s_v2",
+    "Standard_F8s_v2",
+    "Standard_F16s_v2",
+    "Standard_E4s_v3",
+    "Standard_E8s_v3",
+    "Standard_E16s_v3",
+    "Standard_NC6",
+    "Standard_NC12",
+    "Standard_NC24",
+    "Standard_NV6",
+    "Standard_NV12",
+    "Standard_NV24",
+  ]
+
+  min_node_counts = [0, 1, 4, 8, 16]
+
+  permutations = distinct(flatten([
+    for vm_size in local.vm_sizes : [
+      for min_node_count in local.min_node_counts : {
+        vm_size        = vm_size
+        min_node_count = min_node_count
+      }
+    ]
+  ]))
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplestorageaccount"
+  location                 = azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_machine_learning_workspace" "example" {
+  name                    = "example-workspace"
+  location                = azurerm_resource_group.example.location
+  resource_group_name     = azurerm_resource_group.example.name
+  key_vault_id            = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.KeyVault/vaults/example"
+  application_insights_id = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Insights/components/example"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  storage_account_id = azurerm_storage_account.example.id
+}
+
+resource "azurerm_machine_learning_compute_cluster" "example" {
+  for_each = { for entry in local.permutations : "${entry.vm_size}.${entry.min_node_count}" => entry }
+
+  name                          = "example-cluster"
+  location                      = azurerm_resource_group.example.location
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  vm_size                       = each.value.vm_size
+
+  scale_settings {
+    min_node_count                       = each.value.min_node_count
+    max_node_count                       = each.value.min_node_count + 1
+    scale_down_nodes_after_idle_duration = 30
+  }
+
+  vm_priority = "LowPriority"
+}
+
+resource "azurerm_machine_learning_compute_cluster" "with_monthly_hrs" {
+  name                          = "with-monthly-hrs"
+  location                      = azurerm_resource_group.example.location
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  vm_size                       = "Standard_D2s_v3"
+
+  scale_settings {
+    min_node_count                       = 2
+    max_node_count                       = 20
+    scale_down_nodes_after_idle_duration = 30
+  }
+
+  vm_priority = "LowPriority"
+}
+
+resource "azurerm_machine_learning_compute_cluster" "with_monthly_hrs_zero_min_node_count" {
+  name                          = "with-monthly-hrs"
+  location                      = azurerm_resource_group.example.location
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  vm_size                       = "Standard_D2s_v3"
+
+  scale_settings {
+    min_node_count                       = 0
+    max_node_count                       = 20
+    scale_down_nodes_after_idle_duration = 30
+  }
+
+  vm_priority = "LowPriority"
+}
+
+resource "azurerm_machine_learning_compute_cluster" "with_instances" {
+  name                          = "with-monthly-hrs"
+  location                      = azurerm_resource_group.example.location
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  vm_size                       = "Standard_D2s_v3"
+
+  scale_settings {
+    min_node_count                       = 2
+    max_node_count                       = 20
+    scale_down_nodes_after_idle_duration = 30
+  }
+
+  vm_priority = "LowPriority"
+}
+
+resource "azurerm_machine_learning_compute_cluster" "with_instances_and_monthly_hrs" {
+  name                          = "with-monthly-hrs"
+  location                      = azurerm_resource_group.example.location
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  vm_size                       = "Standard_D2s_v3"
+
+  scale_settings {
+    min_node_count                       = 2
+    max_node_count                       = 20
+    scale_down_nodes_after_idle_duration = 30
+  }
+
+  vm_priority = "LowPriority"
+}
+

--- a/internal/providers/terraform/azure/testdata/machine_learning_compute_cluster_test/machine_learning_compute_cluster_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/machine_learning_compute_cluster_test/machine_learning_compute_cluster_test.usage.yml
@@ -1,0 +1,11 @@
+version: 0.1
+resource_usage:
+  azurerm_machine_learning_compute_cluster.with_monthly_hrs:
+    monthly_hrs: 100
+  azurerm_machine_learning_compute_cluster.with_monthly_hrs_zero_min_node_count:
+    monthly_hrs: 100
+  azurerm_machine_learning_compute_cluster.with_instances:
+    instances: 10
+  azurerm_machine_learning_compute_cluster.with_instances_and_monthly_hrs:
+    instances: 10
+    monthly_hrs: 2

--- a/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.golden
+++ b/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.golden
@@ -1,0 +1,78 @@
+
+ Name                                                                          Monthly Qty  Unit                      Monthly Cost 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_D16s_v3"]                                                             
+ └─ Instance usage (Linux, pay as you go, Standard_D16s_v3)                            730  hours                          $700.80 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_D2s_v3"]                                                              
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                             730  hours                           $87.60 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_D4s_v3"]                                                              
+ └─ Instance usage (Linux, pay as you go, Standard_D4s_v3)                             730  hours                          $175.20 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_D8s_v3"]                                                              
+ └─ Instance usage (Linux, pay as you go, Standard_D8s_v3)                             730  hours                          $350.40 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_DS12_v2"]                                                             
+ └─ Instance usage (Linux, pay as you go, Standard_DS12_v2)                            730  hours                          $276.67 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_E16s_v3"]                                                             
+ └─ Instance usage (Linux, pay as you go, Standard_E16s_v3)                            730  hours                          $934.40 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_E4s_v3"]                                                              
+ └─ Instance usage (Linux, pay as you go, Standard_E4s_v3)                             730  hours                          $233.60 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_E8s_v3"]                                                              
+ └─ Instance usage (Linux, pay as you go, Standard_E8s_v3)                             730  hours                          $467.20 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_F16s_v2"]                                                             
+ └─ Instance usage (Linux, pay as you go, Standard_F16s_v2)                            730  hours                          $566.48 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_F4s_v2"]                                                              
+ └─ Instance usage (Linux, pay as you go, Standard_F4s_v2)                             730  hours                          $141.62 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_F8s_v2"]                                                              
+ └─ Instance usage (Linux, pay as you go, Standard_F8s_v2)                             730  hours                          $283.24 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_NC12"]                                                                
+ └─ Instance usage (Linux, pay as you go, Standard_NC12)                               730  hours                        $1,703.09 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_NC24"]                                                                
+ └─ Instance usage (Linux, pay as you go, Standard_NC24)                               730  hours                        $3,406.18 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_NC6"]                                                                 
+ └─ Instance usage (Linux, pay as you go, Standard_NC6)                                730  hours                          $851.18 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_NV12"]                                                                
+ └─ Instance usage (Linux, pay as you go, Standard_NV12)                               730  hours                        $1,992.90 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_NV24"]                                                                
+ └─ Instance usage (Linux, pay as you go, Standard_NV24)                               730  hours                        $3,985.80 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.example["Standard_NV6"]                                                                 
+ └─ Instance usage (Linux, pay as you go, Standard_NV6)                                730  hours                          $996.45 
+                                                                                                                                   
+ azurerm_machine_learning_compute_instance.with_monthly_hrs                                                                        
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                             100  hours                           $12.00 
+                                                                                                                                   
+ azurerm_storage_account.example                                                                                                   
+ ├─ Capacity                                                            Monthly cost depends on usage: $0.0392 per GB              
+ ├─ Write operations                                                    Monthly cost depends on usage: $0.11 per 10k operations    
+ ├─ List and create container operations                                Monthly cost depends on usage: $0.11 per 10k operations    
+ ├─ Read operations                                                     Monthly cost depends on usage: $0.0043 per 10k operations  
+ ├─ All other operations                                                Monthly cost depends on usage: $0.0043 per 10k operations  
+ └─ Blob index                                                          Monthly cost depends on usage: $0.075 per 10k tags         
+                                                                                                                                   
+ OVERALL TOTAL                                                                                                          $17,164.81 
+──────────────────────────────────
+21 cloud resources were detected:
+∙ 19 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+∙ 2 were free:
+  ∙ 1 x azurerm_machine_learning_workspace
+  ∙ 1 x azurerm_resource_group
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                            ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ TestMachineLearningComputeInstance                 ┃ $17,165      ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.tf
+++ b/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.tf
@@ -1,0 +1,70 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+locals {
+  vm_sizes = [
+    "Standard_D2s_v3",
+    "Standard_D4s_v3",
+    "Standard_D8s_v3",
+    "Standard_D16s_v3",
+    "Standard_DS12_v2",
+    "Standard_F4s_v2",
+    "Standard_F8s_v2",
+    "Standard_F16s_v2",
+    "Standard_E4s_v3",
+    "Standard_E8s_v3",
+    "Standard_E16s_v3",
+    "Standard_NC6",
+    "Standard_NC12",
+    "Standard_NC24",
+    "Standard_NV6",
+    "Standard_NV12",
+    "Standard_NV24",
+  ]
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplestorageaccount"
+  location                 = azurerm_resource_group.example.location
+  resource_group_name      = azurerm_resource_group.example.name
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_machine_learning_workspace" "example" {
+  name                    = "example-workspace"
+  location                = azurerm_resource_group.example.location
+  resource_group_name     = azurerm_resource_group.example.name
+  key_vault_id            = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.KeyVault/vaults/example"
+  application_insights_id = "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/example-resource-group/providers/Microsoft.Insights/components/example"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  storage_account_id = azurerm_storage_account.example.id
+}
+
+resource "azurerm_machine_learning_compute_instance" "example" {
+  for_each = toset(local.vm_sizes)
+
+  name                          = "example-instance"
+  location                      = azurerm_resource_group.example.location
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  virtual_machine_size          = each.value
+
+}
+
+resource "azurerm_machine_learning_compute_instance" "with_monthly_hrs" {
+  name                          = "with-monthly-hrs"
+  location                      = azurerm_resource_group.example.location
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
+  virtual_machine_size          = "Standard_D2s_v3"
+}

--- a/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.usage.yml
@@ -1,0 +1,4 @@
+version: 0.1
+resource_usage:
+  azurerm_machine_learning_compute_instance.with_monthly_hrs:
+    monthly_hrs: 100

--- a/internal/resources/azure/machine_learning_compute_cluster.go
+++ b/internal/resources/azure/machine_learning_compute_cluster.go
@@ -1,0 +1,73 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// MachineLearningComputeCluster struct represents a Azure Machine Learning Compute Cluster.
+//
+// These use the same pricing as Azure Linux Virtual Machines. We default to the minimum scale of
+// the cluster, but allow the number of instances and monthly hours of each instance to be set.
+//
+// Resource information: https://azure.microsoft.com/en-gb/pricing/details/machine-learning/#overview
+// Pricing information: https://azure.microsoft.com/en-gb/pricing/details/machine-learning/
+type MachineLearningComputeCluster struct {
+	Address      string
+	Region       string
+	InstanceType string
+	MinNodeCount int64
+	Instances    *int64   `infracost_usage:"instances"`
+	MonthlyHours *float64 `infracost_usage:"monthly_hrs"`
+}
+
+// CoreType returns the name of this resource type
+func (r *MachineLearningComputeCluster) CoreType() string {
+	return "MachineLearningComputeCluster"
+}
+
+// UsageSchema defines a list which represents the usage schema of MachineLearningComputeCluster.
+func (r *MachineLearningComputeCluster) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "instances", ValueType: schema.Int64, DefaultValue: 0},
+		{Key: "monthly_hrs", ValueType: schema.Float64, DefaultValue: 0},
+	}
+}
+
+// PopulateUsage parses the u schema.UsageData into the MachineLearningComputeCluster.
+// It uses the `infracost_usage` struct tags to populate data into the MachineLearningComputeCluster.
+func (r *MachineLearningComputeCluster) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid MachineLearningComputeCluster struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *MachineLearningComputeCluster) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{
+		linuxVirtualMachineCostComponent(r.Region, r.InstanceType, r.MonthlyHours),
+	}
+
+	res := &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    r.UsageSchema(),
+		CostComponents: costComponents,
+	}
+
+	instances := r.MinNodeCount
+
+	// If the user has set the monthly hours, but the min node count is 0,
+	// we assume that the user wants to calculate the cost of 1 instance.
+	if r.MonthlyHours != nil && instances == 0 {
+		instances = 1
+	}
+
+	if r.Instances != nil {
+		instances = *r.Instances
+	}
+
+	schema.MultiplyQuantities(res, decimal.NewFromInt(instances))
+
+	return res
+}

--- a/internal/resources/azure/machine_learning_compute_instance.go
+++ b/internal/resources/azure/machine_learning_compute_instance.go
@@ -1,0 +1,52 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+// MachineLearningComputeInstance struct represents a Azure Machine Learning Compute Instance.
+//
+// These use the same pricing as Azure Linux Virtual Machines.
+//
+// Resource information: https://azure.microsoft.com/en-gb/pricing/details/machine-learning/#overview
+// Pricing information: https://azure.microsoft.com/en-gb/pricing/details/machine-learning/
+type MachineLearningComputeInstance struct {
+	Address      string
+	Region       string
+	InstanceType string
+	MonthlyHours *float64 `infracost_usage:"monthly_hrs"`
+}
+
+// CoreType returns the name of this resource type
+func (r *MachineLearningComputeInstance) CoreType() string {
+	return "MachineLearningComputeInstance"
+}
+
+// UsageSchema defines a list which represents the usage schema of MachineLearningComputeInstance.
+func (r *MachineLearningComputeInstance) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "monthly_hrs", ValueType: schema.Float64, DefaultValue: 0},
+	}
+}
+
+// PopulateUsage parses the u schema.UsageData into the MachineLearningComputeInstance.
+// It uses the `infracost_usage` struct tags to populate data into the MachineLearningComputeInstance.
+func (r *MachineLearningComputeInstance) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid MachineLearningComputeInstance struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *MachineLearningComputeInstance) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{
+		linuxVirtualMachineCostComponent(r.Region, r.InstanceType, r.MonthlyHours),
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    r.UsageSchema(),
+		CostComponents: costComponents,
+	}
+}


### PR DESCRIPTION
Adds support for `azurerm_machine_learning_compute_cluster` and  `azurerm_machine_learning_compute_instance`. These resources use the same pricing as Azure VMs.