### PR TITLE
fix: use regex to handle version matching instead of awk

### DIFF
--- a/scripts/get_version.sh
+++ b/scripts/get_version.sh
@@ -21,14 +21,14 @@ LATEST_V_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
 if [ -n "$LATEST_V_TAG" ]; then
   if git describe --tags --exact-match "${COMMITISH}" 2>/dev/null | grep -q "^${LATEST_V_TAG}$"; then
     TAG=$LATEST_V_TAG
-  elif git describe --tags "${COMMITISH}" --match 'v*' > /dev/null 2>&1; then
+  else
     full_tag=$(git describe --tags "${COMMITISH}" --match 'v*')
-    commit_count=$(echo ${full_tag} | awk -F'-' '{print $(NF-1)}')
-    commit_sha=$(echo ${full_tag} | awk -F'-' '{print $NF}')
-
-    # Assuming the latest "v" prefixed tag is part of the description
-    TAG=$(echo ${full_tag} | grep -o '^v[^-]*')
-    BUILD=$(echo +${commit_count}-${commit_sha})
+    if [[ $full_tag =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([0-9a-f]+)$ ]]; then
+      TAG=${BASH_REMATCH[1]}
+      BUILD=$(echo +${BASH_REMATCH[2]}-${BASH_REMATCH[3]})
+    else
+      TAG=${full_tag}
+    fi
   fi
 fi
 


### PR DESCRIPTION
Some release assets ended up with version 'Infracost v0.10.35+v0.10.35-v0.10.35' after the last release.  I wasn't able to reproduce the problem, but this change updates the version script to be more robust. It uses regex (instead of awk) to parse the expected tag format and falls back to using the full tag string as the version if it is in an unexpected format.