### PR TITLE
fix: this can cause a panic if count is set to a negative number

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -711,7 +711,7 @@ func (e *Evaluator) expandBlockCounts(blocks Blocks) Blocks {
 		value := countAttr.Value()
 		if !value.IsNull() && value.IsKnown() {
 			v := countAttr.AsInt()
-			if v <= math.MaxInt32 {
+			if v >= 0 && v <= math.MaxInt32 {
 				count = int(v)
 			}
 		}


### PR DESCRIPTION
We have a check for the max int size already, so just adding an extra one for negative numbers.

This ensures we don't try to make a slice with a negative length.