### PR TITLE
feat: readd templatefile support

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1322,3 +1322,43 @@ func TestBreakdownSkipAutodetectionIfTerraformVarFilePassed(t *testing.T) {
 		nil,
 	)
 }
+
+func TestBreakdownTerragruntFileFuncs(t *testing.T) {
+	if os.Getenv("GITHUB_ACTIONS") == "" {
+		t.Skip("skipping as this test is only designed for GitHub Actions")
+	}
+
+	t.Setenv("INFRACOST_CI_PLATFORM", "github_app")
+
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", dir,
+		},
+		&GoldenFileOptions{IgnoreLogs: true, IgnoreNonGraph: true},
+	)
+}
+
+func TestBreakdownTerraformFileFuncs(t *testing.T) {
+	if os.Getenv("GITHUB_ACTIONS") == "" {
+		t.Skip("skipping as this test is only designed for GitHub Actions")
+	}
+
+	t.Setenv("INFRACOST_CI_PLATFORM", "github_app")
+
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", dir,
+		},
+		&GoldenFileOptions{IgnoreLogs: true, IgnoreNonGraph: true},
+	)
+}

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -41,6 +41,7 @@ type GoldenFileOptions = struct {
 	// RunTerraformCLI sets the cmd test to also run the cmd with --terraform-force-cli set
 	RunTerraformCLI bool
 	IgnoreNonGraph  bool
+	IgnoreLogs      bool
 }
 
 func DefaultOptions() *GoldenFileOptions {
@@ -130,7 +131,7 @@ func GetCommandOutput(t *testing.T, args []string, testOptions *GoldenFileOption
 
 		if testOptions.CaptureLogs {
 			logBuf = testutil.ConfigureTestToCaptureLogs(t, c)
-		} else {
+		} else if !testOptions.IgnoreLogs {
 			testutil.ConfigureTestToFailOnLogs(t, c)
 		}
 

--- a/cmd/infracost/testdata/breakdown_terraform_file_funcs/breakdown_terraform_file_funcs.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_file_funcs/breakdown_terraform_file_funcs.golden
@@ -1,0 +1,165 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terraform_file_funcs
+
+ Name                                                                         Monthly Qty  Unit   Monthly Cost   
+                                                                                                                 
+ module.mod_files.aws_instance.file["cd"]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.2xlarge)                                730  hours       $280.32   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["abs"]                                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                                  730  hours        $70.08   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["cd"]                                                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                                  730  hours        $70.08   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.file["rootcd"]                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                                  730  hours        $70.08   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.template_file["abs"]                                                                               
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)                                  730  hours         $8.47   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.template_file["cd"]                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)                                  730  hours         $8.47   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["pd"]                                                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["pdabs"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["sym"]                                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["abs"]                                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, e)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["cd"]                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, e)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["pd"]                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, ne)                                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["pdabs"]                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, ne)                                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["sym"]                                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, ne)                                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["abs"]                                                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, f6ccad7be10c3d1fbedee0c976c942b9)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["cd"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, f6ccad7be10c3d1fbedee0c976c942b9)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["pd"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, d41d8cd98f00b204e9800998ecf8427e)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["pdabs"]                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, d41d8cd98f00b204e9800998ecf8427e)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["sym"]                                                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, d41d8cd98f00b204e9800998ecf8427e)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileset["abs"]                                                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, 1)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileset["cd"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, 1)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileset["pd"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, 0)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileset["pdabs"]                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, 0)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.template_file["pd"]                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.template_file["pdabs"]                                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.file["pd"]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, )                                          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.fileexists["cd"]                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, e)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.fileexists["pd"]                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, ne)                                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.fileexists["rootcd"]                                                              
+ ├─ Instance usage (Linux/UNIX, on-demand, e)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ OVERALL TOTAL                                                                                        $530.70 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+29 cloud resources were detected:
+∙ 29 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...breakdown_terraform_file_funcs ┃ $531          ┃ $0.00       ┃ $531       ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terraform_file_funcs/instance.json
+++ b/cmd/infracost/testdata/breakdown_terraform_file_funcs/instance.json
@@ -1,0 +1,3 @@
+{
+ "instance_type": "m5.large"
+}

