### PR TITLE
fix: don't remove child of errored prior projects that exist in current

### DIFF
--- a/cmd/infracost/diff_test.go
+++ b/cmd/infracost/diff_test.go
@@ -265,6 +265,21 @@ func TestDiffTerragruntNested(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"diff", "--path", "../../examples", "--terraform-force-cli"}, nil)
 }
 
+func TestDiffTerragruntSyntaxError(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"diff",
+			"--compare-to", filepath.Join(dir, "baseline.withouterror.json"),
+			"--config-file", filepath.Join(dir, "infracost.config.yml"),
+		},
+		&GoldenFileOptions{},
+	)
+}
+
 func TestDiffWithTarget(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"diff", "--path", "./testdata/plan_with_target.json"}, nil)
 }

--- a/cmd/infracost/testdata/diff_terragrunt_syntax_error/baseline.withouterror.json
+++ b/cmd/infracost/testdata/diff_terragrunt_syntax_error/baseline.withouterror.json
@@ -1,0 +1,620 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "stub-branch",
+    "vcsCommitSha": "stub-sha",
+    "vcsCommitAuthorName": "stub-author",
+    "vcsCommitAuthorEmail": "stub@stub.com",
+    "vcsCommitTimestamp": "2024-04-16T11:47:36.976505Z",
+    "vcsCommitMessage": "stub-message",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost",
+    "configFilePath": "testdata/diff_terragrunt_syntax_error/infracost.config.yml"
+  },
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "dems-ag1",
+      "metadata": {
+        "path": "testdata/diff_terragrunt_syntax_error/terragrunt/dev",
+        "type": "terragrunt_dir",
+        "terraformModulePath": "terragrunt/dev",
+        "vcsSubPath": "cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/dev"
+      },
+      "pastBreakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app",
+                  "endLine": 40,
+                  "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+                  "startLine": 26
+                }
+              ],
+              "checksum": "9d5686abb1504e7ea06a56c2c1997956424fb39d74039eee65d9fe33e848656e",
+              "endLine": 40,
+              "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+              "startLine": 26
+            },
+            "hourlyCost": "0.0711890410958904115",
+            "monthlyCost": "51.968",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, t2.micro)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.0116",
+                "hourlyCost": "0.0116",
+                "monthlyCost": "8.468"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.0527397260273972615",
+                "monthlyCost": "38.5",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.136986301369863",
+                    "monthlyQuantity": "100",
+                    "price": "0.125",
+                    "hourlyCost": "0.017123287671232875",
+                    "monthlyCost": "12.5"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "0.5479452054794521",
+                    "monthlyQuantity": "400",
+                    "price": "0.065",
+                    "hourlyCost": "0.0356164383561643865",
+                    "monthlyCost": "26"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.hello_world",
+            "resourceType": "aws_lambda_function",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_lambda_function.hello_world",
+                  "endLine": 49,
+                  "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+                  "startLine": 42
+                }
+              ],
+              "checksum": "eb537a4b85bd5ec02439f7e4c8efe78c79f0e9b92a338e9566df0595f4935344",
+              "endLine": 49,
+              "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+              "startLine": 42
+            },
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.2",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true
+              },
+              {
+                "name": "Ephemeral storage",
+                "unit": "GB-seconds",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.0000000309",
+                "hourlyCost": null,
+                "monthlyCost": null
+              },
+              {
+                "name": "Duration (first 6B)",
+                "unit": "GB-seconds",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.0000166667",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "0.0711890410958904115",
+        "totalMonthlyCost": "51.968",
+        "totalMonthlyUsageCost": "0"
+      },
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app",
+                  "endLine": 40,
+                  "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+                  "startLine": 26
+                }
+              ],
+              "checksum": "9d5686abb1504e7ea06a56c2c1997956424fb39d74039eee65d9fe33e848656e",
+              "endLine": 40,
+              "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+              "startLine": 26
+            },
+            "hourlyCost": "0.0711890410958904115",
+            "monthlyCost": "51.968",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, t2.micro)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.0116",
+                "hourlyCost": "0.0116",
+                "monthlyCost": "8.468"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.0527397260273972615",
+                "monthlyCost": "38.5",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.136986301369863",
+                    "monthlyQuantity": "100",
+                    "price": "0.125",
+                    "hourlyCost": "0.017123287671232875",
+                    "monthlyCost": "12.5"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "0.5479452054794521",
+                    "monthlyQuantity": "400",
+                    "price": "0.065",
+                    "hourlyCost": "0.0356164383561643865",
+                    "monthlyCost": "26"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.hello_world",
+            "resourceType": "aws_lambda_function",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_lambda_function.hello_world",
+                  "endLine": 49,
+                  "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+                  "startLine": 42
+                }
+              ],
+              "checksum": "eb537a4b85bd5ec02439f7e4c8efe78c79f0e9b92a338e9566df0595f4935344",
+              "endLine": 49,
+              "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+              "startLine": 42
+            },
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.2",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true
+              },
+              {
+                "name": "Ephemeral storage",
+                "unit": "GB-seconds",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.0000000309",
+                "hourlyCost": null,
+                "monthlyCost": null
+              },
+              {
+                "name": "Duration (first 6B)",
+                "unit": "GB-seconds",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.0000166667",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "0.0711890410958904115",
+        "totalMonthlyCost": "51.968",
+        "totalMonthlyUsageCost": "0"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 2,
+        "totalSupportedResources": 2,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 2,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
+      }
+    },
+    {
+      "name": "dems-ag1",
+      "metadata": {
+        "path": "testdata/diff_terragrunt_syntax_error/terragrunt/prod",
+        "type": "terragrunt_dir",
+        "terraformModulePath": "terragrunt/prod",
+        "vcsSubPath": "cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/prod"
+      },
+      "pastBreakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app",
+                  "endLine": 40,
+                  "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+                  "startLine": 26
+                }
+              ],
+              "checksum": "68a408f4bf19420a57d0faab69d346b9c160280a7d3c172938837f9744a288c9",
+              "endLine": 40,
+              "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+              "startLine": 26
+            },
+            "hourlyCost": "1.024164383561643829",
+            "monthlyCost": "747.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.0136986301369863",
+                "monthlyCost": "10",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.136986301369863",
+                    "monthlyQuantity": "100",
+                    "price": "0.1",
+                    "hourlyCost": "0.0136986301369863",
+                    "monthlyCost": "10"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.hello_world",
+            "resourceType": "aws_lambda_function",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_lambda_function.hello_world",
+                  "endLine": 49,
+                  "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+                  "startLine": 42
+                }
+              ],
+              "checksum": "60a2f83ce9c8af13318d4885d554022ed5896a97e8c930a156f612b7274eb8cc",
+              "endLine": 49,
+              "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+              "startLine": 42
+            },
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.2",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true
+              },
+              {
+                "name": "Ephemeral storage",
+                "unit": "GB-seconds",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.0000000309",
+                "hourlyCost": null,
+                "monthlyCost": null
+              },
+              {
+                "name": "Duration (first 6B)",
+                "unit": "GB-seconds",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.0000166667",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.024164383561643829",
+        "totalMonthlyCost": "747.64",
+        "totalMonthlyUsageCost": "0"
+      },
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app",
+                  "endLine": 40,
+                  "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+                  "startLine": 26
+                }
+              ],
+              "checksum": "68a408f4bf19420a57d0faab69d346b9c160280a7d3c172938837f9744a288c9",
+              "endLine": 40,
+              "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+              "startLine": 26
+            },
+            "hourlyCost": "1.024164383561643829",
+            "monthlyCost": "747.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.0136986301369863",
+                "monthlyCost": "10",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.136986301369863",
+                    "monthlyQuantity": "100",
+                    "price": "0.1",
+                    "hourlyCost": "0.0136986301369863",
+                    "monthlyCost": "10"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.hello_world",
+            "resourceType": "aws_lambda_function",
+            "tags": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_lambda_function.hello_world",
+                  "endLine": 49,
+                  "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+                  "startLine": 42
+                }
+              ],
+              "checksum": "60a2f83ce9c8af13318d4885d554022ed5896a97e8c930a156f612b7274eb8cc",
+              "endLine": 49,
+              "filename": "testdata/.infracost/.terragrunt-cache/Ry51B17-5L-TUeogwjy_Ie214sw-UE5g00fnu6Xl8bU4Czra1P4YRNg/modules/example/main.tf",
+              "startLine": 42
+            },
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.2",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true
+              },
+              {
+                "name": "Ephemeral storage",
+                "unit": "GB-seconds",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.0000000309",
+                "hourlyCost": null,
+                "monthlyCost": null
+              },
+              {
+                "name": "Duration (first 6B)",
+                "unit": "GB-seconds",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.0000166667",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.024164383561643829",
+        "totalMonthlyCost": "747.64",
+        "totalMonthlyUsageCost": "0"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 2,
+        "totalSupportedResources": 2,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 2,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
+      }
+    }
+  ],
+  "totalHourlyCost": "1.0953534246575342405",
+  "totalMonthlyCost": "799.608",
+  "totalMonthlyUsageCost": "0",
+  "pastTotalHourlyCost": "1.0953534246575342405",
+  "pastTotalMonthlyCost": "799.608",
+  "pastTotalMonthlyUsageCost": "0",
+  "diffTotalHourlyCost": "0",
+  "diffTotalMonthlyCost": "0",
+  "diffTotalMonthlyUsageCost": "0",
+  "timeGenerated": "2024-04-16T11:47:36.976505Z",
+  "summary": {
+    "totalDetectedResources": 4,
+    "totalSupportedResources": 4,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 4,
+    "totalNoPriceResources": 0,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {}
+  }
+}

