### PR TITLE
feat: Add vcsBaseCommitSha to estimate metadata

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - errcheck
     - gocritic
     - gofmt
@@ -13,10 +12,8 @@ linters:
     - misspell
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
 linters-settings:
   gocritic:

--- a/cmd/infracost/diff_test.go
+++ b/cmd/infracost/diff_test.go
@@ -156,6 +156,26 @@ func TestDiffWithCompareToFormatJSON(t *testing.T) {
 	)
 }
 
+func TestDiffWithCompareToNoMetadataFormatJSON(t *testing.T) {
+	dir := path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"diff",
+			"--path",
+			dir,
+			"--compare-to",
+			path.Join(dir, "prior.json"),
+			"--format",
+			"json",
+		}, &GoldenFileOptions{
+			RunTerraformCLI: true,
+			IsJSON:          true,
+		},
+	)
+}
+
 func TestDiffWithCompareToPreserveSummary(t *testing.T) {
 	dir := path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())
 	GoldenFileCommandTest(

--- a/cmd/infracost/output_test.go
+++ b/cmd/infracost/output_test.go
@@ -25,6 +25,12 @@ func TestOutputFormatJSON(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "json", "--path", "./testdata/example_out.json", "--path", "./testdata/azure_firewall_out.json"}, opts)
 }
 
