### PR TITLE
fix: clean "upload release assets" pipeline

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,6 +27,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Remove build assets
+        run: rm -rf build
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -53,6 +56,9 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+
+      - name: Clean Docker images
+        run: docker rmi $(docker images -q) -f
 
       - name: Docker meta (CI)
         id: meta-ci


### PR DESCRIPTION
Adds additional pipeline steps which removes large items from the pipeline before continuing to the next step. This should hopefully resolve the `No space left on device` error we were seeing when trying to build the CI docker images.