### PR TITLE
fix: ensure sanitized stacktraces match for equivalent stacktraces

### DIFF
--- a/internal/clierror/error.go
+++ b/internal/clierror/error.go
@@ -5,10 +5,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"regexp"
+	"strings"
 
 	"github.com/maruel/panicparse/v2/stack"
 	"github.com/rs/zerolog/log"
 )
+
+var goroutineSuffixRegex = regexp.MustCompile(`(goroutine)\s*\d+$`)
 
 // SanitizedError allows errors to be wrapped with a sanitized message for sending upstream
 type SanitizedError interface {
@@ -93,7 +97,7 @@ func processStack(rawStack []byte) ([]byte, error) {
 	srcLen := 0
 	for _, bucket := range buckets {
 		for _, line := range bucket.Signature.Stack.Calls {
-			if l := len(fmt.Sprintf("%s:%d", line.ImportPath, line.Line)); l > srcLen {
+			if l := len(fmt.Sprintf("%s/%s:%d", stripInfracostImportPrefix(line.ImportPath), line.SrcName, line.Line)); l > srcLen {
 				srcLen = l
 			}
 		}
@@ -110,7 +114,10 @@ func processStack(rawStack []byte) ([]byte, error) {
 		}
 
 		if len(bucket.CreatedBy.Calls) != 0 {
-			extra += fmt.Sprintf(" [Created by %s.%s @ %s:%d]", bucket.CreatedBy.Calls[0].Func.DirName, bucket.CreatedBy.Calls[0].Func.Name, bucket.CreatedBy.Calls[0].SrcName, bucket.CreatedBy.Calls[0].Line)
+			// Goroutine number can be different across equivalent stacktraces so we remove it.
+			funcName := bucket.CreatedBy.Calls[0].Func.Name
+			funcName = goroutineSuffixRegex.ReplaceAllString(funcName, "$1")
+			extra += fmt.Sprintf(" [Created by %s.%s @ %s:%d]", bucket.CreatedBy.Calls[0].Func.DirName, funcName, bucket.CreatedBy.Calls[0].SrcName, bucket.CreatedBy.Calls[0].Line)
 		}
 		fmt.Fprintf(w, "%d: %s%s\n", len(bucket.IDs), bucket.State, extra)
 
@@ -119,7 +126,7 @@ func processStack(rawStack []byte) ([]byte, error) {
 			_, err := fmt.Fprintf(w,
 				"   %-*s %s()\n",
 				srcLen,
-				fmt.Sprintf("%s:%d", line.RelSrcPath, line.Line),
+				fmt.Sprintf("%s/%s:%d", stripInfracostImportPrefix(line.ImportPath), line.SrcName, line.Line),
 				line.Func.Name)
 			if err != nil {
 				return []byte{}, err
@@ -148,6 +155,10 @@ func processStack(rawStack []byte) ([]byte, error) {
 	w.Flush()
 
 	return buf.Bytes(), nil
+}
+
+func stripInfracostImportPrefix(s string) string {
+	return strings.TrimPrefix(s, "github.com/infracost/infracost/")
 }
 
 // WarningError is an error that adhears to the error interface but is used to convey


### PR DESCRIPTION
This fixes 2 issues:
1. The goroutine number was in the sanitized stacktrace, which could be different for equivalent stack traces
2. The path to the function was not showing for certain builds. Using import path should make this work consistently

Before:
```
1: running [Created by errgroup.(*Group).Go in goroutine 12 @ errgroup.go:72]
   runtime/debug/stack.go:24                        Stack()
   :272                                             (*parallelRunner).run.func1.1()
   runtime/panic.go:770                             panic()
   :341                                             (*parallelRunner).runProvider()
   :282                                             (*parallelRunner).run.func1()
   :75                                              (*Group).Go.func1()
```

After:
```
1: running [Created by errgroup.(*Group).Go in goroutine @ errgroup.go:72]
   runtime/debug/stack.go:24                        Stack()
   cmd/infracost/run.go:272                         (*parallelRunner).run.func1.1()
   runtime/panic.go:770                             panic()
   cmd/infracost/run.go:341                         (*parallelRunner).runProvider()
   cmd/infracost/run.go:282                         (*parallelRunner).run.func1()
   golang.org/x/sync@v0.4.0/errgroup/errgroup.go:75 (*Group).Go.func1()
 ```