### PR TITLE
fix: skip tfvar file decoding if name follows default conventions

### DIFF
--- a/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
@@ -5,36 +5,42 @@ projects:
     name: apps-bar-baz
     terraform_var_files:
       - ../default.tfvars
+      - ../common.tfvars.json
       - ../baz-custom-ext
     skip_autodetect: true
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:
       - ../default.tfvars
+      - ../common.tfvars.json
       - ../dev.tfvars
     skip_autodetect: true
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - ../default.tfvars
+      - ../common.tfvars.json
       - ../prod-custom-ext
     skip_autodetect: true
   - path: apps/foo
     name: apps-foo-baz
     terraform_var_files:
       - ../default.tfvars
+      - ../common.tfvars.json
       - ../baz-custom-ext
     skip_autodetect: true
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../default.tfvars
+      - ../common.tfvars.json
       - ../dev.tfvars
     skip_autodetect: true
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../default.tfvars
+      - ../common.tfvars.json
       - ../prod-custom-ext
     skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/env_var_extensions/tree.txt
+++ b/cmd/infracost/testdata/generate/env_var_extensions/tree.txt
@@ -7,5 +7,6 @@
     ├── baz-custom-ext
     ├── Jenkinsfile
     ├── dev.tfvars
+    ├── common.tfvars.json
     ├── prod-custom-ext
     └── default.tfvars

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -1379,6 +1379,12 @@ func (p *ProjectLocator) isTerraformVarFile(name string, fullPath string) bool {
 		// is so that when we have a custom extension that specifies no extension e.g.
 		// "", this doesn't match all files (as it would with strings.HasSuffix).
 		if p.hasCustomEnvExt {
+			// first check if the file has a default var file extension
+			// if it does we can skip the custom extension check.
+			if hasDefaultVarFileExtension(name) {
+				return true
+			}
+
 			fileExt := fullExtension(name)
 			if fileExt == envExt {
 				// if we have custom extensions enabled in the autodetect configuration we need
@@ -1409,6 +1415,16 @@ func (p *ProjectLocator) isTerraformVarFile(name string, fullPath string) bool {
 	// we also check for tfvars.json files as these are non-standard naming
 	// conventions which are used by some projects.
 	return strings.HasPrefix(name, "tfvars") && strings.HasSuffix(name, ".json")
+}
+
+func hasDefaultVarFileExtension(name string) bool {
+	for _, extension := range defaultExtensions {
+		if strings.HasSuffix(name, extension) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // fullExtension returns the full extension of a file, starting from the first

--- a/internal/testutil/generate.go
+++ b/internal/testutil/generate.go
@@ -101,6 +101,14 @@ instance_type = "m5.4xlarge"
 `
 	}
 
+	if strings.HasSuffix(filename, ".tfvars.json") {
+		content = `
+{
+  "region": "us-west-2"
+}
+`
+	}
+
 	return os.WriteFile(filePath, []byte(content), 0600)
 }
 


### PR DESCRIPTION
Adds a check for default tfvar naming conventions if `terraform_var_file_extensions` are specified. This fixes an issue if the `terraform_var_file_names` contained a `.tfvars.json` extension. This would fail the `ParseHCLFile` check and drop the autodetected var file.

A side effect of this change is that we no longer need to specify the default var file extensions in the autodetect config, just the exception cases.