### PR TITLE
feat: add support project config for cloud workspace and org

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,10 @@ type Project struct {
 	TerraformBinary string `yaml:"terraform_binary,omitempty" envconfig:"TERRAFORM_BINARY"`
 	// TerraformWorkspace is an optional field used to set the Terraform workspace
 	TerraformWorkspace string `yaml:"terraform_workspace,omitempty" envconfig:"TERRAFORM_WORKSPACE"`
+	// TerraformCloudWorkspace is used to override the terraform configuration blocks workspace value.
+	TerraformCloudWorkspace string `yaml:"terraform_cloud_workspace,omitempty" envconfig:"TERRAFORM_CLOUD_WORKSPACE"`
+	// TerraformCloudOrg is used to override the terraform configuration blocks organization value.
+	TerraformCloudOrg string `yaml:"terraform_cloud_org,omitempty" envconfig:"TERRAFORM_CLOUD_ORG"`
 	// TerraformCloudHost is used to override the default app.terraform.io backend host. Only applicable for
 	// terraform cloud/enterprise users.
 	TerraformCloudHost string `yaml:"terraform_cloud_host,omitempty" envconfig:"TERRAFORM_CLOUD_HOST"`

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -205,13 +205,12 @@ func OptionWithRawCtyInput(input cty.Value) (op Option) {
 
 // OptionWithRemoteVarLoader accepts Terraform Cloud/Enterprise host and token
 // values to load remote execution variables.
-func OptionWithRemoteVarLoader(host, token, localWorkspace string) Option {
+func OptionWithRemoteVarLoader(host, token, localWorkspace string, loaderOpts ...RemoteVariablesLoaderOption) Option {
 	return func(p *Parser) {
 		if host == "" || token == "" {
 			return
 		}
 
-		var loaderOpts []RemoteVariablesLoaderOption
 		if p.newSpinner != nil {
 			loaderOpts = append(loaderOpts, RemoteVariablesLoaderWithSpinner(p.newSpinner))
 		}

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -123,10 +123,20 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 	})
 	localWorkspace := ctx.ProjectConfig.TerraformWorkspace
 	if err == nil {
+		var loaderOpts []hcl.RemoteVariablesLoaderOption
+		if ctx.ProjectConfig.TerraformCloudWorkspace != "" && ctx.ProjectConfig.TerraformCloudOrg != "" {
+			loaderOpts = append(loaderOpts, hcl.RemoteVariablesLoaderWithRemoteConfig(hcl.TFCRemoteConfig{
+				Organization: ctx.ProjectConfig.TerraformCloudOrg,
+				Workspace:    ctx.ProjectConfig.TerraformCloudWorkspace,
+				Host:         credsSource.BaseCredentialSet.Host,
+			}))
+		}
+
 		options = append(options, hcl.OptionWithRemoteVarLoader(
 			credsSource.BaseCredentialSet.Host,
 			credsSource.BaseCredentialSet.Token,
-			localWorkspace),
+			localWorkspace,
+			loaderOpts...),
 		)
 	}
 

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -83,6 +83,12 @@
         "terraform_workspace": {
           "type": "string"
         },
+        "terraform_cloud_workspace": {
+          "type": "string"
+        },
+        "terraform_cloud_org": {
+          "type": "string"
+        },
         "terraform_cloud_host": {
           "type": "string"
         },


### PR DESCRIPTION
Adds support to allow users to override the cloud workspace and org that are used by infracost cloud. This is useful when users want to "force" which org/workspace should be used and not rely on Infracost to infer it from the IaC.