--- a/cmd/infracost/testdata/breakdown_terraform_file_funcs/main.tf
+++ b/cmd/infracost/testdata/breakdown_terraform_file_funcs/main.tf
@@ -1,0 +1,70 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+locals {
+  files = [
+    { name = "cd", file = "instance.json", },
+    { name = "sym", file = "sym-instance.json", },
+    { name = "pd", file = "../../../testdata/instance.json", },
+    {
+      name = "abs",
+      file = "/home/runner/work/infracost/infracost/cmd/infracost/testdata/breakdown_terraform_file_funcs/instance.json",
+    },
+    { name = "pdabs", file = "/home/runner/work/infracost/infracost/cmd/testdata/instance.json", },
+  ]
+  dirs = [
+    { name = "cd", dir = "." },
+    { name = "pd", dir = "../../../testdata" },
+    { name = "abs", dir = "/home/runner/work/infracost/infracost/cmd/infracost/testdata/breakdown_terraform_file_funcs/" },
+    { name = "pdabs", dir = "/home/runner/work/infracost/infracost/cmd/testdata/" },
+
+  ]
+  template_files = [
+    { name = "cd", file = "templ.tftpl", },
+    { name = "pd", file = "../../../testdata/templ.tftpl", },
+    {
+      name = "abs", file = "/home/runner/work/infracost/infracost/cmd/infracost/testdata/breakdown_terraform_file_funcs/templ.tftpl",
+    },
+    { name = "pdabs", file = "/home/runner/work/infracost/infracost/cmd/testdata/templ.tftpl", }
+  ]
+}
+
+resource "aws_instance" "file" {
+  for_each = { for f in local.files : f.name => f.file }
+
+  ami           = "ami-674cbc1e"
+  instance_type = jsondecode(file(each.value)).instance_type
+}
+
+module "mod_files" {
+  source = "./modules/test"
+}
+
+resource "aws_instance" "fileexists" {
+  for_each      = { for f in local.files : f.name => f.file }
+  ami           = "ami-674cbc1e"
+  instance_type = fileexists(each.value) ? "e" : "ne"
+}
+
+resource "aws_instance" "fileset" {
+  for_each      = { for f in local.dirs : f.name => f.dir }
+  ami           = "ami-674cbc1e"
+  instance_type = length(fileset(each.value, "*.json"))
+}
+
+resource "aws_instance" "filemd5" {
+  for_each      = { for f in local.files : f.name => f.file }
+  ami           = "ami-674cbc1e"
+  instance_type = filemd5(each.value)
+}
+
+resource "aws_instance" "template_file" {
+  for_each      = { for f in local.template_files : f.name => f.file }
+  ami           = "ami-674cbc1e"
+  instance_type = jsondecode(templatefile(each.value, {})).instance_type
+}

