### PR TITLE
fix: unknown value issues with `formatdate` and invalid dates

### DIFF
--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -1334,8 +1335,18 @@ var (
 		"data.aws_region":             awsCurrentRegion,
 		"data.aws_default_tags":       awsDefaultTagValues,
 		"resource.random_shuffle":     randomShuffleValues,
+		"resource.time_static":        timeStaticValues,
 	}
 )
+
+// timeStaticValues mocks the values returned from resource.time_static
+// which is a resource that returns the current time in an RFC3339 format.
+// https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static
+func timeStaticValues(b *Block) cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"rfc3339": cty.StringVal(time.Now().Format(time.RFC3339)),
+	})
+}
 
 func awsCurrentRegion(b *Block) cty.Value {
 	return cty.ObjectVal(map[string]cty.Value{

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -1191,7 +1191,7 @@ func ExpFunctions(baseDir string, logger zerolog.Logger) map[string]function.Fun
 		"flatten":          stdlib.FlattenFunc,
 		"floor":            stdlib.FloorFunc,
 		"format":           stdlib.FormatFunc,
-		"formatdate":       stdlib.FormatDateFunc,
+		"formatdate":       funcs.FormatDateFunc,
 		"formatlist":       stdlib.FormatListFunc,
 		"indent":           stdlib.IndentFunc,
 		"index":            funcs.IndexFunc, // stdlib.IndexFunc is not compatible


### PR DESCRIPTION
This change resolves issue where usage of `formatdate` within an attribute value caused the value to resolve to a unknown dynamic value. This was especially problematic when used within maps and map funcitons as it caused the whole map to return as a unknown value.

I've fixed this issue by wrapping the formatdate function, checking the return value does not have any errors returned. If it does we return a safe default. I've also added support for the `time_static` resource, which initially caused us to stumble on this bug.