### PR TITLE
chore: Add descriptions to usage default keys

### DIFF
--- a/infracost-usage-defaults.large.yml
+++ b/infracost-usage-defaults.large.yml
@@ -441,55 +441,55 @@ resource_type_default_usage:
     monthly_outbound_gb: 247 # Monthly number of outbound data transfers in GB.
     monthly_rules_engine_requests: 33000000 # Monthly number of rules engine requests.
   azurerm_cognitive_account:
-    monthly_speech_to_text_standard_hrs: 20
-    monthly_speech_to_text_standard_batch_hrs: 56
-    monthly_speech_to_text_custom_hrs: 17
-    monthly_speech_to_text_custom_batch_hrs: 44
-    monthly_speech_to_text_custom_endpoint_hrs: 372
-    monthly_speech_to_text_custom_training_hrs: 2
-    monthly_speech_to_text_enhanced_add_ons_hrs: 67
-    monthly_speech_to_text_conversation_transcription_multi_channel_audio_hrs: 9.5
-    monthly_text_to_speech_neural_chars: 1_333_333
-    monthly_text_to_speech_custom_neural_training_hrs: 0.4
-    monthly_text_to_speech_custom_neural_chars: 833_333
-    monthly_text_to_speech_custom_neural_endpoint_hrs: 5
-    monthly_text_to_speech_long_audio_chars: 200_000
-    monthly_text_to_speech_personal_voice_profiles: 33
-    monthly_text_to_speech_personal_voice_chars: 833_333
-    monthly_speech_translation_hrs: 8
-    monthly_speaker_verification_transactions: 4_000
-    monthly_speaker_identification_transactions: 2_000
-    monthly_voice_profiles: 100_000
+    monthly_speech_to_text_standard_hrs: 20 # Monthly number of hours of Speech to Text audio hours
+    monthly_speech_to_text_standard_batch_hrs: 56 # Monthly number of hours of Speech to Text audio hours for batch processing
+    monthly_speech_to_text_custom_hrs: 17 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model
+    monthly_speech_to_text_custom_batch_hrs: 44 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model batch processing
+    monthly_speech_to_text_custom_endpoint_hrs: 372 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model endpoint hosting
+    monthly_speech_to_text_custom_training_hrs: 2 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model training
+    monthly_speech_to_text_enhanced_add_ons_hrs: 67 # Monthly number of hours of Speech to Text audio hours for enhanced add-on features
+    monthly_speech_to_text_conversation_transcription_multi_channel_audio_hrs: 9.5 # Monthly number of hours of Speech to Text audio hours for conversation transcription multi-channel audio
+    monthly_text_to_speech_neural_chars: 1_333_333 # Monthly number of characters for Text to Speech with neural voices
+    monthly_text_to_speech_custom_neural_training_hrs: 0.4 # Monthly number of hours of Text to Speech Customized Neural training
+    monthly_text_to_speech_custom_neural_chars: 833_333 # Monthly number of characters for Text to Speech with Custom Ceural Voices
+    monthly_text_to_speech_custom_neural_endpoint_hrs: 5 # Monthly number of hours of Text to Speech Custom Neural Voice endpoint hosting
+    monthly_text_to_speech_long_audio_chars: 200_000 # Monthly number of characters for Text to Speech with Long Audio Creation
+    monthly_text_to_speech_personal_voice_profiles: 33 # Monthly number of personal voice profiles for Text to Speech
+    monthly_text_to_speech_personal_voice_chars: 833_333 # Monthly number of characters for Text to Speech with Personal Voice Profiles
+    monthly_speech_translation_hrs: 8 # Monthly number of hours of Speech Translation audio hours
+    monthly_speaker_verification_transactions: 4_000 # Monthly number of speaker verification transactions
+    monthly_speaker_identification_transactions: 2_000 # Monthly number of speaker identification transactions
+    monthly_voice_profiles: 100_000 # Monthly number of voice profiles
+    # LUIS
+    monthly_luis_text_requests: 13_333 # Monthly number of text requests to LUIS
+    monthly_luis_speech_requests: 3_636 # Monthly number of speech requests to LUIS
+    # TextAnalytics
+    monthly_language_text_analytics_records: 20_000 # Monthly number of Text Analytics records (Sentiment Analysis, Key Phrase Extraction, Language Detection, Named Entity Recognition, PII Detection)
+    monthly_language_summarization_records: 10_000 # Monthly number of summarization records
+    monthly_language_conversational_language_understanding_records: 10_000 # Monthly number of Conversational Language Understanding and Orchestration Workflow records.
+    monthly_language_conversational_language_understanding_advanced_training_hours: 6.7 # Monthly number of Conversational Language Understanding and Orchestration Workflow advanced training hours.
+    monthly_language_customized_text_classification_records: 4_000 # Monthly number of customized text classification records.
+    monthly_language_customized_summarization_records: 5_000 # Monthly number of customized summarization records.
+    monthly_language_customized_question_answering_records: 13_333 # Monthly number of customized question answering records.
+    monthly_language_customized_training_hours: 6.7 # Monthly number of customized training hours.
+    monthly_language_text_analytics_for_health_records: 5_800 # Monthly number of Text Analytics for health records.
   azurerm_cognitive_deployment:
     # SpeechServices
