### PR TITLE
feat: support wildcards for autodetect `envNames`

### DIFF
--- a/cmd/infracost/testdata/generate/wildcard_env_names/expected.golden
+++ b/cmd/infracost/testdata/generate/wildcard_env_names/expected.golden
@@ -1,0 +1,34 @@
+version: 0.1
+
+projects:
+  - path: terraform
+    name: terraform-conf-dev-foo
+    terraform_var_files:
+      - env/conf-dev-foo.tfvars
+    skip_autodetect: true
+  - path: terraform
+    name: terraform-conf-prod-foo
+    terraform_var_files:
+      - env/conf-prod-foo.tfvars
+    skip_autodetect: true
+  - path: terraform
+    name: terraform-dev
+    terraform_var_files:
+      - env/dev.tfvars
+    skip_autodetect: true
+  - path: terraform
+    name: terraform-ops-dev
+    terraform_var_files:
+      - env/ops-dev.tfvars
+    skip_autodetect: true
+  - path: terraform
+    name: terraform-ops-prod-bar
+    terraform_var_files:
+      - env/ops-prod-bar.tfvars
+    skip_autodetect: true
+  - path: terraform
+    name: terraform-ops-prod-foo
+    terraform_var_files:
+      - env/ops-prod-foo.tfvars
+    skip_autodetect: true
+

--- a/cmd/infracost/testdata/generate/wildcard_env_names/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/wildcard_env_names/infracost.yml.tmpl
@@ -1,0 +1,7 @@
+version: 0.1
+autodetect:
+  env_names:
+    - ops-*
+    - conf-*
+    - dev
+

--- a/cmd/infracost/testdata/generate/wildcard_env_names/tree.txt
+++ b/cmd/infracost/testdata/generate/wildcard_env_names/tree.txt
@@ -1,0 +1,10 @@
+.
+└── terraform
+    ├── env
+    │   ├── ops-prod-foo.tfvars
+    │   ├── ops-prod-bar.tfvars
+    │   ├── ops-dev.tfvars
+    │   ├── conf-dev-foo.tfvars
+    │   ├── dev.tfvars
+    │   └── conf-prod-foo.tfvars
+    └── main.tf


### PR DESCRIPTION
Adds support for wildcard naming in autodetect `envNames` configuration. This enables users to define conventions for env names that can dynamically expand in the future. This greatly reduces the burden of managing the envNames section and makes it more maintainable.