--- a/cmd/infracost/testdata/breakdown_terraform_file_funcs/modules/test/instance.json
+++ b/cmd/infracost/testdata/breakdown_terraform_file_funcs/modules/test/instance.json
@@ -1,0 +1,3 @@
+{
+ "instance_type": "m5.2xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_terraform_file_funcs/modules/test/main.tf
+++ b/cmd/infracost/testdata/breakdown_terraform_file_funcs/modules/test/main.tf
@@ -1,0 +1,21 @@
+locals {
+  files = [
+    { name = "cd", file = "${path.module}/instance.json", },
+    { name = "rootcd", file = "${path.module}/../../instance.json", },
+    { name = "pd", file = "${path.module}/../../../../testdata/instance.json", },
+  ]
+}
+
+resource "aws_instance" "file" {
+  for_each = { for f in local.files : f.name => f.file }
+
+  ami           = "ami-674cbc1e"
+  instance_type = jsondecode(file(each.value)).instance_type
+}
+
+resource "aws_instance" "fileexists" {
+  for_each = { for f in local.files : f.name => f.file }
+
+  ami           = "ami-674cbc1e"
+  instance_type = fileexists(each.value) ? "e" : "ne"
+}

--- a/cmd/infracost/testdata/breakdown_terraform_file_funcs/sym-instance.json
+++ b/cmd/infracost/testdata/breakdown_terraform_file_funcs/sym-instance.json
@@ -1,0 +1,1 @@
+../../../testdata/instance.json

--- a/cmd/infracost/testdata/breakdown_terraform_file_funcs/templ.tftpl
+++ b/cmd/infracost/testdata/breakdown_terraform_file_funcs/templ.tftpl
@@ -1,0 +1,3 @@
+${jsonencode({
+"instance_type": "t2.micro",
+})}

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/breakdown_terragrunt_file_funcs.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/breakdown_terragrunt_file_funcs.golden
@@ -1,0 +1,165 @@
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_file_funcs
+
+ Name                                                                         Monthly Qty  Unit   Monthly Cost   
+                                                                                                                 
+ module.mod_files.aws_instance.file["cd"]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.2xlarge)                                730  hours       $280.32   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["abs"]                                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                                  730  hours        $70.08   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["cd"]                                                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                                  730  hours        $70.08   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.file["rootcd"]                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                                  730  hours        $70.08   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.template_file["abs"]                                                                               
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)                                  730  hours         $8.47   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.template_file["cd"]                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)                                  730  hours         $8.47   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["pd"]                                                                                         
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["pdabs"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.file["sym"]                                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["abs"]                                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, e)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["cd"]                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, e)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["pd"]                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, ne)                                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["pdabs"]                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, ne)                                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileexists["sym"]                                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, ne)                                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["abs"]                                                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, f6ccad7be10c3d1fbedee0c976c942b9)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["cd"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, f6ccad7be10c3d1fbedee0c976c942b9)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["pd"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, d41d8cd98f00b204e9800998ecf8427e)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["pdabs"]                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, d41d8cd98f00b204e9800998ecf8427e)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.filemd5["sym"]                                                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, d41d8cd98f00b204e9800998ecf8427e)          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileset["abs"]                                                                                     
+ ├─ Instance usage (Linux/UNIX, on-demand, 1)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileset["cd"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, 1)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileset["pd"]                                                                                      
+ ├─ Instance usage (Linux/UNIX, on-demand, 0)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.fileset["pdabs"]                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, 0)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.template_file["pd"]                                                                                
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ aws_instance.template_file["pdabs"]                                                                             
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-mock)                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.file["pd"]                                                                        
+ ├─ Instance usage (Linux/UNIX, on-demand, )                                          730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.fileexists["cd"]                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, e)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.fileexists["pd"]                                                                  
+ ├─ Instance usage (Linux/UNIX, on-demand, ne)                                        730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ module.mod_files.aws_instance.fileexists["rootcd"]                                                              
+ ├─ Instance usage (Linux/UNIX, on-demand, e)                                         730  hours         $0.00   
+ └─ root_block_device                                                                                            
+    └─ Storage (general purpose SSD, gp2)                                               8  GB            $0.80   
+                                                                                                                 
+ OVERALL TOTAL                                                                                        $530.70 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+29 cloud resources were detected:
+∙ 29 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                                          ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ infracost/infracost/cmd/infraco...reakdown_terragrunt_file_funcs ┃ $531          ┃ $0.00       ┃ $531       ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/instance.json
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/instance.json
@@ -1,0 +1,3 @@
+{
+ "instance_type": "m5.large"
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/main.tf
@@ -1,0 +1,70 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+locals {
+  files = [
+    { name = "cd", file = "instance.json", },
+    { name = "sym", file = "sym-instance.json", },
+    { name = "pd", file = "../../../testdata/instance.json", },
+    {
+      name = "abs",
+      file = "/home/runner/work/infracost/infracost/cmd/infracost/testdata/breakdown_terraform_file_funcs/instance.json",
+    },
+    { name = "pdabs", file = "/home/runner/work/infracost/infracost/cmd/testdata/instance.json", },
+  ]
+  dirs = [
+    { name = "cd", dir = "." },
+    { name = "pd", dir = "../../../testdata" },
+    { name = "abs", dir = "/home/runner/work/infracost/infracost/cmd/infracost/testdata/breakdown_terraform_file_funcs/" },
+    { name = "pdabs", dir = "/home/runner/work/infracost/infracost/cmd/testdata/" },
+
+  ]
+  template_files = [
+    { name = "cd", file = "templ.tftpl", },
+    { name = "pd", file = "../../../testdata/templ.tftpl", },
+    {
+      name = "abs", file = "/home/runner/work/infracost/infracost/cmd/infracost/testdata/breakdown_terraform_file_funcs/templ.tftpl",
+    },
+    { name = "pdabs", file = "/home/runner/work/infracost/infracost/cmd/testdata/templ.tftpl", }
+  ]
+}
+
+resource "aws_instance" "file" {
+  for_each = { for f in local.files : f.name => f.file }
+
+  ami           = "ami-674cbc1e"
+  instance_type = jsondecode(file(each.value)).instance_type
+}
+
+module "mod_files" {
+  source = "./modules/test"
+}
+
+resource "aws_instance" "fileexists" {
+  for_each      = { for f in local.files : f.name => f.file }
+  ami           = "ami-674cbc1e"
+  instance_type = fileexists(each.value) ? "e" : "ne"
+}
+
+resource "aws_instance" "fileset" {
+  for_each      = { for f in local.dirs : f.name => f.dir }
+  ami           = "ami-674cbc1e"
+  instance_type = length(fileset(each.value, "*.json"))
+}
+
+resource "aws_instance" "filemd5" {
+  for_each      = { for f in local.files : f.name => f.file }
+  ami           = "ami-674cbc1e"
+  instance_type = filemd5(each.value)
+}
+
+resource "aws_instance" "template_file" {
+  for_each      = { for f in local.template_files : f.name => f.file }
+  ami           = "ami-674cbc1e"
+  instance_type = jsondecode(templatefile(each.value, {})).instance_type
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/modules/test/instance.json
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/modules/test/instance.json
@@ -1,0 +1,3 @@
+{
+ "instance_type": "m5.2xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/modules/test/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/modules/test/main.tf
@@ -1,0 +1,21 @@
+locals {
+  files = [
+    { name = "cd", file = "${path.module}/instance.json", },
+    { name = "rootcd", file = "${path.module}/../../instance.json", },
+    { name = "pd", file = "${path.module}/../../../../testdata/instance.json", },
+  ]
+}
+
+resource "aws_instance" "file" {
+  for_each = { for f in local.files : f.name => f.file }
+
+  ami           = "ami-674cbc1e"
+  instance_type = jsondecode(file(each.value)).instance_type
+}
+
+resource "aws_instance" "fileexists" {
+  for_each = { for f in local.files : f.name => f.file }
+
+  ami           = "ami-674cbc1e"
+  instance_type = fileexists(each.value) ? "e" : "ne"
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/sym-instance.json
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/sym-instance.json
@@ -1,0 +1,1 @@
+../../../testdata/instance.json

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/templ.tftpl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/templ.tftpl
@@ -1,0 +1,3 @@
+${jsonencode({
+"instance_type": "t2.micro",
+})}

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/terragrunt.hcl
@@ -1,0 +1,5 @@
+inputs = {
+  get_aws_account_id = get_aws_account_id()
+  get_aws_caller_identity_arn = get_aws_caller_identity_arn()
+  get_aws_caller_identity_user_id = get_aws_caller_identity_user_id()
+}

--- a/cmd/testdata/instance.json
+++ b/cmd/testdata/instance.json
@@ -1,0 +1,3 @@
+{
+ "instance_type": "m5.8xlarge"
+}

--- a/cmd/testdata/templ.tftpl
+++ b/cmd/testdata/templ.tftpl
@@ -1,0 +1,3 @@
+${jsonencode({
+"instance_type": "m5.12xlarge",
+})}

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -1150,7 +1150,7 @@ func (e *Evaluator) loadModules(lastContext hcl.EvalContext) {
 // ExpFunctions returns the set of functions that should be used to when evaluating
 // expressions in the receiving scope.
 func ExpFunctions(baseDir string, logger zerolog.Logger) map[string]function.Function {
-	return map[string]function.Function{
+	fns := map[string]function.Function{
 		"abs":              stdlib.AbsoluteFunc,
 		"abspath":          funcs.AbsPathFunc,
 		"basename":         funcs.BasenameFunc,
@@ -1261,4 +1261,9 @@ func ExpFunctions(baseDir string, logger zerolog.Logger) map[string]function.Fun
 		"zipmap":           stdlib.ZipmapFunc,
 	}
 
+	fns["templatefile"] = funcs.MakeTemplateFileFunc(baseDir, func() map[string]function.Function {
+		return fns
+	})
+
+	return fns
 }

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -459,6 +459,9 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 
 			funcs["run_cmd"] = mockSliceFuncStaticReturn(cty.StringVal("run_cmd-mock"))
 			funcs["sops_decrypt_file"] = mockSliceFuncStaticReturn(cty.StringVal("sops_decrypt_file-mock"))
+			funcs["get_aws_account_id"] = mockSliceFuncStaticReturn(cty.StringVal("account_id-mock"))
+			funcs["get_aws_caller_identity_arn"] = mockSliceFuncStaticReturn(cty.StringVal("arn:aws:iam::123456789012:user/terragrunt-mock"))
+			funcs["get_aws_caller_identity_user_id"] = mockSliceFuncStaticReturn(cty.StringVal("caller_identity_user_id-mock"))
 
 			return funcs
 		},


### PR DESCRIPTION
Changes `isPathInRepo` to use wd directory instead of `RepoPath` which is likely incorrect for Terragrunt projects.

The `RepoPath` property that is infered from detected projects was returning full project path for detected projects when the autdetected project was inferred from a config file. A fix for this will be addressed in a further PR.

To fix the templatefile logic I've opted to use the os working directory instead, as this is more robust.