### PR TITLE
feat: add support for `RDS` `ExtendedSupport` cost component

### DIFF
--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
@@ -1,43 +1,43 @@
 Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_state.json
 
- Name                                                              Monthly Qty  Unit   Monthly Cost 
-                                                                                                    
- aws_instance.instance_1                                                                            
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_counted[0]                                                                   
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_named["test.1"]                                                              
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                   
- ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
- └─ Extended support (year 1)                                              730  hour         $73.00 
-                                                                                                    
- module.instances.aws_instance.module_instance_1                                                    
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_counted[0]                                           
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_named["test.1"]                                      
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- OVERALL TOTAL                                                                              $113.56 
+ Name                                                              Monthly Qty  Unit        Monthly Cost 
+                                                                                                         
+ aws_instance.instance_1                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_counted[0]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_named["test.1"]                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours             $12.41 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB                 $0.58 
+ └─ Extended support (year 1)                                            1,460  vCPU-hours       $146.00 
+                                                                                                         
+ module.instances.aws_instance.module_instance_1                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_counted[0]                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_named["test.1"]                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ OVERALL TOTAL                                                                                   $186.56 
 ──────────────────────────────────
 14 cloud resources were detected:
 ∙ 7 were estimated, 5 of which include usage-based costs, see https://infracost.io/usage-file
@@ -46,7 +46,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_state.json
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...ata/terraform_v0.12_state.json ┃ $114         ┃
+┃ infracost/infracost/cmd/infraco...ata/terraform_v0.12_state.json ┃ $187         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_12/breakdown_terraform_use_state_v0_12.golden
@@ -19,7 +19,8 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_state.json
                                                                                                     
  module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                   
  ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- └─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ └─ Extended support (year 1)                                              730  hour         $73.00 
                                                                                                     
  module.instances.aws_instance.module_instance_1                                                    
  ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
@@ -36,7 +37,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_state.json
  └─ root_block_device                                                                               
     └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
                                                                                                     
- OVERALL TOTAL                                                                               $40.56 
+ OVERALL TOTAL                                                                              $113.56 
 ──────────────────────────────────
 14 cloud resources were detected:
 ∙ 7 were estimated, 5 of which include usage-based costs, see https://infracost.io/usage-file
@@ -45,7 +46,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_state.json
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...ata/terraform_v0.12_state.json ┃ $41          ┃
+┃ infracost/infracost/cmd/infraco...ata/terraform_v0.12_state.json ┃ $114         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
@@ -19,7 +19,8 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_state.json
                                                                                                     
  module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                   
  ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- └─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ └─ Extended support (year 1)                                              730  hour         $73.00 
                                                                                                     
  module.instances.aws_instance.module_instance_1                                                    
  ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
@@ -36,7 +37,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_state.json
  └─ root_block_device                                                                               
     └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
                                                                                                     
- OVERALL TOTAL                                                                               $40.56 
+ OVERALL TOTAL                                                                              $113.56 
 ──────────────────────────────────
 14 cloud resources were detected:
 ∙ 7 were estimated, 5 of which include usage-based costs, see https://infracost.io/usage-file
@@ -45,7 +46,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_state.json
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...ata/terraform_v0.14_state.json ┃ $41          ┃
+┃ infracost/infracost/cmd/infraco...ata/terraform_v0.14_state.json ┃ $114         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_use_state_v0_14/breakdown_terraform_use_state_v0_14.golden
@@ -1,43 +1,43 @@
 Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_state.json
 
- Name                                                              Monthly Qty  Unit   Monthly Cost 
-                                                                                                    
- aws_instance.instance_1                                                                            
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_counted[0]                                                                   
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_named["test.1"]                                                              
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                   
- ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
- └─ Extended support (year 1)                                              730  hour         $73.00 
-                                                                                                    
- module.instances.aws_instance.module_instance_1                                                    
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_counted[0]                                           
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_named["test.1"]                                      
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- OVERALL TOTAL                                                                              $113.56 
+ Name                                                              Monthly Qty  Unit        Monthly Cost 
+                                                                                                         
+ aws_instance.instance_1                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_counted[0]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_named["test.1"]                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours             $12.41 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB                 $0.58 
+ └─ Extended support (year 1)                                            1,460  vCPU-hours       $146.00 
+                                                                                                         
+ module.instances.aws_instance.module_instance_1                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_counted[0]                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_named["test.1"]                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ OVERALL TOTAL                                                                                   $186.56 
 ──────────────────────────────────
 14 cloud resources were detected:
 ∙ 7 were estimated, 5 of which include usage-based costs, see https://infracost.io/usage-file
@@ -46,7 +46,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_state.json
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...ata/terraform_v0.14_state.json ┃ $114         ┃
+┃ infracost/infracost/cmd/infraco...ata/terraform_v0.14_state.json ┃ $187         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
@@ -34,11 +34,13 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
                                                                                                     
  module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                   
  ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- └─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ └─ Extended support (year 1)                                              730  hour         $73.00 
                                                                                                     
  module.db.module.db_2.module.db_instance.aws_db_instance.this[0]                                   
  ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- └─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ └─ Extended support (year 1)                                              730  hour         $73.00 
                                                                                                     
  module.instances.aws_instance.module_instance_1                                                    
  ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
@@ -70,7 +72,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
  └─ root_block_device                                                                               
     └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
                                                                                                     
- OVERALL TOTAL                                                                               $81.12 
+ OVERALL TOTAL                                                                              $227.12 
 ──────────────────────────────────
 26 cloud resources were detected:
 ∙ 14 were estimated, 10 of which include usage-based costs, see https://infracost.io/usage-file
@@ -79,7 +81,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...data/terraform_v0.12_plan.json ┃ $81          ┃
+┃ infracost/infracost/cmd/infraco...data/terraform_v0.12_plan.json ┃ $227         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_12/breakdown_terraform_v0_12.golden
@@ -1,78 +1,78 @@
 Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
 
