### PR TITLE
bug: debug-report panics

### DIFF
--- a/cmd/infracost/main.go
+++ b/cmd/infracost/main.go
@@ -102,7 +102,7 @@ type debugWriter struct {
 
 func (d debugWriter) Write(p []byte) (n int, err error) {
 	p = bytes.Trim(p, " \n\t")
-	return d.f.Write(append(p, []byte(",\n")...))
+	return d.f.Write(append(p, []byte("\n")...))
 }
 
 func newRootCmd(ctx *config.RunContext) *cobra.Command {


### PR DESCRIPTION
This resolves an issue where the debug-report panics when the
`--debug-report` argument is passed. This looks like its because more
characters are being assumed to have been removed that have so
simplifying it by removing the comma

Resolves #3011

### Before
```
INFRACOST_ENV=dev go run ./cmd/infracost breakdown --path examples/terraform --debug-report
panic: bytes.Buffer.WriteTo: invalid Write count [recovered]
        panic: bytes.Buffer.WriteTo: invalid Write count

goroutine 1 [running]:
bytes.(*Buffer).WriteTo(0x140005a1d70, {0x103048338?, 0x14000092d80?})
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/bytes/buffer.go:263 +0x108
github.com/rs/zerolog.ConsoleWriter.Write({{0x103048338, 0x14000092d80}, 0x1, {0x101c0f986, 0x19}, {0x140004b7280, 0x4, 0x4}, {0x0, 0x0, ...}, ...}, ...)
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/console.go:145 +0x454
github.com/rs/zerolog.LevelWriterAdapter.WriteLevel(...)
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/writer.go:27
github.com/rs/zerolog.(*Event).write(0x140004c8230)
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/event.go:80 +0x12c
github.com/rs/zerolog.(*Event).msg(0x140004c8230, {0x140009192c0, 0x51})
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/event.go:151 +0x1e0
github.com/rs/zerolog.(*Event).Msgf(0x140004c8230, {0x101c65417?, 0x24?}, {0x14000835350?, 0x14000835248?, 0x35554aaaa?})
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/event.go:131 +0x50
github.com/infracost/infracost/internal/apiclient.(*APIClient).doRequest(0x140004c81c0, {0x101bcca9b, 0x4}, {0x101bcf764, 0x6}, {0x10285d3e0, 0x14000793da0})
        /Users/owen/code/owenrum/infracost/internal/apiclient/client.go:71 +0x140
github.com/infracost/infracost/internal/apiclient.(*PricingAPIClient).AddEvent(0x140004c81c0, {0x101be9396, 0xf}, 0x14000793aa0)
        /Users/owen/code/owenrum/infracost/internal/apiclient/pricing.go:253 +0x204
github.com/infracost/infracost/internal/apiclient.ReportCLIError(0x14000529340, {0x103048318, 0x140005a1e00}, 0x0)
        /Users/owen/code/owenrum/infracost/internal/apiclient/errors.go:39 +0x244
main.handleUnexpectedErr(0x14000529340, {0x103048318, 0x140005a1e00})
        /Users/owen/code/owenrum/infracost/cmd/infracost/main.go:327 +0x54
main.Run.func1()
        /Users/owen/code/owenrum/infracost/cmd/infracost/main.go:79 +0x120
panic({0x1026883c0?, 0x103042980?})
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/runtime/panic.go:770 +0x124
bytes.(*Buffer).WriteTo(0x140005a1d70, {0x103048338?, 0x14000092d80?})
        /opt/homebrew/Cellar/go/1.22.2/libexec/src/bytes/buffer.go:263 +0x108
github.com/rs/zerolog.ConsoleWriter.Write({{0x103048338, 0x14000092d80}, 0x1, {0x101c0f986, 0x19}, {0x140004b7280, 0x4, 0x4}, {0x0, 0x0, ...}, ...}, ...)
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/console.go:145 +0x454
github.com/rs/zerolog.LevelWriterAdapter.WriteLevel(...)
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/writer.go:27
github.com/rs/zerolog.(*Event).write(0x140004bbb20)
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/event.go:80 +0x12c
github.com/rs/zerolog.(*Event).msg(0x140004bbb20, {0x101ca6522, 0x34})
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/event.go:151 +0x1e0
github.com/rs/zerolog.(*Event).Msg(...)
        /Users/owen/go/pkg/mod/github.com/rs/zerolog@v1.31.0/event.go:110
github.com/infracost/infracost/internal/config.(*RunContext).IsCloudEnabled(0x14000529340)
        /Users/owen/code/owenrum/infracost/internal/config/run_context.go:267 +0x104
main.loadGlobalFlags(0x14000529340, 0x140005acdc8)
        /Users/owen/code/owenrum/infracost/cmd/infracost/main.go:358 +0x90
main.newRootCmd.func1(0x140005acdc8, {0x101bcca83?, 0x4?, 0x101bcca43?})
        /Users/owen/code/owenrum/infracost/cmd/infracost/main.go:156 +0x2c0
github.com/spf13/cobra.(*Command).execute(0x140005acdc8, {0x140005a1ce0, 0x3, 0x3})
        /Users/owen/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:835 +0x4ac
github.com/spf13/cobra.(*Command).ExecuteC(0x140005a3348)
        /Users/owen/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:974 +0x318
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/owen/go/pkg/mod/github.com/spf13/cobra@v1.4.0/command.go:902
main.Run(0x0, 0x0)
        /Users/owen/code/owenrum/infracost/cmd/infracost/main.go:96 +0x164
main.main()
        /Users/owen/code/owenrum/infracost/cmd/infracost/main.go:40 +0x1a4
exit status 2
```


### After
```
INFRACOST_ENV=dev go run ./cmd/infracost breakdown --path examples/terraform --debug-report
Evaluating Terraform directory at examples/terraform
  ✔ Downloading Terraform modules
  ✔ Evaluating Terraform directory
  ✔ Retrieving usage defaults for 2 resources from Infracost Cloud
  ✔ Retrieving cloud prices to calculate costs

Project: owenrum/infracost/examples/terraform

 Name                                                   Monthly Qty  Unit         Monthly Cost

 aws_instance.web_app
 ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)          730  hours             $560.64
 ├─ root_block_device
 │  └─ Storage (general purpose SSD, gp2)                        50  GB                  $5.00
 └─ ebs_block_device[0]
    ├─ Storage (provisioned IOPS SSD, io1)                    1,000  GB                $125.00
    └─ Provisioned IOPS                                         800  IOPS               $52.00

 aws_lambda_function.hello_world
 ├─ Requests                                                     25  1M requests         $5.00  *
 └─ Duration (first 6B)                                     625,000  GB-seconds         $10.42  *

 OVERALL TOTAL                                                                         $758.06

*Usage costs were estimated using Infracost Cloud settings, see docs for other options.

──────────────────────────────────
2 cloud resources were detected:
∙ 2 were estimated

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
┃ owenrum/infracost/examples/terraform               ┃ $743          ┃ $15         ┃ $758       ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
```

Report generated

```
ls | grep report
.rwxr-xr-x@ 2.8k owen 29 Apr 12:12 -I infracost-debug-report.json
```
