### PR TITLE
feat: add `Env` to `DetectedProject`

### DIFF
--- a/cmd/infracost/generate.go
+++ b/cmd/infracost/generate.go
@@ -123,6 +123,7 @@ func (g *generateConfigCommand) run(cmd *cobra.Command, args []string) error {
 			detectedProjects[i] = template.DetectedProject{
 				Name:              p.ProjectName(),
 				Path:              relPath,
+				Env:               p.EnvName(),
 				TerraformVarFiles: p.TerraformVarFiles(),
 			}
 

--- a/cmd/infracost/testdata/generate/detected_projects/expected.golden
+++ b/cmd/infracost/testdata/generate/detected_projects/expected.golden
@@ -1,0 +1,32 @@
+version: 0.1
+
+projects:
+  - path: apps/bar
+    name: apps-bar-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+    terraform_vars:
+      environment: dev
+  - path: apps/bar
+    name: apps-bar-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
+    terraform_vars:
+      environment: prod
+  - path: apps/foo
+    name: apps-foo-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+    terraform_vars:
+      environment: dev
+  - path: apps/foo
+    name: apps-foo-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
+    terraform_vars:
+      environment: prod
+

--- a/cmd/infracost/testdata/generate/detected_projects/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/detected_projects/infracost.yml.tmpl
@@ -1,0 +1,13 @@
+version: 0.1
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+    terraform_var_files:
+    {{- range $varFile := $project.TerraformVarFiles }}
+      - {{ $varFile }}
+    {{- end }}
+    terraform_vars:
+      environment: {{ $project.Env }}
+{{- end }}

--- a/cmd/infracost/testdata/generate/detected_projects/tree.txt
+++ b/cmd/infracost/testdata/generate/detected_projects/tree.txt
@@ -1,0 +1,9 @@
+.
+└── apps
+    ├── bar
+    │   └── main.tf
+    ├── foo
+    │   └── main.tf
+    ├── dev.tfvars
+    ├── prod.tfvars
+    └── default.tfvars

--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -23,6 +23,7 @@ type DetectedProject struct {
 	Name              string
 	Path              string
 	TerraformVarFiles []string
+	Env               string
 }
 
 type DetectedRooModule struct {

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -266,6 +266,7 @@ func OptionGraphEvaluator() Option {
 
 type DetectedProject interface {
 	ProjectName() string
+	EnvName() string
 	RelativePath() string
 	TerraformVarFiles() []string
 	YAML() string
@@ -489,6 +490,15 @@ func (p *Parser) ProjectName() string {
 	}
 
 	return name
+}
+
+// EnvName returns the module suffix of the parser (normally the environment name).
+func (p *Parser) EnvName() string {
+	if p.moduleSuffix != "" {
+		return p.moduleSuffix
+	}
+
+	return p.ProjectName()
 }
 
 // TerraformVarFiles returns the list of terraform var files that the parser

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -177,6 +177,10 @@ func (p *HCLProvider) ProjectName() string {
 	return p.Parser.ProjectName()
 }
 
+func (p *HCLProvider) EnvName() string {
+	return p.Parser.EnvName()
+}
+
 func (p *HCLProvider) RelativePath() string {
 	return p.Parser.RelativePath()
 }

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -177,6 +177,10 @@ func (p *TerragruntHCLProvider) ProjectName() string {
 	return ""
 }
 
+func (p *TerragruntHCLProvider) EnvName() string {
+	return ""
+}
+
 func (p *TerragruntHCLProvider) RelativePath() string {
 	r, err := filepath.Rel(p.Path.RepoPath, p.Path.Path)
 	if err != nil {


### PR DESCRIPTION
This change adds a `Env` property to the `DetectedProject` struct. This allows users to access the Infracost autodetected `env` in the projects loop. This enables optional logic in the template. For example a common pattern is users provide environment as the `env` as a tfvar. Additionally regions/other logic can be configured with templ if/else logic.