### PR TITLE
feat(azure): add `azurerm_network_ddos_protection_plan` support

### DIFF
--- a/infracost-usage-defaults.large.yml
+++ b/infracost-usage-defaults.large.yml
@@ -639,6 +639,8 @@ resource_type_default_usage:
     monthly_data_processed_gb: 444 # Monthly data processed by the NAT Gateway in GB.
   #  azurerm_network_connection_monitor:
   #    tests: 100000 # Overrides the number of tests done in the connection monitor
+  azurerm_network_ddos_protection_plan.my_plan:
+    overage_amount: 50 # Monthly number of protected resources over the plan protection limit (100).
   azurerm_network_watcher:
     monthly_diagnostic_checks: 20000 # Monthly number of diagnostic API calls.
   azurerm_network_watcher_flow_log:

--- a/infracost-usage-defaults.medium.yml
+++ b/infracost-usage-defaults.medium.yml
@@ -639,6 +639,8 @@ resource_type_default_usage:
     monthly_data_processed_gb: 222 # Monthly data processed by the NAT Gateway in GB.
     #  azurerm_network_connection_monitor:
     #    tests: 100000 # Overrides the number of tests done in the connection monitor
+  azurerm_network_ddos_protection_plan.my_plan:
+    overage_amount: 10 # Monthly number of protected resources over the plan protection limit (100).
   azurerm_network_watcher:
     monthly_diagnostic_checks: 10000 # Monthly number of diagnostic API calls.
   azurerm_network_watcher_flow_log:

--- a/infracost-usage-defaults.small.yml
+++ b/infracost-usage-defaults.small.yml
@@ -639,6 +639,9 @@ resource_type_default_usage:
     monthly_data_processed_gb: 111 # Monthly data processed by the NAT Gateway in GB.
     #  azurerm_network_connection_monitor:
     #    tests: 100000 # Overrides the number of tests done in the connection monitor
+
+  azurerm_network_ddos_protection_plan.my_plan:
+    overage_amount: 0 # Monthly number of protected resources over the plan protection limit (100).
   azurerm_network_watcher:
     monthly_diagnostic_checks: 5000 # Monthly number of diagnostic API calls.
   azurerm_network_watcher_flow_log:

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -1087,6 +1087,9 @@ resource_usage:
   azurerm_nat_gateway.my_gateway:
     monthly_data_processed_gb: 10 # Monthly data processed by the NAT Gateway in GB.
 
+  azurerm_network_ddos_protection_plan.my_plan:
+    overage_amount: 5 # Monthly number of protected resources over the plan protection limit (100).
+
   azurerm_network_watcher.my_watcher:
     monthly_diagnostic_checks: 10000 # Monthly number of diagnostic API calls.
 

--- a/internal/providers/terraform/azure/network_ddos_protection_plan.go
+++ b/internal/providers/terraform/azure/network_ddos_protection_plan.go
@@ -1,0 +1,24 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getNetworkDdosProtectionPlanRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "azurerm_network_ddos_protection_plan",
+		CoreRFunc: newNetworkDdosProtectionPlan,
+		ReferenceAttributes: []string{
+			"resource_group_name",
+		},
+	}
+}
+
+func newNetworkDdosProtectionPlan(d *schema.ResourceData) schema.CoreResource {
+	region := lookupRegion(d, []string{"resource_group_name"})
+	return &azure.NetworkDdosProtectionPlan{
+		Address: d.Address,
+		Region:  region,
+	}
+}

--- a/internal/providers/terraform/azure/network_ddos_protection_plan_test.go
+++ b/internal/providers/terraform/azure/network_ddos_protection_plan_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestNetworkDdosProtectionPlan(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "network_ddos_protection_plan_test")
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -162,6 +162,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getPrivateDnsResolverDnsForwardingRulesetRegistryItem(),
 	getMachineLearningComputeInstanceRegistryItem(),
 	getMachineLearningComputeClusterRegistryItem(),
+	getNetworkDdosProtectionPlanRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/testdata/network_ddos_protection_plan_test/network_ddos_protection_plan_test.golden
+++ b/internal/providers/terraform/azure/testdata/network_ddos_protection_plan_test/network_ddos_protection_plan_test.golden
@@ -1,0 +1,22 @@
+
+ Name                                                                               Monthly Qty  Unit                  Monthly Cost 
+                                                                                                                                    
+ azurerm_network_ddos_protection_plan.network_ddos_protection_plan_with_usage                                                       
+ ├─ DDoS Protection Plan                                                                    730  hours                    $2,943.55 
+ └─ Overage charges                                                                           5  resources                  $147.18 
+                                                                                                                                    
+ azurerm_network_ddos_protection_plan.network_ddos_protection_plan                                                                  
+ ├─ DDoS Protection Plan                                                                    730  hours                    $2,943.55 
+ └─ Overage charges                                                            Monthly cost depends on usage: $29.44 per resource   
+                                                                                                                                    
+ OVERALL TOTAL                                                                                                            $6,034.27 
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 2 were estimated, all of which include usage-based costs, see https://infracost.io/usage-file
+∙ 1 was free
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                            ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ TestNetworkDdosProtectionPlan                      ┃ $6,034       ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/network_ddos_protection_plan_test/network_ddos_protection_plan_test.tf
+++ b/internal/providers/terraform/azure/testdata/network_ddos_protection_plan_test/network_ddos_protection_plan_test.tf
@@ -1,0 +1,22 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+
+resource "azurerm_network_ddos_protection_plan" "network_ddos_protection_plan" {
+  name                = "exampleresource"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_network_ddos_protection_plan" "network_ddos_protection_plan_with_usage" {
+  name                = "exampleresource"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}