-    monthly_language_input_tokens: 40_000_000
-    monthly_language_output_tokens: 13_333_333
-    monthly_code_interpreter_sessions: 667
-    monthly_base_model_tokens: 2847
-    monthly_fine_tuning_training_hours: 0.4
-    monthly_fine_tuning_hosting_hours: 6.6
-    monthly_fine_tuning_input_tokens: 13_333_333
-    monthly_fine_tuning_output_tokens: 10_000_000
-    monthly_standard_1024_1024_images: 500
-    monthly_standard_1024_1792_images: 250
-    monthly_hd_1024_1024_images: 250
-    monthly_hd_1024_1792_images: 167
-    monthly_text_embedding_tokens: 1_000_000_000
-    monthly_text_to_speech_characters: 1_333_333
-    monthly_text_to_speech_hours: 55.6
-    # LUIS
-    monthly_luis_text_requests: 13_333
-    monthly_luis_speech_requests: 3_636
-    # TextAnalytics
-    monthly_language_text_analytics_records: 20_000
-    monthly_language_summarization_records: 10_000
-    monthly_language_conversational_language_understanding_records: 10_000
-    monthly_language_conversational_language_understanding_advanced_training_hours: 6.7
-    monthly_language_customized_text_classification_records: 4_000
-    monthly_language_customized_summarization_records: 5_000
-    monthly_language_customized_question_answering_records: 13_333
-    monthly_language_customized_training_hours: 6.7
-    monthly_language_text_analytics_for_health_records: 5_800
+    monthly_language_input_tokens: 40_000_000 # Monthly number of language input tokens.
+    monthly_language_output_tokens: 13_333_333 # Monthly number of language output tokens.
+    monthly_code_interpreter_sessions: 667 # Monthly number of code interpreter sessions.
+    monthly_base_model_tokens: 2847 # Monthly number of base model tokens.
+    monthly_fine_tuning_training_hours: 0.4 # Monthly number of fine-tuning training hours.
+    monthly_fine_tuning_hosting_hours: 6.6 # Monthly number of fine-tuning hosting hours.
+    monthly_fine_tuning_input_tokens: 13_333_333 # Monthly number of fine-tuning input tokens.
+    monthly_fine_tuning_output_tokens: 10_000_000 # Monthly number of fine-tuning output tokens.
+    monthly_standard_1024_1024_images: 500 # Monthly number of standard 1024x1024 (low res) images.
+    monthly_standard_1024_1792_images: 250 # Monthly number of standard 1024x1792 (high res) images.
+    monthly_hd_1024_1024_images: 250 # Monthly number of HD 1024x1024 (low res) images.
+    monthly_hd_1024_1792_images: 167 # Monthly number of HD 1024x1792 (high res) images.
+    monthly_text_embedding_tokens: 1_000_000_000 # Monthly number of text embedding tokens.
+    monthly_text_to_speech_characters: 1_333_333 # Monthly number of text to speech characters.
+    monthly_text_to_speech_hours: 55.6 # Monthly number of text to speech hours.
   azurerm_container_registry:
     storage_gb: 200
     monthly_build_vcpu_hrs: 55.5

