### PR TITLE
Revert "enhance: comment should show skipped resources and projects by default"

### DIFF
--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -62,7 +62,7 @@ func commentCmd(ctx *config.RunContext) *cobra.Command {
 		subCmd.Flags().StringArray("policy-path", nil, "Path to Infracost policy files, glob patterns need quotes (experimental)")
 		subCmd.Flags().Bool("show-all-projects", false, "Show all projects in the table of the comment output")
 		subCmd.Flags().Bool("show-changed", false, "Show only projects in the table that have code changes")
-		subCmd.Flags().Bool("show-skipped", true, "List unsupported resources")
+		subCmd.Flags().Bool("show-skipped", false, "List unsupported resources")
 		_ = subCmd.Flags().MarkHidden("show-changed")
 		subCmd.Flags().Bool("skip-no-diff", false, "Skip posting comment if there are no resource changes. Only applies to update, hide-and-new, and delete-and-new behaviors")
 		_ = subCmd.Flags().MarkHidden("skip-no-diff")

--- a/cmd/infracost/testdata/comment_azure_repos_help/comment_azure_repos_help.golden
+++ b/cmd/infracost/testdata/comment_azure_repos_help/comment_azure_repos_help.golden
@@ -22,7 +22,7 @@ FLAGS
       --pull-request int            Pull request number to post comment on
       --repo-url string             Repository URL, e.g. https://dev.azure.com/my-org/my-project/_git/my-repo
       --show-all-projects           Show all projects in the table of the comment output
-      --show-skipped                List unsupported resources (default true)
+      --show-skipped                List unsupported resources
       --tag string                  Customize hidden markdown tag used to detect comments posted by Infracost
 
 GLOBAL FLAGS

--- a/cmd/infracost/testdata/comment_bitbucket_help/comment_bitbucket_help.golden
+++ b/cmd/infracost/testdata/comment_bitbucket_help/comment_bitbucket_help.golden
@@ -29,7 +29,7 @@ FLAGS
       --pull-request int              Pull request number to post comment on
       --repo string                   Repository in format workspace/repo
       --show-all-projects             Show all projects in the table of the comment output
-      --show-skipped                  List unsupported resources (default true)
+      --show-skipped                  List unsupported resources
       --tag string                    Customize special text used to detect comments posted by Infracost (placed at the bottom of a comment)
 
 GLOBAL FLAGS

--- a/cmd/infracost/testdata/comment_git_hub_help/comment_git_hub_help.golden
+++ b/cmd/infracost/testdata/comment_git_hub_help/comment_git_hub_help.golden
@@ -32,7 +32,7 @@ FLAGS
       --pull-request int                  Pull request number to post comment on, mutually exclusive with commit
       --repo string                       Repository in format owner/repo
       --show-all-projects                 Show all projects in the table of the comment output
-      --show-skipped                      List unsupported resources (default true)
+      --show-skipped                      List unsupported resources
       --tag string                        Customize hidden markdown tag used to detect comments posted by Infracost
 
 GLOBAL FLAGS

--- a/cmd/infracost/testdata/comment_git_hub_no_diff/comment_git_hub_no_diff.golden
+++ b/cmd/infracost/testdata/comment_git_hub_no_diff/comment_git_hub_no_diff.golden
@@ -7,20 +7,11 @@
 
 ```
 ──────────────────────────────────
-The following projects have no cost estimate changes: test (Module path: test)
-Run the following command to see their breakdown: infracost breakdown --path=/path/to/code
 
-──────────────────────────────────
 189 cloud resources were detected:
 ∙ 31 were estimated
 ∙ 152 were free
-∙ 6 are not supported yet, see https://infracost.io/requested-resources:
-  ∙ 1 x aws_ami_from_instance
-  ∙ 1 x aws_appstream_fleet
-  ∙ 1 x aws_appstream_fleet_stack_association
-  ∙ 1 x aws_appstream_stack
-  ∙ 1 x aws_lightsail_instance_public_ports
-  ∙ 1 x aws_route53_vpc_association_authorization
+∙ 6 are not supported yet, rerun with --show-skipped to see details
 ```
 </details>
 

--- a/cmd/infracost/testdata/comment_git_hub_show_all_projects/comment_git_hub_show_all_projects.golden
+++ b/cmd/infracost/testdata/comment_git_hub_show_all_projects/comment_git_hub_show_all_projects.golden
@@ -122,10 +122,7 @@ Percent: +100%
 
 ──────────────────────────────────
 Key: * usage cost, ~ changed, + added, - removed
-The following projects have no cost estimate changes: infracost/infracost/cmd/infracost/testdata/terraform_v0.14_nochange_plan.json
-Run the following command to see their breakdown: infracost breakdown --path=/path/to/code
 
-──────────────────────────────────
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 26 cloud resources were detected:

--- a/cmd/infracost/testdata/comment_git_hub_show_changed_projects/comment_git_hub_show_changed_projects.golden
+++ b/cmd/infracost/testdata/comment_git_hub_show_changed_projects/comment_git_hub_show_changed_projects.golden
@@ -30,10 +30,7 @@
 
 ```
 ──────────────────────────────────
-The following projects have no cost estimate changes: infracost/infracost/internal/hcl/testdata/project_locator/multi_project_with_module/dev (Module path: dev), infracost/infracost/internal/hcl/testdata/project_locator/multi_project_with_module/prod (Module path: prod)
-Run the following command to see their breakdown: infracost breakdown --path=/path/to/code
 
-──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated
 ```

--- a/cmd/infracost/testdata/comment_git_hub_with_additional_comment_path/comment_git_hub_with_additional_comment_path.golden
+++ b/cmd/infracost/testdata/comment_git_hub_with_additional_comment_path/comment_git_hub_with_additional_comment_path.golden
@@ -30,10 +30,7 @@
 
 ```
 ──────────────────────────────────
-The following projects have no cost estimate changes: infracost/infracost/internal/hcl/testdata/project_locator/multi_project_with_module/dev (Module path: dev), infracost/infracost/internal/hcl/testdata/project_locator/multi_project_with_module/prod (Module path: prod)
-Run the following command to see their breakdown: infracost breakdown --path=/path/to/code
 
-──────────────────────────────────
 3 cloud resources were detected:
 ∙ 3 were estimated
 ```

--- a/cmd/infracost/testdata/comment_git_lab_help/comment_git_lab_help.golden
+++ b/cmd/infracost/testdata/comment_git_lab_help/comment_git_lab_help.golden
@@ -28,7 +28,7 @@ FLAGS
       --policy-path stringArray    Path to Infracost policy files, glob patterns need quotes (experimental)
       --repo string                Repository in format owner/repo
       --show-all-projects          Show all projects in the table of the comment output
-      --show-skipped               List unsupported resources (default true)
+      --show-skipped               List unsupported resources
       --tag string                 Customize hidden markdown tag used to detect comments posted by Infracost
 
 GLOBAL FLAGS

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -116,6 +116,8 @@ func ToDiff(out Root, opts Options) ([]byte, error) {
 		s += "──────────────────────────────────"
 	}
 
+	// for now only show the new usage-costs-including comment if the usage api has been enabled
+	// once we have all the other usage cost stuff done this will replace the old comment template
 	if hasDiffProjects {
 		s += "\n"
 		s += usageCostsMessage(out, false)
@@ -161,6 +163,8 @@ func projectTitle(project Project) string {
 }
 
 func tableForDiff(out Root, opts Options) string {
+	// for now only show the new usage-costs in the table if the usage api has been enabled
+	// once we have all the other usage cost stuff done this will replace the old table
 	t := table.NewWriter()
 	t.SetStyle(table.StyleBold)
 	t.Style().Format.Header = text.FormatDefault

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -384,6 +384,8 @@ func filterZeroValResources(resources []Resource, resourceName string) []Resourc
 }
 
 func breakdownSummaryTable(out Root, opts Options) string {
+	// for now only show the new usage-costs in the table if the usage api has been enabled
+	// once we have all the other usage cost stuff done this will replace the old table
 	t := table.NewWriter()
 	t.SetStyle(table.StyleBold)
 	t.Style().Format.Header = text.FormatDefault


### PR DESCRIPTION
Reverts infracost/infracost#3002.

We don't want to show a long list of skipped projects by default, so we might need to adjust the functionality to truncate this or something. For now, I'm reverting this.