### PR TITLE
feat: add eks extended support cost

### DIFF
--- a/internal/providers/terraform/aws/eks_cluster.go
+++ b/internal/providers/terraform/aws/eks_cluster.go
@@ -15,6 +15,7 @@ func NewEKSCluster(d *schema.ResourceData) schema.CoreResource {
 	r := &aws.EKSCluster{
 		Address: d.Address,
 		Region:  d.Get("region").String(),
+		Version: d.Get("version").String(),
 	}
 	return r
 }

--- a/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
@@ -1,16 +1,37 @@
 
- Name                                Monthly Qty  Unit   Monthly Cost 
-                                                                      
- aws_eks_cluster.my_aws_eks_cluster                                   
- └─ EKS cluster                              730  hours        $73.00 
-                                                                      
- OVERALL TOTAL                                                 $73.00 
+ Name                                      Monthly Qty  Unit   Monthly Cost 
+                                                                            
+ aws_eks_cluster.extended_support["1.23"]                                   
+ └─ EKS cluster (extended support)                 730  hours       $438.00 
+                                                                            
+ aws_eks_cluster.extended_support["1.24"]                                   
+ └─ EKS cluster (extended support)                 730  hours       $438.00 
+                                                                            
+ aws_eks_cluster.extended_support["1.25"]                                   
+ └─ EKS cluster                                    730  hours        $73.00 
+                                                                            
+ aws_eks_cluster.extended_support["1.26"]                                   
+ └─ EKS cluster                                    730  hours        $73.00 
+                                                                            
+ aws_eks_cluster.extended_support["1.27"]                                   
+ └─ EKS cluster                                    730  hours        $73.00 
+                                                                            
+ aws_eks_cluster.extended_support["1.28"]                                   
+ └─ EKS cluster                                    730  hours        $73.00 
+                                                                            
+ aws_eks_cluster.extended_support["1.29"]                                   
+ └─ EKS cluster                                    730  hours        $73.00 
+                                                                            
+ aws_eks_cluster.my_aws_eks_cluster                                         
+ └─ EKS cluster                                    730  hours        $73.00 
+                                                                            
+ OVERALL TOTAL                                                    $1,314.00 
 ──────────────────────────────────
-1 cloud resource was detected:
-∙ 1 was estimated
+8 cloud resources were detected:
+∙ 8 were estimated
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestEKSClusterGoldenFile                           ┃ $73          ┃
+┃ TestEKSClusterGoldenFile                           ┃ $1,314       ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.tf
+++ b/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.tf
@@ -21,3 +21,32 @@ resource "aws_eks_cluster" "my_aws_eks_cluster" {
   depends_on = [
   ]
 }
+
+
+locals {
+  versions = [
+    "1.29",
+    "1.28",
+    "1.27",
+    "1.26",
+    "1.25",
+    "1.24",
+    "1.23",
+  ]
+}
+
+resource "aws_eks_cluster" "extended_support" {
+  for_each = { for version in local.versions : version => version }
+  name     = "cluster"
+  role_arn = "arn:aws:iam::123456789012:role/role"
+  version  = each.value
+
+  vpc_config {
+    subnet_ids = ["subnet-123456"]
+  }
+
+  # Ensure that IAM Role permissions are created before and deleted after EKS Cluster handling.
+  # Otherwise, EKS will not be able to properly delete EKS managed EC2 infrastructure such as Security Groups.
+  depends_on = [
+  ]
+}

--- a/internal/resources/aws/eks_cluster.go
+++ b/internal/resources/aws/eks_cluster.go
@@ -1,14 +1,29 @@
 package aws
 
 import (
+	"time"
+
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
 
 	"github.com/shopspring/decimal"
 )
 
+var (
+	eksSupportMap = map[string]time.Time{
+		"1.29": time.Date(2025, time.March, 23, 0, 0, 0, 0, time.UTC),
+		"1.28": time.Date(2024, time.November, 26, 0, 0, 0, 0, time.UTC),
+		"1.27": time.Date(2024, time.July, 24, 0, 0, 0, 0, time.UTC),
+		"1.26": time.Date(2024, time.June, 11, 0, 0, 0, 0, time.UTC),
+		"1.25": time.Date(2024, time.May, 1, 0, 0, 0, 0, time.UTC),
+		"1.24": time.Date(2024, time.January, 31, 0, 0, 0, 0, time.UTC),
+		"1.23": time.Date(2023, time.October, 11, 0, 0, 0, 0, time.UTC),
+	}
+)
+
 type EKSCluster struct {
 	Address string
+	Version string
 	Region  string
 }
 
@@ -32,8 +47,13 @@ func (r *EKSCluster) BuildResource() *schema.Resource {
 	}
 }
 
+// clusterHoursCostComponent returns the management cost of the EKS cluster. This
+// can include extended support cost if the version is not supported by AWS
+// anymore. In this case we set a custom price of 0.6$ per hour. This is a
+// placeholder until AWS provides the price. and we can look it up in the Pricing
+// API.
 func (r *EKSCluster) clusterHoursCostComponent() *schema.CostComponent {
-	return &schema.CostComponent{
+	baseCost := &schema.CostComponent{
 		Name:           "EKS cluster",
 		Unit:           "hours",
 		UnitMultiplier: decimal.NewFromInt(1),
@@ -51,4 +71,24 @@ func (r *EKSCluster) clusterHoursCostComponent() *schema.CostComponent {
 			PurchaseOption: strPtr("on_demand"),
 		},
 	}
+
+	if r.Version == "" {
+		return baseCost
+	}
+
+	supportDate := eksSupportMap[r.Version]
+	if supportDate.IsZero() {
+		return baseCost
+	}
+
+	if !supportDate.Before(time.Now()) {
+		return baseCost
+	}
+
+	baseCost.Name = "EKS cluster (extended support)"
+	// @TODO: Add price when AWS provides it
+	baseCost.SetCustomPrice(decimalPtr(decimal.NewFromFloat(0.6)))
+
+	return baseCost
+
 }


### PR DESCRIPTION
Changes the eks resource to use the extended support cost for the management cost of the cluster if the version specified in the resource is past the AWS support date. Extended support is charged at $0.6 per hour per cluster and replaces old management cost of $0.1.

We currently hard code the cost ($0.6) as this cost is not currently available in the pricing API.