+func TestOutputDiffFormatJSON(t *testing.T) {
+	opts := DefaultOptions()
+	opts.IsJSON = true
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"output", "--format", "json", "--path", "./testdata/example_diff_out.json"}, opts)
+}
+
 func TestOutputFormatBitbucketCommentWithProjectNames(t *testing.T) {
 	testName := testutil.CalcGoldenFileTestdataDirName()
 	GoldenFileCommandTest(t, testName,

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -91,6 +91,7 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 		logging.Logger.Debug().Err(err).Msgf("failed to fetch vcs metadata for path %s", wd)
 	}
 	runCtx.VCSMetadata = metadata
+	runCtx.VCSMetadata.BaseCommit = vcs.Commit{}
 
 	pr, err := newParallelRunner(cmd, runCtx)
 	if err != nil {
@@ -125,6 +126,13 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 		r, err = output.CompareTo(runCtx.Config, r, *pr.prior)
 		if err != nil {
 			return err
+		}
+		runCtx.VCSMetadata.BaseCommit = vcs.Commit{
+			SHA:         pr.prior.Metadata.CommitSHA,
+			AuthorName:  pr.prior.Metadata.CommitAuthorName,
+			AuthorEmail: pr.prior.Metadata.CommitAuthorEmail,
+			Time:        pr.prior.Metadata.CommitTimestamp,
+			Message:     pr.prior.Metadata.CommitMessage,
 		}
 	}
 

--- a/cmd/infracost/testdata/diff_prior_empty_project_json/diff_prior_empty_project_json.golden
+++ b/cmd/infracost/testdata/diff_prior_empty_project_json/diff_prior_empty_project_json.golden
@@ -3,6 +3,7 @@
   "metadata": {
     "infracostCommand": "diff",
     "vcsBranch": "stub-branch",
+    "vcsBaseCommitSha": "71785af96bce822bd54f359d0883cfa4ca805432",
     "vcsCommitSha": "stub-sha",
     "vcsCommitAuthorName": "stub-author",
     "vcsCommitAuthorEmail": "stub@stub.com",

--- a/cmd/infracost/testdata/diff_with_compare_to_format_json/diff_with_compare_to_format_json.hcl.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_format_json/diff_with_compare_to_format_json.hcl.golden
@@ -3,6 +3,7 @@
   "metadata": {
     "infracostCommand": "diff",
     "vcsBranch": "stub-branch",
+    "vcsBaseCommitSha": "71785af96bce822bd54f359d0883cfa4ca805432",
     "vcsCommitSha": "stub-sha",
     "vcsCommitAuthorName": "stub-author",
     "vcsCommitAuthorEmail": "stub@stub.com",

--- a/cmd/infracost/testdata/diff_with_compare_to_format_json/prior.json
+++ b/cmd/infracost/testdata/diff_with_compare_to_format_json/prior.json
@@ -1,5 +1,15 @@
 {
   "version": "0.2",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "master",
+    "vcsCommitSha": "71785af96bce822bd54f359d0883cfa4ca805432",
+    "vcsCommitAuthorName": "Hugo",
+    "vcsCommitAuthorEmail": "",
+    "vcsCommitTimestamp": "2024-02-23T11:04:26Z",
+    "vcsCommitMessage": "wip",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost.git"
+  },
   "currency": "USD",
   "projects": [
     {

--- a/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json/diff_with_compare_to_no_metadata_format_json.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json/diff_with_compare_to_no_metadata_format_json.golden
@@ -3,7 +3,6 @@
   "metadata": {
     "infracostCommand": "diff",
     "vcsBranch": "stub-branch",
-    "vcsBaseCommitSha": "71785af96bce822bd54f359d0883cfa4ca805432",
     "vcsCommitSha": "stub-sha",
     "vcsCommitAuthorName": "stub-author",
     "vcsCommitAuthorEmail": "stub@stub.com",
@@ -14,13 +13,13 @@
   "currency": "USD",
   "projects": [
     {
-      "name": "infracost/infracost/cmd/infracost/testdata/diff_with_compare_to_format_json",
+      "name": "infracost/infracost/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json",
       "displayName": "main",
       "metadata": {
-        "path": "testdata/diff_with_compare_to_format_json",
+        "path": "testdata/diff_with_compare_to_no_metadata_format_json",
         "type": "terraform_cli",
         "terraformWorkspace": "default",
-        "vcsSubPath": "cmd/infracost/testdata/diff_with_compare_to_format_json",
+        "vcsSubPath": "cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json",
         "providers": [
           {
             "name": "aws"

--- a/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json/diff_with_compare_to_no_metadata_format_json.hcl.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json/diff_with_compare_to_no_metadata_format_json.hcl.golden
@@ -3,7 +3,6 @@
   "metadata": {
     "infracostCommand": "diff",
     "vcsBranch": "stub-branch",
-    "vcsBaseCommitSha": "71785af96bce822bd54f359d0883cfa4ca805432",
     "vcsCommitSha": "stub-sha",
     "vcsCommitAuthorName": "stub-author",
     "vcsCommitAuthorEmail": "stub@stub.com",
@@ -14,16 +13,18 @@
   "currency": "USD",
   "projects": [
     {
-      "name": "infracost/infracost/cmd/infracost/testdata/diff_with_compare_to_format_json",
+      "name": "infracost/infracost/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json",
       "displayName": "main",
       "metadata": {
-        "path": "testdata/diff_with_compare_to_format_json",
-        "type": "terraform_cli",
-        "terraformWorkspace": "default",
-        "vcsSubPath": "cmd/infracost/testdata/diff_with_compare_to_format_json",
+        "path": "testdata/diff_with_compare_to_no_metadata_format_json",
+        "type": "terraform_dir",
+        "vcsSubPath": "cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json",
         "providers": [
           {
-            "name": "aws"
+            "name": "aws",
+            "filename": "testdata/diff_with_compare_to_no_metadata_format_json/main.tf",
+            "startLine": 1,
+            "endLine": 7
           }
         ]
       },
@@ -172,7 +173,20 @@
             "name": "aws_instance.web_app",
             "resourceType": "aws_instance",
             "tags": {},
-            "metadata": {},
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app",
+                  "endLine": 23,
+                  "filename": "testdata/diff_with_compare_to_no_metadata_format_json/main.tf",
+                  "startLine": 9
+                }
+              ],
+              "checksum": "3326e79d502305b9e1f50ad5efedb7528b9e59ded094785b1ca91c6f88812fa5",
+              "endLine": 23,
+              "filename": "testdata/diff_with_compare_to_no_metadata_format_json/main.tf",
+              "startLine": 9
+            },
             "hourlyCost": "1.785315068493150679",
             "monthlyCost": "1303.28",
             "costComponents": [

--- a/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json/main.tf
+++ b/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.8xlarge"
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}

--- a/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json/prior.json
+++ b/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json/prior.json
@@ -1,100 +1,23 @@
 {
   "version": "0.2",
-  "metadata": {
-    "infracostCommand": "diff",
-    "vcsBranch": "stub-branch",
-    "vcsBaseCommitSha": "71785af96bce822bd54f359d0883cfa4ca805432",
-    "vcsCommitSha": "stub-sha",
-    "vcsCommitAuthorName": "stub-author",
-    "vcsCommitAuthorEmail": "stub@stub.com",
-    "vcsCommitTimestamp": "REPLACED_TIME",
-    "vcsCommitMessage": "stub-message",
-    "vcsRepositoryUrl": "https://github.com/infracost/infracost"
-  },
   "currency": "USD",
   "projects": [
     {
-      "name": "infracost/infracost/cmd/infracost/testdata/diff_with_compare_to_format_json",
-      "displayName": "main",
+      "name": "infracost/infracost/cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json",
       "metadata": {
-        "path": "testdata/diff_with_compare_to_format_json",
-        "type": "terraform_cli",
-        "terraformWorkspace": "default",
-        "vcsSubPath": "cmd/infracost/testdata/diff_with_compare_to_format_json",
-        "providers": [
-          {
-            "name": "aws"
-          }
-        ]
+        "path": "testdata/diff_with_compare_to_no_metadata_format_json",
+        "type": "terraform_dir",
+        "vcsRepositoryUrl": "git@github.com:infracost/infracost.git",
+        "vcsSubPath": "cmd/infracost/testdata/diff_with_compare_to_no_metadata_format_json",
+        "terraformWorkspace": "default"
       },
       "pastBreakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "breakdown": {
         "resources": [
-          {
-            "name": "aws_instance.web_app2",
-            "metadata": {},
-            "hourlyCost": "1.785315068493150679",
-            "monthlyCost": "1303.28",
-            "costComponents": [
-              {
-                "name": "Instance usage (Linux/UNIX, on-demand, m5.8xlarge)",
-                "unit": "hours",
-                "hourlyQuantity": "1",
-                "monthlyQuantity": "730",
-                "price": "1.536",
-                "hourlyCost": "1.536",
-                "monthlyCost": "1121.28",
-                "priceNotFound": false
-              }
-            ],
-            "subresources": [
-              {
-                "name": "root_block_device",
-                "metadata": {},
-                "hourlyCost": "0.00684931506849315",
-                "monthlyCost": "5",
-                "costComponents": [
-                  {
-                    "name": "Storage (general purpose SSD, gp2)",
-                    "unit": "GB",
-                    "hourlyQuantity": "0.0684931506849315",
-                    "monthlyQuantity": "50",
-                    "price": "0.1",
-                    "hourlyCost": "0.00684931506849315",
-                    "monthlyCost": "5",
-                    "priceNotFound": false
-                  }
-                ]
-              },
-              {
-                "name": "ebs_block_device[0]",
-                "metadata": {},
-                "hourlyCost": "0.242465753424657529",
-                "monthlyCost": "177",
-                "costComponents": [
-                  {
-                    "name": "Storage (provisioned IOPS SSD, io1)",
-                    "unit": "GB",
-                    "hourlyQuantity": "1.3698630136986301",
-                    "monthlyQuantity": "1000",
-                    "price": "0.125",
-                    "hourlyCost": "0.1712328767123287625",
-                    "monthlyCost": "125",
-                    "priceNotFound": false
-                  },
-                  {
-                    "name": "Provisioned IOPS",
-                    "unit": "IOPS",
-                    "hourlyQuantity": "1.0958904109589041",
-                    "monthlyQuantity": "800",
-                    "price": "0.065",
-                    "hourlyCost": "0.0712328767123287665",
-                    "monthlyCost": "52",
-                    "priceNotFound": false
-                  }
-                ]
-              }
-            ]
-          },
           {
             "name": "aws_instance.web_app",
             "metadata": {},
@@ -108,8 +31,7 @@
                 "monthlyQuantity": "730",
                 "price": "0.768",
                 "hourlyCost": "0.768",
-                "monthlyCost": "560.64",
-                "priceNotFound": false
+                "monthlyCost": "560.64"
               }
             ],
             "subresources": [
@@ -126,8 +48,7 @@
                     "monthlyQuantity": "50",
                     "price": "0.1",
                     "hourlyCost": "0.00684931506849315",
-                    "monthlyCost": "5",
-                    "priceNotFound": false
+                    "monthlyCost": "5"
                   }
                 ]
               },
@@ -144,8 +65,7 @@
                     "monthlyQuantity": "1000",
                     "price": "0.125",
                     "hourlyCost": "0.1712328767123287625",
-                    "monthlyCost": "125",
-                    "priceNotFound": false
+                    "monthlyCost": "125"
                   },
                   {
                     "name": "Provisioned IOPS",
@@ -154,24 +74,14 @@
                     "monthlyQuantity": "800",
                     "price": "0.065",
                     "hourlyCost": "0.0712328767123287665",
-                    "monthlyCost": "52",
-                    "priceNotFound": false
+                    "monthlyCost": "52"
                   }
                 ]
               }
             ]
-          }
-        ],
-        "totalHourlyCost": "2.802630136986301358",
-        "totalMonthlyCost": "2045.92",
-        "totalMonthlyUsageCost": "0"
-      },
-      "breakdown": {
-        "resources": [
+          },
           {
-            "name": "aws_instance.web_app",
-            "resourceType": "aws_instance",
-            "tags": {},
+            "name": "aws_instance.web_app2",
             "metadata": {},
             "hourlyCost": "1.785315068493150679",
             "monthlyCost": "1303.28",
@@ -183,8 +93,7 @@
                 "monthlyQuantity": "730",
                 "price": "1.536",
                 "hourlyCost": "1.536",
-                "monthlyCost": "1121.28",
-                "priceNotFound": false
+                "monthlyCost": "1121.28"
               }
             ],
             "subresources": [
@@ -201,8 +110,7 @@
                     "monthlyQuantity": "50",
                     "price": "0.1",
                     "hourlyCost": "0.00684931506849315",
-                    "monthlyCost": "5",
-                    "priceNotFound": false
+                    "monthlyCost": "5"
                   }
                 ]
               },
@@ -219,8 +127,7 @@
                     "monthlyQuantity": "1000",
                     "price": "0.125",
                     "hourlyCost": "0.1712328767123287625",
-                    "monthlyCost": "125",
-                    "priceNotFound": false
+                    "monthlyCost": "125"
                   },
                   {
                     "name": "Provisioned IOPS",
@@ -229,146 +136,171 @@
                     "monthlyQuantity": "800",
                     "price": "0.065",
                     "hourlyCost": "0.0712328767123287665",
-                    "monthlyCost": "52",
-                    "priceNotFound": false
+                    "monthlyCost": "52"
                   }
                 ]
               }
             ]
           }
         ],