--- a/infracost-usage-defaults.medium.yml
+++ b/infracost-usage-defaults.medium.yml
@@ -441,55 +441,55 @@ resource_type_default_usage:
     monthly_outbound_gb: 123 # Monthly number of outbound data transfers in GB.
     monthly_rules_engine_requests: 16500000 # Monthly number of rules engine requests.
   azurerm_cognitive_account:
-    monthly_speech_to_text_standard_hrs: 10
-    monthly_speech_to_text_standard_batch_hrs: 28
-    monthly_speech_to_text_custom_hrs: 8.5
-    monthly_speech_to_text_custom_batch_hrs: 22
-    monthly_speech_to_text_custom_endpoint_hrs: 186
-    monthly_speech_to_text_custom_training_hrs: 1
-    monthly_speech_to_text_enhanced_add_ons_hrs: 33.5
-    monthly_speech_to_text_conversation_transcription_multi_channel_audio_hrs: 4.8
-    monthly_text_to_speech_neural_chars: 666_667
-    monthly_text_to_speech_custom_neural_training_hrs: 0.2
-    monthly_text_to_speech_custom_neural_chars: 416_667
-    monthly_text_to_speech_custom_neural_endpoint_hrs: 2.5
-    monthly_text_to_speech_long_audio_chars: 100_000
-    monthly_text_to_speech_personal_voice_profiles: 16.5
-    monthly_text_to_speech_personal_voice_chars: 416_667
-    monthly_speech_translation_hrs: 4
-    monthly_speaker_verification_transactions: 2_000
-    monthly_speaker_identification_transactions: 1_000
-    monthly_voice_profiles: 50_000
+    monthly_speech_to_text_standard_hrs: 10 # Monthly number of hours of Speech to Text audio hours
+    monthly_speech_to_text_standard_batch_hrs: 28 # Monthly number of hours of Speech to Text audio hours for batch processing
+    monthly_speech_to_text_custom_hrs: 8.5  # Monthly number of hours of Speech to Text audio hours for Custom Speech Model
+    monthly_speech_to_text_custom_batch_hrs: 22 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model batch processing
+    monthly_speech_to_text_custom_endpoint_hrs: 186 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model endpoint hosting
+    monthly_speech_to_text_custom_training_hrs: 1 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model training
+    monthly_speech_to_text_enhanced_add_ons_hrs: 33.5 # Monthly number of hours of Speech to Text audio hours for enhanced add-on features
+    monthly_speech_to_text_conversation_transcription_multi_channel_audio_hrs: 4.8 # Monthly number of hours of Speech to Text audio hours for conversation transcription multi-channel audio
+    monthly_text_to_speech_neural_chars: 666_667 # Monthly number of characters for Text to Speech with neural voices
+    monthly_text_to_speech_custom_neural_training_hrs: 0.2 # Monthly number of hours of Text to Speech Customized Neural training
+    monthly_text_to_speech_custom_neural_chars: 416_667 # Monthly number of characters for Text to Speech with Custom Ceural Voices
+    monthly_text_to_speech_custom_neural_endpoint_hrs: 2.5 # Monthly number of hours of Text to Speech Custom Neural Voice endpoint hosting
+    monthly_text_to_speech_long_audio_chars: 100_000 # Monthly number of characters for Text to Speech with Long Audio Creation
+    monthly_text_to_speech_personal_voice_profiles: 16.5 # Monthly number of personal voice profiles for Text to Speech
+    monthly_text_to_speech_personal_voice_chars: 416_667 # Monthly number of characters for Text to Speech with Personal Voice Profiles
+    monthly_speech_translation_hrs: 4 # Monthly number of hours of Speech Translation audio hours
+    monthly_speaker_verification_transactions: 2_000 # Monthly number of speaker verification transactions
+    monthly_speaker_identification_transactions: 1_000 # Monthly number of speaker identification transactions
+    monthly_voice_profiles: 50_000 # Monthly number of voice profiles
+    # LUIS
+    monthly_luis_text_requests: 6_667 # Monthly number of text requests to LUIS
+    monthly_luis_speech_requests: 1_818 # Monthly number of speech requests to LUIS
+    # TextAnalytics
+    monthly_language_text_analytics_records: 10_000 # Monthly number of Text Analytics records (Sentiment Analysis, Key Phrase Extraction, Language Detection, Named Entity Recognition, PII Detection)
+    monthly_language_summarization_records: 5_000 # Monthly number of summarization records
+    monthly_language_conversational_language_understanding_records: 5_000 # Monthly number of Conversational Language Understanding and Orchestration Workflow records.
+    monthly_language_conversational_language_understanding_advanced_training_hours: 3.3 # Monthly number of Conversational Language Understanding and Orchestration Workflow advanced training hours.
+    monthly_language_customized_text_classification_records: 2_000 # Monthly number of customized text classification records.
+    monthly_language_customized_summarization_records: 2_500 # Monthly number of customized summarization records.
+    monthly_language_customized_question_answering_records: 6_666 # Monthly number of customized question answering records.
+    monthly_language_customized_training_hours: 3.3 # Monthly number of customized training hours.
+    monthly_language_text_analytics_for_health_records: 2_900 # Monthly number of Text Analytics for health records.
   azurerm_cognitive_deployment:
     # SpeechServices
