### PR TITLE
feat(azure): add support for Azure AI Language (TextAnalytics)

### DIFF
--- a/infracost-usage-defaults.large.yml
+++ b/infracost-usage-defaults.large.yml
@@ -480,6 +480,16 @@ resource_type_default_usage:
     # LUIS
     monthly_luis_text_requests: 13_333
     monthly_luis_speech_requests: 3_636
+    # TextAnalytics
+    monthly_language_text_analytics_records: 20_000
+    monthly_language_summarization_records: 10_000
+    monthly_language_conversational_language_understanding_records: 10_000
+    monthly_language_conversational_language_understanding_advanced_training_hours: 6.7
+    monthly_language_customized_text_classification_records: 4_000
+    monthly_language_customized_summarization_records: 5_000
+    monthly_language_customized_question_answering_records: 13_333
+    monthly_language_customized_training_hours: 6.7
+    monthly_language_text_analytics_for_health_records: 5_800
   azurerm_container_registry:
     storage_gb: 200
     monthly_build_vcpu_hrs: 55.5

--- a/infracost-usage-defaults.medium.yml
+++ b/infracost-usage-defaults.medium.yml
@@ -480,6 +480,16 @@ resource_type_default_usage:
     # LUIS
     monthly_luis_text_requests: 6_667
     monthly_luis_speech_requests: 1_818
+    # TextAnalytics
+    monthly_language_text_analytics_records: 10_000
+    monthly_language_summarization_records: 5_000
+    monthly_language_conversational_language_understanding_records: 5_000
+    monthly_language_conversational_language_understanding_advanced_training_hours: 3.3
+    monthly_language_customized_text_classification_records: 2_000
+    monthly_language_customized_summarization_records: 2_500
+    monthly_language_customized_question_answering_records: 6_666
+    monthly_language_customized_training_hours: 3.3
+    monthly_language_text_analytics_for_health_records: 2_900
   azurerm_container_registry:
     storage_gb: 100
     monthly_build_vcpu_hrs: 27.75

--- a/infracost-usage-defaults.small.yml
+++ b/infracost-usage-defaults.small.yml
@@ -480,6 +480,16 @@ resource_type_default_usage:
     # LUIS
     monthly_luis_text_requests: 3_333
     monthly_luis_speech_requests: 909
+    # TextAnalytics
+    monthly_language_text_analytics_records: 5_000
+    monthly_language_summarization_records: 2_500
+    monthly_language_conversational_language_understanding_records: 2_500
+    monthly_language_conversational_language_understanding_advanced_training_hours: 1.7
+    monthly_language_customized_text_classification_records: 1_000
+    monthly_language_customized_summarization_records: 1_250
+    monthly_language_customized_question_answering_records: 3_333
+    monthly_language_customized_training_hours: 1.7
+    monthly_language_text_analytics_for_health_records: 1_450
   azurerm_container_registry:
     storage_gb: 50
     monthly_build_vcpu_hrs: 13.875

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -888,11 +888,34 @@ resource_usage:
     monthly_connected_container_commitment_text_to_speech_neural_commitment_chars: 80_000_000 # Monthly number of committed characters for Text to Speech with neural voices (80M, 40M or 200M)
     monthly_connected_container_commitment_text_to_speech_neural_overage_chars: 1_000_000 # Monthly number of characters for Text to Speech with neural voices over the committed amountinfracost-usage-example.yml
     ## LUIS
-    monthly_luis_text_requests: 1_000 # Monthly number of text requests to LUIS.
-    monthly_luis_speech_requests: 1_000 # Monthly number of speech requests to LUIS.
+    monthly_luis_text_requests: 1_000 # Monthly number of text requests to LUIS
+    monthly_luis_speech_requests: 1_000 # Monthly number of speech requests to LUIS
     # Standard commitment
     monthly_commitment_luis_text_requests: 1_000_000 # Monthly number of committed text requests to LUIS (1M, 5M or 25M)
     monthly_commitment_luis_text_overage_requests: 1_000 # Monthly number of text requests to LUIS over the committed amount
+    # Connected container commitment
+    monthly_connected_container_commitment_luis_text_requests: 1_000_000 # Monthly number of committed text requests to LUIS (1M, 5M or 25M)
+    monthly_connected_container_commitment_luis_text_overage_requests: 1_000 # Monthly number of text requests to LUIS over the committed amount
+    ## TextAnalytics / Language
+    monthly_language_text_analytics_records: 10_000 # Monthly number of Text Analytics records (Sentiment Analysis, Key Phrase Extraction, Language Detection, Named Entity Recognition, PII Detection)
+    monthly_language_summarization_records: 10_000 # Monthly number of summarization records
+    monthly_language_conversational_language_understanding_records: 10_000 # Monthly number of Conversational Language Understanding and Orchestration Workflow records.
+    monthly_language_conversational_language_understanding_advanced_training_hours: 10 # Monthly number of Conversational Language Understanding and Orchestration Workflow advanced training hours.
+    monthly_language_customized_text_classification_records: 10_000 # Monthly number of customized text classification records.
+    monthly_language_customized_summarization_records: 10_000 # Monthly number of customized summarization records.
+    monthly_language_customized_question_answering_records: 10_000 # Monthly number of customized question answering records.
+    monthly_language_customized_training_hours: 10 # Monthly number of customized training hours.
+    monthly_language_text_analytics_for_health_records: 10_000 # Monthly number of Text Analytics for health records.
+    # Standard commitment
+    monthly_commitment_language_text_analytics_records: 1_000_000 # Monthly number of committed Text Analytics records (1M, 3M or 10M)
+    monthly_commitment_language_text_analytics_overage_records: 10_000 # Monthly number of Text Analytics records over the committed amount
+    monthly_commitment_language_summarization_records: 3_000_000 # Monthly number of committed summarization records (3M or 10M)
+    monthly_commitment_language_summarization_overage_records: 10_000 # Monthly number of summarization records over the committed amount
+    # Connected container commitment
+    monthly_connected_container_commitment_language_text_analytics_records: 1_000_000 # Monthly number of committed Text Analytics records (1M, 3M or 10M)
+    monthly_connected_container_commitment_language_text_analytics_overage_records: 10_000 # Monthly number of Text Analytics records over the committed amount
+    monthly_connected_container_commitment_language_summarization_records: 3_000_000 # Monthly number of committed summarization records (3M or 10M)
+    monthly_connected_container_commitment_language_summarization_overage_records: 10_000  # Monthly number of summarization records over the committed amount
 
   azurerm_cognitive_deployment.my_openai_deployment:
     monthly_language_input_tokens: 10_000_000 # Monthly number of language input tokens.

