### PR TITLE
fix: value is null panic

### DIFF
--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -552,7 +552,7 @@ func (p *HCLProvider) marshalDefaultTagsBlock(providerBlock *hcl.Block) map[stri
 	}
 
 	value := tags.Value()
-	if !value.IsKnown() || !value.CanIterateElements() {
+	if value.IsNull() || !value.IsKnown() || !value.CanIterateElements() {
 		return nil
 	}
 


### PR DESCRIPTION
Resolves panic if value is null befor passing to `AsValueMap`