-    monthly_language_input_tokens: 20_000_000
-    monthly_language_output_tokens: 6_666_667
-    monthly_code_interpreter_sessions: 333
-    monthly_base_model_tokens: 1423
-    monthly_fine_tuning_training_hours: 0.2
-    monthly_fine_tuning_hosting_hours: 3.3
-    monthly_fine_tuning_input_tokens: 6_666_667
-    monthly_fine_tuning_output_tokens: 5_000_000
-    monthly_standard_1024_1024_images: 250
-    monthly_standard_1024_1792_images: 125
-    monthly_hd_1024_1024_images: 125
-    monthly_hd_1024_1792_images: 83
-    monthly_text_embedding_tokens: 500_000_000
-    monthly_text_to_speech_characters: 666_667
-    monthly_text_to_speech_hours: 27.8
-    # LUIS
-    monthly_luis_text_requests: 6_667
-    monthly_luis_speech_requests: 1_818
-    # TextAnalytics
-    monthly_language_text_analytics_records: 10_000
-    monthly_language_summarization_records: 5_000
-    monthly_language_conversational_language_understanding_records: 5_000
-    monthly_language_conversational_language_understanding_advanced_training_hours: 3.3
-    monthly_language_customized_text_classification_records: 2_000
-    monthly_language_customized_summarization_records: 2_500
-    monthly_language_customized_question_answering_records: 6_666
-    monthly_language_customized_training_hours: 3.3
-    monthly_language_text_analytics_for_health_records: 2_900
+    monthly_language_input_tokens: 20_000_000 # Monthly number of language input tokens.
+    monthly_language_output_tokens: 6_666_667 # Monthly number of language output tokens.
+    monthly_code_interpreter_sessions: 333 # Monthly number of code interpreter sessions.
+    monthly_base_model_tokens: 1423 # Monthly number of base model tokens.
+    monthly_fine_tuning_training_hours: 0.2 # Monthly number of fine-tuning training hours.
+    monthly_fine_tuning_hosting_hours: 3.3 # Monthly number of fine-tuning hosting hours.
+    monthly_fine_tuning_input_tokens: 6_666_667 # Monthly number of fine-tuning input tokens.
+    monthly_fine_tuning_output_tokens: 5_000_000 # Monthly number of fine-tuning output tokens.
+    monthly_standard_1024_1024_images: 250 # Monthly number of standard 1024x1024 (low res) images.
+    monthly_standard_1024_1792_images: 125 # Monthly number of standard 1024x1792 (high res) images.
+    monthly_hd_1024_1024_images: 125 # Monthly number of HD 1024x1024 (low res) images.
+    monthly_hd_1024_1792_images: 83 # Monthly number of HD 1024x1792 (high res) images.
+    monthly_text_embedding_tokens: 500_000_000 # Monthly number of text embedding tokens.
+    monthly_text_to_speech_characters: 666_667 # Monthly number of text to speech characters.
+    monthly_text_to_speech_hours: 27.8 # Monthly number of text to speech hours.
   azurerm_container_registry:
     storage_gb: 100
     monthly_build_vcpu_hrs: 27.75

