### PR TITLE
feat: exit early if Infracost API Key is invalid

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
           terragrunt --version
 
       - name: Test invalid api key
-        run: make ARGS="-run TestBreakdownInvalidAPIKey -update" test
+        run: make ARGS="-run TestBreakdownInvalidAPIKey" test
         env:
           INFRACOST_API_KEY: "00000000000000000000000000000000"
           INFRACOST_LOG_LEVEL: info

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,21 +18,21 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Check Terraform format
-        run: make tf_fmt_check
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
-        with:
-          version: latest
-          skip-pkg-cache: true
-          args: --timeout 5m
-
-      - name: Install Terragrunt v0.31.8
-        run: |
-          sudo wget -q -O /usr/bin/terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v0.31.8/terragrunt_linux_amd64"
-          sudo chmod +x /usr/bin/terragrunt
-          terragrunt --version
+#      - name: Check Terraform format
+#        run: make tf_fmt_check
+#
+#      - name: Run golangci-lint
+#        uses: golangci/golangci-lint-action@v3.7.0
+#        with:
+#          version: latest
+#          skip-pkg-cache: true
+#          args: --timeout 5m
+#
+#      - name: Install Terragrunt v0.31.8
+#        run: |
+#          sudo wget -q -O /usr/bin/terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v0.31.8/terragrunt_linux_amd64"
+#          sudo chmod +x /usr/bin/terragrunt
+#          terragrunt --version
 
       - name: Test invalid api key
         run: make ARGS="-run TestBreakdownInvalidAPIKey" test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,28 +18,21 @@ jobs:
         with:
           go-version-file: go.mod
 
-#      - name: Check Terraform format
-#        run: make tf_fmt_check
-#
-#      - name: Run golangci-lint
-#        uses: golangci/golangci-lint-action@v3.7.0
-#        with:
-#          version: latest
-#          skip-pkg-cache: true
-#          args: --timeout 5m
-#
-#      - name: Install Terragrunt v0.31.8
-#        run: |
-#          sudo wget -q -O /usr/bin/terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v0.31.8/terragrunt_linux_amd64"
-#          sudo chmod +x /usr/bin/terragrunt
-#          terragrunt --version
+      - name: Check Terraform format
+        run: make tf_fmt_check
 
-      - name: Test invalid api key
-        run: make ARGS="-run TestBreakdownInvalidAPIKey" test
-        env:
-          INFRACOST_API_KEY: "00000000000000000000000000000000"
-          INFRACOST_LOG_LEVEL: info
-          INFRACOST_TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3.7.0
+        with:
+          version: latest
+          skip-pkg-cache: true
+          args: --timeout 5m
+
+      - name: Install Terragrunt v0.31.8
+        run: |
+          sudo wget -q -O /usr/bin/terragrunt "https://github.com/gruntwork-io/terragrunt/releases/download/v0.31.8/terragrunt_linux_amd64"
+          sudo chmod +x /usr/bin/terragrunt
+          terragrunt --version
 
       - name: Test (unit and shared integration)
         run: make test_shared_int

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,13 @@ jobs:
           sudo chmod +x /usr/bin/terragrunt
           terragrunt --version
 
+      - name: Test invalid api key
+        run: make ARGS="-run TestBreakdownInvalidAPIKey -update" test
+        env:
+          INFRACOST_API_KEY: "00000000000000000000000000000000"
+          INFRACOST_LOG_LEVEL: info
+          INFRACOST_TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
+
       - name: Test (unit and shared integration)
         run: make test_shared_int
         env:

