### PR TITLE
fix: return empty value if usage is nil

### DIFF
--- a/internal/schema/usage_data.go
+++ b/internal/schema/usage_data.go
@@ -77,6 +77,10 @@ func (u *UsageData) Merge(other *UsageData) *UsageData {
 }
 
 func (u *UsageData) Get(key string) gjson.Result {
+	if u == nil {
+		return gjson.Result{}
+	}
+
 	if u.Attributes[key].Type != gjson.Null {
 		return u.Attributes[key]
 	} else if strings.Contains(key, "[") && strings.Contains(key, "]") {


### PR DESCRIPTION
Refactors `Get` so that if the underlying Usage is nil we return an empty value and don't try and index the map resulting in a panic.

Changing here means we don't have to constantly fix `u != nil` in resources.