### PR TITLE
fix: close output file

### DIFF
--- a/tools/describezones/main.go
+++ b/tools/describezones/main.go
@@ -165,6 +165,7 @@ func writeOutput(provider string, input []byte) {
 	if err != nil {
 		log.Fatalf("could not create output file: %s", err)
 	}
+	defer f.Close()
 
 	formatted, err := format.Source(input)
 	if err != nil {


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Add a <code>defer</code> statement to ensure the output file is closed after writing in <code>writeOutput</code> function of <code>main.go</code>.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/infracost/infracost/3016?tool=ast&topic=File+Closure>File Closure</a>
        </td><td>Ensure the output file is closed after writing in <code>writeOutput</code>.<details><summary>Modified files (1)</summary><ul><li>tools/describezones/main.go</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>hugorut@gmail.com</td><td>fix-Duplicate-project-...</td><td>May 03, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @testwill and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    