--- a/cmd/infracost/breakdown.go
+++ b/cmd/infracost/breakdown.go
@@ -22,7 +22,7 @@ func breakdownCmd(ctx *config.RunContext) *cobra.Command {
       terraform show -json tfplan.binary > plan.json
       infracost breakdown --path plan.json`,
 		ValidArgs: []string{"--", "-"},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: checkAPIKeyIsValid(ctx, func(cmd *cobra.Command, args []string) error {
 			if err := checkAPIKey(ctx.Config.APIKey, ctx.Config.PricingAPIEndpoint, ctx.Config.DefaultPricingAPIEndpoint); err != nil {
 				return err
 			}
@@ -41,7 +41,7 @@ func breakdownCmd(ctx *config.RunContext) *cobra.Command {
 			}
 
 			return runMain(cmd, ctx)
-		},
+		}),
 	}
 
 	addRunFlags(cmd)

--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1250,7 +1250,6 @@ func TestBreakdownInvalidAPIKey(t *testing.T) {
 		func(ctx *config.RunContext) {
 			ctx.Config.APIKey = "BAD_KEY"
 			ctx.Config.Credentials.APIKey = "BAD_KEY"
-			ctx.Config.PricingCacheDisabled = true
 		},
 	)
 }
@@ -1269,7 +1268,6 @@ func TestBreakdownEmptyAPIKey(t *testing.T) {
 		func(ctx *config.RunContext) {
 			ctx.Config.APIKey = ""
 			ctx.Config.Credentials.APIKey = ""
-			ctx.Config.PricingCacheDisabled = true
 		},
 	)
 }

--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1250,6 +1250,7 @@ func TestBreakdownInvalidAPIKey(t *testing.T) {
 		func(ctx *config.RunContext) {
 			ctx.Config.APIKey = "BAD_KEY"
 			ctx.Config.Credentials.APIKey = "BAD_KEY"
+			ctx.Config.PricingCacheDisabled = true
 		},
 	)
 }
@@ -1268,6 +1269,7 @@ func TestBreakdownEmptyAPIKey(t *testing.T) {
 		func(ctx *config.RunContext) {
 			ctx.Config.APIKey = ""
 			ctx.Config.Credentials.APIKey = ""
+			ctx.Config.PricingCacheDisabled = true
 		},
 	)
 }

--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1235,3 +1235,39 @@ func TestBreakdownConfigFileWithSkipAutoDetect(t *testing.T) {
 		},
 	)
 }
+
+func TestBreakdownInvalidAPIKey(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", dir,
+		},
+		nil,
+		func(ctx *config.RunContext) {
+			ctx.Config.APIKey = "BAD_KEY"
+			ctx.Config.Credentials.APIKey = "BAD_KEY"
+		},
+	)
+}
+
+func TestBreakdownEmptyAPIKey(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", dir,
+		},
+		nil,
+		func(ctx *config.RunContext) {
+			ctx.Config.APIKey = ""
+			ctx.Config.Credentials.APIKey = ""
+		},
+	)
+}

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -27,6 +27,7 @@ var (
 	versionRegex     = regexp.MustCompile(`Infracost v.*`)
 	panicRegex       = regexp.MustCompile(`runtime\serror:([\w\d\n\r\[\]\:\/\.\\(\)\+\,\{\}\*\@\s\?]*)Environment`)
 	pathRegex        = regexp.MustCompile(`(/.*/)(infracost/infracost/cmd/infracost/testdata/.*)`)
+	credsRegex       = regexp.MustCompile(`/.*/credentials\.yml`)
 )
 
 type GoldenFileOptions = struct {
@@ -234,6 +235,7 @@ func stripDynamicValues(actual []byte) []byte {
 	actual = versionRegex.ReplaceAll(actual, []byte("Infracost vREPLACED_VERSION"))
 	actual = panicRegex.ReplaceAll(actual, []byte("runtime error: REPLACED ERROR\nEnvironment"))
 	actual = pathRegex.ReplaceAll(actual, []byte("REPLACED_PROJECT_PATH/$2"))
+	actual = credsRegex.ReplaceAll(actual, []byte("REPLACED_CREDENTIALS_PATH"))
 
 	return actual
 }

--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -57,6 +57,8 @@ func commentCmd(ctx *config.RunContext) *cobra.Command {
 
 	cmds := []*cobra.Command{commentGitHubCmd(ctx), commentGitLabCmd(ctx), commentAzureReposCmd(ctx), commentBitbucketCmd(ctx)}
 	for _, subCmd := range cmds {
+		subCmd.RunE = checkAPIKeyIsValid(ctx, subCmd.RunE)
+
 		subCmd.Flags().StringArray("policy-path", nil, "Path to Infracost policy files, glob patterns need quotes (experimental)")
 		subCmd.Flags().Bool("show-all-projects", false, "Show all projects in the table of the comment output")
 		subCmd.Flags().Bool("show-changed", false, "Show only projects in the table that have code changes")

--- a/cmd/infracost/diff.go
+++ b/cmd/infracost/diff.go
@@ -32,7 +32,7 @@ func diffCmd(ctx *config.RunContext) *cobra.Command {
       terraform show -json tfplan.binary > plan.json
       infracost diff --path plan.json`,
 		ValidArgs: []string{"--", "-"},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: checkAPIKeyIsValid(ctx, func(cmd *cobra.Command, args []string) error {
 			if err := checkAPIKey(ctx.Config.APIKey, ctx.Config.PricingAPIEndpoint, ctx.Config.DefaultPricingAPIEndpoint); err != nil {
 				return err
 			}
@@ -55,7 +55,7 @@ func diffCmd(ctx *config.RunContext) *cobra.Command {
 			}
 
 			return runDiff(cmd, ctx)
-		},
+		}),
 	}
 
 	addRunFlags(cmd)

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -944,12 +944,13 @@ func checkAPIKeyIsValid(ctx *config.RunContext, next runCommandFunc) runCommandF
 		}
 
 		pricingClient := apiclient.GetPricingAPIClient(ctx)
