### PR TITLE
feat(azure): add support for `azurerm_federated_identity_credential`

### DIFF
--- a/infracost-usage-defaults.large.yml
+++ b/infracost-usage-defaults.large.yml
@@ -415,7 +415,7 @@ resource_type_default_usage:
   #
   # Terraform AzureRM resources
   #
-  azurerm_app_configuration.my_configuration:
+  azurerm_app_configuration:
     monthly_additional_requests: 3333333 # Monthly number of requests which are above the included 200,000 per day per replica.
   azurerm_api_management:
     monthly_api_calls: 5710000 # Monthly number of api calls (only for consumption tier).
@@ -529,6 +529,8 @@ resource_type_default_usage:
     monthly_all_purpose_compute_dbu_hrs: 50 # Monthly number of All-purpose Compute Databricks Units in DBU-hours.
     monthly_jobs_compute_dbu_hrs: 133 # Monthly number of Jobs Compute Databricks Units in DBU-hours.
     monthly_jobs_light_compute_dbu_hrs: 285 # Monthly number of Jobs Light Compute Databricks Units in DBU-hours.
+  azurerm_federated_identity_credential:
+    monthly_active_p1_users: 56153 # Monthly number of active users if you are using the Premium P1 license.
   azurerm_function_app:
     monthly_executions: 100000000 # Monthly executions to the function. Only applicable for Consumption plan.
     execution_duration_ms: 100 # Average duration of each execution in milliseconds. Only applicable for Consumption plan.
@@ -641,7 +643,7 @@ resource_type_default_usage:
     monthly_data_processed_gb: 444 # Monthly data processed by the NAT Gateway in GB.
   #  azurerm_network_connection_monitor:
   #    tests: 100000 # Overrides the number of tests done in the connection monitor
-  azurerm_network_ddos_protection_plan.my_plan:
+  azurerm_network_ddos_protection_plan:
     overage_amount: 50 # Monthly number of protected resources over the plan protection limit (100).
   azurerm_network_watcher:
     monthly_diagnostic_checks: 20000 # Monthly number of diagnostic API calls.

--- a/infracost-usage-defaults.medium.yml
+++ b/infracost-usage-defaults.medium.yml
@@ -415,7 +415,7 @@ resource_type_default_usage:
   #
   # Terraform AzureRM resources
   #
-  azurerm_app_configuration.my_configuration:
+  azurerm_app_configuration:
     monthly_additional_requests: 1666666 # Monthly number of requests which are above the included 200,000 per day per replica.
   azurerm_api_management:
     monthly_api_calls: 2855000 # Monthly number of api calls (only for consumption tier).
@@ -529,6 +529,8 @@ resource_type_default_usage:
     monthly_all_purpose_compute_dbu_hrs: 25 # Monthly number of All-purpose Compute Databricks Units in DBU-hours.
     monthly_jobs_compute_dbu_hrs: 66 # Monthly number of Jobs Compute Databricks Units in DBU-hours.
     monthly_jobs_light_compute_dbu_hrs: 142 # Monthly number of Jobs Light Compute Databricks Units in DBU-hours.
+  azurerm_federated_identity_credential:
+    monthly_active_p1_users: 53075 # Monthly number of active users if you are using the Premium P1 license.
   azurerm_function_app:
     monthly_executions: 50000000 # Monthly executions to the function. Only applicable for Consumption plan.
     execution_duration_ms: 50 # Average duration of each execution in milliseconds. Only applicable for Consumption plan.
@@ -641,7 +643,7 @@ resource_type_default_usage:
     monthly_data_processed_gb: 222 # Monthly data processed by the NAT Gateway in GB.
     #  azurerm_network_connection_monitor:
     #    tests: 100000 # Overrides the number of tests done in the connection monitor
-  azurerm_network_ddos_protection_plan.my_plan:
+  azurerm_network_ddos_protection_plan:
     overage_amount: 10 # Monthly number of protected resources over the plan protection limit (100).
   azurerm_network_watcher:
     monthly_diagnostic_checks: 10000 # Monthly number of diagnostic API calls.

--- a/infracost-usage-defaults.small.yml
+++ b/infracost-usage-defaults.small.yml
@@ -415,7 +415,7 @@ resource_type_default_usage:
   #
   # Terraform AzureRM resources
   #
-  azurerm_app_configuration.my_configuration:
+  azurerm_app_configuration:
     monthly_additional_requests: 833333 # Monthly number of requests which are above the included 200,000 per day per replica.
   azurerm_api_management:
     monthly_api_calls: 1427500 # Monthly number of api calls (only for consumption tier).
@@ -529,6 +529,8 @@ resource_type_default_usage:
     monthly_all_purpose_compute_dbu_hrs: 12 # Monthly number of All-purpose Compute Databricks Units in DBU-hours.
     monthly_jobs_compute_dbu_hrs: 33 # Monthly number of Jobs Compute Databricks Units in DBU-hours.
     monthly_jobs_light_compute_dbu_hrs: 71 # Monthly number of Jobs Light Compute Databricks Units in DBU-hours.
