### PR TITLE
feat: allow configuration of max search depth for autodetect

### DIFF
--- a/cmd/infracost/generate.go
+++ b/cmd/infracost/generate.go
@@ -87,10 +87,7 @@ func (g *generateConfigCommand) run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to unmarshal autodetect section: %w", err)
 		}
 
-		ctx.Config.Autodetect.ExcludeDirs = partialConfig.Autodetect.ExcludeDirs
-		ctx.Config.Autodetect.IncludeDirs = partialConfig.Autodetect.IncludeDirs
-		ctx.Config.Autodetect.EnvNames = partialConfig.Autodetect.EnvNames
-		ctx.Config.Autodetect.PathOverrides = partialConfig.Autodetect.PathOverrides
+		ctx.Config.Autodetect = partialConfig.Autodetect
 
 		_, _ = reader.Seek(0, io.SeekStart)
 		definedProjects = hasLineStartingWith(reader, "projects:")

--- a/cmd/infracost/testdata/generate/max_search_depth/expected.golden
+++ b/cmd/infracost/testdata/generate/max_search_depth/expected.golden
@@ -1,0 +1,8 @@
+version: 0.1
+autodetect:
+  max_search_depth: 3
+
+projects:
+  - path: infra/foo
+    name: infra-foo
+

--- a/cmd/infracost/testdata/generate/max_search_depth/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/max_search_depth/infracost.yml.tmpl
@@ -1,0 +1,9 @@
+version: 0.1
+autodetect:
+  max_search_depth: 3
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+{{- end }}

--- a/cmd/infracost/testdata/generate/max_search_depth/tree.txt
+++ b/cmd/infracost/testdata/generate/max_search_depth/tree.txt
@@ -1,0 +1,7 @@
+.
+└── infra
+    ├── foo
+    │   └── main.tf
+    └── nested
+        └── bar
+            └── main.tf

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,9 @@ type AutodetectConfig struct {
 	// PathOverrides defines paths that should be overridden with specific
 	// environment variable grouping.
 	PathOverrides []PathOverride `yaml:"path_overrides,omitempty" ignored:"true"`
+	// MaxSearchDepth configures the number of folders that Infracost should
+	// traverse to detect projects.
+	MaxSearchDepth int `yaml:"max_search_depth,omitempty" ignored:"true"`
 }
 
 type PathOverride struct {

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -207,6 +207,7 @@ type ProjectLocator struct {
 	pathOverrides          []pathOverride
 	wdContainsTerragrunt   bool
 	fallbackToIncludePaths bool
+	maxConfiguredDepth     int
 }
 
 // ProjectLocatorConfig provides configuration options on how the locator functions.
@@ -219,6 +220,7 @@ type ProjectLocatorConfig struct {
 	EnvNames               []string
 	PathOverrides          []PathOverrideConfig
 	FallbackToIncludePaths bool
+	MaxSearchDepth         int
 }
 
 type PathOverrideConfig struct {
@@ -276,6 +278,7 @@ func NewProjectLocator(logger zerolog.Logger, config *ProjectLocatorConfig) *Pro
 			envMatcher:         matcher,
 			useAllPaths:        config.UseAllPaths,
 			skip:               config.SkipAutoDetection,
+			maxConfiguredDepth: config.MaxSearchDepth,
 			shouldSkipDir: func(s string) bool {
 				return false
 			},
@@ -1198,6 +1201,10 @@ func getChildDepth(basePath string, targetPath string) (int, error) {
 }
 
 func (p *ProjectLocator) maxSearchDepth() int {
+	if p.maxConfiguredDepth > 0 {
+		return p.maxConfiguredDepth
+	}
+
 	if p.useAllPaths {
 		return 14
 	}

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -68,6 +68,7 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 		UseAllPaths:            project.IncludeAllPaths,
 		SkipAutoDetection:      project.SkipAutodetect,
 		FallbackToIncludePaths: ctx.IsAutoDetect(),
+		MaxSearchDepth:         ctx.Config.Autodetect.MaxSearchDepth,
 	}
 	pl := hcl.NewProjectLocator(logging.Logger, locatorConfig)
 	rootPaths := pl.FindRootModules(project.Path)


### PR DESCRIPTION
Adds a new `max_search_depth` key to the `autodetect` config file configuration. This enables users to specify the depth that Infracost should search to to try and locate different infrastructure projects (Terraform/Terragrunt).