- Name                                                              Monthly Qty  Unit   Monthly Cost 
-                                                                                                    
- aws_instance.instance_1                                                                            
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_2                                                                            
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_counted[0]                                                                   
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_counted[1]                                                                   
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_named["test.1"]                                                              
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_named["test.2"]                                                              
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                   
- ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
- └─ Extended support (year 1)                                              730  hour         $73.00 
-                                                                                                    
- module.db.module.db_2.module.db_instance.aws_db_instance.this[0]                                   
- ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
- └─ Extended support (year 1)                                              730  hour         $73.00 
-                                                                                                    
- module.instances.aws_instance.module_instance_1                                                    
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_2                                                    
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_counted[0]                                           
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_counted[1]                                           
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_named["test.1"]                                      
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_named["test.2"]                                      
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- OVERALL TOTAL                                                                              $227.12 
+ Name                                                              Monthly Qty  Unit        Monthly Cost 
+                                                                                                         
+ aws_instance.instance_1                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_2                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_counted[0]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_counted[1]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_named["test.1"]                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_named["test.2"]                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours             $12.41 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB                 $0.58 
+ └─ Extended support (year 1)                                            1,460  vCPU-hours       $146.00 
+                                                                                                         
+ module.db.module.db_2.module.db_instance.aws_db_instance.this[0]                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours             $12.41 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB                 $0.58 
+ └─ Extended support (year 1)                                            1,460  vCPU-hours       $146.00 
+                                                                                                         
+ module.instances.aws_instance.module_instance_1                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_2                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_counted[0]                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_counted[1]                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_named["test.1"]                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_named["test.2"]                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ OVERALL TOTAL                                                                                   $373.12 
 ──────────────────────────────────
 26 cloud resources were detected:
 ∙ 14 were estimated, 10 of which include usage-based costs, see https://infracost.io/usage-file
@@ -81,7 +81,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...data/terraform_v0.12_plan.json ┃ $227         ┃
+┃ infracost/infracost/cmd/infraco...data/terraform_v0.12_plan.json ┃ $373         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
@@ -34,11 +34,13 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
                                                                                                     
  module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                   
  ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- └─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ └─ Extended support (year 1)                                              730  hour         $73.00 
                                                                                                     
  module.db.module.db_2.module.db_instance.aws_db_instance.this[0]                                   
  ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- └─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
+ └─ Extended support (year 1)                                              730  hour         $73.00 
                                                                                                     
  module.instances.aws_instance.module_instance_1                                                    
  ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
@@ -70,7 +72,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
  └─ root_block_device                                                                               
     └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
                                                                                                     
- OVERALL TOTAL                                                                               $81.12 
+ OVERALL TOTAL                                                                              $227.12 
 ──────────────────────────────────
 26 cloud resources were detected:
 ∙ 14 were estimated, 10 of which include usage-based costs, see https://infracost.io/usage-file
@@ -79,7 +81,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json ┃ $81          ┃
+┃ infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json ┃ $227         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_v0_14/breakdown_terraform_v0_14.golden
@@ -1,78 +1,78 @@
 Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
 
- Name                                                              Monthly Qty  Unit   Monthly Cost 
-                                                                                                    
- aws_instance.instance_1                                                                            
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_2                                                                            
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_counted[0]                                                                   
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_counted[1]                                                                   
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_named["test.1"]                                                              
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- aws_instance.instance_named["test.2"]                                                              
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                   
- ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
- └─ Extended support (year 1)                                              730  hour         $73.00 
-                                                                                                    
- module.db.module.db_2.module.db_instance.aws_db_instance.this[0]                                   
- ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours        $12.41 
- ├─ Storage (general purpose SSD, gp2)                                       5  GB            $0.58 
- └─ Extended support (year 1)                                              730  hour         $73.00 
-                                                                                                    
- module.instances.aws_instance.module_instance_1                                                    
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_2                                                    
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_counted[0]                                           
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_counted[1]                                           
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_named["test.1"]                                      
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- module.instances.aws_instance.module_instance_named["test.2"]                                      
- ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours         $3.80 
- └─ root_block_device                                                                               
-    └─ Storage (general purpose SSD, gp2)                                    8  GB            $0.80 
-                                                                                                    
- OVERALL TOTAL                                                                              $227.12 
+ Name                                                              Monthly Qty  Unit        Monthly Cost 
+                                                                                                         
+ aws_instance.instance_1                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_2                                                                                 
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_counted[0]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_counted[1]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_named["test.1"]                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ aws_instance.instance_named["test.2"]                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.db.module.db_1.module.db_instance.aws_db_instance.this[0]                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours             $12.41 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB                 $0.58 
+ └─ Extended support (year 1)                                            1,460  vCPU-hours       $146.00 
+                                                                                                         
+ module.db.module.db_2.module.db_instance.aws_db_instance.this[0]                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.micro)                  730  hours             $12.41 
+ ├─ Storage (general purpose SSD, gp2)                                       5  GB                 $0.58 
+ └─ Extended support (year 1)                                            1,460  vCPU-hours       $146.00 
+                                                                                                         
+ module.instances.aws_instance.module_instance_1                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_2                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_counted[0]                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_counted[1]                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_named["test.1"]                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ module.instances.aws_instance.module_instance_named["test.2"]                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.nano)                        730  hours              $3.80 
+ └─ root_block_device                                                                                    
+    └─ Storage (general purpose SSD, gp2)                                    8  GB                 $0.80 
+                                                                                                         
+ OVERALL TOTAL                                                                                   $373.12 
 ──────────────────────────────────
 26 cloud resources were detected:
 ∙ 14 were estimated, 10 of which include usage-based costs, see https://infracost.io/usage-file
@@ -81,7 +81,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json ┃ $227         ┃
+┃ infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json ┃ $373         ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
@@ -44,7 +44,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
           +$0.80
 
 + module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
-  +$86
+  +$159
 
     + Database instance (on-demand, Single-AZ, db.t3.micro)
       +$12
@@ -53,7 +53,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
       +$0.58
 
     + Extended support (year 1)
-      +$73
+      +$146
 
 + module.instances.aws_instance.module_instance_2
   +$5
@@ -98,7 +98,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
           +$0.80
 
 Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
-Amount:  +$114 ($114 → $227)
+Amount:  +$187 ($187 → $373)
 Percent: +100%
 
 ──────────────────────────────────
