### PR TITLE
Fix providers that depend on output of module

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -994,6 +994,20 @@ func TestBreakdownWithMultipleProviders(t *testing.T) {
 	)
 }
 
+func TestBreakdownWithProvidersDependingOnData(t *testing.T) {
+	// This test doesn't pass for the non-graph evaluator
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path",
+			path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName()),
+		},
+		&GoldenFileOptions{IgnoreNonGraph: true},
+	)
+}
+
 func TestBreakdownMultiProjectWithError(t *testing.T) {
 	testName := testutil.CalcGoldenFileTestdataDirName()
 	dir := path.Join("./testdata", testName)

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -39,6 +39,7 @@ type GoldenFileOptions = struct {
 	Env         map[string]string
 	// RunTerraformCLI sets the cmd test to also run the cmd with --terraform-force-cli set
 	RunTerraformCLI bool
+	IgnoreNonGraph  bool
 }
 
 func DefaultOptions() *GoldenFileOptions {
@@ -50,9 +51,11 @@ func DefaultOptions() *GoldenFileOptions {
 }
 
 func GoldenFileCommandTest(t *testing.T, testName string, args []string, testOptions *GoldenFileOptions, ctxOptions ...func(ctx *config.RunContext)) {
-	t.Run("HCL", func(t *testing.T) {
-		goldenFileCommandTest(t, testName, args, testOptions, true, ctxOptions...)
-	})
+	if testOptions == nil || !testOptions.IgnoreNonGraph {
+		t.Run("HCL", func(t *testing.T) {
+			goldenFileCommandTest(t, testName, args, testOptions, true, ctxOptions...)
+		})
+	}
 
 	t.Run("HCL Graph", func(t *testing.T) {
 		ctxOptions = append(ctxOptions, func(ctx *config.RunContext) {

--- a/cmd/infracost/testdata/breakdown_with_providers_depending_on_data/breakdown_with_providers_depending_on_data.golden
+++ b/cmd/infracost/testdata/breakdown_with_providers_depending_on_data/breakdown_with_providers_depending_on_data.golden
@@ -1,0 +1,27 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_providers_depending_on_data
+
+ Name                                                 Monthly Qty  Unit   Monthly Cost 
+                                                                                       
+ module.mod_eu1.aws_instance.instance_eu1[0]                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours         $9.20 
+ └─ root_block_device                                                                  
+    └─ Storage (general purpose SSD, gp2)                       8  GB            $0.88 
+                                                                                       
+ module.mod_us2.aws_instance.instance_us2[0]                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours         $8.47 
+ └─ root_block_device                                                                  
+    └─ Storage (general purpose SSD, gp2)                       8  GB            $0.80 
+                                                                                       
+ OVERALL TOTAL                                                                  $19.35 
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...th_providers_depending_on_data ┃ $19          ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_providers_depending_on_data/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_providers_depending_on_data/main.tf
@@ -1,0 +1,29 @@
+provider "aws" {
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+  region                      = module.mod_us2.region_us2
+}
+
+provider "aws" {
+  alias                       = "eu1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+  region                      = module.mod_eu1.region_eu1
+
+}
+
+module "mod_us2" {
+  source = "./mod"
+}
+
+module "mod_eu1" {
+  source = "./mod"
+
+  providers = {
+    aws = aws.eu1
+  }
+}

--- a/cmd/infracost/testdata/breakdown_with_providers_depending_on_data/mod/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_providers_depending_on_data/mod/main.tf
@@ -1,0 +1,21 @@
+output "region_us2" {
+  value = "us-east-2"
+}
+
+output "region_eu1" {
+  value = "eu-west-1"
+}
+
+data "aws_region" "current" {}
+
+resource "aws_instance" "instance_us2" {
+  count         = data.aws_region.current.name == "us-east-2" ? 1 : 0
+  ami           = "ami-674cbc1e"
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "instance_eu1" {
+  count         = data.aws_region.current.name == "eu-west-1" ? 1 : 0
+  ami           = "ami-674cbc1e"
+  instance_type = "t2.micro"
+}

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -992,8 +992,7 @@ func (attr *Attribute) VerticesReferenced(b *Block) []VertexReference {
 			continue
 		}
 
-		isProviderReference := (usesProviderConfiguration(b) && attr.Name() == "provider") || (b.Type() == "module" && attr.Name() == "providers")
-
+		isProviderReference := usesProviderConfiguration(b) && attr.Name() == "provider"
 		if isProviderReference {
 			key = fmt.Sprintf("provider.%s", strings.TrimSuffix(key, "."))
 		}
@@ -1350,7 +1349,7 @@ func shouldSkipRef(block *Block, attr *Attribute, key string) bool {
 	}
 
 	// Provider references can come through as `aws.`
-	isProviderReference := (usesProviderConfiguration(block) && attr.Name() == "provider") || (block.Type() == "module" && attr.Name() == "providers")
+	isProviderReference := usesProviderConfiguration(block) && attr.Name() == "provider"
 	if !isProviderReference && strings.HasSuffix(key, ".") {
 		return true
 	}

--- a/internal/hcl/graph_vertex_data.go
+++ b/internal/hcl/graph_vertex_data.go
@@ -43,6 +43,15 @@ func (v *VertexData) Visit(mutex *sync.Mutex) error {
 			return fmt.Errorf("could not find block %q in module %q", v.block.FullName(), moduleInstance.name)
 		}
 
+		// Reload the provider references for this module instance
+		// We need to do this because we might be evaluating a data block that
+		// needs to get data from a provider block, e.g. aws_default_tags.
+		// We might be able to improve this by only evaluating the
+		// provider block when we need it.
+		for name, providerBlock := range e.module.ProviderReferences {
+			e.ctx.Set(providerBlock.Values(), name)
+		}
+
 		err := v.evaluate(e, blockInstance)
 		if err != nil {
 			return fmt.Errorf("could not evaluate data block %q", v.ID())

--- a/internal/hcl/module.go
+++ b/internal/hcl/module.go
@@ -3,8 +3,6 @@ package hcl
 import (
 	"strconv"
 
-	"github.com/zclconf/go-cty/cty"
-
 	"github.com/infracost/infracost/internal/schema"
 )
 
@@ -22,9 +20,8 @@ type ModuleCall struct {
 
 // Module encapsulates all the Blocks that are part of a Module in a Terraform project.
 type Module struct {
-	Name      string
-	Source    string
-	Providers map[string]cty.Value
+	Name   string
+	Source string
 
 	Blocks Blocks
 	// RawBlocks are the Blocks that were built when the module was loaded from the filesystem.
@@ -47,6 +44,11 @@ type Module struct {
 	// SourceURL is the discovered remote url for the module. This will only be
 	// filled if the module is a remote module.
 	SourceURL string
+
+	// ProviderReferences is a map of provider names (relative to the module) to
+	// the provider block that defines that provider. We keep track of this so we
+	// can re-evaluate the provider blocks when we need to.
+	ProviderReferences map[string]*Block
 }
 
 // Index returns the count index of the Module using the name.


### PR DESCRIPTION
This fixes the case where a `provider` block depends on an output of a module and then that provider is passed to the module and used in a data resource.

Before this would create a circular dependency in the graph evaluator because we were treating providers passed into modules as an edge in the graph. Instead now we just maintain a reference to providers when a module is created and then evaluate them and add them to the context at various points in the evaluation process:
1. Before we evaluate a data block, since for special data attributes we might need the provider on the context (e.g. `aws_current_region`)
2. When we are closing out the module, since after this we collect the default tags values from the module to add to any of the resources.

We could improve this in two ways, but this would be a bigger refactor at the moment:
1. Maintaining a global context for the evaluated providers, instead of adding them to each modules evaluation context.
2. Only evaluating the provider blocks if we need to, instead of for all data resources.