### PR TITLE
fix(azure): support Azure Redis when shards is set to 0

### DIFF
--- a/internal/providers/terraform/azure/redis_cache.go
+++ b/internal/providers/terraform/azure/redis_cache.go
@@ -36,7 +36,9 @@ func NewAzureRMRedisCache(d *schema.ResourceData, u *schema.UsageData) *schema.R
 	shards := int64(1)
 
 	if strings.EqualFold(skuName, "premium") {
-		if d.Get("shard_count").Type != gjson.Null {
+		// If shards is set to 0 then we still want to calculate the cost for 1 shard
+		// since the cache will be in HA-mode not cluster mode.
+		if d.Get("shard_count").Int() > 0 {
 			shards = d.Get("shard_count").Int()
 		}
 

--- a/internal/providers/terraform/azure/testdata/redis_cache_test/redis_cache_test.golden
+++ b/internal/providers/terraform/azure/testdata/redis_cache_test/redis_cache_test.golden
@@ -16,18 +16,21 @@
  azurerm_redis_cache.premium_p3_replicas_per_primary                                   
  └─ Cache usage (Premium_P3)                                   12  nodes     $9,714.84 
                                                                                        
+ azurerm_redis_cache.premium_zero_shards                                               
+ └─ Cache usage (Premium_P1)                                    2  nodes       $404.42 
+                                                                                       
  azurerm_redis_cache.standard_c3                                                       
  └─ Cache usage (Standard_C3)                                   2  nodes       $328.50 
                                                                                        
- OVERALL TOTAL                                                              $15,460.67 
+ OVERALL TOTAL                                                              $15,865.09 
 ──────────────────────────────────
-7 cloud resources were detected:
-∙ 6 were estimated
+8 cloud resources were detected:
+∙ 7 were estimated
 ∙ 1 was free:
   ∙ 1 x azurerm_resource_group
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestAzureRedisCacheGoldenFile                      ┃ $15,461      ┃
+┃ TestAzureRedisCacheGoldenFile                      ┃ $15,865      ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/redis_cache_test/redis_cache_test.tf
+++ b/internal/providers/terraform/azure/testdata/redis_cache_test/redis_cache_test.tf
@@ -68,3 +68,14 @@ resource "azurerm_redis_cache" "premium_p3_replicas_per_primary" {
   replicas_per_primary = 3
 }
 
+resource "azurerm_redis_cache" "premium_zero_shards" {
+  name                = "example-cache"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  capacity            = 1
+  family              = "P"
+  sku_name            = "Premium"
+  shard_count         = 0
+}
+
+


### PR DESCRIPTION
In this case we should still calculate the cost of 2 nodes, since the cache will be set up in HA mode