@@ -108,11 +108,11 @@ Key: ~ changed, + added, - removed
 ∙ 14 were estimated, 10 of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 12 were free, rerun with --show-skipped to see details
 
-Infracost estimate: Monthly cost will increase by $114 ↑
+Infracost estimate: Monthly cost will increase by $187 ↑
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Cost change   ┃ New monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...data/terraform_v0.12_plan.json ┃ +$114 (+100%) ┃ $227             ┃
+┃ infracost/infracost/cmd/infraco...data/terraform_v0.12_plan.json ┃ +$187 (+100%) ┃ $373             ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_12/diff_terraform_v0_12.golden
@@ -44,13 +44,16 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
           +$0.80
 
 + module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
-  +$13
+  +$86
 
     + Database instance (on-demand, Single-AZ, db.t3.micro)
       +$12
 
     + Storage (general purpose SSD, gp2)
       +$0.58
+
+    + Extended support (year 1)
+      +$73
 
 + module.instances.aws_instance.module_instance_2
   +$5
@@ -95,7 +98,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
           +$0.80
 
 Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.12_plan.json
-Amount:  +$41 ($41 → $81)
+Amount:  +$114 ($114 → $227)
 Percent: +100%
 
 ──────────────────────────────────
@@ -105,12 +108,12 @@ Key: ~ changed, + added, - removed
 ∙ 14 were estimated, 10 of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 12 were free, rerun with --show-skipped to see details
 
-Infracost estimate: Monthly cost will increase by $41 ↑
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
-┃ Project                                                          ┃ Cost change  ┃ New monthly cost ┃
-┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...data/terraform_v0.12_plan.json ┃ +$41 (+100%) ┃ $81              ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━┛
+Infracost estimate: Monthly cost will increase by $114 ↑
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Cost change   ┃ New monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...data/terraform_v0.12_plan.json ┃ +$114 (+100%) ┃ $227             ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━┛
 
 Err:
 

--- a/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
@@ -44,7 +44,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
           +$0.80
 
 + module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
-  +$86
+  +$159
 
     + Database instance (on-demand, Single-AZ, db.t3.micro)
       +$12
@@ -53,7 +53,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
       +$0.58
 
     + Extended support (year 1)
-      +$73
+      +$146
 
 + module.instances.aws_instance.module_instance_2
   +$5
@@ -98,7 +98,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
           +$0.80
 
 Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
-Amount:  +$114 ($114 → $227)
+Amount:  +$187 ($187 → $373)
 Percent: +100%
 
 ──────────────────────────────────
@@ -108,11 +108,11 @@ Key: ~ changed, + added, - removed
 ∙ 14 were estimated, 10 of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 12 were free, rerun with --show-skipped to see details
 
-Infracost estimate: Monthly cost will increase by $114 ↑
+Infracost estimate: Monthly cost will increase by $187 ↑
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Cost change   ┃ New monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json ┃ +$114 (+100%) ┃ $227             ┃
+┃ infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json ┃ +$187 (+100%) ┃ $373             ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
+++ b/cmd/infracost/testdata/diff_terraform_v0_14/diff_terraform_v0_14.golden
@@ -44,13 +44,16 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
           +$0.80
 
 + module.db.module.db_2.module.db_instance.aws_db_instance.this[0]
-  +$13
+  +$86
 
     + Database instance (on-demand, Single-AZ, db.t3.micro)
       +$12
 
     + Storage (general purpose SSD, gp2)
       +$0.58
+
+    + Extended support (year 1)
+      +$73
 
 + module.instances.aws_instance.module_instance_2
   +$5
@@ -95,7 +98,7 @@ Project: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
           +$0.80
 
 Monthly cost change for infracost/infracost/cmd/infracost/testdata/terraform_v0.14_plan.json
-Amount:  +$41 ($41 → $81)
+Amount:  +$114 ($114 → $227)
 Percent: +100%
 
 ──────────────────────────────────
@@ -105,12 +108,12 @@ Key: ~ changed, + added, - removed
 ∙ 14 were estimated, 10 of which include usage-based costs, see https://infracost.io/usage-file
 ∙ 12 were free, rerun with --show-skipped to see details
 
-Infracost estimate: Monthly cost will increase by $41 ↑
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
-┃ Project                                                          ┃ Cost change  ┃ New monthly cost ┃
-┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json ┃ +$41 (+100%) ┃ $81              ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━┛
+Infracost estimate: Monthly cost will increase by $114 ↑
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Cost change   ┃ New monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...data/terraform_v0.14_plan.json ┃ +$114 (+100%) ┃ $227             ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━┛
 
 Err:
 

--- a/internal/providers/terraform/aws/db_instance.go
+++ b/internal/providers/terraform/aws/db_instance.go
@@ -37,6 +37,7 @@ func NewDBInstance(d *schema.ResourceData) schema.CoreResource {
 		Region:                               d.Get("region").String(),
 		InstanceClass:                        d.Get("instance_class").String(),
 		Engine:                               engine,
+		Version:                              d.Get("engine_version").String(),
 		MultiAZ:                              d.Get("multi_az").Bool(),
 		LicenseModel:                         d.Get("license_model").String(),
 		BackupRetentionPeriod:                d.Get("backup_retention_period").Int(),

--- a/internal/providers/terraform/aws/rds_cluster_instance.go
+++ b/internal/providers/terraform/aws/rds_cluster_instance.go
@@ -22,6 +22,7 @@ func NewRDSClusterInstance(d *schema.ResourceData, u *schema.UsageData) *schema.
 		InstanceClass:                        d.Get("instance_class").String(),
 		IOOptimized:                          false, // IO Optimized isn't supported by terraform yet
 		Engine:                               d.Get("engine").String(),
+		Version:                              d.Get("engine_version").String(),
 		PerformanceInsightsEnabled:           piEnabled,
 		PerformanceInsightsLongTermRetention: piLongTerm,
 	}

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
@@ -79,12 +79,12 @@
  aws_db_instance.extended_support["mysql-5.7"]                                                                        
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
  ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
- └─ Extended support (year 1)                                               730  hour                          $73.00 
+ └─ Extended support (year 1)                                             1,460  vCPU-hours                   $146.00 
                                                                                                                       
  aws_db_instance.extended_support["mysql-5.7.44"]                                                                     
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
  ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
