### PR TITLE
fix: show cloud URL link for Bitbucket comments

### DIFF
--- a/internal/output/templates/markdown-usage-api.tmpl
+++ b/internal/output/templates/markdown-usage-api.tmpl
@@ -113,10 +113,15 @@ Cost details were left out because expandable comment sections are not supported
 
 {{ .MarkdownOptions.Additional }}
 {{- end }}
+{{- if .Root.CloudURL }}
+
+View report in [Infracost Cloud]({{ .Root.CloudURL }}).
+{{- end }}
 {{- if .MarkdownOptions.WillUpdate }}
 
 This comment will be updated when code changes.
 {{- end }}
 {{- if .MarkdownOptions.WillReplace }}
+
 This comment will be replaced when code changes.
 {{- end }}

--- a/internal/output/templates/markdown.tmpl
+++ b/internal/output/templates/markdown.tmpl
@@ -89,10 +89,15 @@
 
 {{ .MarkdownOptions.Additional }}
 {{- end }}
+{{- if .Root.CloudURL }}
+
+View report in [Infracost Cloud]({{ .Root.CloudURL }}).
+{{- end }}
 {{- if .MarkdownOptions.WillUpdate }}
 
 This comment will be updated when code changes.
 {{- end }}
 {{- if .MarkdownOptions.WillReplace }}
+
 This comment will be replaced when code changes.
 {{- end }}


### PR DESCRIPTION
To make this consistent with the other comment formats