### PR TITLE
fix: dynamic block names in logs

### DIFF
--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -1116,7 +1116,21 @@ func (b *Block) Reference() *Reference {
 
 	var parts []string
 
-	if b.Type() != "resource" || b.parent != nil {
+	parent := b.parent
+	for parent != nil {
+		var parentParts []string
+
+		if parent.Type() != "resource" {
+			parentParts = append(parentParts, parent.Type())
+		}
+
+		parentParts = append(parentParts, parent.Labels()...)
+
+		parts = append(parentParts, parts...)
+		parent = parent.parent
+	}
+
+	if b.Type() != "resource" {
 		parts = append(parts, b.Type())
 	}
 

--- a/internal/hcl/block_test.go
+++ b/internal/hcl/block_test.go
@@ -46,6 +46,56 @@ func TestBlock_LocalName(t *testing.T) {
 			},
 			want: "data.my-block.my-name",
 		},
+		{
+			name: "dynamic block inside resource blocks will return reference with parent blocks",
+			block: &Block{
+				HCLBlock: &hcl.Block{
+					Type:   "content",
+					Labels: []string{},
+				},
+				parent: &Block{
+					HCLBlock: &hcl.Block{
+						Type:   "dynamic",
+						Labels: []string{"my-dynamic-block"},
+					},
+					logger: newDiscardLogger(),
+					parent: &Block{
+						HCLBlock: &hcl.Block{
+							Type:   "resource",
+							Labels: []string{"my-resource", "my-name"},
+						},
+						logger: newDiscardLogger(),
+					},
+				},
+				logger: newDiscardLogger(),
+			},
+			want: "my-resource.my-name.dynamic.my-dynamic-block.content",
+		},
+		{
+			name: "dynamic block inside data blocks will return reference with parent blocks",
+			block: &Block{
+				HCLBlock: &hcl.Block{
+					Type:   "content",
+					Labels: []string{},
+				},
+				parent: &Block{
+					HCLBlock: &hcl.Block{
+						Type:   "dynamic",
+						Labels: []string{"my-dynamic-block"},
+					},
+					logger: newDiscardLogger(),
+					parent: &Block{
+						HCLBlock: &hcl.Block{
+							Type:   "data",
+							Labels: []string{"my-block", "my-name"},
+						},
+						logger: newDiscardLogger(),
+					},
+				},
+				logger: newDiscardLogger(),
+			},
+			want: "data.my-block.my-name.dynamic.my-dynamic-block.content",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/hcl/reference.go
+++ b/internal/hcl/reference.go
@@ -29,11 +29,14 @@ func newReference(parts []string) (*Reference, error) {
 
 	ref.blockType = *blockType
 
+	remainderIndex := 3
+
 	if ref.blockType.removeTypeInReference && parts[0] != blockType.name {
 		ref.typeLabel = parts[0]
 		if len(parts) > 1 {
 			ref.nameLabel = parts[1]
 		}
+		remainderIndex = 2
 	} else if len(parts) > 1 {
 		ref.typeLabel = parts[1]
 		if len(parts) > 2 {
@@ -50,8 +53,8 @@ func newReference(parts []string) (*Reference, error) {
 		ref.key = "[" + bits[1]
 	}
 
-	if len(parts) > 3 {
-		ref.remainder = parts[3:]
+	if len(parts) > remainderIndex {
+		ref.remainder = parts[remainderIndex:]
 	}
 
 	return &ref, nil


### PR DESCRIPTION
Previously these appeared in logs as `block_name=content.` This now fixes it so it shows `block_name=aws_security_group.my_sg.dynamic.ingress.content`.

We do this by looping through any parent blocks and prefixing the block name with their labels.