- └─ Extended support (year 1)                                               730  hour                          $73.00 
+ └─ Extended support (year 1)                                             1,460  vCPU-hours                   $146.00 
                                                                                                                       
  aws_db_instance.extended_support["mysql-8.0"]                                                                        
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
@@ -302,7 +302,7 @@
  ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
  └─ Additional backup storage                                             1,000  GB                            $95.00 
                                                                                                                       
- OVERALL TOTAL                                                                                             $11,150.39 
+ OVERALL TOTAL                                                                                             $11,296.39 
 ──────────────────────────────────
 68 cloud resources were detected:
 ∙ 68 were estimated, 54 of which include usage-based costs, see https://infracost.io/usage-file
@@ -310,5 +310,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestDBInstanceGoldenFile                           ┃ $11,150      ┃
+┃ TestDBInstanceGoldenFile                           ┃ $11,296      ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
@@ -1,208 +1,314 @@
 
- Name                                                             Monthly Qty  Unit                    Monthly Cost 
-                                                                                                                    
- aws_db_instance.aurora                                                                                             
- ├─ Database instance (on-demand, Single-AZ, db.t3.small)                 730  hours                         $29.93 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $21.00 
-                                                                                                                    
- aws_db_instance.aurora-mysql                                                                                       
- ├─ Database instance (on-demand, Single-AZ, db.t3.small)                 730  hours                         $29.93 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                               Monthly cost depends on usage: $0.021 per GB            
-                                                                                                                    
- aws_db_instance.aurora-postgresql                                                                                  
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                        $119.72 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                               Monthly cost depends on usage: $0.021 per GB            
-                                                                                                                    
- aws_db_instance.gp3["above_high_baseline"]                                                                         
- ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                730  hours                         $23.36 
- ├─ Storage (general purpose SSD, gp3)                                    400  GB                            $46.00 
- └─ Provisioned GP3 IOPS (above 12,000)                                 2,000  IOPS                          $40.00 
-                                                                                                                    
- aws_db_instance.gp3["above_low_baseline"]                                                                          
- ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                730  hours                         $23.36 
- ├─ Storage (general purpose SSD, gp3)                                     20  GB                             $2.30 
- └─ Provisioned GP3 IOPS (above 3,000)                                  1,000  IOPS                          $20.00 
-                                                                                                                    
- aws_db_instance.gp3["below_high_baseline"]                                                                         
- ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                730  hours                         $23.36 
- └─ Storage (general purpose SSD, gp3)                                    400  GB                            $46.00 
-                                                                                                                    
- aws_db_instance.gp3["below_low_baseline"]                                                                          
- ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                730  hours                         $23.36 
- └─ Storage (general purpose SSD, gp3)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.gp3["multi_az"]                                                                                    
- ├─ Database instance (on-demand, Multi-AZ, db.t4g.small)                 730  hours                         $47.45 
- ├─ Storage (general purpose SSD, gp3)                                    400  GB                            $92.00 
- └─ Provisioned GP3 IOPS (above 12,000)                                 2,000  IOPS                          $80.00 
-                                                                                                                    
- aws_db_instance.mariadb                                                                                            
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.mysql                                                                                              
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.mysql-1yr-all-upfront-multi-az                                                                     
- ├─ Database instance (reserved, Multi-AZ, db.t3.large)                   730  hours                          $0.00 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $4.60 
-                                                                                                                    
- aws_db_instance.mysql-1yr-all-upfront-single-az                                                                    
- ├─ Database instance (reserved, Single-AZ, db.t3.large)                  730  hours                          $0.00 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.mysql-1yr-no-upfront-multi-az                                                                      
- ├─ Database instance (reserved, Multi-AZ, db.t3.large)                   730  hours                        $139.72 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $4.60 
-                                                                                                                    
- aws_db_instance.mysql-1yr-no-upfront-single-az                                                                     
- ├─ Database instance (reserved, Single-AZ, db.t3.large)                  730  hours                         $69.86 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.mysql-1yr-partial-upfront-multi-az                                                                 
- ├─ Database instance (reserved, Multi-AZ, db.t3.large)                   730  hours                         $66.50 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $4.60 
-                                                                                                                    
- aws_db_instance.mysql-1yr-partial-upfront-single-az                                                                
- ├─ Database instance (reserved, Single-AZ, db.t3.large)                  730  hours                         $33.29 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.mysql-allocated-storage                                                                            
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                               Monthly cost depends on usage: $0.095 per GB            
-                                                                                                                    
- aws_db_instance.mysql-default                                                                                      
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.mysql-default-iops                                                                                 
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- ├─ Storage (provisioned IOPS SSD, io1)                                   100  GB                            $12.50 
- └─ Provisioned IOPS                                                    1,000  IOPS                         $100.00 
-                                                                                                                    
- aws_db_instance.mysql-iops                                                                                         
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- ├─ Storage (provisioned IOPS SSD, io1)                                   100  GB                            $12.50 
- ├─ Provisioned IOPS                                                    1,200  IOPS                         $120.00 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.mysql-iops-below-min                                                                               
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- ├─ Storage (provisioned IOPS SSD, io1)                                   100  GB                            $12.50 
- ├─ Provisioned IOPS                                                    1,000  IOPS                         $100.00 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.mysql-magnetic                                                                                     
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- ├─ Storage (magnetic)                                                     40  GB                             $4.00 
- └─ I/O requests                                            Monthly cost depends on usage: $0.10 per 1M requests    
-                                                                                                                    
- aws_db_instance.mysql-multi-az                                                                                     
- ├─ Database instance (on-demand, Multi-AZ, db.t3.large)                  730  hours                        $198.56 
- ├─ Storage (general purpose SSD, gp2)                                     30  GB                             $6.90 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.mysql-performance-insights                                                                         
- ├─ Database instance (on-demand, Single-AZ, db.m5.large)                 730  hours                        $124.83 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- ├─ Performance Insights Long Term Retention (db.m5.large)                  2  vCPU-month                     $7.63 
- └─ Performance Insights API                                Monthly cost depends on usage: $0.01 per 1000 requests  
-                                                                                                                    
- aws_db_instance.mysql-performance-insights-usage                                                                   
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- ├─ Performance Insights Long Term Retention (db.t3.large)                  2  vCPU-month                     $5.90 
- └─ Performance Insights API                                           12.345  1000 requests                  $0.12 
-                                                                                                                    
- aws_db_instance.mysql-replica                                                                                      
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.oracle-ee                                                                                          
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.oracle-ee-cdb                                                                                      
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.oracle-se                                                                                          
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.oracle-se1                                                                                         
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                        $204.40 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.oracle-se1-byol                                                                                    
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                         $99.28 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.oracle-se2                                                                                         
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                        $219.00 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.oracle-se2-cdb                                                                                     
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                        $219.00 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.postgres                                                                                           
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                        $105.85 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.postgres-3yr-all-upfront-multi-az                                                                  
- ├─ Database instance (reserved, Multi-AZ, db.t3.large)                   730  hours                          $0.00 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $4.60 
-                                                                                                                    
- aws_db_instance.postgres-3yr-all-upfront-single-az                                                                 
- ├─ Database instance (reserved, Single-AZ, db.t3.large)                  730  hours                          $0.00 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.postgres-3yr-partial-upfront-multi-az                                                              
- ├─ Database instance (reserved, Multi-AZ, db.t3.large)                   730  hours                         $50.74 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $4.60 
-                                                                                                                    
- aws_db_instance.postgres-3yr-partial-upfront-single-az                                                             
- ├─ Database instance (reserved, Single-AZ, db.t3.large)                  730  hours                         $25.40 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.sqlserver-ee                                                                                       
- ├─ Database instance (on-demand, Single-AZ, db.m5.xlarge)                730  hours                      $1,705.28 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.sqlserver-ex                                                                                       
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                        $118.26 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- aws_db_instance.sqlserver-se                                                                                       
- ├─ Database instance (on-demand, Single-AZ, db.m5.xlarge)                730  hours                        $893.52 
- └─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
-                                                                                                                    
- aws_db_instance.sqlserver-web                                                                                      
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                 730  hours                        $169.36 
- ├─ Storage (general purpose SSD, gp2)                                     20  GB                             $2.30 
- └─ Additional backup storage                                           1,000  GB                            $95.00 
-                                                                                                                    
- OVERALL TOTAL                                                                                            $8,010.72 
+ Name                                                               Monthly Qty  Unit                    Monthly Cost 
+                                                                                                                      
+ aws_db_instance.aurora                                                                                               
+ ├─ Database instance (on-demand, Single-AZ, db.t3.small)                   730  hours                         $29.93 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $21.00 
+                                                                                                                      
+ aws_db_instance.aurora-mysql                                                                                         
+ ├─ Database instance (on-demand, Single-AZ, db.t3.small)                   730  hours                         $29.93 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                 Monthly cost depends on usage: $0.021 per GB            
+                                                                                                                      
+ aws_db_instance.aurora-postgresql                                                                                    
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                 Monthly cost depends on usage: $0.021 per GB            
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-5.7"]                                                                       
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-5.7.44"]                                                                    
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-8.0"]                                                                       
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-8.0.36"]                                                                    
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-mysql-5.7"]                                                                 
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-mysql-5.7.44"]                                                              
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-mysql-8.0"]                                                                 
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-mysql-8.0.36"]                                                              
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-postgresql-11"]                                                             
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-postgresql-11.22"]                                                          
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-postgresql-12"]                                                             
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-postgresql-13"]                                                             
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-postgresql-14"]                                                             
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-postgresql-15"]                                                             
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["aurora-postgresql-16"]                                                             
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["mysql-5.7"]                                                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Extended support (year 1)                                               730  hour                          $73.00 
+                                                                                                                      
+ aws_db_instance.extended_support["mysql-5.7.44"]                                                                     
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Extended support (year 1)                                               730  hour                          $73.00 
+                                                                                                                      
+ aws_db_instance.extended_support["mysql-8.0"]                                                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["mysql-8.0.36"]                                                                     
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["postgres-11"]                                                                      
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $105.85 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["postgres-11.22"]                                                                   
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $105.85 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["postgres-12"]                                                                      
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $105.85 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["postgres-13"]                                                                      
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $105.85 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["postgres-14"]                                                                      
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $105.85 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["postgres-15"]                                                                      
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $105.85 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.extended_support["postgres-16"]                                                                      
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $105.85 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.gp3["above_high_baseline"]                                                                           
+ ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                  730  hours                         $23.36 
+ ├─ Storage (general purpose SSD, gp3)                                      400  GB                            $46.00 
+ └─ Provisioned GP3 IOPS (above 12,000)                                   2,000  IOPS                          $40.00 
+                                                                                                                      
+ aws_db_instance.gp3["above_low_baseline"]                                                                            
+ ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                  730  hours                         $23.36 
+ ├─ Storage (general purpose SSD, gp3)                                       20  GB                             $2.30 
+ └─ Provisioned GP3 IOPS (above 3,000)                                    1,000  IOPS                          $20.00 
+                                                                                                                      
+ aws_db_instance.gp3["below_high_baseline"]                                                                           
+ ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                  730  hours                         $23.36 
+ └─ Storage (general purpose SSD, gp3)                                      400  GB                            $46.00 
+                                                                                                                      
+ aws_db_instance.gp3["below_low_baseline"]                                                                            
+ ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                  730  hours                         $23.36 
+ └─ Storage (general purpose SSD, gp3)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.gp3["multi_az"]                                                                                      
+ ├─ Database instance (on-demand, Multi-AZ, db.t4g.small)                   730  hours                         $47.45 
+ ├─ Storage (general purpose SSD, gp3)                                      400  GB                            $92.00 
+ └─ Provisioned GP3 IOPS (above 12,000)                                   2,000  IOPS                          $80.00 
+                                                                                                                      
+ aws_db_instance.mariadb                                                                                              
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.mysql                                                                                                
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.mysql-1yr-all-upfront-multi-az                                                                       
+ ├─ Database instance (reserved, Multi-AZ, db.t3.large)                     730  hours                          $0.00 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $4.60 
+                                                                                                                      
+ aws_db_instance.mysql-1yr-all-upfront-single-az                                                                      
+ ├─ Database instance (reserved, Single-AZ, db.t3.large)                    730  hours                          $0.00 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.mysql-1yr-no-upfront-multi-az                                                                        
+ ├─ Database instance (reserved, Multi-AZ, db.t3.large)                     730  hours                        $139.72 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $4.60 
+                                                                                                                      
+ aws_db_instance.mysql-1yr-no-upfront-single-az                                                                       
+ ├─ Database instance (reserved, Single-AZ, db.t3.large)                    730  hours                         $69.86 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.mysql-1yr-partial-upfront-multi-az                                                                   
+ ├─ Database instance (reserved, Multi-AZ, db.t3.large)                     730  hours                         $66.50 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $4.60 
+                                                                                                                      
+ aws_db_instance.mysql-1yr-partial-upfront-single-az                                                                  
+ ├─ Database instance (reserved, Single-AZ, db.t3.large)                    730  hours                         $33.29 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.mysql-allocated-storage                                                                              
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                 Monthly cost depends on usage: $0.095 per GB            
+                                                                                                                      
+ aws_db_instance.mysql-default                                                                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.mysql-default-iops                                                                                   
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (provisioned IOPS SSD, io1)                                     100  GB                            $12.50 
+ └─ Provisioned IOPS                                                      1,000  IOPS                         $100.00 
+                                                                                                                      
+ aws_db_instance.mysql-iops                                                                                           
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (provisioned IOPS SSD, io1)                                     100  GB                            $12.50 
+ ├─ Provisioned IOPS                                                      1,200  IOPS                         $120.00 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.mysql-iops-below-min                                                                                 
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (provisioned IOPS SSD, io1)                                     100  GB                            $12.50 
+ ├─ Provisioned IOPS                                                      1,000  IOPS                         $100.00 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.mysql-magnetic                                                                                       
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (magnetic)                                                       40  GB                             $4.00 
+ └─ I/O requests                                              Monthly cost depends on usage: $0.10 per 1M requests    
+                                                                                                                      
+ aws_db_instance.mysql-multi-az                                                                                       
+ ├─ Database instance (on-demand, Multi-AZ, db.t3.large)                    730  hours                        $198.56 
+ ├─ Storage (general purpose SSD, gp2)                                       30  GB                             $6.90 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.mysql-performance-insights                                                                           
+ ├─ Database instance (on-demand, Single-AZ, db.m5.large)                   730  hours                        $124.83 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ ├─ Performance Insights Long Term Retention (db.m5.large)                    2  vCPU-month                     $7.63 
+ └─ Performance Insights API                                  Monthly cost depends on usage: $0.01 per 1000 requests  
+                                                                                                                      
+ aws_db_instance.mysql-performance-insights-usage                                                                     
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ ├─ Performance Insights Long Term Retention (db.t3.large)                    2  vCPU-month                     $5.90 
+ └─ Performance Insights API                                             12.345  1000 requests                  $0.12 
+                                                                                                                      
+ aws_db_instance.mysql-replica                                                                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.oracle-ee                                                                                            
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.oracle-ee-cdb                                                                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.oracle-se                                                                                            
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.oracle-se1                                                                                           
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $204.40 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.oracle-se1-byol                                                                                      
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.oracle-se2                                                                                           
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $219.00 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.oracle-se2-cdb                                                                                       
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $219.00 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.postgres                                                                                             
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $105.85 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.postgres-3yr-all-upfront-multi-az                                                                    
+ ├─ Database instance (reserved, Multi-AZ, db.t3.large)                     730  hours                          $0.00 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $4.60 
+                                                                                                                      
+ aws_db_instance.postgres-3yr-all-upfront-single-az                                                                   
+ ├─ Database instance (reserved, Single-AZ, db.t3.large)                    730  hours                          $0.00 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.postgres-3yr-partial-upfront-multi-az                                                                
+ ├─ Database instance (reserved, Multi-AZ, db.t3.large)                     730  hours                         $50.74 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $4.60 
+                                                                                                                      
+ aws_db_instance.postgres-3yr-partial-upfront-single-az                                                               
+ ├─ Database instance (reserved, Single-AZ, db.t3.large)                    730  hours                         $25.40 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.sqlserver-ee                                                                                         
+ ├─ Database instance (on-demand, Single-AZ, db.m5.xlarge)                  730  hours                      $1,705.28 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.sqlserver-ex                                                                                         
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $118.26 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ aws_db_instance.sqlserver-se                                                                                         
+ ├─ Database instance (on-demand, Single-AZ, db.m5.xlarge)                  730  hours                        $893.52 
+ └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+                                                                                                                      
+ aws_db_instance.sqlserver-web                                                                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $169.36 
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30 
+ └─ Additional backup storage                                             1,000  GB                            $95.00 
+                                                                                                                      
+ OVERALL TOTAL                                                                                             $11,150.39 
 ──────────────────────────────────