-		_, err := pricingClient.DoQueries([]apiclient.GraphQLQuery{
-			{
-				Query:     `query { apiKey {} }`,
-				Variables: nil,
-			},
+		resp, err := pricingClient.DoQueries([]apiclient.GraphQLQuery{
+			{},
 		})
+		if len(resp) > 0 {
+			cmd.Println(resp[0])
+		}
+		cmd.Println(err)
 		var apiError *apiclient.APIError
 		if errors.As(err, &apiError) {
 			if apiError.ErrorCode == apiclient.ErrorCodeAPIKeyInvalid {

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -945,7 +945,10 @@ func checkAPIKeyIsValid(ctx *config.RunContext, next runCommandFunc) runCommandF
 
 		pricingClient := apiclient.GetPricingAPIClient(ctx)
 		_, err := pricingClient.DoQueries([]apiclient.GraphQLQuery{
-			{},
+			{
+				Query:     `query { apiKey {} }`,
+				Variables: nil,
+			},
 		})
 		var apiError *apiclient.APIError
 		if errors.As(err, &apiError) {

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -943,14 +943,11 @@ func checkAPIKeyIsValid(ctx *config.RunContext, next runCommandFunc) runCommandF
 				"if you continue having issues.")
 		}
 
-		pricingClient := apiclient.GetPricingAPIClient(ctx)
-		resp, err := pricingClient.DoQueries([]apiclient.GraphQLQuery{
+		pricingClient := apiclient.NewPricingAPIClient(ctx)
+		_, err := pricingClient.DoQueries([]apiclient.GraphQLQuery{
 			{},
 		})
-		if len(resp) > 0 {
-			cmd.Println(resp[0])
-		}
-		//cmd.Println(err)
+
 		var apiError *apiclient.APIError
 		if errors.As(err, &apiError) {
 			if apiError.ErrorCode == apiclient.ErrorCodeAPIKeyInvalid {

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -950,7 +950,7 @@ func checkAPIKeyIsValid(ctx *config.RunContext, next runCommandFunc) runCommandF
 		if len(resp) > 0 {
 			cmd.Println(resp[0])
 		}
-		cmd.Println(err)
+		//cmd.Println(err)
 		var apiError *apiclient.APIError
 		if errors.As(err, &apiError) {
 			if apiError.ErrorCode == apiclient.ErrorCodeAPIKeyInvalid {

--- a/cmd/infracost/testdata/breakdown_empty_apikey/breakdown_empty_apikey.golden
+++ b/cmd/infracost/testdata/breakdown_empty_apikey/breakdown_empty_apikey.golden
@@ -1,0 +1,5 @@
+
+Err:
+Error: INFRACOST_API_KEY is not set but is required, check your environment variable is named correctly or add your API key to your REPLACED_CREDENTIALS_PATH credentials file.
+If you recently regenerated your API key, you can retrieve it from https://dashboard.infracost.io.
+See https://infracost.io/support if you continue having issues.

--- a/cmd/infracost/testdata/breakdown_invalid_apikey/breakdown_invalid_apikey.golden
+++ b/cmd/infracost/testdata/breakdown_invalid_apikey/breakdown_invalid_apikey.golden
@@ -1,0 +1,5 @@
+
+Err:
+Error: Invalid API Key, please check your INFRACOST_API_KEY environment variable or REPLACED_CREDENTIALS_PATH credentials file.
+If you recently regenerated your API key, you can retrieve it from https://dashboard.infracost.io.
+See https://infracost.io/support if you continue having issues.

--- a/cmd/infracost/upload.go
+++ b/cmd/infracost/upload.go
@@ -39,7 +39,7 @@ See https://infracost.io/docs/features/cli_commands/#upload-runs`,
 
       infracost upload --path infracost.json`,
 		ValidArgs: []string{"--", "-"},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: checkAPIKeyIsValid(ctx, func(cmd *cobra.Command, args []string) error {
 			var err error
 
 			format, _ := cmd.Flags().GetString("format")
@@ -83,7 +83,7 @@ See https://infracost.io/docs/features/cli_commands/#upload-runs`,
 			}
 
 			return nil
-		},
+		}),
 	}
 
 	cmd.Flags().String("path", "p", "Path to Infracost JSON file.")

--- a/cmd/infracost/upload_test.go
+++ b/cmd/infracost/upload_test.go
@@ -21,12 +21,17 @@ func TestUploadHelp(t *testing.T) {
 }
 
 func TestUploadSelfHosted(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer s.Close()
+
 	GoldenFileCommandTest(t,
 		testutil.CalcGoldenFileTestdataDirName(),
 		[]string{"upload", "--path", "./testdata/example_out.json"},
 		&GoldenFileOptions{CaptureLogs: true},
 		func(c *config.RunContext) {
-			c.Config.PricingAPIEndpoint = "https://fake.url"
+			c.Config.PricingAPIEndpoint = s.URL
 		},
 	)
 }

--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -57,7 +57,7 @@ type APIErrorResponse struct {
 	ErrorCode string `json:"error_code"`
 }
 
-func (c *APIClient) doQueries(queries []GraphQLQuery) ([]gjson.Result, error) {
+func (c *APIClient) DoQueries(queries []GraphQLQuery) ([]gjson.Result, error) {
 	if len(queries) == 0 {
 		log.Debug().Msg("Skipping GraphQL request as no queries have been specified")
 		return []gjson.Result{}, nil

--- a/internal/apiclient/dashboard.go
+++ b/internal/apiclient/dashboard.go
@@ -166,7 +166,7 @@ func (c *DashboardAPIClient) AddRun(ctx *config.RunContext, out output.Root, com
 			}
 		}
 	`
-	results, err := c.doQueries([]GraphQLQuery{{q, v}})
+	results, err := c.DoQueries([]GraphQLQuery{{q, v}})
 	if err != nil {
 		return response, err
 	}
@@ -245,7 +245,7 @@ func (c *DashboardAPIClient) QueryCLISettings() (QueryCLISettingsResponse, error
         	}
     	}
 	`
-	results, err := c.doQueries([]GraphQLQuery{{q, map[string]interface{}{}}})
+	results, err := c.DoQueries([]GraphQLQuery{{q, map[string]interface{}{}}})
 	if err != nil {
 		return response, fmt.Errorf("query failed when requesting org settings %w", err)
 	}

--- a/internal/apiclient/policy.go
+++ b/internal/apiclient/policy.go
@@ -92,7 +92,7 @@ func (c *PolicyAPIClient) uploadProjectPolicyData(p2rs []policy2Resource) (strin
 		"policyResources": p2rs,
 	}
 
-	results, err := c.doQueries([]GraphQLQuery{{q, v}})
+	results, err := c.DoQueries([]GraphQLQuery{{q, v}})
 	if err != nil {
 		return "", fmt.Errorf("query storePolicyResources failed  %w", err)
 	}
@@ -302,7 +302,7 @@ func (c *PolicyAPIClient) getPolicyResourceAllowList() (map[string]allowList, er
 	`
 	v := map[string]interface{}{}
 
-	results, err := c.doQueries([]GraphQLQuery{{q, v}})
+	results, err := c.DoQueries([]GraphQLQuery{{q, v}})
 	if err != nil {
 		return nil, fmt.Errorf("query policyResourceAllowList failed %w", err)
 	}

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -76,6 +76,19 @@ func GetPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 		return pricingClient
 	}
 
+	c := NewPricingAPIClient(ctx)
+
+	initCache(ctx, c)
+	pricingClient = c
+	return c
+}
+
+// NewPricingAPIClient creates a new instance of PricingAPIClient using the given
+// RunContext configuration. Most callers should use GetPricingAPIClient instead
+// of this function to ensure that the client cache is global across the
+// application. This function is useful for creating isolated pricing clients
+// which do not share the global cache.
+func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 	if ctx == nil {
 		return nil
 	}
@@ -129,8 +142,6 @@ func GetPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 		EventsDisabled: ctx.Config.EventsDisabled,
 	}
 
-	initCache(ctx, c)
-	pricingClient = c
 	return c
 }
 

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -77,6 +77,9 @@ func GetPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 	}
 
 	c := NewPricingAPIClient(ctx)
+	if c == nil {
+		return nil
+	}
 
 	initCache(ctx, c)
 	pricingClient = c

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -364,7 +364,7 @@ func (c *PricingAPIClient) PerformRequest(req BatchRequest) ([]PriceQueryResult,
 	for i, query := range deduplicatedServerQueries {
 		rawQueries[i] = query.query
 	}
-	resultsFromServer, err := c.doQueries(rawQueries)
+	resultsFromServer, err := c.DoQueries(rawQueries)
 	if err != nil {
 		return []PriceQueryResult{}, err
 	}

--- a/internal/apiclient/usage.go
+++ b/internal/apiclient/usage.go
@@ -101,7 +101,7 @@ func (c *UsageAPIClient) ListActualCosts(vars ActualCostsQueryVariables) ([]Actu
 
 	logging.Logger.Debug().Msgf("Getting actual costs from %s for %s", c.endpoint, vars.Address)
 
-	results, err := c.doQueries([]GraphQLQuery{query})
+	results, err := c.DoQueries([]GraphQLQuery{query})
 	if err != nil {
 		return nil, err
 	} else if len(results) > 0 && results[0].Get("errors").Exists() {
@@ -181,7 +181,7 @@ func (c *UsageAPIClient) ListUsageQuantities(vars UsageQuantitiesQueryVariables)
 
 	logging.Logger.Debug().Msgf("Getting usage quantities from %s for %s %s %v", c.endpoint, vars.ResourceType, vars.Address, vars.UsageKeys)
 
-	results, err := c.doQueries([]GraphQLQuery{query})
+	results, err := c.DoQueries([]GraphQLQuery{query})
 	if err != nil {
 		return nil, err
 	} else if len(results) > 0 && results[0].Get("errors").Exists() {
@@ -306,7 +306,7 @@ func (c *UsageAPIClient) UploadCloudResourceIDs(vars CloudResourceIDVariables) e
 
 	logging.Logger.Debug().Msgf("Uploading cloud resource IDs to %s for %s %s", c.endpoint, vars.RepoURL, vars.ProjectWithWorkspace)
 
-	results, err := c.doQueries([]GraphQLQuery{query})
+	results, err := c.DoQueries([]GraphQLQuery{query})
 	if err != nil {
 		return err
 	} else if len(results) > 0 && results[0].Get("errors").Exists() {


### PR DESCRIPTION
Changes the `breakdown`, `diff`, `upload` and `comment` commands to exit early if the INFRACOST_API_KEY is invalid. This is done so that users can better debug their pipelines where an API key might be incorrectly set.

To accomodate this change i've introduced the idea of command middleware which will wrap commands before their execution. This means we can easily chain on additional functionality/checks in the future if required. The specific checkAPIKeyIsValid middleware works by making a empty request to the pricing API service and check if the error returned has an Invalid API Key code. I think this the simplest and most effective way to achieve the API key validation. But you have thoughts of a better way, please let me know.

I have checked with @alikhajeh1 to make sure the error messaging is acceptable.