+  azurerm_federated_identity_credential:
+    monthly_active_p1_users: 51573 # Monthly number of active users if you are using the Premium P1 license.
   azurerm_function_app:
     monthly_executions: 25000000 # Monthly executions to the function. Only applicable for Consumption plan.
     execution_duration_ms: 25 # Average duration of each execution in milliseconds. Only applicable for Consumption plan.
@@ -642,7 +644,7 @@ resource_type_default_usage:
     #  azurerm_network_connection_monitor:
     #    tests: 100000 # Overrides the number of tests done in the connection monitor
 
-  azurerm_network_ddos_protection_plan.my_plan:
+  azurerm_network_ddos_protection_plan:
     overage_amount: 0 # Monthly number of protected resources over the plan protection limit (100).
   azurerm_network_watcher:
     monthly_diagnostic_checks: 5000 # Monthly number of diagnostic API calls.

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -834,6 +834,10 @@ resource_usage:
     monthly_jobs_compute_dbu_hrs: 1000 # Monthly number of Jobs Compute Databricks Units in DBU-hours.
     monthly_jobs_light_compute_dbu_hrs: 2000 # Monthly number of Jobs Light Compute Databricks Units in DBU-hours.
 
+  azurerm_federated_identity_credential.my_credential:
+    monthly_active_p1_users: 50100 # Monthly number of active users if you are using the Premium P1 license.
+    monthly_active_p2_users: 50100 # Monthly number of active users if you are using the Premium P2 license.
+
   azurerm_function_app.my_functions:
     monthly_executions: 100000 # Monthly executions to the function. Only applicable for Consumption plan.
     execution_duration_ms: 500 # Average duration of each execution in milliseconds. Only applicable for Consumption plan.

--- a/internal/providers/terraform/azure/federated_identity_credential.go
+++ b/internal/providers/terraform/azure/federated_identity_credential.go
@@ -1,0 +1,24 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getFederatedIdentityCredentialRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "azurerm_federated_identity_credential",
+		CoreRFunc: newFederatedIdentityCredential,
+		ReferenceAttributes: []string{
+			"resource_group_name",
+		},
+	}
+}
+
+func newFederatedIdentityCredential(d *schema.ResourceData) schema.CoreResource {
+	region := lookupRegion(d, []string{"resource_group_name"})
+	return &azure.FederatedIdentityCredential{
+		Address: d.Address,
+		Region:  region,
+	}
+}

--- a/internal/providers/terraform/azure/federated_identity_credential_test.go
+++ b/internal/providers/terraform/azure/federated_identity_credential_test.go
@@ -1,0 +1,16 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestFederatedIdentityCredential(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "federated_identity_credential_test")
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -164,6 +164,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getMachineLearningComputeClusterRegistryItem(),
 	getNetworkDdosProtectionPlanRegistryItem(),
 	getAppConfigurationRegistryItem(),
+	getFederatedIdentityCredentialRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/testdata/federated_identity_credential_test/federated_identity_credential_test.golden
+++ b/internal/providers/terraform/azure/testdata/federated_identity_credential_test/federated_identity_credential_test.golden
@@ -1,0 +1,24 @@
+
+ Name                                                Monthly Qty  Unit                Monthly Cost 
+                                                                                                   
+ azurerm_federated_identity_credential.usage_p2                                                    
+ └─ Active users (P2)                                        100  users                      $1.63 
+                                                                                                   
+ azurerm_federated_identity_credential.usage_p1                                                    
+ └─ Active users (P1)                                        100  users                      $0.33 
+                                                                                                   
+ azurerm_federated_identity_credential.base                                                        
+ ├─ Active users (P1)                            Monthly cost depends on usage: $0.00325 per users 
+ └─ Active users (P2)                            Monthly cost depends on usage: $0.01625 per users 
+                                                                                                   
+ OVERALL TOTAL                                                                               $1.95 
+──────────────────────────────────
+5 cloud resources were detected:
+∙ 3 were estimated
+∙ 2 were free
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ Project                                            ┃ Monthly cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
+┃ TestFederatedIdentityCredential                    ┃ $2           ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/federated_identity_credential_test/federated_identity_credential_test.tf
+++ b/internal/providers/terraform/azure/testdata/federated_identity_credential_test/federated_identity_credential_test.tf
@@ -1,0 +1,42 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_user_assigned_identity" "example" {
+  location            = azurerm_resource_group.example.location
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_federated_identity_credential" "base" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  audience            = ["foo"]
+  issuer              = "https://foo"
+  parent_id           = azurerm_user_assigned_identity.example.id
+  subject             = "foo"
+}
+
+resource "azurerm_federated_identity_credential" "usage_p1" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  audience            = ["foo"]
+  issuer              = "https://foo"
+  parent_id           = azurerm_user_assigned_identity.example.id
+  subject             = "foo"
+}
+
+resource "azurerm_federated_identity_credential" "usage_p2" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  audience            = ["foo"]
+  issuer              = "https://foo"
+  parent_id           = azurerm_user_assigned_identity.example.id
+  subject             = "foo"
+}

