### PR TITLE
enhance: update matching files to env names to be case insensitive

### DIFF
--- a/cmd/infracost/testdata/generate/env_names_case_insensitive/expected.golden
+++ b/cmd/infracost/testdata/generate/env_names_case_insensitive/expected.golden
@@ -1,0 +1,40 @@
+version: 0.1
+autodetect:
+  env_names:
+    - baz
+    - bat
+
+projects:
+  - path: apps/bar
+    name: apps-bar-bat
+    terraform_var_files:
+      - ../prod.tfvars
+      - ../dev.tfvars
+      - ../default.tfvars
+      - ../network-Bat.tfvars
+      - ../bat.tfvars
+  - path: apps/bar
+    name: apps-bar-baz
+    terraform_var_files:
+      - ../prod.tfvars
+      - ../dev.tfvars
+      - ../default.tfvars
+      - ../network-Baz.tfvars
+      - ../baz.tfvars
+  - path: apps/foo
+    name: apps-foo-bat
+    terraform_var_files:
+      - ../prod.tfvars
+      - ../dev.tfvars
+      - ../default.tfvars
+      - ../network-Bat.tfvars
+      - ../bat.tfvars
+  - path: apps/foo
+    name: apps-foo-baz
+    terraform_var_files:
+      - ../prod.tfvars
+      - ../dev.tfvars
+      - ../default.tfvars
+      - ../network-Baz.tfvars
+      - ../baz.tfvars
+

--- a/cmd/infracost/testdata/generate/env_names_case_insensitive/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/env_names_case_insensitive/infracost.yml.tmpl
@@ -1,0 +1,15 @@
+version: 0.1
+autodetect:
+  env_names:
+    - baz
+    - bat
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+    terraform_var_files:
+    {{- range $varFile := $project.TerraformVarFiles }}
+      - {{ $varFile }}
+    {{- end }}
+{{- end }}

--- a/cmd/infracost/testdata/generate/env_names_case_insensitive/tree.txt
+++ b/cmd/infracost/testdata/generate/env_names_case_insensitive/tree.txt
@@ -1,0 +1,13 @@
+.
+└── apps
+    ├── bar
+    │   └── main.tf
+    ├── foo
+    │   └── main.tf
+    ├── baz.tfvars
+    ├── bat.tfvars
+    ├── network-Baz.tfvars
+    ├── network-Bat.tfvars
+    ├── dev.tfvars
+    ├── prod.tfvars
+    └── default.tfvars

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -83,8 +83,14 @@ func CreateEnvFileMatcher(names []string, extensions []string) *EnvFileMatcher {
 		return CreateEnvFileMatcher(defaultEnvs, extensions)
 	}
 
+	// ensure all env names to lowercase so we can match case insensitively.
+	envNames := make([]string, len(names))
+	for i, name := range names {
+		envNames[i] = strings.ToLower(name)
+	}
+
 	lookup := make(map[string]struct{}, len(names))
-	for _, name := range names {
+	for _, name := range envNames {
 		lookup[name] = struct{}{}
 	}
 
@@ -128,7 +134,7 @@ func (e *EnvFileMatcher) IsEnvName(file string) bool {
 
 func (e *EnvFileMatcher) clean(name string) string {
 	base := filepath.Base(name)
-	return strings.TrimSuffix(base, fullExtension(base))
+	return strings.ToLower(strings.TrimSuffix(base, fullExtension(base)))
 }
 
 // EnvName returns the environment name for the given var file.


### PR DESCRIPTION
If we have a file called Dev.tfvars in one directory, that should be counted as the same env as dev.tfvars when we do autodetect.

I went with the approach of updating `clean` to lowercase the file name when we do the matching. This means it works across `hasEnvPrefix`, `hasEnvSuffix`, `EnvName`, and `IsEnvName`.

I think the behaviour of `CollectRootPaths` should also be okay with this, since we want to treat the env files as found if they match case insensitively too.