### PR TITLE
fix: update golden test prices

### DIFF
--- a/internal/providers/terraform/aws/testdata/config_organization_custom_rule_test/config_organization_custom_rule_test.tf
+++ b/internal/providers/terraform/aws/testdata/config_organization_custom_rule_test/config_organization_custom_rule_test.tf
@@ -9,13 +9,13 @@ provider "aws" {
 }
 
 resource "aws_config_organization_custom_rule" "my_config_organization_custom_rule" {
-  lambda_function_arn = "fake"
+  lambda_function_arn = "arn:aws:lambda:us-west-2:123456789012:function:my-function"
   name                = "example"
   trigger_types       = ["ConfigurationItemChangeNotification"]
 }
 
 resource "aws_config_organization_custom_rule" "my_config_organization_custom_rule_usage" {
-  lambda_function_arn = "fake"
+  lambda_function_arn = "arn:aws:lambda:us-west-2:123456789012:function:my-function"
   name                = "example"
   trigger_types       = ["ConfigurationItemChangeNotification"]
 }

--- a/internal/providers/terraform/aws/testdata/neptune_cluster_instance_test/neptune_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/neptune_cluster_instance_test/neptune_cluster_instance_test.golden
@@ -20,14 +20,14 @@
  └─ CPU credits                                                  7,300  vCPU-hours               $1,095.00 
                                                                                                            
  aws_neptune_cluster_instance.dbT3Medium-iooptimized                                                       
- ├─ Database instance (on-demand, db.t3.medium)                    730  hours                      $110.38 
+ ├─ Database instance (on-demand, db.t3.medium)                    730  hours                      $110.23 
  └─ CPU credits                                       Monthly cost depends on usage: $0.15 per vCPU-hours  
                                                                                                            
  aws_neptune_cluster_instance.dbT3WithoutUsage                                                             
  ├─ Database instance (on-demand, db.t3.medium)                    730  hours                       $81.76 
  └─ CPU credits                                       Monthly cost depends on usage: $0.15 per vCPU-hours  
                                                                                                            
- OVERALL TOTAL                                                                                   $1,964.58 
+ OVERALL TOTAL                                                                                   $1,964.43 
 ──────────────────────────────────
 7 cloud resources were detected:
 ∙ 7 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
@@ -35,5 +35,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestNeptuneClusterInstanceGoldenFile               ┃ $1,965       ┃
+┃ TestNeptuneClusterInstanceGoldenFile               ┃ $1,964       ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/linux_virtual_machine_test/linux_virtual_machine_test.golden
@@ -26,14 +26,14 @@
     └─ Disk operations                                     Monthly cost depends on usage: $0.0005 per 10k operations  
                                                                                                                       
  azurerm_linux_virtual_machine.standard_a2_ultra_enabled                                                              
- ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                 730  hours                           $66.43 
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                 730  hours                           $65.92 
  ├─ Ultra disk reservation (if unattached)                 Monthly cost depends on usage: $4.38 per vCPU              
  └─ os_disk                                                                                                           
     ├─ Storage (E4, LRS)                                                    1  months                           $2.40 
     └─ Disk operations                                     Monthly cost depends on usage: $0.002 per 10k operations   
                                                                                                                       
  azurerm_linux_virtual_machine.standard_a2_v2_custom_disk                                                             
- ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                 730  hours                           $66.43 
+ ├─ Instance usage (Linux, pay as you go, Standard_A2_v2)                 730  hours                           $65.92 
  └─ os_disk                                                                                                           
     ├─ Storage (E30, LRS)                                                   1  months                          $76.80 
     └─ Disk operations                                                      2  10k operations                   $0.00 
@@ -48,7 +48,7 @@
  └─ os_disk                                                                                                           
     └─ Storage (P4, LRS)                                                    1  months                           $5.28 
                                                                                                                       
- OVERALL TOTAL                                                                                                $447.20 
+ OVERALL TOTAL                                                                                                $446.18 
 ──────────────────────────────────
 8 cloud resources were detected:
 ∙ 8 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
@@ -56,5 +56,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestAzureRMLinuxVirtualMachineGoldenFile           ┃ $447         ┃
+┃ TestAzureRMLinuxVirtualMachineGoldenFile           ┃ $446         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛


### PR DESCRIPTION
I have updated the relevant prices for the failing tests. However, the warnings about multiple prices look like azure is just switching over as they are present using latest products dump. 