--- a/infracost-usage-defaults.small.yml
+++ b/infracost-usage-defaults.small.yml
@@ -441,55 +441,55 @@ resource_type_default_usage:
     monthly_outbound_gb: 61 # Monthly number of outbound data transfers in GB.
     monthly_rules_engine_requests: 8250000 # Monthly number of rules engine requests.
   azurerm_cognitive_account:
-    monthly_speech_to_text_standard_hrs: 5
-    monthly_speech_to_text_standard_batch_hrs: 14
-    monthly_speech_to_text_custom_hrs: 4.3
-    monthly_speech_to_text_custom_batch_hrs: 11
-    monthly_speech_to_text_custom_endpoint_hrs: 93
-    monthly_speech_to_text_custom_training_hrs: 0.5
-    monthly_speech_to_text_enhanced_add_ons_hrs: 17
-    monthly_speech_to_text_conversation_transcription_multi_channel_audio_hrs: 2.4
-    monthly_text_to_speech_neural_chars: 333_333
-    monthly_text_to_speech_custom_neural_training_hrs: 0.1
-    monthly_text_to_speech_custom_neural_chars: 208_333
-    monthly_text_to_speech_custom_neural_endpoint_hrs: 1.3
-    monthly_text_to_speech_long_audio_chars: 50_000
-    monthly_text_to_speech_personal_voice_profiles: 8.3
-    monthly_text_to_speech_personal_voice_chars: 208_333
-    monthly_speech_translation_hrs: 2
-    monthly_speaker_verification_transactions: 1_000
-    monthly_speaker_identification_transactions: 500
-    monthly_voice_profiles: 25_000
+    monthly_speech_to_text_standard_hrs: 5 # Monthly number of hours of Speech to Text audio hours
+    monthly_speech_to_text_standard_batch_hrs: 14 # Monthly number of hours of Speech to Text audio hours for batch processing
+    monthly_speech_to_text_custom_hrs: 4.3  # Monthly number of hours of Speech to Text audio hours for Custom Speech Model
+    monthly_speech_to_text_custom_batch_hrs: 11 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model batch processing
+    monthly_speech_to_text_custom_endpoint_hrs: 93 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model endpoint hosting
+    monthly_speech_to_text_custom_training_hrs: 0.5 # Monthly number of hours of Speech to Text audio hours for Custom Speech Model training
+    monthly_speech_to_text_enhanced_add_ons_hrs: 17 # Monthly number of hours of Speech to Text audio hours for enhanced add-on features
+    monthly_speech_to_text_conversation_transcription_multi_channel_audio_hrs: 2.4 # Monthly number of hours of Speech to Text audio hours for conversation transcription multi-channel audio
+    monthly_text_to_speech_neural_chars: 333_333 # Monthly number of characters for Text to Speech with neural voices
+    monthly_text_to_speech_custom_neural_training_hrs: 0.1 # Monthly number of hours of Text to Speech Customized Neural training
+    monthly_text_to_speech_custom_neural_chars: 208_333 # Monthly number of characters for Text to Speech with Custom Ceural Voices
+    monthly_text_to_speech_custom_neural_endpoint_hrs: 1.3 # Monthly number of hours of Text to Speech Custom Neural Voice endpoint hosting
+    monthly_text_to_speech_long_audio_chars: 50_000 # Monthly number of characters for Text to Speech with Long Audio Creation
+    monthly_text_to_speech_personal_voice_profiles: 8.3 # Monthly number of personal voice profiles for Text to Speech
+    monthly_text_to_speech_personal_voice_chars: 208_333 # Monthly number of characters for Text to Speech with Personal Voice Profiles
+    monthly_speech_translation_hrs: 2 # Monthly number of hours of Speech Translation audio hours
+    monthly_speaker_verification_transactions: 1_000 # Monthly number of speaker verification transactions
+    monthly_speaker_identification_transactions: 500 # Monthly number of speaker identification transactions
+    monthly_voice_profiles: 25_000 # Monthly number of voice profiles
+    # LUIS
+    monthly_luis_text_requests: 3_333 # Monthly number of text requests to LUIS
+    monthly_luis_speech_requests: 909 # Monthly number of speech requests to LUIS
+    # TextAnalytics
+    monthly_language_text_analytics_records: 5_000 # Monthly number of Text Analytics records (Sentiment Analysis, Key Phrase Extraction, Language Detection, Named Entity Recognition, PII Detection)
+    monthly_language_summarization_records: 2_500 # Monthly number of summarization records
+    monthly_language_conversational_language_understanding_records: 2_500 # Monthly number of Conversational Language Understanding and Orchestration Workflow records.
+    monthly_language_conversational_language_understanding_advanced_training_hours: 1.7 # Monthly number of Conversational Language Understanding and Orchestration Workflow advanced training hours.
+    monthly_language_customized_text_classification_records: 1_000 # Monthly number of customized text classification records.
+    monthly_language_customized_summarization_records: 1_250 # Monthly number of customized summarization records.
+    monthly_language_customized_question_answering_records: 3_333 # Monthly number of customized question answering records.
+    monthly_language_customized_training_hours: 1.7 # Monthly number of customized training hours.
+    monthly_language_text_analytics_for_health_records: 1_450 # Monthly number of Text Analytics for health records.
   azurerm_cognitive_deployment:
     # SpeechServices