-42 cloud resources were detected:
-∙ 42 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+68 cloud resources were detected:
+∙ 68 were estimated, 54 of which include usage-based costs, see https://infracost.io/usage-file
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestDBInstanceGoldenFile                           ┃ $8,011       ┃
+┃ TestDBInstanceGoldenFile                           ┃ $11,150      ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.tf
@@ -240,3 +240,59 @@ resource "aws_db_instance" "postgres-3yr-partial-upfront-multi-az" {
   instance_class = "db.t3.large"
   multi_az       = true
 }
+
+locals {
+  extended_support_engined = {
+    aurora = [
+      "5.7",
+      "5.7.44",
+      "8.0",
+      "8.0.36",
+    ]
+    aurora-mysql = [
+      "5.7",
+      "5.7.44",
+      "8.0",
+      "8.0.36",
+    ]
+    aurora-postgresql = [
+      "11",
+      "11.22",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16"
+    ]
+    mysql = [
+      "5.7",
+      "5.7.44",
+      "8.0",
+      "8.0.36",
+    ]
+    postgres = [
+      "16",
+      "15",
+      "14",
+      "13",
+      "12",
+      "11",
+      "11.22"
+    ]
+  }
+}
+
+resource "aws_db_instance" "extended_support" {
+  for_each = { for entry in flatten([
+    for engine, versions in local.extended_support_engined : [
+      for version in versions : {
+        engine  = engine
+        version = version
+      }
+    ]
+  ]) : "${entry.engine}-${entry.version}" => entry }
+
+  engine         = each.value.engine
+  engine_version = each.value.version
+  instance_class = "db.t3.large"
+}

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
@@ -46,13 +46,46 @@
  ├─ Database instance (on-demand, db.t3.medium)                                             730  hours                             $59.86 
  └─ CPU credits                                                                              48  vCPU-hours                         $4.32 
                                                                                                                                           
