### PR TITLE
feat: add support for `env_var_extensions` autodetect configuration

### DIFF
--- a/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
@@ -1,0 +1,40 @@
+version: 0.1
+
+projects:
+  - path: apps/bar
+    name: apps-bar-baz
+    terraform_var_files:
+      - ../default.tfvars
+      - ../baz-custom-ext
+    skip_autodetect: true
+  - path: apps/bar
+    name: apps-bar-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+    skip_autodetect: true
+  - path: apps/bar
+    name: apps-bar-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod-custom-ext
+    skip_autodetect: true
+  - path: apps/foo
+    name: apps-foo-baz
+    terraform_var_files:
+      - ../default.tfvars
+      - ../baz-custom-ext
+    skip_autodetect: true
+  - path: apps/foo
+    name: apps-foo-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+    skip_autodetect: true
+  - path: apps/foo
+    name: apps-foo-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod-custom-ext
+    skip_autodetect: true
+

--- a/cmd/infracost/testdata/generate/env_var_extensions/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/env_var_extensions/infracost.yml.tmpl
@@ -1,0 +1,9 @@
+version: 0.1
+autodetect:
+  env_names:
+    - baz
+    - dev
+    - prod
+  env_var_extensions:
+    - ".tfvars"
+    - ""

--- a/cmd/infracost/testdata/generate/env_var_extensions/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/env_var_extensions/infracost.yml.tmpl
@@ -4,6 +4,6 @@ autodetect:
     - baz
     - dev
     - prod
-  env_var_extensions:
+  terraform_var_file_extensions:
     - ".tfvars"
     - ""

