### PR TITLE
fix: change `clean` functionality for var files

### DIFF
--- a/cmd/infracost/testdata/breakdown_with_optional_variables/breakdown_with_optional_variables.golden
+++ b/cmd/infracost/testdata/breakdown_with_optional_variables/breakdown_with_optional_variables.golden
@@ -1,4 +1,4 @@
-Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_optional_variables
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_optional_variables-dev
 
  Name                       Monthly Qty  Unit   Monthly Cost 
                                                              
@@ -34,7 +34,7 @@ Project: infracost/infracost/cmd/infracost/testdata/breakdown_with_optional_vari
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                                          ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ infracost/infracost/cmd/infraco...akdown_with_optional_variables ┃ $29          ┃
+┃ infracost/infracost/cmd/infraco...wn_with_optional_variables-dev ┃ $29          ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 
 Err:

--- a/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
@@ -20,6 +20,7 @@ projects:
     terraform_var_files:
       - ../default.tfvars
       - ../common.tfvars.json
+      - ../prod.env.tfvars
       - ../prod-custom-ext
     skip_autodetect: true
   - path: apps/foo
@@ -41,6 +42,7 @@ projects:
     terraform_var_files:
       - ../default.tfvars
       - ../common.tfvars.json
+      - ../prod.env.tfvars
       - ../prod-custom-ext
     skip_autodetect: true
 

--- a/cmd/infracost/testdata/generate/env_var_extensions/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/env_var_extensions/infracost.yml.tmpl
@@ -6,4 +6,5 @@ autodetect:
     - prod
   terraform_var_file_extensions:
     - ".tfvars"
+    - ".env.tfvars"
     - ""

--- a/cmd/infracost/testdata/generate/env_var_extensions/tree.txt
+++ b/cmd/infracost/testdata/generate/env_var_extensions/tree.txt
@@ -9,4 +9,5 @@
     ├── dev.tfvars
     ├── common.tfvars.json
     ├── prod-custom-ext
+    ├── prod.env.tfvars
     └── default.tfvars

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -128,12 +128,7 @@ func (e *EnvFileMatcher) IsEnvName(file string) bool {
 
 func (e *EnvFileMatcher) clean(name string) string {
 	base := filepath.Base(name)
-
-	for _, suffix := range e.extensions {
-		base = strings.TrimSuffix(base, suffix)
-	}
-
-	return base
+	return strings.TrimSuffix(base, fullExtension(base))
 }
 
 // EnvName returns the environment name for the given var file.


### PR DESCRIPTION
Resolves an issue where prior `clean` functionality would return part of the file extension if the file extension had a substring that was part of two or more custom extension names.

We now just strip all the extension from the file name as we only want the name of the file to create env names/matches.