--- a/internal/providers/terraform/azure/testdata/network_ddos_protection_plan_test/network_ddos_protection_plan_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/network_ddos_protection_plan_test/network_ddos_protection_plan_test.usage.yml
@@ -1,0 +1,4 @@
+version: 0.1
+resource_usage:
+  azurerm_network_ddos_protection_plan.network_ddos_protection_plan_with_usage:
+    overage_amount: 5

--- a/internal/resources/azure/network_ddos_protection_plan.go
+++ b/internal/resources/azure/network_ddos_protection_plan.go
@@ -1,0 +1,103 @@
+package azure
+
+import (
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+// NetworkDdosProtectionPlan struct represents Azure DDoS Protection Plan.
+// DDoS Protection Plan is a resource that provides DDoS protection for virtual networks and IPs.
+//
+// Resource information: https://azure.microsoft.com/en-us/products/ddos-protection/
+// Pricing information: https://azure.microsoft.com/en-us/pricing/details/ddos-protection/#pricing
+type NetworkDdosProtectionPlan struct {
+	Address       string
+	Region        string
+	OverageAmount *int64 `infracost_usage:"overage_amount"`
+}
+
+// CoreType returns the name of this resource type.
+func (r *NetworkDdosProtectionPlan) CoreType() string {
+	return "NetworkDdosProtectionPlan"
+}
+
+// UsageSchema defines a list which represents the usage schema of
+// NetworkDdosProtectionPlan. There is only one usage item, `overage_amount`,
+// which represents the number of resources that fall outside the base ddos
+// coverage.
+func (r *NetworkDdosProtectionPlan) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "overage_amount", DefaultValue: 0, ValueType: schema.Int64},
+	}
+}
+
+// PopulateUsage parses the u schema.UsageData into the
+// NetworkDdosProtectionPlan. It uses the `infracost_usage` struct tags to
+// populate data into the NetworkDdosProtectionPlan.
+func (r *NetworkDdosProtectionPlan) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid NetworkDdosProtectionPlan
+// struct. This method is called after the resource is initialised by an IaC
+// provider.
+//
+// BuildResource returns two cost components:
+//
+//  1. DDoS Protection Plan: The cost of the DDoS Protection Plan.
+//  2. Overage charges: The cost of the overage charges for the DDoS Protection Plan.
+//     This is the number of resources that fall outside the base coverage offered by
+//     the protection plan (100). This amount is defined in the usage file as it is
+//     difficult to infer the number of resources that fall outside the base coverage
+//     from the IaC.
+func (r *NetworkDdosProtectionPlan) BuildResource() *schema.Resource {
+	var overageAmount *decimal.Decimal
+	overageUnit := "resource"
+	if r.OverageAmount != nil {
+		overageAmount = decimalPtr(decimal.NewFromInt(*r.OverageAmount))
+		if overageAmount.GreaterThan(decimal.NewFromInt(1)) {
+			overageUnit = "resources"
+		}
+	}
+
+	return &schema.Resource{
+		Name:        r.Address,
+		UsageSchema: r.UsageSchema(),
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:           "DDoS Protection Plan",
+				Unit:           "hours",
+				UnitMultiplier: decimal.NewFromInt(1),
+				HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr(vendorName),
+					Region:        strPtr(r.Region),
+					Service:       strPtr("Azure DDOS Protection"),
+					ProductFamily: strPtr("Networking"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "skuName", Value: strPtr("Network Protection")},
+						{Key: "meterName", Value: strPtr("Network Protection Plan")},
+					},
+				},
+			},
+			{
+				Name:           "Overage charges",
+				Unit:           overageUnit,
+				UnitMultiplier: schema.HourToMonthUnitMultiplier,
+				HourlyQuantity: overageAmount,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr(vendorName),
+					Region:        strPtr(r.Region),
+					Service:       strPtr("Azure DDOS Protection"),
+					ProductFamily: strPtr("Networking"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "skuName", Value: strPtr("Network Protection")},
+						{Key: "meterName", Value: strPtr("Network Protection Resource")},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Adds support for the Azure DDoS Protection service. This is a managed service that helps protected resources from DDos attacks. This service is enabled using the `azurerm_network_ddos_protection_plan` resource in Terraform.

The resource has two cost components associated with it:

1. DDoS Protection Plan: The cost of the DDoS Protection Plan.
2. Overage charges: The cost of the overage charges for the DDoS Protection Plan. This is the number of resources that fall outside the base coverage offered by the protection plan (100). This amount is defined in the usage file as it is difficult to infer the number of resources that fall outside the base coverage from the IaC.