- OVERALL TOTAL                                                                                                                  $4,208.32 
+ aws_rds_cluster_instance.extended_support["aurora-mysql-5.7"]                                                                            
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-mysql-5.7.44"]                                                                         
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-mysql-8.0"]                                                                            
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-mysql-8.0.36"]                                                                         
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-postgresql-11"]                                                                        
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-postgresql-11.22"]                                                                     
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-postgresql-12"]                                                                        
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-postgresql-13"]                                                                        
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-postgresql-14"]                                                                        
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-postgresql-15"]                                                                        
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ aws_rds_cluster_instance.extended_support["aurora-postgresql-16"]                                                                        
+ └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72 
+                                                                                                                                          
+ OVERALL TOTAL                                                                                                                  $5,525.24 
 ──────────────────────────────────
-11 cloud resources were detected:
-∙ 11 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+22 cloud resources were detected:
+∙ 22 were estimated, 17 of which include usage-based costs, see https://infracost.io/usage-file
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestRDSClusterInstanceGoldenFile                   ┃ $4,208       ┃
+┃ TestRDSClusterInstanceGoldenFile                   ┃ $5,525       ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.tf
@@ -101,3 +101,41 @@ resource "aws_rds_cluster_instance" "cluster_instance_3yr_all_upfront" {
   engine             = aws_rds_cluster.default.engine
   engine_version     = aws_rds_cluster.default.engine_version
 }