--- a/internal/providers/terraform/azure/testdata/federated_identity_credential_test/federated_identity_credential_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/federated_identity_credential_test/federated_identity_credential_test.usage.yml
@@ -1,0 +1,6 @@
+version: 0.1
+resource_usage:
+  azurerm_federated_identity_credential.usage_p2:
+    monthly_active_p2_users: 50100
+  azurerm_federated_identity_credential.usage_p1:
+    monthly_active_p1_users: 50100

--- a/internal/resources/azure/federated_identity_credential.go
+++ b/internal/resources/azure/federated_identity_credential.go
@@ -1,0 +1,122 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+// FederatedIdentityCredential struct represents an Azure Federated Identity
+// Credential. are a new type of credential that enables workload identity
+// federation for software workloads. Workload identity federation allows you to
+// access Microsoft Entra protected resources without needing to manage secrets
+// (for supported scenarios).
+//
+// Resource information: https://learn.microsoft.com/en-us/graph/api/resources/federatedidentitycredentials-overview?view=graph-rest-1.0
+// Pricing information: https://azure.microsoft.com/en-us/pricing/details/active-directory-external-identities/
+type FederatedIdentityCredential struct {
+	Address string
+	Region  string
+
+	MonthlyActiveP1Users *int64 `infracost_usage:"monthly_active_p1_users"`
+	MonthlyActiveP2Users *int64 `infracost_usage:"monthly_active_p2_users"`
+}
+
+// CoreType returns the name of this resource type
+func (r *FederatedIdentityCredential) CoreType() string {
+	return "FederatedIdentityCredential"
+}
+
+// UsageSchema defines a list which represents the usage schema of FederatedIdentityCredential.
+func (r *FederatedIdentityCredential) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "monthly_active_p1_users", ValueType: schema.Int64, DefaultValue: 0},
+		{Key: "monthly_active_p2_users", ValueType: schema.Int64, DefaultValue: 0},
+	}
+}
+
+// PopulateUsage parses the u schema.UsageData into the FederatedIdentityCredential.
+// It uses the `infracost_usage` struct tags to populate data into the FederatedIdentityCredential.
+func (r *FederatedIdentityCredential) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid
+// FederatedIdentityCredential struct. This method is called after the resource
+// is initialised by an IaC provider. See providers folder for more information.
+//
+// BuildResource returns cost components for the monthly active users for both P1
+// and P2 licence types for Microsoft Entra. It is not possible to infer the
+// licence type from the IaC code, so we rely on the user to provide the monthly
+// active users for each licence type as a usage parameter. The resource can not
+// have both P1 and P2 licence types at the same time, so we check which one is
+// set and return the cost component for that licence type.
+func (r *FederatedIdentityCredential) BuildResource() *schema.Resource {
+	if r.MonthlyActiveP1Users != nil {
+		return &schema.Resource{
+			Name:        r.Address,
+			UsageSchema: r.UsageSchema(),
+			CostComponents: []*schema.CostComponent{
+				r.activeUserComponent("P1", decimalPtr(decimal.NewFromInt(*r.MonthlyActiveP1Users))),
+			},
+		}
+	}
+
+	if r.MonthlyActiveP2Users != nil {
+		return &schema.Resource{
+			Name:        r.Address,
+			UsageSchema: r.UsageSchema(),
+			CostComponents: []*schema.CostComponent{
+				r.activeUserComponent("P2", decimalPtr(decimal.NewFromInt(*r.MonthlyActiveP2Users))),
+			},
+		}
+	}
+
+	return &schema.Resource{
+		Name:        r.Address,
+		UsageSchema: r.UsageSchema(),
+		CostComponents: []*schema.CostComponent{
+			r.activeUserComponent("P1", nil),
+			r.activeUserComponent("P2", nil),
+		},
+	}
+}
+
+func (r *FederatedIdentityCredential) activeUserComponent(licence string, quantity *decimal.Decimal) *schema.CostComponent {
+	var minusFreeTier *decimal.Decimal
+	if quantity != nil {
+		val := quantity.Sub(decimal.NewFromInt(50000))
+		if val.LessThan(decimal.NewFromInt(0)) {
+			minusFreeTier = decimalPtr(decimal.NewFromInt(0))
+		} else {
+			minusFreeTier = decimalPtr(val)
+		}
+	}
+
+	titled := strings.ToUpper(licence)
+
+	return &schema.CostComponent{
+		Name:            fmt.Sprintf("Active users (%s)", titled),
+		Unit:            "users",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: minusFreeTier,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Azure Active Directory for External Identities"),
+			ProductFamily: strPtr("Security"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "skuName", Value: strPtr(titled)},
+				{Key: "meterName", Value: strPtr(titled + " Monthly Active Users")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			StartUsageAmount: strPtr("50000"),
+		},
+		UsageBased: true,
+	}
+}


### PR DESCRIPTION
Adds support for Microsoft Entra (Azure Active Directory) External Identities through the `azurerm_federated_identity_credential`. This resource is only billed for monthly active users above the 50000 free limit. Monthly active users are charged differently based on the Microsoft Entra license type (P1 vs P2), however we cannot infer the license type from the IaC so I've added two usage parameters to support both.