### PR TITLE
fix: don't evaluate or marshal `depends_on` or `lifecycle` meta attributes

### DIFF
--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
@@ -156,9 +156,9 @@ Module path: ref2
 
  OVERALL TOTAL                                                                                                        $5,290.62 
 ──────────────────────────────────
-115 cloud resources were detected:
+112 cloud resources were detected:
 ∙ 21 were estimated, 14 of which include usage-based costs, see https://infracost.io/usage-file
-∙ 93 were free, rerun with --show-skipped to see details
+∙ 90 were free, rerun with --show-skipped to see details
 ∙ 1 is not supported yet, rerun with --show-skipped to see details
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -698,7 +698,7 @@ func blockToReferences(block *hcl.Block) map[string]interface{} {
 func (p *HCLProvider) marshalBlock(block *hcl.Block, jsonValues map[string]interface{}) {
 	for _, b := range block.Children() {
 		key := b.Type()
-		if key == "dynamic" || key == "depends_on" {
+		if key == "dynamic" {
 			continue
 		}
 


### PR DESCRIPTION
These meta attributes never need to be evaluated since they will never affect the costs/tags.

Additionally, since `depends_on` attributes point to entire resources, we run into problems marshaling them, since the type of the object includes the types of any nested resources referenced by the `depends_on` attribute.