### PR TITLE
fix: filter empty path error from diff baseline

### DIFF
--- a/cmd/infracost/diff_test.go
+++ b/cmd/infracost/diff_test.go
@@ -334,3 +334,20 @@ func TestDiffPriorEmptyProject(t *testing.T) {
 			dir,
 		}, nil)
 }
+
+func TestDiffPriorEmptyProjectJSON(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(), []string{
+			"diff",
+			"--compare-to",
+			path.Join(dir, "base.json"),
+			"--path",
+			dir,
+			"--format", "json",
+		}, &GoldenFileOptions{
+			IsJSON: true,
+		})
+}

--- a/cmd/infracost/testdata/diff_prior_empty_project_json/base.json
+++ b/cmd/infracost/testdata/diff_prior_empty_project_json/base.json
@@ -1,0 +1,72 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "master",
+    "vcsCommitSha": "71785af96bce822bd54f359d0883cfa4ca805432",
+    "vcsCommitAuthorName": "Hugo",
+    "vcsCommitAuthorEmail": "",
+    "vcsCommitTimestamp": "2024-02-23T11:04:26Z",
+    "vcsCommitMessage": "wip",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost.git"
+  },
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "infracost/infracost/cmd/infracost/testdata/diff_prior_empty_project_json",
+      "metadata": {
+        "path": ".",
+        "type": "error",
+        "vcsSubPath": "cmd/infracost/testdata/diff_prior_empty_project_js",
+        "errors": [
+          {
+            "code": 106,
+            "message": "could not detect path type for '.'\n\nTry adding a config-file to configure how Infracost should run. See \u001b[4;1mhttps://infracost.io/config-file\u001b[0m for details and examples.",
+            "data": null,
+            "isError": true
+          }
+        ]
+      },
+      "pastBreakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "breakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 0,
+        "totalSupportedResources": 0,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 0,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
+      }
+    }
+  ],
+  "totalHourlyCost": "0",
+  "totalMonthlyCost": "0",
+  "pastTotalHourlyCost": "0",
+  "pastTotalMonthlyCost": "0",
+  "diffTotalHourlyCost": "0",
+  "diffTotalMonthlyCost": "0",
+  "timeGenerated": "2024-02-23T12:58:15.71255Z",
+  "summary": {
+    "totalDetectedResources": 0,
+    "totalSupportedResources": 0,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 0,
+    "totalNoPriceResources": 0,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {}
+  }
+}

--- a/cmd/infracost/testdata/diff_prior_empty_project_json/diff_prior_empty_project_json.golden
+++ b/cmd/infracost/testdata/diff_prior_empty_project_json/diff_prior_empty_project_json.golden
@@ -1,0 +1,231 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "diff",
+    "vcsBranch": "stub-branch",
+    "vcsCommitSha": "stub-sha",
+    "vcsCommitAuthorName": "stub-author",
+    "vcsCommitAuthorEmail": "stub@stub.com",
+    "vcsCommitTimestamp": "REPLACED_TIME",
+    "vcsCommitMessage": "stub-message",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost"
+  },
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "infracost/infracost/cmd/infracost/testdata/diff_prior_empty_project_json",
+      "metadata": {
+        "path": "testdata/diff_prior_empty_project_json",
+        "type": "terraform_dir",
+        "vcsSubPath": "cmd/infracost/testdata/diff_prior_empty_project_json",
+        "providers": [
+          {
+            "name": "aws",
+            "filename": "testdata/diff_prior_empty_project_json/main.tf",
+            "startLine": 1,
+            "endLine": 7
+          }
+        ]
+      },
+      "pastBreakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app",
+                  "endLine": 23,
+                  "filename": "testdata/diff_prior_empty_project_json/main.tf",
+                  "startLine": 9
+                }
+              ],
+              "checksum": "e529ad309bb6d647fae2d2854bc0d7f04a7888eceb9580ac224d15cc3384a825",
+              "endLine": 23,
+              "filename": "testdata/diff_prior_empty_project_json/main.tf",
+              "startLine": 9
+            },
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.017315068493150679",
+        "totalMonthlyCost": "742.64"
+      },
+      "diff": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app",
+                  "endLine": 23,
+                  "filename": "testdata/diff_prior_empty_project_json/main.tf",
+                  "startLine": 9
+                }
+              ],
+              "checksum": "e529ad309bb6d647fae2d2854bc0d7f04a7888eceb9580ac224d15cc3384a825",
+              "endLine": 23,
+              "filename": "testdata/diff_prior_empty_project_json/main.tf",
+              "startLine": 9
+            },
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.017315068493150679",
+        "totalMonthlyCost": "742.64"
+      },
+      "summary": {
+        "totalDetectedResources": 1,
+        "totalSupportedResources": 1,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 1,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
+      }
+    }
+  ],
+  "totalHourlyCost": "1.017315068493150679",
+  "totalMonthlyCost": "742.64",
+  "pastTotalHourlyCost": "0",
+  "pastTotalMonthlyCost": "0",
+  "diffTotalHourlyCost": "1.017315068493150679",
+  "diffTotalMonthlyCost": "742.64",
+  "timeGenerated": "REPLACED_TIME",
+  "summary": {
+    "totalDetectedResources": 1,
+    "totalSupportedResources": 1,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 1,
+    "totalNoPriceResources": 0,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {}
+  }
+}
+
+Err:
+

--- a/cmd/infracost/testdata/diff_prior_empty_project_json/main.tf
+++ b/cmd/infracost/testdata/diff_prior_empty_project_json/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -147,6 +147,14 @@ func CompareTo(c *config.Config, current, prior Root) (Root, error) {
 			}
 
 			for _, pastE := range v.Metadata.Errors {
+				if schema.IsEmptyPathTypeError(pastE) {
+					// If the error is a path type error we want to remove it from the metadata as
+					// this is normally indicative of a project that has been added. Thus the project
+					// path only appears in the current branch and so the baseline error is safe to
+					// be ignored.
+					continue
+				}
+
 				pastE.Message = "Diff baseline error: " + pastE.Message
 				scp.Metadata.Errors = append(scp.Metadata.Errors, pastE)
 			}

--- a/internal/schema/project.go
+++ b/internal/schema/project.go
@@ -48,6 +48,16 @@ type ProjectDiag struct {
 	FriendlyMessage string `json:"-"`
 }
 
+// IsEmptyPathTypeError checks if the error is a diag for an empty path type.
+func IsEmptyPathTypeError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var diag *ProjectDiag
+	return errors.As(err, &diag) && diag.Code == diagEmptyPathType
+}
+
 // NewEmptyPathTypeError returns a project diag to indicate that a path type
 // cannot be detected.
 func NewEmptyPathTypeError(err error) *ProjectDiag {


### PR DESCRIPTION
Changes the combined logic so that we filter any empty path errors that originate from the baseline of a current project. This is done because in the majority of cases an empty path error on the baseline just means that the project was simply added.

This resolves a UI error in Infracost Cloud where newly added projects were not shown because of the basline error.