### PR TITLE
fix: only apply `force_project_type` on project duplicates

### DIFF
--- a/cmd/infracost/testdata/generate/force_project_type/expected.golden
+++ b/cmd/infracost/testdata/generate/force_project_type/expected.golden
@@ -1,14 +1,15 @@
 version: 0.1
 
 projects:
-  - path: terraform
-    name: terraform-dev
+  - path: dup
+    name: dup-dev
     terraform_var_files:
       - dev.tfvars
     skip_autodetect: true
-  - path: terraform
-    name: terraform-prod
+  - path: dup
+    name: dup-prod
     terraform_var_files:
       - prod.tfvars
     skip_autodetect: true
+  - path: nondup
 

--- a/cmd/infracost/testdata/generate/force_project_type/tree.txt
+++ b/cmd/infracost/testdata/generate/force_project_type/tree.txt
@@ -1,6 +1,8 @@
 .
-└── terraform
-    ├── terragrunt.hcl
-    ├── main.tf
-    ├── prod.tfvars
-    └── dev.tfvars
+├── dup
+│   ├── terragrunt.hcl
+│   ├── main.tf
+│   ├── prod.tfvars
+│   └── dev.tfvars
+└── nondup
+    └── terragrunt.hcl


### PR DESCRIPTION
changes the force project type logic to only work with projects that have been detected as duplicates (they have been detected as both Terraform and Terragrunt project types).