-        "totalHourlyCost": "1.785315068493150679",
-        "totalMonthlyCost": "1303.28",
-        "totalMonthlyUsageCost": "0"
+        "totalHourlyCost": "2.802630136986301358",
+        "totalMonthlyCost": "2045.92"
       },
       "diff": {
         "resources": [
           {
             "name": "aws_instance.web_app",
-            "resourceType": "aws_instance",
-            "tags": {},
             "metadata": {},
-            "hourlyCost": "0.768",
-            "monthlyCost": "560.64",
-            "monthlyUsageCost": "0",
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
             "costComponents": [
               {
-                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge → m5.8xlarge)",
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
                 "unit": "hours",
-                "hourlyQuantity": "0",
-                "monthlyQuantity": "0",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
                 "price": "0.768",
                 "hourlyCost": "0.768",
-                "monthlyCost": "560.64",
-                "priceNotFound": false
-              }
-            ]
-          },
-          {
-            "name": "aws_instance.web_app2",
-            "metadata": {},
-            "hourlyCost": "-1.785315068493150679",
-            "monthlyCost": "-1303.28",
-            "monthlyUsageCost": "0",
-            "costComponents": [
-              {
-                "name": "Instance usage (Linux/UNIX, on-demand, m5.8xlarge)",
-                "unit": "hours",
-                "hourlyQuantity": "-1",
-                "monthlyQuantity": "-730",
-                "price": "-1.536",
-                "hourlyCost": "-1.536",
-                "monthlyCost": "-1121.28",
-                "priceNotFound": false
+                "monthlyCost": "560.64"
               }
             ],
             "subresources": [
               {
                 "name": "root_block_device",
                 "metadata": {},
-                "hourlyCost": "-0.00684931506849315",
-                "monthlyCost": "-5",
-                "monthlyUsageCost": "0",
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
                 "costComponents": [
                   {
                     "name": "Storage (general purpose SSD, gp2)",
                     "unit": "GB",
-                    "hourlyQuantity": "-0.0684931506849315",
-                    "monthlyQuantity": "-50",
-                    "price": "-0.1",
-                    "hourlyCost": "-0.00684931506849315",
-                    "monthlyCost": "-5",
-                    "priceNotFound": false
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
                   }
                 ]
               },
               {
                 "name": "ebs_block_device[0]",
                 "metadata": {},
-                "hourlyCost": "-0.242465753424657529",
-                "monthlyCost": "-177",
-                "monthlyUsageCost": "0",
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
                 "costComponents": [
                   {
                     "name": "Storage (provisioned IOPS SSD, io1)",
                     "unit": "GB",
-                    "hourlyQuantity": "-1.3698630136986301",
-                    "monthlyQuantity": "-1000",
-                    "price": "-0.125",
-                    "hourlyCost": "-0.1712328767123287625",
-                    "monthlyCost": "-125",
-                    "priceNotFound": false
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
                   },
                   {
                     "name": "Provisioned IOPS",
                     "unit": "IOPS",
-                    "hourlyQuantity": "-1.0958904109589041",
-                    "monthlyQuantity": "-800",
-                    "price": "-0.065",
-                    "hourlyCost": "-0.0712328767123287665",
-                    "monthlyCost": "-52",
-                    "priceNotFound": false
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_instance.web_app2",
+            "metadata": {},
+            "hourlyCost": "1.785315068493150679",
+            "monthlyCost": "1303.28",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.8xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "1.536",
+                "hourlyCost": "1.536",
+                "monthlyCost": "1121.28"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
                   }
                 ]
               }
             ]
           }
         ],