--- a/cmd/infracost/testdata/diff_terragrunt_syntax_error/diff_terragrunt_syntax_error.golden
+++ b/cmd/infracost/testdata/diff_terragrunt_syntax_error/diff_terragrunt_syntax_error.golden
@@ -1,0 +1,16 @@
+──────────────────────────────────
+Project: dems-ag1
+Errors:
+  Error processing module at 'REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/dev/terragrunt.hcl'. How this module was found:
+    Terragrunt config file found in a subdirectory of testdata/diff_terragrunt_syntax_error/terragrunt/dev. Underlying error:
+      REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/dev/terragrunt.hcl:16,1-1:
+        Missing expression; Expected the start of an expression, but found the end of the file.
+
+──────────────────────────────────
+
+2 cloud resources were detected:
+∙ 2 were estimated
+
+Err:
+
+

--- a/cmd/infracost/testdata/diff_terragrunt_syntax_error/infracost.config.yml
+++ b/cmd/infracost/testdata/diff_terragrunt_syntax_error/infracost.config.yml
@@ -1,0 +1,4 @@
+version: 0.1
+projects:
+      - path: ./testdata/diff_terragrunt_syntax_error/terragrunt
+        name: dems-ag1

--- a/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/dev/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type = "t2.micro"
+  root_block_device_volume_size = 50
+  block_device_volume_size = 100
+  block_device_iops = 400
+  hello_world_function_memory_size = 512
+