+
+locals {
+  extended_support_engined = {
+    aurora-mysql = [
+      "5.7",
+      "5.7.44",
+      "8.0",
+      "8.0.36",
+    ]
+    aurora-postgresql = [
+      "11",
+      "11.22",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16"
+    ]
+  }
+}
+
+resource "aws_rds_cluster_instance" "extended_support" {
+  for_each = { for entry in flatten([
+    for engine, versions in local.extended_support_engined : [
+      for version in versions : {
+        engine  = engine
+        version = version
+      }
+    ]
+  ]) : "${entry.engine}-${entry.version}" => entry }
+
+  identifier         = "aurora-cluster-demo"
+  cluster_identifier = aws_rds_cluster.default.id
+
+  engine         = each.value.engine
+  engine_version = each.value.version
+  instance_class = "db.t3.large"
+}

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -1,13 +1,14 @@
 package aws
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/rs/zerolog/log"
 
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
-
-	"fmt"
-	"strings"
 
 	"github.com/shopspring/decimal"
 )
@@ -24,6 +25,7 @@ type DBInstance struct {
 	MultiAZ                                      bool
 	InstanceClass                                string
 	Engine                                       string
+	Version                                      string
 	IOPS                                         float64
 	AllocatedStorageGB                           *float64
 	MonthlyStandardIORequests                    *int64   `infracost_usage:"monthly_standard_io_requests"`
@@ -372,13 +374,17 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 		}
 	}
 
+	extendedSupport := extendedSupportCostComponent(r.Version, r.Region, r.Engine)
+	if extendedSupport != nil {
+		costComponents = append(costComponents, extendedSupport)
+	}
+
 	return &schema.Resource{
 		Name:           r.Address,
 		CostComponents: costComponents,
 		UsageSchema:    DBInstanceUsageSchema,
 	}
 }
-
 func performanceInsightsLongTermRetentionCostComponent(region, instanceClass string) *schema.CostComponent {
 	instanceType := strings.TrimPrefix(instanceClass, "db.")
 
@@ -427,4 +433,146 @@ func performanceInsightsAPIRequestCostComponent(region string, additionalRequest
 			},
 		},
 	}