-        "totalHourlyCost": "-1.017315068493150679",
-        "totalMonthlyCost": "-742.64",
-        "totalMonthlyUsageCost": "0"
+        "totalHourlyCost": "2.802630136986301358",
+        "totalMonthlyCost": "2045.92"
       },
       "summary": {
-        "totalDetectedResources": 1,
-        "totalSupportedResources": 1,
+        "totalDetectedResources": 2,
+        "totalSupportedResources": 2,
         "totalUnsupportedResources": 0,
-        "totalUsageBasedResources": 1,
+        "totalUsageBasedResources": 2,
         "totalNoPriceResources": 0,
         "unsupportedResourceCounts": {},
         "noPriceResourceCounts": {}
       }
     }
   ],
-  "totalHourlyCost": "1.785315068493150679",
-  "totalMonthlyCost": "1303.28",
-  "totalMonthlyUsageCost": "0",
-  "pastTotalHourlyCost": "2.802630136986301358",
-  "pastTotalMonthlyCost": "2045.92",
-  "pastTotalMonthlyUsageCost": "0",
-  "diffTotalHourlyCost": "-1.017315068493150679",
-  "diffTotalMonthlyCost": "-742.64",
-  "diffTotalMonthlyUsageCost": "0",
-  "timeGenerated": "REPLACED_TIME",
+  "totalHourlyCost": "2.802630136986301358",
+  "totalMonthlyCost": "2045.92",
+  "pastTotalHourlyCost": "0",
+  "pastTotalMonthlyCost": "0",
+  "diffTotalHourlyCost": "2.802630136986301358",
+  "diffTotalMonthlyCost": "2045.92",
+  "timeGenerated": "2022-04-18T10:27:22.533107+01:00",
   "summary": {
-    "totalDetectedResources": 1,
-    "totalSupportedResources": 1,
+    "totalDetectedResources": 2,
+    "totalSupportedResources": 2,
     "totalUnsupportedResources": 0,
-    "totalUsageBasedResources": 1,
+    "totalUsageBasedResources": 2,
     "totalNoPriceResources": 0,
     "unsupportedResourceCounts": {},
     "noPriceResourceCounts": {}
   }
 }