--- a/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/modules/example/main.tf
+++ b/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/modules/example/main.tf
@@ -1,0 +1,49 @@
+variable "instance_type" {
+  description = "The EC2 instance type for the web app"
+  type        = string
+}
+
+variable "root_block_device_volume_size" {
+  description = "The size of the root block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_volume_size" {
+  description = "The size of the block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_iops" {
+  description = "The number of IOPS for the block device for the web app EC2 instance"
+  type        = number
+}
+
+variable "hello_world_function_memory_size" {
+  description = "The memory to allocate to the hello world Lambda function"
+  type        = number
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = var.root_block_device_volume_size
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = var.block_device_volume_size
+    iops        = var.block_device_iops
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:aws:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  filename      = "function.zip"
+  memory_size   = var.hello_world_function_memory_size
+}

--- a/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/prod/terragrunt.hcl
+++ b/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/prod/terragrunt.hcl
@@ -1,0 +1,16 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type = "m5.4xlarge"
+  root_block_device_volume_size = 100
+  block_device_volume_size = 1000
+  block_device_iops = 800
+  
+  hello_world_function_memory_size = 1024
+}

--- a/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/terragrunt.hcl
+++ b/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+  aws_region = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+}
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region                      = "${local.aws_region}"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+EOF
+}

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -112,6 +112,10 @@ func LoadPaths(paths []string) ([]ReportInput, error) {
 // in the prior Root. If we can't find a matching project then we assume that the project
 // has been newly created and will show a 100% increase in the output Root.
 func CompareTo(c *config.Config, current, prior Root) (Root, error) {
+	currentProjectLabels := make(map[string]bool, len(current.Projects))
+	for _, p := range current.Projects {
+		currentProjectLabels[p.LabelWithMetadata()] = true
+	}
 	priorProjects := make(map[string]*schema.Project)
 	for _, p := range prior.Projects {
 		if _, ok := priorProjects[p.LabelWithMetadata()]; ok {
@@ -162,6 +166,10 @@ func CompareTo(c *config.Config, current, prior Root) (Root, error) {
 			delete(priorProjects, metadata)
 		} else if children := findChildrenOfErroredProject(p, priorProjects); len(children) > 0 {
 			for _, child := range children {
+				if _, ok := currentProjectLabels[child]; ok {
+					// this child has a match in the current projects so it should not be deleted
+					continue
+				}
 				delete(priorProjects, child)
 			}
 		}


### PR DESCRIPTION
If a nested terragrunt project has syntax errors, the error is reported at the parent project path. To prevent the child project from appearing as "removed" when diff'd against a baseline without the syntax error, we search for and remove child projects of the parent path. BUT, since some child projects may have been processed successfully, we should only remove past children that don't exist in the current.