### PR TITLE
feat: add prerelease pipeline

### DIFF
--- a/.github/workflows/create-docker-prerelease.yml
+++ b/.github/workflows/create-docker-prerelease.yml
@@ -1,0 +1,60 @@
+name: Create docker prerelease
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Create docker prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v4
+        id: build_push_docker
+        with:
+          context: .
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+
+      - name: Clean Docker image
+        run: docker rmi ${{ steps.build_push_docker.outputs.imageid }} -f
+
+      - name: Docker meta (CI)
+        id: meta-ci
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}
+          flavor: |
+            prefix=ci-,onlatest=true
+
+      - name: Build and push Docker images (CI)
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile.ci
+          platforms: linux/amd64
+          tags: ${{ steps.meta-ci.outputs.tags }}
+          push: true

--- a/.github/workflows/create-docker-prerelease.yml
+++ b/.github/workflows/create-docker-prerelease.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           images: |
             ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}
+          tags: |
+            type=edge
+          flavor: |
+            latest=false
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4
@@ -47,8 +51,11 @@ jobs:
         with:
           images: |
             ${{ secrets.DOCKER_ORG }}/${{ secrets.DOCKER_REPOSITORY }}
+          tags: |
+            type=edge
           flavor: |
-            prefix=ci-,onlatest=true
+            prefix=ci-
+            latest=false
 
       - name: Build and push Docker images (CI)
         uses: docker/build-push-action@v4

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Release
         run: go run tools/release/main.go
         env:
-          RELEASE_ID: "untagged-0017de5d992d120d6984"
+          RELEASE_ID: "preview"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Remove build assets

--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -1,0 +1,31 @@
+name: Upload master prerelease
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Upload master prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build project
+        run: |
+          make release
+
+      - name: Release
+        run: go run tools/release/main.go
+        env:
+          RELEASE_ID: "untagged-0017de5d992d120d6984"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove build assets
+        run: rm -rf build

--- a/tools/release/main.go
+++ b/tools/release/main.go
@@ -18,12 +18,19 @@ import (
 func main() {
 	cli := newAuthedGithubClient()
 
-	release, err := createDraftRelease(cli)
+	releaseId := strings.TrimSpace(os.Getenv("RELEASE_ID"))
+	var release *github.RepositoryRelease
+	var err error
+	if releaseId != "" {
+		release, err = fetchExistingRelease(cli, releaseId)
+	} else {
+		release, err = createDraftRelease(cli)
+	}
+
 	if err != nil {
 		log.Error().Msgf("failed to create draft release %s", err)
 		return
 	}
-
 	toUpload, err := findReleaseAssets()
 	if err != nil {
 		log.Error().Msgf("failed to collect release assets %s", err)
@@ -37,6 +44,22 @@ func main() {
 	}
 
 	log.Info().Msg("successfully created draft release")
+}
+
+func fetchExistingRelease(cli *github.Client, releaseId string) (*github.RepositoryRelease, error) {
+	release, _, err := cli.Repositories.GetReleaseByTag(context.Background(), "infracost", "infracost", releaseId)
+
+	// delete all the assets of the release as we are going to re-upload them and
+	// GitHub does not allow name conflicts with assets
+	for _, asset := range release.Assets {
+		_, err = cli.Repositories.DeleteReleaseAsset(context.Background(), "infracost", "infracost", asset.GetID())
+		if err != nil {
+			log.Error().Msgf("failed to delete asset %s", err)
+			continue
+		}
+	}
+
+	return release, err
 }
 
 func createDraftRelease(cli *github.Client) (*github.RepositoryRelease, error) {


### PR DESCRIPTION
Adds two prerelease pipelines. The first `create-prerelease` which calls the release go script with a new `RELEASE_ID` env variable. This variable is a static env variable that points to the [master github prerelease](https://github.com/infracost/infracost/releases/tag/untagged-0017de5d992d120d6984) that will have its assets overwritten on each master branch push. This enables users use a master branch build if they so wish.

The second `create-docker-prerelease` uploads docker image to the registry with the master tag. It does not set it as the latest release, as per the https://github.com/docker/metadata-action docs.

I've chosen to split these two actions to make the release step a bit quicker. We can run the two build steps concurrently on prerelease as we don't have as much worry that the build might be bad.

I've also had to change the `get_version.sh` script to ignore the "preview" tag so it doesn't fail tests.