### PR TITLE
enhance: do not exit with error when governance failures happen on upload

### DIFF
--- a/cmd/infracost/testdata/upload_with_blocking_fin_ops_policy_failure/upload_with_blocking_fin_ops_policy_failure.golden
+++ b/cmd/infracost/testdata/upload_with_blocking_fin_ops_policy_failure/upload_with_blocking_fin_ops_policy_failure.golden
@@ -1,10 +1,4 @@
 
-Err:
-Error: Governance check failed:
-
- - finops policy check failed: should show as failing
-
-
 Logs:
 INF Estimate uploaded to Infracost Cloud
 INF 2 finops policies checked

--- a/cmd/infracost/testdata/upload_with_blocking_guardrail_failure/upload_with_blocking_guardrail_failure.golden
+++ b/cmd/infracost/testdata/upload_with_blocking_guardrail_failure/upload_with_blocking_guardrail_failure.golden
@@ -1,10 +1,4 @@
 
-Err:
-Error: Governance check failed:
-
- - guardrail check failed: medical problems
-
-
 Logs:
 INF Estimate uploaded to Infracost Cloud
 INF 2 guardrails checked

--- a/cmd/infracost/testdata/upload_with_blocking_tag_policy_failure/upload_with_blocking_tag_policy_failure.golden
+++ b/cmd/infracost/testdata/upload_with_blocking_tag_policy_failure/upload_with_blocking_tag_policy_failure.golden
@@ -1,10 +1,4 @@
 
-Err:
-Error: Governance check failed:
-
- - tag policy check failed: should show as failing
-
-
 Logs:
 INF Estimate uploaded to Infracost Cloud
 INF 2 tag policies checked

--- a/cmd/infracost/upload.go
+++ b/cmd/infracost/upload.go
@@ -82,10 +82,6 @@ See https://infracost.io/docs/features/cli_commands/#upload-runs`,
 				logging.Logger.Warn().Err(err).Msg("could not report `infracost-upload` event")
 			}
 
-			if len(result.GovernanceFailures) > 0 {
-				return result.GovernanceFailures
-			}
-
 			return nil
 		},
 	}


### PR DESCRIPTION
People who need to check for failures can run upload with --format=json and check the "governance_failures" key.