--- a/cmd/infracost/testdata/generate/env_var_extensions/tree.txt
+++ b/cmd/infracost/testdata/generate/env_var_extensions/tree.txt
@@ -1,0 +1,11 @@
+.
+└── apps
+    ├── bar
+    │   └── main.tf
+    ├── foo
+    │   └── main.tf
+    ├── baz-custom-ext
+    ├── Jenkinsfile
+    ├── dev.tfvars
+    ├── prod-custom-ext
+    └── default.tfvars

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,10 +39,10 @@ type AutodetectConfig struct {
 	// Terragrunt and Terraform and we want to force the project type to be one or
 	// the other.
 	ForceProjectType string `yaml:"force_project_type,omitempty" ignored:"true"`
-	// EnvVarExtensions is a list of suffixes that should be used to group terraform
+	// TerraformVarFileExtensions is a list of suffixes that should be used to group terraform
 	// var files. This is useful when there are non-standard terraform var file
 	// names which use different extensions.
-	EnvVarExtensions []string `yaml:"env_var_extensions,omitempty" ignored:"true"`
+	TerraformVarFileExtensions []string `yaml:"terraform_var_file_extensions,omitempty" ignored:"true"`
 }
 
 type PathOverride struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,10 @@ type AutodetectConfig struct {
 	// Terragrunt and Terraform and we want to force the project type to be one or
 	// the other.
 	ForceProjectType string `yaml:"force_project_type,omitempty" ignored:"true"`
+	// EnvVarExtensions is a list of suffixes that should be used to group terraform
+	// var files. This is useful when there are non-standard terraform var file
+	// names which use different extensions.
+	EnvVarExtensions []string `yaml:"env_var_extensions,omitempty" ignored:"true"`
 }
 
 type PathOverride struct {

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -55,7 +55,7 @@ data "cats_cat" "the-cats-mother" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -150,7 +150,7 @@ output "loadbalancer"  {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -223,7 +223,7 @@ output "exp2" {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -270,7 +270,7 @@ output "instances" {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -309,7 +309,7 @@ resource "other_resource" "test" {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -354,7 +354,7 @@ output "attr_not_exists" {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -394,7 +394,7 @@ resource "other_resource" "test" {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -446,7 +446,7 @@ output "serviceendpoint_principals" {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -484,7 +484,7 @@ output "val" {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -502,7 +502,7 @@ func Test_SetsHasChangesOnMod(t *testing.T) {
 	path := createTestFile("test.tf", `variable "foo" {}`)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path), HasChanges: true}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path), HasChanges: true}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -524,7 +524,7 @@ output "val" {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -567,7 +567,7 @@ output "mod_result" {
 	loader := modules.NewModuleLoader(dir, modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: path},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -632,7 +632,7 @@ output "mod_result" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: path},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -687,7 +687,7 @@ resource "aws_instance" "my_instance" {
 `)
 
 	logger := newDiscardLogger()
-	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
+	parser := NewParser(RootPath{Path: filepath.Dir(path)}, CreateEnvFileMatcher([]string{}, nil), modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}), logger)
 	module, err := parser.ParseDirectory()
 	require.NoError(t, err)
 
@@ -831,7 +831,7 @@ resource "test_resource_two" "test" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -891,7 +891,7 @@ resource "test_resource_two" "test" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -957,7 +957,7 @@ output "mod_result" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: path},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1109,7 +1109,7 @@ output "mod_result" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: path},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1195,7 +1195,7 @@ resource "dynamic" "resource" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: path},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1261,7 +1261,7 @@ resource "azurerm_linux_function_app" "function" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1315,7 +1315,7 @@ resource "test_resource" "second" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1371,7 +1371,7 @@ data "google_compute_zones" "us" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1426,7 +1426,7 @@ data "aws_availability_zones" "ne" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1477,7 +1477,7 @@ resource "random_shuffle" "bad" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1548,7 +1548,7 @@ locals {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1603,7 +1603,7 @@ resource "baz" "bat" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 	)
@@ -1667,7 +1667,7 @@ resource "aws_instance" "example" {
 
 	parser := NewParser(
 		RootPath{Path: path},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 		OptionGraphEvaluator(),
@@ -1721,7 +1721,7 @@ resource "aws_instance" "example" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: path},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 		OptionGraphEvaluator(),
@@ -1759,7 +1759,7 @@ resource "aws_instance" "example" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 		OptionGraphEvaluator(),
@@ -1807,7 +1807,7 @@ resource "aws_instance" "example" {
 	loader := modules.NewModuleLoader(filepath.Dir(path), modules.NewSharedHCLParser(), nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 	parser := NewParser(
 		RootPath{Path: filepath.Dir(path)},
-		CreateEnvFileMatcher([]string{}),
+		CreateEnvFileMatcher([]string{}, nil),
 		loader,
 		logger,
 		OptionGraphEvaluator(),
@@ -1833,7 +1833,7 @@ func BenchmarkParserEvaluate(b *testing.B) {
 		loader := modules.NewModuleLoader(dir, modules.NewSharedHCLParser(), source, config.TerraformSourceMap{}, logger, &sync.KeyMutex{})
 		parser := NewParser(
 			RootPath{Path: dir},
-			CreateEnvFileMatcher([]string{}),
+			CreateEnvFileMatcher([]string{}, nil),
 			loader,
 			logger,
 		)

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -57,17 +57,30 @@ var (
 		"mgmt",
 		"playground",
 	}
+	defaultExtensions = []string{
+		".tfvars",
+		".auto.tfvars",
+		".tfvars.json",
+		".auto.tfvars.json",
+	}
 )
 
 // EnvFileMatcher is used to match environment specific var files.
 type EnvFileMatcher struct {
-	envNames  []string
-	envLookup map[string]struct{}
+	envNames   []string
+	envLookup  map[string]struct{}
+	extensions []string
 }
 
-func CreateEnvFileMatcher(names []string) *EnvFileMatcher {
+func CreateEnvFileMatcher(names []string, extensions []string) *EnvFileMatcher {
+	if extensions == nil {
+		// create a matcher with the .json extensions as well so that we support
+		// tfars-env.json use case.
+		extensions = append(defaultExtensions, ".json") // nolint
+	}
+
 	if len(names) == 0 {
-		return CreateEnvFileMatcher(defaultEnvs)
+		return CreateEnvFileMatcher(defaultEnvs, extensions)
 	}
 
 	lookup := make(map[string]struct{}, len(names))
@@ -76,8 +89,9 @@ func CreateEnvFileMatcher(names []string) *EnvFileMatcher {
 	}
 
 	return &EnvFileMatcher{
-		envNames:  names,
-		envLookup: lookup,
+		envNames:   names,
+		envLookup:  lookup,
+		extensions: extensions,
 	}
 }
 
@@ -113,7 +127,13 @@ func (e *EnvFileMatcher) IsEnvName(file string) bool {
 }
 
 func (e *EnvFileMatcher) clean(name string) string {
-	return cleanVarName(filepath.Base(name))
+	base := filepath.Base(name)
+
+	for _, suffix := range e.extensions {
+		base = strings.TrimSuffix(base, suffix)
+	}
+
+	return base
 }
 
 // EnvName returns the environment name for the given var file.
@@ -166,11 +186,6 @@ func (e *EnvFileMatcher) hasEnvSuffix(clean string, name string) bool {
 	return strings.HasSuffix(clean, "_"+name) || strings.HasSuffix(clean, "-"+name)
 }
 
-// cleanVarName removes the .tfvars or .tfvars.json suffix from the file name.
-func cleanVarName(file string) string {
-	return filepath.Base(strings.TrimSuffix(strings.TrimSuffix(file, ".json"), ".tfvars"))
-}
-
 type discoveredProject struct {
 	isTerragrunt bool
 
@@ -210,6 +225,9 @@ type ProjectLocator struct {
 	fallbackToIncludePaths bool
 	maxConfiguredDepth     int
 	forceProjectType       string
+	envVarExtensions       []string
+	hclParser              *hclparse.Parser
+	hasCustomEnvExt        bool
 }
 
 // ProjectLocatorConfig provides configuration options on how the locator functions.
@@ -224,6 +242,7 @@ type ProjectLocatorConfig struct {
 	FallbackToIncludePaths bool
 	MaxSearchDepth         int
 	ForceProjectType       string
+	EnvVarExtensions       []string
 }
 
 type PathOverrideConfig struct {
@@ -258,10 +277,14 @@ func newPathOverride(override PathOverrideConfig) pathOverride {
 
 // NewProjectLocator returns safely initialized ProjectLocator.
 func NewProjectLocator(logger zerolog.Logger, config *ProjectLocatorConfig) *ProjectLocator {
-	matcher := CreateEnvFileMatcher(defaultEnvs)
+	matcher := CreateEnvFileMatcher(nil, nil)
 	if config != nil {
-		if len(config.EnvNames) > 0 {
-			matcher = CreateEnvFileMatcher(config.EnvNames)
+		extensions := defaultExtensions
+		if config.EnvVarExtensions != nil {
+			extensions = config.EnvVarExtensions
+			matcher = CreateEnvFileMatcher(config.EnvNames, config.EnvVarExtensions)
+		} else {
+			matcher = CreateEnvFileMatcher(config.EnvNames, nil)
 		}
 
 		overrides := make([]pathOverride, len(config.PathOverrides))
@@ -290,6 +313,9 @@ func NewProjectLocator(logger zerolog.Logger, config *ProjectLocatorConfig) *Pro
 			},
 			fallbackToIncludePaths: config.FallbackToIncludePaths,
 			forceProjectType:       config.ForceProjectType,
+			envVarExtensions:       extensions,
+			hclParser:              hclparse.NewParser(),
+			hasCustomEnvExt:        len(config.EnvVarExtensions) > 0,
 		}
 	}
 
@@ -298,6 +324,8 @@ func NewProjectLocator(logger zerolog.Logger, config *ProjectLocatorConfig) *Pro
 		discoveredVarFiles: make(map[string][]RootPathVarFile),
 		logger:             logger,
 		envMatcher:         matcher,
+		envVarExtensions:   defaultExtensions,
+		hclParser:          hclparse.NewParser(),
 	}
 }
 
@@ -424,7 +452,7 @@ func buildVarFileEnvNames(root *TreeNode, e *EnvFileMatcher) {
 			namesToSearch := append([]string{f.Name}, possibleEnvNames...)
 			var envName string
 			for _, search := range namesToSearch {
-				if e.IsEnvName(cleanVarName(search)) {
+				if e.IsEnvName(search) {
 					envName = search
 					break
 				}
@@ -798,7 +826,7 @@ func (t *TreeNode) AssociateAuntVarFiles() {
 }
 
 // CollectRootPaths returns a list of all the Terraform projects found in the tree.
-func (t *TreeNode) CollectRootPaths() []RootPath {
+func (t *TreeNode) CollectRootPaths(e *EnvFileMatcher) []RootPath {
 	var projects []RootPath
 	t.Visit(func(t *TreeNode) {
 		if t.RootPath != nil {
@@ -816,7 +844,7 @@ func (t *TreeNode) CollectRootPaths() []RootPath {
 	for _, root := range projects {
 		for _, varFile := range root.TerraformVarFiles {
 			base := filepath.Base(root.Path)
-			name := cleanVarName(varFile.Name)
+			name := e.clean(varFile.Name)
 			if base == name {
 				found[varFile.FullPath] = true
 			}
@@ -830,7 +858,7 @@ func (t *TreeNode) CollectRootPaths() []RootPath {
 	for i, root := range projects {
 		var filtered RootPathVarFiles
 		for _, varFile := range root.TerraformVarFiles {
-			name := cleanVarName(varFile.Name)
+			name := e.clean(varFile.Name)
 			base := filepath.Base(root.Path)
 			if found[varFile.FullPath] && base != name {
 				continue
@@ -916,7 +944,7 @@ type VarFileGrouping struct {
 // to group and dedup var files that would otherwise create new projects.
 func (r *RootPath) EnvGroupings() []VarFileGrouping {
 	if r.Matcher == nil {
-		r.Matcher = CreateEnvFileMatcher(defaultEnvs)
+		r.Matcher = CreateEnvFileMatcher(defaultEnvs, nil)
 	}
 
 	varFiles := r.EnvFiles()
@@ -1078,7 +1106,7 @@ func (p *ProjectLocator) FindRootModules(fullPath string) []RootPath {
 	node.AssociateParentVarFiles()
 	node.AssociateAuntVarFiles()
 
-	paths := node.CollectRootPaths()
+	paths := node.CollectRootPaths(p.envMatcher)
 	p.excludeEnvFromPaths(paths)
 
 	sort.Slice(paths, func(i, j int) bool {
@@ -1285,7 +1313,7 @@ func (p *ProjectLocator) walkPaths(fullPath string, level int) {
 			parseFunc = hclParser.ParseJSONFile
 		}
 
-		if p.isTerraformVarFile(name) {
+		if p.isTerraformVarFile(name, filepath.Join(fullPath, name)) {
 			v, ok := p.discoveredVarFiles[fullPath]
 			if !ok {
 				v = []RootPathVarFile{{
@@ -1344,10 +1372,46 @@ func (p *ProjectLocator) walkPaths(fullPath string, level int) {
 	}
 }
 
-func (p *ProjectLocator) isTerraformVarFile(name string) bool {
-	return strings.HasSuffix(name, ".tfvars") ||
-		strings.HasSuffix(name, ".tfvars.json") ||
-		(strings.HasPrefix(name, "tfvars") && strings.HasSuffix(name, ".json"))
+func (p *ProjectLocator) isTerraformVarFile(name string, fullPath string) bool {
+	for _, envExt := range p.envVarExtensions {
+		fileExt := fullExtension(name)
+		if fileExt == envExt {
+			// if we have custom extensions enabled in the autodetect configuration we need
+			// to make sure that this file is a valid HCL file before we add it to the list
+			// of discovered var files. This is because we can have collisions with custom
+			// env var extensions and other files that are not valid HCL files. e.g. with an
+			// empty/wildcard extension we could match a file called "tfvars" and also
+			// "Jenkinsfile", the latter being a non-HCL file.
+			if p.hasCustomEnvExt {
+				_, d := p.hclParser.ParseHCLFile(fullPath)
+				if d != nil {
+					continue
+				}
+			}
+
+			return true
+		}
+	}
+
+	// we also check for tfvars.json files as these are non-standard naming
+	// conventions which are used by some projects.
+	return strings.HasPrefix(name, "tfvars") && strings.HasSuffix(name, ".json")
+}
+
+// fullExtension returns the full extension of a file, starting from the first
+// dot in the file name. This is used instead of the builtin filepath.Ext
+// function as the latter only returns the last extension in the file name. For
+// example filepath.Ext("file.tfvars.json") would return ".json" instead of
+// ".tfvars.json".
+func fullExtension(fileName string) string {
+	// Find the index of the first dot.
+	dotIndex := strings.Index(fileName, ".")
+	if dotIndex == -1 {
+		// No dot found, return empty string.
+		return ""
+	}
+	// Return the substring from the first dot to the end of the string.
+	return fileName[dotIndex:]
 }
 
 type terraformDirInfo struct {

--- a/internal/hcl/project_locator_test.go
+++ b/internal/hcl/project_locator_test.go
@@ -92,7 +92,7 @@ func TestEnvFileMatcher_EnvName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := CreateEnvFileMatcher(tt.fields.envNames)
+			e := CreateEnvFileMatcher(tt.fields.envNames, nil)
 			assert.Equalf(t, tt.want, e.EnvName(tt.args.file), "EnvName(%v)", tt.args.file)
 		})
 	}

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -60,17 +60,17 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 	}
 
 	locatorConfig := &hcl.ProjectLocatorConfig{
-		ExcludedDirs:           append(project.ExcludePaths, ctx.Config.Autodetect.ExcludeDirs...),
-		IncludedDirs:           ctx.Config.Autodetect.IncludeDirs,
-		PathOverrides:          pathOverrides,
-		EnvNames:               ctx.Config.Autodetect.EnvNames,
-		ChangedObjects:         ctx.VCSMetadata.Commit.ChangedObjects,
-		UseAllPaths:            project.IncludeAllPaths,
-		SkipAutoDetection:      project.SkipAutodetect,
-		FallbackToIncludePaths: ctx.IsAutoDetect(),
-		MaxSearchDepth:         ctx.Config.Autodetect.MaxSearchDepth,
-		ForceProjectType:       ctx.Config.Autodetect.ForceProjectType,
-		EnvVarExtensions:       ctx.Config.Autodetect.EnvVarExtensions,
+		ExcludedDirs:               append(project.ExcludePaths, ctx.Config.Autodetect.ExcludeDirs...),
+		IncludedDirs:               ctx.Config.Autodetect.IncludeDirs,
+		PathOverrides:              pathOverrides,
+		EnvNames:                   ctx.Config.Autodetect.EnvNames,
+		ChangedObjects:             ctx.VCSMetadata.Commit.ChangedObjects,
+		UseAllPaths:                project.IncludeAllPaths,
+		SkipAutoDetection:          project.SkipAutodetect,
+		FallbackToIncludePaths:     ctx.IsAutoDetect(),
+		MaxSearchDepth:             ctx.Config.Autodetect.MaxSearchDepth,
+		ForceProjectType:           ctx.Config.Autodetect.ForceProjectType,
+		TerraformVarFileExtensions: ctx.Config.Autodetect.TerraformVarFileExtensions,
 	}
 	pl := hcl.NewProjectLocator(logging.Logger, locatorConfig)
 	rootPaths := pl.FindRootModules(project.Path)

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -70,6 +70,7 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 		FallbackToIncludePaths: ctx.IsAutoDetect(),
 		MaxSearchDepth:         ctx.Config.Autodetect.MaxSearchDepth,
 		ForceProjectType:       ctx.Config.Autodetect.ForceProjectType,
+		EnvVarExtensions:       ctx.Config.Autodetect.EnvVarExtensions,
 	}
 	pl := hcl.NewProjectLocator(logging.Logger, locatorConfig)
 	rootPaths := pl.FindRootModules(project.Path)

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -164,7 +164,7 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 	rootPath.Path = initialPath
 	return &HCLProvider{
 		policyClient:   policyClient,
-		Parser:         hcl.NewParser(rootPath, hcl.CreateEnvFileMatcher(ctx.RunContext.Config.Autodetect.EnvNames), loader, logger, options...),
+		Parser:         hcl.NewParser(rootPath, hcl.CreateEnvFileMatcher(ctx.RunContext.Config.Autodetect.EnvNames, nil), loader, logger, options...),
 		planJSONParser: NewParser(ctx, true),
 		ctx:            ctx,
 		config:         *config,

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -201,7 +201,7 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 
 			parser := hcl.NewParser(
 				mods[0],
-				hcl.CreateEnvFileMatcher([]string{}),
+				hcl.CreateEnvFileMatcher([]string{}, nil),
 				modules.NewModuleLoader(testPath, moduleParser, nil, config.TerraformSourceMap{}, logger, &sync.KeyMutex{}),
 				logger,
 				options...,

--- a/internal/testutil/generate.go
+++ b/internal/testutil/generate.go
@@ -75,8 +75,30 @@ func createFileWithContents(filePath string) error {
 		content = `include {
 	path = find_in_parent_folders()		
 }`
+	case "Jenkinsfile":
+		content = `
+pipeline {
+    agent any
+    options {
+        timeout(time: 1, unit: 'SECONDS')
+    }
+    stages {
+        stage('Example') {
+            steps {
+                echo 'Hello World'
+            }
+        }
+    }
+}
+`
 	default:
 		content = ""
+	}
+
+	if strings.HasSuffix(filename, "-custom-ext") {
+		content = `
+instance_type = "m5.4xlarge"
+`
 	}
 
 	return os.WriteFile(filePath, []byte(content), 0600)
@@ -153,13 +175,7 @@ func buildFileSystemTree(lines []string, currentLine int, currentIndent int) (*f
 	}
 
 	node := &fileSystemNode{
-		name:  strings.TrimSpace(formattedLine),
-		isDir: filepath.Ext(line) == "" || formattedLine == ".",
-	}
-
-	// files cannot have children underneath them
-	if !node.isDir {
-		return node, nil
+		name: strings.TrimSpace(formattedLine),
 	}
 
 	nextIndent := indent + 1
@@ -177,5 +193,6 @@ func buildFileSystemTree(lines []string, currentLine int, currentIndent int) (*f
 		nextLine += len(child.children)
 	}
 
+	node.isDir = len(node.children) > 0
 	return node, nil
 }


### PR DESCRIPTION
Some projects contain env vars that are have non-standard naming conventions and don't follow the common `.tfvars` and `.tfvars.json` patterns. In this case autodetect fails to pick up the variable files as part of the `ProjectLocator` configuration.

This change adds support for a autodetect configuration to allow us to specify non-standard naming conventions. This, alongside the existing `env_names` configuration field should satifsy most tfvar requirements. 

When specifying `env_var_extensions` we must validate that the file contents are valid HCL, as in many cases custom extensions might have collisions with other non var files. We do this by parsing the file using the hclsyntax library. We only do this validation when extensions are specified so as not to impact performance for other users.

However, we still have the issue of the `tfvars-env.json` usecase which is used by some customers. I've had to make exceptions for this in this PR because I think adding "configurable" support for this might be a bit more complex. In future we might look to add a `env_var_pattern` config, which accepts a regex. This means we could catch the prefix/suffix combo scenario.