### PR TITLE
fix(azure): Fix filters for Dds v5 PostgreSQL Flexible Servers

### DIFF
--- a/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
+++ b/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.golden
@@ -21,6 +21,11 @@
  ├─ Storage                                                           128  GB                      $17.66    
  └─ Additional backup storage                                       5,000  GB                     $475.00  * 
                                                                                                              
+ azurerm_postgresql_flexible_server.d2ds_v5                                                                  
+ ├─ Compute (GP_Standard_D2ds_v5)                                     730  hours                  $148.19    
+ ├─ Storage                                                Monthly cost depends on usage: $0.14 per GB       
+ └─ Additional backup storage                              Monthly cost depends on usage: $0.095 per GB      
+                                                                                                             
  azurerm_postgresql_flexible_server.burstable_b2ms_vcore                                                     
  ├─ Compute (B_Standard_B2ms)                                         730  hours                  $128.48    
  ├─ Storage                                                           128  GB                      $17.66    
@@ -31,17 +36,17 @@
  ├─ Storage                                                Monthly cost depends on usage: $0.12 per GB       
  └─ Additional backup storage                              Monthly cost depends on usage: $0.095 per GB      
                                                                                                              
- OVERALL TOTAL                                                                                  $3,436.55 
+ OVERALL TOTAL                                                                                  $3,584.74 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-7 cloud resources were detected:
-∙ 6 were estimated
+8 cloud resources were detected:
+∙ 7 were estimated
 ∙ 1 was free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ TestPostgreSQLFlexibleServer                       ┃ $2,012        ┃ $1,425      ┃ $3,437     ┃
+┃ TestPostgreSQLFlexibleServer                       ┃ $2,160        ┃ $1,425      ┃ $3,585     ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.tf
+++ b/internal/providers/terraform/azure/testdata/postgresql_flexible_server_test/postgresql_flexible_server_test.tf
@@ -58,3 +58,11 @@ resource "azurerm_postgresql_flexible_server" "readable_location_set" {
   location            = "East US"
   sku_name            = "B_Standard_B1ms"
 }
+
+resource "azurerm_postgresql_flexible_server" "d2ds_v5" {
+  name                = "example-psqlflexibleserver"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  sku_name = "GP_Standard_D2ds_v5"
+}

--- a/internal/resources/azure/postgresql_flexible_server.go
+++ b/internal/resources/azure/postgresql_flexible_server.go
@@ -77,7 +77,7 @@ func (r *PostgreSQLFlexibleServer) computeCostComponent() *schema.CostComponent 
 			Service:       strPtr("Azure Database for PostgreSQL"),
 			ProductFamily: strPtr("Databases"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/^Azure Database for PostgreSQL Flexible Server %s %s/i", attrs.TierName, attrs.Series))},
+				{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/^Azure Database for PostgreSQL Flexible Server %s (?:-\\s)?%s/i", attrs.TierName, attrs.Series))},
 				{Key: "skuName", ValueRegex: regexPtr(fmt.Sprintf("^%s$", attrs.SKUName))},
 				{Key: "meterName", ValueRegex: regexPtr(fmt.Sprintf("^%s$", attrs.MeterName))},
 			},

--- a/internal/resources/azure/postgresql_flexible_server.go
+++ b/internal/resources/azure/postgresql_flexible_server.go
@@ -77,7 +77,7 @@ func (r *PostgreSQLFlexibleServer) computeCostComponent() *schema.CostComponent 
 			Service:       strPtr("Azure Database for PostgreSQL"),
 			ProductFamily: strPtr("Databases"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/^Azure Database for PostgreSQL Flexible Server %s (?:-\\s)?%s/i", attrs.TierName, attrs.Series))},
+				{Key: "productName", ValueRegex: strPtr(fmt.Sprintf("/^%s %s (?:-\\s)?%s/i", attrs.ProductName, attrs.TierName, attrs.Series))},
 				{Key: "skuName", ValueRegex: regexPtr(fmt.Sprintf("^%s$", attrs.SKUName))},
 				{Key: "meterName", ValueRegex: regexPtr(fmt.Sprintf("^%s$", attrs.MeterName))},
 			},
@@ -143,10 +143,11 @@ func (r *PostgreSQLFlexibleServer) backupCostComponent() *schema.CostComponent {
 // flexibleServerFilterAttributes defines CPAPI filter attributes for compute
 // cost component derived from IaC provider's SKU.
 type flexibleServerFilterAttributes struct {
-	SKUName   string
-	TierName  string
-	MeterName string
-	Series    string
+	ProductName string
+	SKUName     string
+	TierName    string
+	MeterName   string
+	Series      string
 }
 
 // getFlexibleServerFilterAttributes returns a struct with CPAPI filter
@@ -159,6 +160,8 @@ func getFlexibleServerFilterAttributes(tier, instanceType, instanceVersion strin
 		"gp": "General Purpose",
 		"mo": "Memory Optimized",
 	}[tier]
+
+	productName := "Azure Database for PostgreSQL Flexible Server"
 
 	if tier == "b" {
 		meterName = fmt.Sprintf("%s[ vcore]*", instanceType)
@@ -173,12 +176,17 @@ func getFlexibleServerFilterAttributes(tier, instanceType, instanceVersion strin
 		skuName = fmt.Sprintf("%s vCore", cores)
 
 		series = coreRegex.ReplaceAllString(instanceType, "") + instanceVersion
+
+		if series == "Esv3" {
+			productName = "Az DB for PGSQL Flexible Server"
+		}
 	}
 
 	return flexibleServerFilterAttributes{
-		SKUName:   skuName,
-		TierName:  tierName,
-		MeterName: meterName,
-		Series:    series,
+		ProductName: productName,
+		SKUName:     skuName,
+		TierName:    tierName,
+		MeterName:   meterName,
+		Series:      series,
 	}
 }


### PR DESCRIPTION
Fixes #3012.

The product name is different for v5:

- `Azure Database for PostgreSQL Flexible Server General Purpose Dadsv5 Series Compute` for Dads v5
- `Azure Database for PostgreSQL Flexible Server General Purpose - Ddsv5 Series Compute` for Dds v5

It also fixes product search for Esv3.