-    monthly_language_input_tokens: 10_000_000
-    monthly_language_output_tokens: 3_333_333
-    monthly_code_interpreter_sessions: 167
-    monthly_base_model_tokens: 712
-    monthly_fine_tuning_training_hours: 0.1
-    monthly_fine_tuning_hosting_hours: 1.7
-    monthly_fine_tuning_input_tokens: 3_333_333
-    monthly_fine_tuning_output_tokens: 2_500_000
-    monthly_standard_1024_1024_images: 125
-    monthly_standard_1024_1792_images: 63
-    monthly_hd_1024_1024_images: 63
-    monthly_hd_1024_1792_images: 42
-    monthly_text_embedding_tokens: 250_000_000
-    monthly_text_to_speech_characters: 333_333
-    monthly_text_to_speech_hours: 13.9
-    # LUIS
-    monthly_luis_text_requests: 3_333
-    monthly_luis_speech_requests: 909
-    # TextAnalytics
-    monthly_language_text_analytics_records: 5_000
-    monthly_language_summarization_records: 2_500
-    monthly_language_conversational_language_understanding_records: 2_500
-    monthly_language_conversational_language_understanding_advanced_training_hours: 1.7
-    monthly_language_customized_text_classification_records: 1_000
-    monthly_language_customized_summarization_records: 1_250
-    monthly_language_customized_question_answering_records: 3_333
-    monthly_language_customized_training_hours: 1.7
-    monthly_language_text_analytics_for_health_records: 1_450
+    monthly_language_input_tokens: 10_000_000 # Monthly number of language input tokens.
+    monthly_language_output_tokens: 3_333_333 # Monthly number of language output tokens.
+    monthly_code_interpreter_sessions: 167 # Monthly number of code interpreter sessions.
+    monthly_base_model_tokens: 712 # Monthly number of base model tokens.
+    monthly_fine_tuning_training_hours: 0.1 # Monthly number of fine-tuning training hours.
+    monthly_fine_tuning_hosting_hours: 1.7 # Monthly number of fine-tuning hosting hours.
+    monthly_fine_tuning_input_tokens: 3_333_333 # Monthly number of fine-tuning input tokens.
+    monthly_fine_tuning_output_tokens: 2_500_000 # Monthly number of fine-tuning output tokens.
+    monthly_standard_1024_1024_images: 125 # Monthly number of standard 1024x1024 (low res) images.
+    monthly_standard_1024_1792_images: 63 # Monthly number of standard 1024x1792 (high res) images.
+    monthly_hd_1024_1024_images: 63 # Monthly number of HD 1024x1024 (low res) images.
+    monthly_hd_1024_1792_images: 42 # Monthly number of HD 1024x1792 (high res) images.
+    monthly_text_embedding_tokens: 250_000_000 # Monthly number of text embedding tokens.
+    monthly_text_to_speech_characters: 333_333 # Monthly number of text to speech characters.
+    monthly_text_to_speech_hours: 13.9 # Monthly number of text to speech hours.
   azurerm_container_registry:
     storage_gb: 50
     monthly_build_vcpu_hrs: 13.875


### PR DESCRIPTION
The usage default keys should have the same comments so they can be picked up Infracost Cloud for use in the overrides UI.