### PR TITLE
fix: avoid panic when calculating label for block

### DIFF
--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -1298,6 +1298,10 @@ func (b *Block) Key() *string {
 }
 
 func (b *Block) Label() string {
+	if b == nil || b.HCLBlock == nil {
+		return ""
+	}
+
 	return strings.Join(b.HCLBlock.Labels, ".")
 }
 


### PR DESCRIPTION
I wasn't able to reproduce but we got a `runtime error: invalid memory address or nil pointer dereference`.

Stack trace is:
```
   /panic.go:770                                    panic()
   internal/hcl/block.go:1276                       (*Block).Label()
   internal/providers/terraform/hcl_provider.go:412 (*HCLProvider).marshalModule.func1()
   sort/zsortfunc.go:12                             insertionSort_func()
   sort/zsortfunc.go:343                            stable_func()
   sort/slice.go:44                                 SliceStable()
   internal/providers/terraform/hcl_provider.go:411 (*HCLProvider).marshalModule()
   internal/providers/terraform/hcl_provider.go:440 (*HCLProvider).marshalModule()
   internal/providers/terraform/hcl_provider.go:440 (*HCLProvider).marshalModule()
   internal/providers/terraform/hcl_provider.go:440 (*HCLProvider).marshalModule()
   internal/providers/terraform/hcl_provider.go:440 (*HCLProvider).marshalModule()
   internal/providers/terraform/hcl_provider.go:440 (*HCLProvider).marshalModule()
   internal/providers/terraform/hcl_provider.go:382 (*HCLProvider).modulesToPlanJSON()
   internal/providers/terraform/hcl_provider.go:302 (*HCLProvider).LoadPlanJSON()
   internal/providers/terraform/hcl_provider.go:215 (*HCLProvider).LoadResources()
   main/run.go:427                                  (*parallelRunner).runProvider()
   main/run.go:282                                  (*parallelRunner).run.func1()
   golang.org/x/sync/errgroup/errgroup.go:75        (*Group).Go.func1()
   ```