-
-Err:
-

--- a/cmd/infracost/testdata/diff_with_compare_to_with_current_and_past_project_error/diff_with_compare_to_with_current_and_past_project_error.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_current_and_past_project_error/diff_with_compare_to_with_current_and_past_project_error.golden
@@ -3,6 +3,7 @@
   "metadata": {
     "infracostCommand": "diff",
     "vcsBranch": "stub-branch",
+    "vcsBaseCommitSha": "stub-sha",
     "vcsCommitSha": "stub-sha",
     "vcsCommitAuthorName": "stub-author",
     "vcsCommitAuthorEmail": "stub@stub.com",

--- a/cmd/infracost/testdata/diff_with_compare_to_with_current_project_error/diff_with_compare_to_with_current_project_error.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_current_project_error/diff_with_compare_to_with_current_project_error.golden
@@ -3,6 +3,7 @@
   "metadata": {
     "infracostCommand": "diff",
     "vcsBranch": "stub-branch",
+    "vcsBaseCommitSha": "stub-sha",
     "vcsCommitSha": "stub-sha",
     "vcsCommitAuthorName": "stub-author",
     "vcsCommitAuthorEmail": "stub@stub.com",

--- a/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error/diff_with_compare_to_with_past_project_error.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error/diff_with_compare_to_with_past_project_error.golden
@@ -3,6 +3,7 @@
   "metadata": {
     "infracostCommand": "diff",
     "vcsBranch": "stub-branch",
+    "vcsBaseCommitSha": "stub-sha",
     "vcsCommitSha": "stub-sha",
     "vcsCommitAuthorName": "stub-author",
     "vcsCommitAuthorEmail": "stub@stub.com",

--- a/cmd/infracost/testdata/diff_with_free_resources_checksum/diff_with_free_resources_checksum.golden
+++ b/cmd/infracost/testdata/diff_with_free_resources_checksum/diff_with_free_resources_checksum.golden
@@ -3,6 +3,7 @@
   "metadata": {
     "infracostCommand": "diff",
     "vcsBranch": "stub-branch",
+    "vcsBaseCommitSha": "stub-sha",
     "vcsCommitSha": "stub-sha",
     "vcsCommitAuthorName": "stub-author",
     "vcsCommitAuthorEmail": "stub@stub.com",

--- a/cmd/infracost/testdata/diff_with_policy_data_upload/diff_with_policy_data_upload.golden
+++ b/cmd/infracost/testdata/diff_with_policy_data_upload/diff_with_policy_data_upload.golden
@@ -3,6 +3,7 @@
   "metadata": {
     "infracostCommand": "diff",
     "vcsBranch": "stub-branch",
+    "vcsBaseCommitSha": "stub-sha",
     "vcsCommitSha": "stub-sha",
     "vcsCommitAuthorName": "stub-author",
     "vcsCommitAuthorEmail": "stub@stub.com",

--- a/cmd/infracost/testdata/example_diff_out.json
+++ b/cmd/infracost/testdata/example_diff_out.json
@@ -1,0 +1,546 @@
+{
+  "version": "0.2",
+  "currency": "USD",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "test",
+    "vcsBaseCommitSha": "base-sha",
+    "vcsCommitSha": "1234",
+    "vcsCommitAuthorName": "hugo",
+    "vcsCommitAuthorEmail": "hugo@test.com",
+    "vcsCommitTimestamp": "2021-10-11T22:41:00.144866-04:00",
+    "vcsCommitMessage": "mymessage",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost.git"
+  },
+  "projects": [
+    {
+      "name": "infracost/infracost/cmd/infracost/testdata",
+      "metadata": {
+        "path": "./cmd/infracost/testdata/",
+        "type": "terraform_dir",
+        "vcsSubPath": "cmd/infracost/testdata",
+        "terraformWorkspace": "default"
+      },
+      "pastBreakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0"
+      },
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "metadata": {},
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "resourceType": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "resourceType": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_instance.zero_cost_instance",
+            "resourceType": "aws_instance",
+            "metadata": {},
+            "hourlyCost": "0.249315068493150679",
+            "monthlyCost": "182",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, reserved, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0",
+                "hourlyCost": "0",
+                "monthlyCost": "0"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "resourceType": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "resourceType": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.hello_world",
+            "resourceType": "aws_lambda_function",
+            "metadata": {},
+            "hourlyCost": "0.59817465753424657534316749",
+            "monthlyCost": "436.6675",
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": "0.136986301369863",
+                "monthlyQuantity": "100",
+                "price": "0.2",
+                "hourlyCost": "0.02739726027397260273972",
+                "monthlyCost": "20"
+              },
+              {
+                "name": "Duration",
+                "unit": "GB-seconds",
+                "hourlyQuantity": "34246.5753424657534247",
+                "monthlyQuantity": "25000000",
+                "price": "0.0000166667",
+                "hourlyCost": "0.57077739726027397260344749",
+                "monthlyCost": "416.6675"
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.zero_cost_lambda",
+            "resourceType": "aws_lambda_function",
+            "metadata": {},
+            "hourlyCost": "0",
+            "monthlyCost": "0",
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.2",
+                "hourlyCost": "0",
+                "monthlyCost": "0"
+              },
+              {
+                "name": "Duration",
+                "unit": "GB-seconds",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.0000166667",
+                "hourlyCost": "0",
+                "monthlyCost": "0"
+              }
+            ]
+          },
+          {
+            "name": "aws_s3_bucket.usage",
+            "resourceType": "aws_s3_bucket",
+            "metadata": {},
+            "hourlyCost": "0",
+            "monthlyCost": "0",
+            "subresources": [
+              {
+                "name": "Standard",
+                "resourceType": "Standard",
+                "metadata": {},
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "costComponents": [
+                  {
+                    "name": "Storage",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.023",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  },
+                  {
+                    "name": "PUT, COPY, POST, LIST requests",
+                    "unit": "1k requests",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.005",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  },
+                  {
+                    "name": "GET, SELECT, and all other requests",
+                    "unit": "1k requests",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.0004",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  },
+                  {
+                    "name": "Select data scanned",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.002",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  },
+                  {
+                    "name": "Select data returned",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.0007",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.86480479452054793334316749",
+        "totalMonthlyCost": "1361.3075"
+      },
+      "diff": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "metadata": {},
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "resourceType": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "resourceType": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_instance.zero_cost_instance",
+            "resourceType": "aws_instance",
+            "metadata": {},
+            "hourlyCost": "0.249315068493150679",
+            "monthlyCost": "182",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, reserved, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0",
+                "hourlyCost": "0",
+                "monthlyCost": "0"
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "resourceType": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5"
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "resourceType": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125"
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.hello_world",
+            "resourceType": "aws_lambda_function",
+            "metadata": {},
+            "hourlyCost": "0.59817465753424657534316749",
+            "monthlyCost": "436.6675",
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": "0.136986301369863",
+                "monthlyQuantity": "100",
+                "price": "0.2",
+                "hourlyCost": "0.02739726027397260273972",
+                "monthlyCost": "20"
+              },
+              {
+                "name": "Duration",
+                "unit": "GB-seconds",
+                "hourlyQuantity": "34246.5753424657534247",
+                "monthlyQuantity": "25000000",
+                "price": "0.0000166667",
+                "hourlyCost": "0.57077739726027397260344749",
+                "monthlyCost": "416.6675"
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.zero_cost_lambda",
+            "resourceType": "aws_lambda_function",
+            "metadata": {},
+            "hourlyCost": "0",
+            "monthlyCost": "0",
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.2",
+                "hourlyCost": "0",
+                "monthlyCost": "0"
+              },
+              {
+                "name": "Duration",
+                "unit": "GB-seconds",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.0000166667",
+                "hourlyCost": "0",
+                "monthlyCost": "0"
+              }
+            ]
+          },
+          {
+            "name": "aws_s3_bucket.usage",
+            "resourceType": "aws_s3_bucket",
+            "metadata": {},
+            "hourlyCost": "0",
+            "monthlyCost": "0",
+            "subresources": [
+              {
+                "name": "Standard",
+                "resourceType": "Standard",
+                "metadata": {},
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "costComponents": [
+                  {
+                    "name": "Storage",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.023",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  },
+                  {
+                    "name": "PUT, COPY, POST, LIST requests",
+                    "unit": "1k requests",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.005",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  },
+                  {
+                    "name": "GET, SELECT, and all other requests",
+                    "unit": "1k requests",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.0004",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  },
+                  {
+                    "name": "Select data scanned",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.002",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  },
+                  {
+                    "name": "Select data returned",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.0007",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.86480479452054793334316749",
+        "totalMonthlyCost": "1361.3075"
+      },
+      "summary": {
+        "unsupportedResourceCounts": {}
+      }
+    }
+  ],
+  "totalHourlyCost": "1.86480479452054793334316749",
+  "totalMonthlyCost": "1361.3075",
+  "timeGenerated": "2021-10-11T22:41:00.144866-04:00",
+  "summary": {
+    "unsupportedResourceCounts": {}
+  }
+}

--- a/cmd/infracost/testdata/output_diff_format_json/output_diff_format_json.golden
+++ b/cmd/infracost/testdata/output_diff_format_json/output_diff_format_json.golden
@@ -1,0 +1,588 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "output",
+    "vcsBranch": "test",
+    "vcsBaseCommitSha": "base-sha",
+    "vcsCommitSha": "1234",
+    "vcsCommitAuthorName": "hugo",
+    "vcsCommitAuthorEmail": "hugo@test.com",
+    "vcsCommitTimestamp": "REPLACED_TIME",
+    "vcsCommitMessage": "mymessage",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost.git"
+  },
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "infracost/infracost/cmd/infracost/testdata",
+      "displayName": "",
+      "metadata": {
+        "path": "./cmd/infracost/testdata/",
+        "type": "terraform_dir",
+        "terraformWorkspace": "default",
+        "vcsSubPath": "cmd/infracost/testdata"
+      },
+      "pastBreakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": null
+      },
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "metadata": {},
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "resourceType": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "resourceType": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_instance.zero_cost_instance",
+            "resourceType": "aws_instance",
+            "metadata": {},
+            "hourlyCost": "0.249315068493150679",
+            "monthlyCost": "182",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, reserved, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0",
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "resourceType": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "resourceType": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.hello_world",
+            "resourceType": "aws_lambda_function",
+            "metadata": {},
+            "hourlyCost": "0.59817465753424657534316749",
+            "monthlyCost": "436.6675",
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": "0.136986301369863",
+                "monthlyQuantity": "100",
+                "price": "0.2",
+                "hourlyCost": "0.02739726027397260273972",
+                "monthlyCost": "20",
+                "priceNotFound": false
+              },
+              {
+                "name": "Duration",
+                "unit": "GB-seconds",
+                "hourlyQuantity": "34246.5753424657534247",
+                "monthlyQuantity": "25000000",
+                "price": "0.0000166667",
+                "hourlyCost": "0.57077739726027397260344749",
+                "monthlyCost": "416.6675",
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.zero_cost_lambda",
+            "resourceType": "aws_lambda_function",
+            "metadata": {},
+            "hourlyCost": "0",
+            "monthlyCost": "0",
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.2",
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "priceNotFound": false
+              },
+              {
+                "name": "Duration",
+                "unit": "GB-seconds",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.0000166667",
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_s3_bucket.usage",
+            "resourceType": "aws_s3_bucket",
+            "metadata": {},
+            "hourlyCost": "0",
+            "monthlyCost": "0",
+            "subresources": [
+              {
+                "name": "Standard",
+                "resourceType": "Standard",
+                "metadata": {},
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "costComponents": [
+                  {
+                    "name": "Storage",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.023",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "PUT, COPY, POST, LIST requests",
+                    "unit": "1k requests",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.005",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "GET, SELECT, and all other requests",
+                    "unit": "1k requests",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.0004",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Select data scanned",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.002",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Select data returned",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.0007",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.86480479452054793334316749",
+        "totalMonthlyCost": "1361.3075",
+        "totalMonthlyUsageCost": null
+      },
+      "diff": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "metadata": {},
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "resourceType": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "resourceType": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_instance.zero_cost_instance",
+            "resourceType": "aws_instance",
+            "metadata": {},
+            "hourlyCost": "0.249315068493150679",
+            "monthlyCost": "182",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, reserved, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0",
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "resourceType": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "resourceType": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.hello_world",
+            "resourceType": "aws_lambda_function",
+            "metadata": {},
+            "hourlyCost": "0.59817465753424657534316749",
+            "monthlyCost": "436.6675",
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": "0.136986301369863",
+                "monthlyQuantity": "100",
+                "price": "0.2",
+                "hourlyCost": "0.02739726027397260273972",
+                "monthlyCost": "20",
+                "priceNotFound": false
+              },
+              {
+                "name": "Duration",
+                "unit": "GB-seconds",
+                "hourlyQuantity": "34246.5753424657534247",
+                "monthlyQuantity": "25000000",
+                "price": "0.0000166667",
+                "hourlyCost": "0.57077739726027397260344749",
+                "monthlyCost": "416.6675",
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_lambda_function.zero_cost_lambda",
+            "resourceType": "aws_lambda_function",
+            "metadata": {},
+            "hourlyCost": "0",
+            "monthlyCost": "0",
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.2",
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "priceNotFound": false
+              },
+              {
+                "name": "Duration",
+                "unit": "GB-seconds",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.0000166667",
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_s3_bucket.usage",
+            "resourceType": "aws_s3_bucket",
+            "metadata": {},
+            "hourlyCost": "0",
+            "monthlyCost": "0",
+            "subresources": [
+              {
+                "name": "Standard",
+                "resourceType": "Standard",
+                "metadata": {},
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "costComponents": [
+                  {
+                    "name": "Storage",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.023",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "PUT, COPY, POST, LIST requests",
+                    "unit": "1k requests",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.005",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "GET, SELECT, and all other requests",
+                    "unit": "1k requests",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.0004",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Select data scanned",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.002",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Select data returned",
+                    "unit": "GB",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.0007",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "1.86480479452054793334316749",
+        "totalMonthlyCost": "1361.3075",
+        "totalMonthlyUsageCost": null
+      },
+      "summary": {
+        "unsupportedResourceCounts": {}
+      }
+    }
+  ],
+  "totalHourlyCost": "1.86480479452054793334316749",
+  "totalMonthlyCost": "1361.3075",
+  "pastTotalHourlyCost": null,
+  "pastTotalMonthlyCost": null,
+  "diffTotalHourlyCost": null,
+  "diffTotalMonthlyCost": null,
+  "timeGenerated": "REPLACED_TIME",
+  "summary": {
+    "unsupportedResourceCounts": {}
+  }
+}

--- a/internal/output/metadata.go
+++ b/internal/output/metadata.go
@@ -11,6 +11,7 @@ type Metadata struct {
 	InfracostCommand string `json:"infracostCommand"`
 
 	Branch            string    `json:"vcsBranch"`
+	BaseCommitSHA     string    `json:"vcsBaseCommitSha,omitempty"`
 	CommitSHA         string    `json:"vcsCommitSha"`
 	CommitAuthorName  string    `json:"vcsCommitAuthorName"`
 	CommitAuthorEmail string    `json:"vcsCommitAuthorEmail"`
@@ -38,6 +39,7 @@ func NewMetadata(ctx *config.RunContext) Metadata {
 	m := Metadata{
 		InfracostCommand:  ctx.CMD,
 		Branch:            ctx.VCSMetadata.Branch.Name,
+		BaseCommitSHA:     ctx.VCSMetadata.BaseCommit.SHA,
 		CommitSHA:         ctx.VCSMetadata.Commit.SHA,
 		CommitAuthorEmail: ctx.VCSMetadata.Commit.AuthorEmail,
 		CommitAuthorName:  ctx.VCSMetadata.Commit.AuthorName,

--- a/internal/vcs/metadata.go
+++ b/internal/vcs/metadata.go
@@ -1056,6 +1056,7 @@ type Metadata struct {
 	Remote      Remote
 	Branch      Branch
 	Commit      Commit
+	BaseCommit  Commit
 	PullRequest *PullRequest
 	Pipeline    *Pipeline
 }

--- a/schema/infracost.schema.json
+++ b/schema/infracost.schema.json
@@ -124,6 +124,9 @@
         "vcsBranch": {
           "type": "string"
         },
+        "vcsBaseCommitSha": {
+          "type": "string"
+        },
         "vcsCommitSha": {
           "type": "string"
         },


### PR DESCRIPTION
It's empty on breakdown, and base branch's HEAD SHA on diff/output.
NB: When combining several JSONs in output command latest item's metadata will be used in the output.