+}
+
+// ExtendedSupportDates contains the extended support dates for a specific RDS
+// engine version Year1 is the date when the extended support starts, Year 3 is
+// the date when the extended increases price.
+type ExtendedSupportDates struct {
+	Year1 time.Time
+	Year3 time.Time
+}
+
+// ExtendedSupport contains the extended support dates for a specific RDS engine.
+type ExtendedSupport struct {
+	Engine   string
+	Versions map[string]ExtendedSupportDates
+}
+
+// CostComponent returns the cost component for the extended support for the
+// given version and date. If the version is not found then it will return nil.
+func (s ExtendedSupport) CostComponent(version string, region string, d time.Time) *schema.CostComponent {
+	matchingVersion := strings.ToLower(version)
+	supportDates, ok := s.Versions[matchingVersion]
+	if !ok {
+		// if the version is not found then it is likely that the
+		// version is a minor version, we should try and match the minor
+		// version to a major version in the map. This is done by
+		// progressively removing the last part of the version until
+		// we find a match.
+		parts := strings.Split(version, ".")
+		for i := len(parts) - 1; i > 0; i-- {
+			matchingVersion = strings.Join(parts[:i], ".")
+			supportDates, ok = s.Versions[matchingVersion]
+			if ok {
+				break
+			}
+		}
+
+		if !ok {
+			return nil
+		}
+	}
+
+	if !supportDates.Year3.IsZero() && d.After(supportDates.Year3) {
+		return &schema.CostComponent{
+			Name:           "Extended support (year 3)",
+			Unit:           "hour",
+			UnitMultiplier: decimal.NewFromInt(1),
+			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			ProductFilter: &schema.ProductFilter{
+				VendorName: strPtr("aws"),
+				Region:     strPtr(region),
+				Service:    strPtr("AmazonRDS"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: regexPtr("ExtendedSupport:Yr3:" + s.Engine + matchingVersion)},
+				},
+			},
+		}
+	}
+
+	if d.After(supportDates.Year1) {
+		return &schema.CostComponent{
+			Name:           "Extended support (year 1)",
+			Unit:           "hour",
+			UnitMultiplier: decimal.NewFromInt(1),
+			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			ProductFilter: &schema.ProductFilter{
+				VendorName: strPtr("aws"),
+				Region:     strPtr(region),
+				Service:    strPtr("AmazonRDS"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "usagetype", ValueRegex: regexPtr("ExtendedSupport:Yr1-Yr2:" + s.Engine + matchingVersion)},
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+var (
+	// https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html#MySQL.Concepts.VersionMgmt.ReleaseCalendar
+	mysqlExtendedSupport = ExtendedSupport{
+		Engine: "MySQL",
+		Versions: map[string]ExtendedSupportDates{
+			"5.7": {Year1: time.Date(2024, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)},
+			"8":   {Year1: time.Date(2026, time.August, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2028, time.August, 1, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.VersionPolicy.html#Aurora.VersionPolicy.MajorVersions
+	mysqlAuroraExtendedSupport = ExtendedSupport{
+		Engine: "AuroraMySQL",
+		Versions: map[string]ExtendedSupportDates{
+			"5.7": {Year1: time.Date(2024, time.December, 1, 0, 0, 0, 0, time.UTC)}, // Year3 is zero because it's N/A
+			"8":   {Year1: time.Date(2027, time.May, 1, 0, 0, 0, 0, time.UTC)},      // Year3 is zero because it's N/A
+		},
+	}
+
+	// https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html#Release.Calendar
+	postgresExtendedSupport = ExtendedSupport{
+		Engine: "PostgreSQL",
+		Versions: map[string]ExtendedSupportDates{
+			"11": {Year1: time.Date(2024, time.April, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)},
+			"12": {Year1: time.Date(2025, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2027, time.March, 1, 0, 0, 0, 0, time.UTC)},
+			"13": {Year1: time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2028, time.March, 1, 0, 0, 0, 0, time.UTC)},
+			"14": {Year1: time.Date(2027, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2029, time.March, 1, 0, 0, 0, 0, time.UTC)},
+			"15": {Year1: time.Date(2028, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2030, time.March, 1, 0, 0, 0, 0, time.UTC)},
+			"16": {Year1: time.Date(2029, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2031, time.March, 1, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.VersionPolicy.html#Aurora.VersionPolicy.MajorVersions
+	postgresAuroraExtendedSupport = ExtendedSupport{
+		Engine: "AuroraPostgreSQL",
+		Versions: map[string]ExtendedSupportDates{
+			"11": {Year1: time.Date(2024, time.April, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)},
+			"12": {Year1: time.Date(2025, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2027, time.March, 1, 0, 0, 0, 0, time.UTC)},
+			"13": {Year1: time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2028, time.March, 1, 0, 0, 0, 0, time.UTC)},
+			"14": {Year1: time.Date(2027, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2029, time.March, 1, 0, 0, 0, 0, time.UTC)},
+			"15": {Year1: time.Date(2028, time.March, 1, 0, 0, 0, 0, time.UTC), Year3: time.Date(2030, time.March, 1, 0, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	today = time.Now()
+)
+
+func extendedSupportCostComponent(version string, region string, engine string) *schema.CostComponent {
+	if version == "" {
+		return nil
+	}
+
+	switch engine {
+	case "postgres":
+		return postgresExtendedSupport.CostComponent(version, region, today)
+	case "mysql":
+		return mysqlExtendedSupport.CostComponent(version, region, today)
+	case "aurora-postgresql":
+		return postgresAuroraExtendedSupport.CostComponent(version, region, today)
+	case "aurora", "aurora-mysql":
+		return mysqlAuroraExtendedSupport.CostComponent(version, region, today)
+	}
+
+	return nil
 }

--- a/internal/resources/aws/rds_cluster_instance.go
+++ b/internal/resources/aws/rds_cluster_instance.go
@@ -122,7 +122,7 @@ func (r *RDSClusterInstance) BuildResource() *schema.Resource {
 		}
 	}
 
-	extendedSupport := extendedSupportCostComponent(r.Version, r.Region, r.Engine)
+	extendedSupport := extendedSupportCostComponent(r.Version, r.Region, r.Engine, r.InstanceClass)
 	if extendedSupport != nil {
 		costComponents = append(costComponents, extendedSupport)
 	}

--- a/internal/resources/aws/rds_cluster_instance.go
+++ b/internal/resources/aws/rds_cluster_instance.go
@@ -16,6 +16,7 @@ type RDSClusterInstance struct {
 	Region                                       string
 	InstanceClass                                string
 	Engine                                       string
+	Version                                      string
 	IOOptimized                                  bool
 	PerformanceInsightsEnabled                   bool
 	PerformanceInsightsLongTermRetention         bool
@@ -119,6 +120,11 @@ func (r *RDSClusterInstance) BuildResource() *schema.Resource {
 			costComponents = append(costComponents,
 				performanceInsightsAPIRequestCostComponent(r.Region, r.MonthlyAdditionalPerformanceInsightsRequests))
 		}
+	}
+
+	extendedSupport := extendedSupportCostComponent(r.Version, r.Region, r.Engine)
+	if extendedSupport != nil {
+		costComponents = append(costComponents, extendedSupport)
 	}
 
 	return &schema.Resource{


### PR DESCRIPTION
Adds cost component to `db_instance` and `rds_cluster_instance` for an extended support cost. This cost is only shown if the instnce engine and version fall into AWS's extended support category, and the current date is within the extended support window.

This is currently only applicable for mysql 5.7, for which extended support started March 2024. However, I have added tests for the rest of the versions listed in AWS docs so that we catch them in future.

The implementation for this feature means we hard code the support window in the resource. This is less than ideal but is the simplest way to accomodate the functionality right now. The pricing API response does contain an `effectiveStartDate` which we could use to filter the prices.

I avoided this, however, as it would involve a decent amount of refactoring and introduce some new concepts on the price fetching end. With this approach we would essentially "filter" the returned prices from the HCPAPI as well as during the lookup. e.g. `effectivePriceDate` is after current date, e.t.c.

I definitely think this is something we should accomodate in the future, however I am hesitant to do it now. Nevertheless, if you think this is a good time to try this, I can have a stab at it.