### PR TITLE
test: Revert "chore: update golden file test"

### DIFF
--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/breakdown_terragrunt_with_remote_source.golden
@@ -156,9 +156,9 @@ Module path: ref2
 
  OVERALL TOTAL                                                                                                        $5,290.62 
 ──────────────────────────────────
-112 cloud resources were detected:
+115 cloud resources were detected:
 ∙ 21 were estimated, 14 of which include usage-based costs, see https://infracost.io/usage-file
-∙ 90 were free, rerun with --show-skipped to see details
+∙ 93 were free, rerun with --show-skipped to see details
 ∙ 1 is not supported yet, rerun with --show-skipped to see details
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓


### PR DESCRIPTION
I'm not sure what happened but the update you did yesterday is now failing.

This reverts commit ab7e3c23e21718c4a642309f051a804813136ab9.