--- a/internal/providers/terraform/azure/cognitive_account.go
+++ b/internal/providers/terraform/azure/cognitive_account.go
@@ -38,6 +38,14 @@ func newCognitiveAccount(d *schema.ResourceData) schema.CoreResource {
 		}
 	}
 
+	if strings.EqualFold(kind, "textanalytics") {
+		return &azure.CognitiveAccountLanguage{
+			Address: d.Address,
+			Region:  region,
+			Sku:     d.Get("sku_name").String(),
+		}
+	}
+
 	if strings.EqualFold(kind, "openai") {
 		// OpenAI costs are counted as part of a Cognitive Deployment so
 		// this resource is counted as free

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -174,7 +174,8 @@ var FreeResources = []string{
 	// Azure App Configuration
 	"azurerm_app_configuration_feature",
 	"azurerm_app_configuration_key",
-
+	// Azure AI Services
+	"azurerm_cognitive_account_customer_managed_key",
 	// Azure Api Management
 	"azurerm_api_management_api",
 	"azurerm_api_management_api_diagnostic",

--- a/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.golden
@@ -34,6 +34,23 @@
  ├─ Speaker identification                                            Monthly cost depends on usage: $10.00 per 1K transactions  
  └─ Voice profiles                                                    Monthly cost depends on usage: $0.20 per 1K profiles       
                                                                                                                                  
+ azurerm_cognitive_account.textanalytics_with_tiers                                                                              
+ ├─ Text analytics (first 500K)                                                      500  1K records                     $500.00 
+ ├─ Text analytics (500K-2.5M)                                                     2,000  1K records                   $1,500.00 
+ ├─ Text analytics (2.5M-10M)                                                      7,500  1K records                   $2,250.00 
+ ├─ Text analytics (over 10M)                                                      5,000  1K records                   $1,250.00 
+ ├─ Summarization                                                     Monthly cost depends on usage: $2.00 per 1K records        
+ ├─ Conversational language understanding                             Monthly cost depends on usage: $2.00 per 1K records        
+ ├─ Conversational language understanding advanced training           Monthly cost depends on usage: $3.00 per hour              
+ ├─ Customized text classification                                    Monthly cost depends on usage: $5.00 per 1K records        
+ ├─ Customized summarization                                          Monthly cost depends on usage: $4.00 per 1K records        
+ ├─ Customized question answering (first 2.5M)                                     2,500  1K records                   $3,750.00 
+ ├─ Customized question answering (over 2.5M)                                        500  1K records                     $500.03 
+ ├─ Customized training                                               Monthly cost depends on usage: $3.00 per hour              
+ ├─ Text analytics for health (5K-500K)                                              495  1K records                  $12,375.00 
+ ├─ Text analytics for health (500K-2.5M)                                          2,000  1K records                  $30,000.00 
+ └─ Text analytics for health (2.5M-10M)                                             500  1K records                   $5,000.00 
+                                                                                                                                 
  azurerm_cognitive_account.speech_with_commitment["medium"]                                                                      
  ├─ Speech to text (commitment)                                                   10,000  hours                        $6,500.00 
  ├─ Speech to text (overage)                                                         100  hours                           $65.00 
@@ -72,6 +89,23 @@
  ├─ Text requests (commitment overage)                                                 1  1K transactions                  $0.87 
  └─ Speech requests                                                   Monthly cost depends on usage: $5.50 per 1K transactions   
                                                                                                                                  
+ azurerm_cognitive_account.textanalytics_with_commitment["large"]                                                                
+ ├─ Text analytics (commitment)                                                   10,000  1K records                   $3,500.00 
+ ├─ Text requests (commitment overage)                                                 1  1K records                       $0.35 
+ ├─ Text analytics (connected container commitment)                               10,000  1K records                   $2,800.00 
+ ├─ Text requests (connected container commitment overage)                             1  1K records                       $0.28 
+ ├─ Summarization (commitment)                                                    10,000  1K records                   $7,000.00 
+ ├─ Summarization (commitment overage)                                                 1  1K records                       $0.70 
+ ├─ Summarization (connected container commitment)                                10,000  1K records                   $5,600.00 
+ ├─ Summarization (connected container commitment overage)                             1  1K records                       $0.56 
+ ├─ Conversational language understanding                             Monthly cost depends on usage: $2.00 per 1K records        
+ ├─ Conversational language understanding advanced training           Monthly cost depends on usage: $3.00 per hour              
+ ├─ Customized text classification                                    Monthly cost depends on usage: $5.00 per 1K records        
+ ├─ Customized summarization                                          Monthly cost depends on usage: $4.00 per 1K records        
+ ├─ Customized question answering (over 2.5M)                         Monthly cost depends on usage: $1.00 per 1K records        
+ ├─ Customized training                                               Monthly cost depends on usage: $3.00 per hour              
+ └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records       
+                                                                                                                                 
  azurerm_cognitive_account.speech_with_commitment["small"]                                                                       
  ├─ Speech to text (commitment)                                                    2,000  hours                        $1,600.00 
  ├─ Speech to text (overage)                                                         100  hours                           $80.00 
@@ -105,6 +139,23 @@
  ├─ Speaker identification                                            Monthly cost depends on usage: $10.00 per 1K transactions  
  └─ Voice profiles                                                    Monthly cost depends on usage: $0.20 per 1K profiles       
                                                                                                                                  
+ azurerm_cognitive_account.textanalytics_with_commitment["medium"]                                                               
+ ├─ Text analytics (commitment)                                                    3,000  1K records                   $1,375.00 
+ ├─ Text requests (commitment overage)                                                 1  1K records                       $0.55 
+ ├─ Text analytics (connected container commitment)                                3,000  1K records                   $1,100.00 
+ ├─ Text requests (connected container commitment overage)                             1  1K records                       $0.44 
+ ├─ Summarization (commitment)                                                     3,000  1K records                   $3,300.00 
+ ├─ Summarization (commitment overage)                                                 1  1K records                       $1.10 
+ ├─ Summarization (connected container commitment)                                 3,000  1K records                   $2,640.00 
+ ├─ Summarization (connected container commitment overage)                             1  1K records                       $0.88 
+ ├─ Conversational language understanding                             Monthly cost depends on usage: $2.00 per 1K records        
+ ├─ Conversational language understanding advanced training           Monthly cost depends on usage: $3.00 per hour              
+ ├─ Customized text classification                                    Monthly cost depends on usage: $5.00 per 1K records        
+ ├─ Customized summarization                                          Monthly cost depends on usage: $4.00 per 1K records        
+ ├─ Customized question answering (over 2.5M)                         Monthly cost depends on usage: $1.00 per 1K records        
+ ├─ Customized training                                               Monthly cost depends on usage: $3.00 per hour              
+ └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records       
+                                                                                                                                 
  azurerm_cognitive_account.luis_with_commitment["medium"]                                                                        
  ├─ Text requests (commitment)                                                 5,000,000  1M transactions              $5,100.00 
  ├─ Text requests (commitment overage)                                                 1  1K transactions                  $1.02 
@@ -114,6 +165,17 @@
  ├─ Text requests (commitment)                                                 1,000,000  1M transactions              $1,200.00 
  ├─ Text requests (commitment overage)                                                 1  1K transactions                  $1.20 
  └─ Speech requests                                                   Monthly cost depends on usage: $5.50 per 1K transactions   
+                                                                                                                                 
+ azurerm_cognitive_account.textanalytics_with_commitment["small"]                                                                
+ ├─ Text analytics (commitment)                                                    1,000  1K records                     $700.00 
+ ├─ Text requests (commitment overage)                                                 1  1K records                       $0.70 
+ ├─ Conversational language understanding                             Monthly cost depends on usage: $2.00 per 1K records        
+ ├─ Conversational language understanding advanced training           Monthly cost depends on usage: $3.00 per hour              
+ ├─ Customized text classification                                    Monthly cost depends on usage: $5.00 per 1K records        
+ ├─ Customized summarization                                          Monthly cost depends on usage: $4.00 per 1K records        
+ ├─ Customized question answering (over 2.5M)                         Monthly cost depends on usage: $1.00 per 1K records        
+ ├─ Customized training                                               Monthly cost depends on usage: $3.00 per hour              
+ └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records       
                                                                                                                                  
  azurerm_cognitive_account.with_usage["SpeechServices-S0"]                                                                       
  ├─ Speech to text                                                                    20  hours                           $20.00 
@@ -135,6 +197,17 @@
  ├─ Speaker verification                                                               4  1K transactions                 $20.00 
  ├─ Speaker identification                                                             2  1K transactions                 $20.00 
  └─ Voice profiles                                                                   100  1K profiles                     $20.00 
+                                                                                                                                 
+ azurerm_cognitive_account.with_usage["TextAnalytics-S0"]                                                                        
+ ├─ Text analytics (first 500K)                                                       20  1K records                      $20.00 
+ ├─ Summarization                                                                     10  1K records                      $20.00 
+ ├─ Conversational language understanding                                             10  1K records                      $20.00 
+ ├─ Conversational language understanding advanced training                          6.7  hour                            $20.10 
+ ├─ Customized text classification                                                     4  1K records                      $20.00 
+ ├─ Customized summarization                                                           5  1K records                      $20.00 
+ ├─ Customized question answering (first 2.5M)                                    13.333  1K records                      $20.00 
+ ├─ Customized training                                                              6.7  hour                            $20.10 
+ └─ Text analytics for health (5K-500K)                                              0.8  1K records                      $20.00 
                                                                                                                                  
  azurerm_cognitive_account.with_usage["LUIS-S0"]                                                                                 
  ├─ Text requests                                                                 13.333  1K transactions                 $20.00 
@@ -163,6 +236,15 @@
  ├─ Speaker identification                                            Monthly cost depends on usage: $10.00 per 1K transactions  
  └─ Voice profiles                                                    Monthly cost depends on usage: $0.20 per 1K profiles       
                                                                                                                                  
+ azurerm_cognitive_account.textanalytics_with_commitment["invalid"]                                                              
+ ├─ Conversational language understanding                             Monthly cost depends on usage: $2.00 per 1K records        
+ ├─ Conversational language understanding advanced training           Monthly cost depends on usage: $3.00 per hour              
+ ├─ Customized text classification                                    Monthly cost depends on usage: $5.00 per 1K records        
+ ├─ Customized summarization                                          Monthly cost depends on usage: $4.00 per 1K records        
+ ├─ Customized question answering (over 2.5M)                         Monthly cost depends on usage: $1.00 per 1K records        
+ ├─ Customized training                                               Monthly cost depends on usage: $3.00 per hour              
+ └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records       
+                                                                                                                                 
  azurerm_cognitive_account.without_usage["LUIS-S0"]                                                                              
  ├─ Text requests                                                     Monthly cost depends on usage: $1.50 per 1K transactions   
  └─ Speech requests                                                   Monthly cost depends on usage: $5.50 per 1K transactions   
@@ -188,21 +270,37 @@
  ├─ Speaker identification                                            Monthly cost depends on usage: $10.00 per 1K transactions  
  └─ Voice profiles                                                    Monthly cost depends on usage: $0.20 per 1K profiles       
                                                                                                                                  
- OVERALL TOTAL                                                                                                       $229,570.95 
+ azurerm_cognitive_account.without_usage["TextAnalytics-S0"]                                                                     
+ ├─ Text analytics (500K-2.5M)                                        Monthly cost depends on usage: $0.75 per 1K records        
+ ├─ Summarization                                                     Monthly cost depends on usage: $2.00 per 1K records        
+ ├─ Conversational language understanding                             Monthly cost depends on usage: $2.00 per 1K records        
+ ├─ Conversational language understanding advanced training           Monthly cost depends on usage: $3.00 per hour              
+ ├─ Customized text classification                                    Monthly cost depends on usage: $5.00 per 1K records        
+ ├─ Customized summarization                                          Monthly cost depends on usage: $4.00 per 1K records        
+ ├─ Customized question answering (over 2.5M)                         Monthly cost depends on usage: $1.00 per 1K records        
+ ├─ Customized training                                               Monthly cost depends on usage: $3.00 per hour              
+ └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records       
+                                                                                                                                 
+ OVERALL TOTAL                                                                                                       $314,896.73 
 ──────────────────────────────────
-18 cloud resources were detected:
-∙ 12 were estimated
-∙ 5 were free
+27 cloud resources were detected:
+∙ 19 were estimated
+∙ 7 were free
 ∙ 1 is not supported yet, see https://infracost.io/requested-resources:
   ∙ 1 x azurerm_cognitive_account
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Monthly cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━┫
-┃ TestCognitiveAccount                               ┃ $229,571     ┃
+┃ TestCognitiveAccount                               ┃ $314,897     ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━┛
 Logs:
 
+WRN Invalid commitment tier 1000000 for azurerm_cognitive_account.textanalytics_with_commitment["small"]
 WRN Invalid commitment tier 200 for azurerm_cognitive_account.luis_with_commitment["invalid"]
+WRN Invalid commitment tier 200 for azurerm_cognitive_account.textanalytics_with_commitment["invalid"]
+WRN Invalid commitment tier 200 for azurerm_cognitive_account.textanalytics_with_commitment["invalid"]
+WRN Invalid commitment tier 200 for azurerm_cognitive_account.textanalytics_with_commitment["invalid"]
+WRN Invalid commitment tier 200 for azurerm_cognitive_account.textanalytics_with_commitment["invalid"]
 WRN Invalid commitment tier amount 100 for azurerm_cognitive_account.speech_with_commitment["invalid"]
 WRN Skipping resource azurerm_cognitive_account.unsupported. Kind "Academic" is not supported

--- a/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.tf
+++ b/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.tf
@@ -12,6 +12,7 @@ locals {
   kind_skus = {
     "SpeechServices" : ["F0", "S0"],
     "LUIS" : ["F0", "S0"],
+    "TextAnalytics" : ["F0", "S0"],
   }
 
   permutations = distinct(flatten([
@@ -61,6 +62,24 @@ resource "azurerm_cognitive_account" "luis_with_commitment" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   kind                = "LUIS"
+  sku_name            = "S0"
+}
+
+resource "azurerm_cognitive_account" "textanalytics_with_commitment" {
+  for_each = toset(["small", "medium", "large", "invalid"])
+
+  name                = "textanalytics-with-commitment-${each.key}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  kind                = "TextAnalytics"
+  sku_name            = "S0"
+}
+
+resource "azurerm_cognitive_account" "textanalytics_with_tiers" {
+  name                = "textanalytics-with-tiers"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  kind                = "TextAnalytics"
   sku_name            = "S0"
 }
 

--- a/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.usage.yml
@@ -24,6 +24,16 @@ resource_usage:
     # LUIS
     monthly_luis_text_requests: 13_333
     monthly_luis_speech_requests: 3_636
+    # TextAnalytics
+    monthly_language_text_analytics_records: 20_000
+    monthly_language_summarization_records: 10_000
+    monthly_language_conversational_language_understanding_records: 10_000
+    monthly_language_conversational_language_understanding_advanced_training_hours: 6.7
+    monthly_language_customized_text_classification_records: 4_000
+    monthly_language_customized_summarization_records: 5_000
+    monthly_language_customized_question_answering_records: 13_333
+    monthly_language_customized_training_hours: 6.7
+    monthly_language_text_analytics_for_health_records: 5_800
 
   azurerm_cognitive_account.speech_with_commitment["small"]:
     monthly_commitment_speech_to_text_standard_hrs: 2000
@@ -96,3 +106,41 @@ resource_usage:
 
   azurerm_cognitive_account.luis_with_commitment["invalid"]:
     monthly_commitment_luis_text_requests: 200
+
+  azurerm_cognitive_account.textanalytics_with_commitment["small"]:
+    monthly_commitment_language_text_analytics_records: 1_000_000
+    monthly_commitment_language_text_analytics_overage_records: 1_000
+    monthly_commitment_language_summarization_records: 1_000_000
+    monthly_commitment_language_summarization_overage_records: 1_000_000
+    # There's no 1M commitment for connected container
+
+  azurerm_cognitive_account.textanalytics_with_commitment["medium"]:
+    monthly_commitment_language_text_analytics_records: 3_000_000
+    monthly_commitment_language_text_analytics_overage_records: 1_000
+    monthly_commitment_language_summarization_records: 3_000_000
+    monthly_commitment_language_summarization_overage_records: 1_000
+    monthly_connected_container_commitment_language_text_analytics_records: 3_000_000
+    monthly_connected_container_commitment_language_text_analytics_overage_records: 1_000
+    monthly_connected_container_commitment_language_summarization_records: 3_000_000
+    monthly_connected_container_commitment_language_summarization_overage_records: 1_000
+
+  azurerm_cognitive_account.textanalytics_with_commitment["large"]:
+    monthly_commitment_language_text_analytics_records: 10_000_000
+    monthly_commitment_language_text_analytics_overage_records: 1_000
+    monthly_commitment_language_summarization_records: 10_000_000
+    monthly_commitment_language_summarization_overage_records: 1_000
+    monthly_connected_container_commitment_language_text_analytics_records: 10_000_000
+    monthly_connected_container_commitment_language_text_analytics_overage_records: 1_000
+    monthly_connected_container_commitment_language_summarization_records: 10_000_000
+    monthly_connected_container_commitment_language_summarization_overage_records: 1_000
+
+  azurerm_cognitive_account.textanalytics_with_commitment["invalid"]:
+    monthly_commitment_language_text_analytics_records: 200
+    monthly_commitment_language_summarization_records: 200
+    monthly_connected_container_commitment_language_text_analytics_records: 200
+    monthly_connected_container_commitment_language_summarization_records: 200
+
+  azurerm_cognitive_account.textanalytics_with_tiers:
+    monthly_language_text_analytics_records: 15_000_000
+    monthly_language_customized_question_answering_records: 3_000_000
+    monthly_language_text_analytics_for_health_records: 3_000_000

--- a/internal/resources/azure/cognitive_account_language.go
+++ b/internal/resources/azure/cognitive_account_language.go
@@ -1,0 +1,609 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/infracost/infracost/internal/logging"
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
+	"github.com/shopspring/decimal"
+)
+
+var validLanguageCommitmentTierTextAnalyticsRecords = []int64{1_000_000, 3_000_000, 10_000_000}
+var validLanguageCommitmentTierSummarizationRecords = []int64{3_000_000, 10_000_000}
+
+// CognitiveAccountSpeech struct represents the Azure AI Language Service.
+// This supports the pay-as-you pricing and the standard and connected container commitment tiers.
+// This doesn't currently support the disconnected container commitment tier.
+//
+// The commitment tiers are implemented using a usage-based cost component for the commitment amount.
+// Since multiple commitment tiers can be used at the same time, we use separate usage-based cost
+// components for each commitment tier and overage, instead of using the same cost component as the
+// pay-as-you-go pricing.
+//
+// Resource information: https://learn.microsoft.com/en-us/azure/ai-services/language-service/overview
+// Pricing information: https://azure.microsoft.com/en-gb/pricing/details/cognitive-services/language-service/
+type CognitiveAccountLanguage struct {
+	Address string
+	Region  string
+
+	Sku string
+
+	// Usage attributes
+
+	MonthlyLanguageTextAnalyticsRecords *int64 `infracost_usage:"monthly_language_text_analytics_records"`
+	MonthlyLanguageSummarizationRecords *int64 `infracost_usage:"monthly_language_summarization_records"`
+
+	MonthlyLanguageConversationalLanguageUnderstandingRecords               *int64   `infracost_usage:"monthly_language_conversational_language_understanding_records"`
+	MonthlyLanguageConversationalLanguageUnderstandingAdvancedTrainingHours *float64 `infracost_usage:"monthly_language_conversational_language_understanding_advanced_training_hours"`
+	MonthlyLanguageCustomizedTextClassificationRecords                      *int64   `infracost_usage:"monthly_language_customized_text_classification_records"`
+	MonthlyLanguageCustomizedSummarizationRecords                           *int64   `infracost_usage:"monthly_language_customized_summarization_records"`
+	MonthlyLanguageCustomizedQuestionAnsweringRecords                       *int64   `infracost_usage:"monthly_language_customized_question_answering_records"`
+	MonthlyLanguageCustomizedTrainingHours                                  *float64 `infracost_usage:"monthly_language_customized_training_hours"`
+	MonthlyLanguageTextAnalyticsForHealthRecords                            *int64   `infracost_usage:"monthly_language_text_analytics_for_health_records"`
+
+	// Commitment tiers
+	MonthlyCommitmentLanguageTextAnalyticsRecords                          *int64 `infracost_usage:"monthly_commitment_language_text_analytics_records"`
+	MonthlyCommitmentLanguageTextAnalyticsOverageRecords                   *int64 `infracost_usage:"monthly_commitment_language_text_analytics_overage_records"`
+	MonthlyCommitmentLanguageSummarizationRecords                          *int64 `infracost_usage:"monthly_commitment_language_summarization_records"`
+	MonthlyCommitmentLanguageSummarizationOverageRecords                   *int64 `infracost_usage:"monthly_commitment_language_summarization_overage_records"`
+	MonthlyConnectedContainerCommitmentLanguageTextAnalyticsRecords        *int64 `infracost_usage:"monthly_connected_container_commitment_language_text_analytics_records"`
+	MonthlyConnectedContainerCommitmentLanguageTextAnalyticsOverageRecords *int64 `infracost_usage:"monthly_connected_container_commitment_language_text_analytics_overage_records"`
+	MonthlyConnectedContainerCommitmentLanguageSummarizationRecords        *int64 `infracost_usage:"monthly_connected_container_commitment_language_summarization_records"`
+	MonthlyConnectedContainerCommitmentLanguageSummarizationOverageRecords *int64 `infracost_usage:"monthly_connected_container_commitment_language_summarization_overage_records"`
+}
+
+// // CoreType returns the name of this resource type
+func (r *CognitiveAccountLanguage) CoreType() string {
+	return "CognitiveAccountLanguage"
+}
+
+// UsageSchema defines a list which represents the usage schema of CognitiveAccountLanguage.
+func (r *CognitiveAccountLanguage) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "monthly_language_text_analytics_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_language_summarization_records", DefaultValue: 0, ValueType: schema.Int64},
+
+		{Key: "monthly_language_conversational_language_understanding_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_language_conversational_language_understanding_advanced_training_hours", DefaultValue: 0, ValueType: schema.Float64},
+		{Key: "monthly_language_customized_text_classification_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_language_customized_summarization_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_language_customized_question_answering_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_language_customized_training_hours", DefaultValue: 0, ValueType: schema.Float64},
+		{Key: "monthly_language_text_analytics_for_health_records", DefaultValue: 0, ValueType: schema.Int64},
+
+		// Commitment tiers
+		{Key: "monthly_commitment_language_text_analytics_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_commitment_language_text_analytics_overage_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_commitment_language_summarization_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_commitment_language_summarization_overage_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_connected_container_commitment_language_text_analytics_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_connected_container_commitment_language_text_analytics_overage_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_connected_container_commitment_language_summarization_records", DefaultValue: 0, ValueType: schema.Int64},
+		{Key: "monthly_connected_container_commitment_language_summarization_overage_records", DefaultValue: 0, ValueType: schema.Int64},
+	}
+}
+
+// PopulateUsage parses the u schema.UsageData into the CognitiveAccountLanguage.
+// It uses the `infracost_usage` struct tags to populate data into the CognitiveAccountLanguage.
+func (r *CognitiveAccountLanguage) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid CognitiveAccountLanguage struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *CognitiveAccountLanguage) BuildResource() *schema.Resource {
+	// F0 is the free tier
+	if strings.EqualFold(r.Sku, "f0") {
+		return &schema.Resource{
+			Name:      r.Address,
+			NoPrice:   true,
+			IsSkipped: true,
+		}
+	}
+
+	// For some reason the SKU can either be S0 or S1 but they map to the same thing
+	if !strings.EqualFold(r.Sku, "s0") && !strings.EqualFold(r.Sku, "s1") {
+		logging.Logger.Warn().Msgf("Unsupported SKU %s for %s", r.Sku, r.Address)
+		return nil
+	}
+
+	costComponents := make([]*schema.CostComponent, 0)
+
+	if r.MonthlyCommitmentLanguageTextAnalyticsRecords != nil {
+		costComponents = append(costComponents, r.commitmentTextAnalyticsCostComponents(standardCommitmentTier, *r.MonthlyCommitmentLanguageTextAnalyticsRecords, intPtrToDecimalPtr(r.MonthlyCommitmentLanguageTextAnalyticsOverageRecords))...)
+	}
+	if r.MonthlyConnectedContainerCommitmentLanguageTextAnalyticsRecords != nil {
+		costComponents = append(costComponents, r.commitmentTextAnalyticsCostComponents(connectedContainerCommitmentTier, *r.MonthlyConnectedContainerCommitmentLanguageTextAnalyticsRecords, intPtrToDecimalPtr(r.MonthlyConnectedContainerCommitmentLanguageTextAnalyticsOverageRecords))...)
+	}
+	if (r.MonthlyCommitmentLanguageTextAnalyticsRecords == nil && r.MonthlyConnectedContainerCommitmentLanguageTextAnalyticsRecords == nil) || r.MonthlyLanguageTextAnalyticsRecords != nil {
+		costComponents = append(costComponents, r.textAnalyticsCostComponents()...)
+	}
+
+	if r.MonthlyCommitmentLanguageSummarizationRecords != nil {
+		costComponents = append(costComponents, r.commitmentSummarizationCostComponents(standardCommitmentTier, *r.MonthlyCommitmentLanguageSummarizationRecords, intPtrToDecimalPtr(r.MonthlyCommitmentLanguageSummarizationOverageRecords))...)
+	}
+	if r.MonthlyConnectedContainerCommitmentLanguageSummarizationRecords != nil {
+		costComponents = append(costComponents, r.commitmentSummarizationCostComponents(connectedContainerCommitmentTier, *r.MonthlyConnectedContainerCommitmentLanguageSummarizationRecords, intPtrToDecimalPtr(r.MonthlyConnectedContainerCommitmentLanguageSummarizationOverageRecords))...)
+	}
+	if (r.MonthlyCommitmentLanguageSummarizationRecords == nil && r.MonthlyConnectedContainerCommitmentLanguageSummarizationRecords == nil) || r.MonthlyLanguageSummarizationRecords != nil {
+		costComponents = append(costComponents, r.summarizationCostComponent())
+	}
+
+	costComponents = append(costComponents, r.conversationalLanguageUnderstandingCostComponent())
+	costComponents = append(costComponents, r.conversationalLanguageUnderstandingAdvancedTrainingCostComponent())
+	costComponents = append(costComponents, r.customizedTextClassificationCostComponent())
+	costComponents = append(costComponents, r.customizedSummarizationCostComponent())
+	costComponents = append(costComponents, r.customizedQuestionAnsweringCostComponents()...)
+	costComponents = append(costComponents, r.customizedTrainingCostComponent())
+	costComponents = append(costComponents, r.textAnalyticsForHealthCostComponents()...)
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    r.UsageSchema(),
+		CostComponents: costComponents,
+	}
+}
+
+func (r *CognitiveAccountLanguage) textAnalyticsCostComponents() []*schema.CostComponent {
+	var costComponents []*schema.CostComponent
+
+	tierLimits := []int{500, 2_000, 7_500}
+	tierData := []struct {
+		suffix     string
+		startUsage string
+	}{
+		{suffix: " (first 500K)", startUsage: "0"},
+		{suffix: " (500K-2.5M)", startUsage: "500"},
+		{suffix: " (2.5M-10M)", startUsage: "2500"},
+		{suffix: " (over 10M)", startUsage: "10000"},
+	}
+
+	var qty *decimal.Decimal
+	if r.MonthlyLanguageTextAnalyticsRecords != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageTextAnalyticsRecords).Div(decimal.NewFromInt(1_000)))
+		tierQtys := usage.CalculateTierBuckets(*qty, tierLimits)
+
+		for i, d := range tierData {
+			if len(tierQtys) <= i {
+				break
+			}
+
+			if tierQtys[i].GreaterThan(decimal.Zero) {
+				costComponents = append(costComponents, r.textAnalyticsCostComponent(d.suffix, d.startUsage, decimalPtr(tierQtys[i])))
+			}
+		}
+	} else {
+		costComponents = append(costComponents, r.textAnalyticsCostComponent(tierData[1].suffix, tierData[1].startUsage, nil))
+	}
+
+	return costComponents
+}
+
+func (r *CognitiveAccountLanguage) textAnalyticsCostComponent(suffix string, startUsage string, qty *decimal.Decimal) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            fmt.Sprintf("Text analytics%s", suffix),
+		Unit:            "1K records",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Cognitive Services"),
+			ProductFamily: strPtr("AI + Machine Learning"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Language")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard Text Records")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			StartUsageAmount: strPtr(startUsage),
+		},
+	}
+}
+
+func (r *CognitiveAccountLanguage) commitmentTextAnalyticsCostComponents(commitmentTierType int64, amount int64, overage *decimal.Decimal) []*schema.CostComponent {
+	if !containsInt64(validLanguageCommitmentTierTextAnalyticsRecords, amount) {
+		logging.Logger.Warn().Msgf("Invalid commitment tier %d for %s", amount, r.Address)
+		return nil
+	}
+
+	desc := amountToDescription(amount)
+
+	qty := decimal.NewFromInt(amount).Div(decimal.NewFromInt(1_000))
+
+	skuName := "Commitment Tier Azure " + desc
+	commitmentLabel := "commitment"
+	if commitmentTierType == connectedContainerCommitmentTier {
+		skuName = "Commitment Tier Connected " + desc
+		commitmentLabel = "connected container commitment"
+	}
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name: fmt.Sprintf("Text analytics (%s)", commitmentLabel),
+			Unit: "1K records",
+			// Use a monthly quantity of 1 and a unit multiplier so we show the
+			// correct number of transactions in the qty field, and divide the price
+			// by the number of transactions in the commitment tier
+			UnitMultiplier:  decimal.NewFromInt(1).Div(qty),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			UnitRounding:    int32Ptr(0),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr(vendorName),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cognitive Services"),
+				ProductFamily: strPtr("AI + Machine Learning"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr("Language")},
+					{Key: "skuName", Value: strPtr(skuName)},
+					{Key: "meterName", ValueRegex: regexPtr("Unit$")},
+				},
+			},
+		},
+	}
+
+	if overage != nil {
+		overageQty := decimalPtr(overage.Div(decimal.NewFromInt(1_000)))
+
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            fmt.Sprintf("Text requests (%s overage)", commitmentLabel),
+			Unit:            "1K records",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: overageQty,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr(vendorName),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cognitive Services"),
+				ProductFamily: strPtr("AI + Machine Learning"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr("Language")},
+					{Key: "skuName", Value: strPtr(skuName)},
+					{Key: "meterName", ValueRegex: regexPtr("Overage")},
+				},
+			},
+		})
+	}
+
+	return costComponents
+}
+
+func (r *CognitiveAccountLanguage) summarizationCostComponent() *schema.CostComponent {
+	var qty *decimal.Decimal
+	if r.MonthlyLanguageSummarizationRecords != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageSummarizationRecords).Div(decimal.NewFromInt(1_000)))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Summarization",
+		Unit:            "1K records",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Cognitive Services"),
+			ProductFamily: strPtr("AI + Machine Learning"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Language")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard Summarization Text Records")},
+			},
+		},
+	}
+}
+
+func (r *CognitiveAccountLanguage) commitmentSummarizationCostComponents(commitmentTierType int64, amount int64, overage *decimal.Decimal) []*schema.CostComponent {
+	if !containsInt64(validLanguageCommitmentTierSummarizationRecords, amount) {
+		logging.Logger.Warn().Msgf("Invalid commitment tier %d for %s", amount, r.Address)
+		return nil
+	}
+
+	desc := amountToDescription(amount)
+
+	qty := decimal.NewFromInt(amount).Div(decimal.NewFromInt(1_000))
+
+	skuName := "Commitment Tier Summarization Azure " + desc
+	commitmentLabel := "commitment"
+	if commitmentTierType == connectedContainerCommitmentTier {
+		skuName = "Commitment Tier Summarization Connected " + desc
+		commitmentLabel = "connected container commitment"
+	}
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name: fmt.Sprintf("Summarization (%s)", commitmentLabel),
+			Unit: "1K records",
+			// Use a monthly quantity of 1 and a unit multiplier so we show the
+			// correct number of transactions in the qty field, and divide the price
+			// by the number of transactions in the commitment tier
+			UnitMultiplier:  decimal.NewFromInt(1).Div(qty),
+			MonthlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			UnitRounding:    int32Ptr(0),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr(vendorName),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cognitive Services"),
+				ProductFamily: strPtr("AI + Machine Learning"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr("Language")},
+					{Key: "skuName", Value: strPtr(skuName)},
+					{Key: "meterName", ValueRegex: regexPtr("Unit$")},
+				},
+			},
+		},
+	}
+
+	if overage != nil {
+		overageQty := decimalPtr(overage.Div(decimal.NewFromInt(1_000)))
+
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            fmt.Sprintf("Summarization (%s overage)", commitmentLabel),
+			Unit:            "1K records",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: overageQty,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr(vendorName),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cognitive Services"),
+				ProductFamily: strPtr("AI + Machine Learning"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr("Language")},
+					{Key: "skuName", Value: strPtr(skuName)},
+					{Key: "meterName", ValueRegex: regexPtr("Overage")},
+				},
+			},
+		})
+	}
+
+	return costComponents
+}
+
+func (r *CognitiveAccountLanguage) conversationalLanguageUnderstandingCostComponent() *schema.CostComponent {
+	var qty *decimal.Decimal
+	if r.MonthlyLanguageConversationalLanguageUnderstandingRecords != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageConversationalLanguageUnderstandingRecords).Div(decimal.NewFromInt(1_000)))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Conversational language understanding",
+		Unit:            "1K records",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Cognitive Services"),
+			ProductFamily: strPtr("AI + Machine Learning"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Language")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard CLU Text Records")},
+			},
+		},
+	}
+}
+
+func (r *CognitiveAccountLanguage) conversationalLanguageUnderstandingAdvancedTrainingCostComponent() *schema.CostComponent {
+	var qty *decimal.Decimal
+	if r.MonthlyLanguageConversationalLanguageUnderstandingAdvancedTrainingHours != nil {
+		qty = decimalPtr(decimal.NewFromFloat(*r.MonthlyLanguageConversationalLanguageUnderstandingAdvancedTrainingHours))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Conversational language understanding advanced training",
+		Unit:            "hour",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Cognitive Services"),
+			ProductFamily: strPtr("AI + Machine Learning"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Language")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard CLU Advanced Training Unit")},
+			},
+		},
+	}
+}
+
+func (r *CognitiveAccountLanguage) customizedTextClassificationCostComponent() *schema.CostComponent {
+	var qty *decimal.Decimal
+	if r.MonthlyLanguageCustomizedTextClassificationRecords != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageCustomizedTextClassificationRecords).Div(decimal.NewFromInt(1_000)))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Customized text classification",
+		Unit:            "1K records",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Cognitive Services"),
+			ProductFamily: strPtr("AI + Machine Learning"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Language")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard Custom Text Records")},
+			},
+		},
+	}
+}
+
+func (r *CognitiveAccountLanguage) customizedSummarizationCostComponent() *schema.CostComponent {
+	var qty *decimal.Decimal
+	if r.MonthlyLanguageCustomizedSummarizationRecords != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageCustomizedSummarizationRecords).Div(decimal.NewFromInt(1_000)))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Customized summarization",
+		Unit:            "1K records",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Cognitive Services"),
+			ProductFamily: strPtr("AI + Machine Learning"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Language")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard Custom Summarization Text Records")},
+			},
+		},
+	}
+}
+
+func (r *CognitiveAccountLanguage) customizedQuestionAnsweringCostComponents() []*schema.CostComponent {
+	var costComponents []*schema.CostComponent
+
+	tierLimits := []int{2_500}
+	tierData := []struct {
+		suffix     string
+		startUsage string
+	}{
+		{suffix: " (first 2.5M)", startUsage: "0"},
+		{suffix: " (over 2.5M)", startUsage: "2500"},
+	}
+
+	var qty *decimal.Decimal
+	if r.MonthlyLanguageCustomizedQuestionAnsweringRecords != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageCustomizedQuestionAnsweringRecords).Div(decimal.NewFromInt(1_000)))
+		tierQtys := usage.CalculateTierBuckets(*qty, tierLimits)
+
+		for i, d := range tierData {
+			if len(tierQtys) <= i {
+				break
+			}
+
+			if tierQtys[i].GreaterThan(decimal.Zero) {
+				costComponents = append(costComponents, r.customizedQuestionAnsweringCostComponent(d.suffix, d.startUsage, decimalPtr(tierQtys[i])))
+			}
+		}
+	} else {
+		costComponents = append(costComponents, r.customizedQuestionAnsweringCostComponent(tierData[1].suffix, tierData[1].startUsage, nil))
+	}
+
+	return costComponents
+}
+
+func (r *CognitiveAccountLanguage) customizedQuestionAnsweringCostComponent(suffix string, startUsage string, qty *decimal.Decimal) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            fmt.Sprintf("Customized question answering%s", suffix),
+		Unit:            "1K records",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Cognitive Services"),
+			ProductFamily: strPtr("AI + Machine Learning"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Language")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard QA Text Records")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			StartUsageAmount: strPtr(startUsage),
+		},
+	}
+}
+
+func (r *CognitiveAccountLanguage) customizedTrainingCostComponent() *schema.CostComponent {
+	var qty *decimal.Decimal
+	if r.MonthlyLanguageCustomizedTrainingHours != nil {
+		qty = decimalPtr(decimal.NewFromFloat(*r.MonthlyLanguageCustomizedTrainingHours))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Customized training",
+		Unit:            "hour",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Cognitive Services"),
+			ProductFamily: strPtr("AI + Machine Learning"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Language")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard Custom Training Unit")},
+			},
+		},
+	}
+}
+
+func (r *CognitiveAccountLanguage) textAnalyticsForHealthCostComponents() []*schema.CostComponent {
+	var costComponents []*schema.CostComponent
+
+	tierLimits := []int{5, 495, 2_000, 7_500}
+	tierData := []struct {
+		suffix     string
+		startUsage string
+	}{
+		{suffix: " (first 5K)", startUsage: "0"},
+		{suffix: " (5K-500K)", startUsage: "5"},
+		{suffix: " (500K-2.5M)", startUsage: "500"},
+		{suffix: " (2.5M-10M)", startUsage: "2500"},
+		{suffix: " (over 10M)", startUsage: "10000"},
+	}
+
+	var qty *decimal.Decimal
+	if r.MonthlyLanguageTextAnalyticsForHealthRecords != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageTextAnalyticsForHealthRecords).Div(decimal.NewFromInt(1_000)))
+		tierQtys := usage.CalculateTierBuckets(*qty, tierLimits)
+
+		for i, d := range tierData {
+			// Skip the first tier since it's free
+			if i == 0 {
+				continue
+			}
+
+			if len(tierQtys) <= i {
+				break
+			}
+
+			if tierQtys[i].GreaterThan(decimal.Zero) {
+				costComponents = append(costComponents, r.textAnalyticsForHealthCostComponent(d.suffix, d.startUsage, decimalPtr(tierQtys[i])))
+			}
+		}
+	} else {
+		costComponents = append(costComponents, r.textAnalyticsForHealthCostComponent(tierData[1].suffix, tierData[1].startUsage, nil))
+	}
+
+	return costComponents
+}
+
+func (r *CognitiveAccountLanguage) textAnalyticsForHealthCostComponent(suffix string, startUsage string, qty *decimal.Decimal) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            fmt.Sprintf("Text analytics for health%s", suffix),
+		Unit:            "1K records",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: qty,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr(vendorName),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Cognitive Services"),
+			ProductFamily: strPtr("AI + Machine Learning"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "productName", Value: strPtr("Language")},
+				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "meterName", Value: strPtr("Standard Health Text Records")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			StartUsageAmount: strPtr(startUsage),
+		},
+	}
+}


### PR DESCRIPTION
This adds to https://github.com/infracost/infracost/pull/2975, adding support for the Azure AI Language (TextAnalytics) service. It uses similar usage params as the previous the previous change.