### PR TITLE
fix: aws/azure failing tests

### DIFF
--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -283,13 +283,16 @@ func buildCostComponentRows(t table.Writer, currency string, costComponents []Co
 				c.Unit,
 			)
 
+			if c.PriceNotFound {
+				price = "not found"
+			}
+
 			t.AppendRow(table.Row{
 				label,
 				price,
 				price,
 				price,
 			}, table.RowConfig{AutoMerge: true, AlignAutoMerge: text.AlignLeft})
-
 		} else {
 			var tableRow table.Row
 			tableRow = append(tableRow, label)

--- a/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
@@ -8,7 +8,7 @@
  └─ EKS cluster (extended support)                 730  hours       $438.00   
                                                                               
  aws_eks_cluster.extended_support["1.25"]                                     
- └─ EKS cluster                                    730  hours        $73.00   
+ └─ EKS cluster (extended support)                 730  hours       $438.00   
                                                                               
  aws_eks_cluster.extended_support["1.26"]                                     
  └─ EKS cluster                                    730  hours        $73.00   
@@ -25,7 +25,7 @@
  aws_eks_cluster.my_aws_eks_cluster                                           
  └─ EKS cluster                                    730  hours        $73.00   
                                                                               
- OVERALL TOTAL                                                   $1,314.00 
+ OVERALL TOTAL                                                   $1,679.00 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -36,5 +36,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃ $1,314        ┃ $0.00       ┃ $1,314     ┃
+┃ main                                               ┃ $1,679        ┃ $0.00       ┃ $1,679     ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
@@ -2,12 +2,12 @@
  Name                            Monthly Qty  Unit   Monthly Cost   
                                                                     
  aws_lightsail_instance.linux1                                      
- └─ Virtual server (Linux/UNIX)          730  hours        $78.50   
+ └─ Virtual server (Linux/UNIX)          730  hours        $82.42   
                                                                     
  aws_lightsail_instance.win1                                        
  └─ Virtual server (Windows)             730  hours        $19.62   
                                                                     
- OVERALL TOTAL                                            $98.12 
+ OVERALL TOTAL                                           $102.04 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -18,5 +18,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃ $98           ┃ $0.00       ┃ $98        ┃
+┃ main                                               ┃ $102          ┃ $0.00       ┃ $102       ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.golden
@@ -6,12 +6,12 @@
  ├─ Speech to text (overage)                                                         100  hours                           $50.00   
  ├─ Speech to text (connected container commitment)                               50,000  hours                       $23,750.00   
  ├─ Speech to text (connected container overage)                                     100  hours                           $48.00   
- ├─ Speech to text batch                                              Monthly cost depends on usage: $0.36 per hours               
+ ├─ Speech to text batch                                              Monthly cost depends on usage: $0.18 per hours               
  ├─ Speech to text custom model (commitment)                                      50,000  hours                       $30,000.00   
  ├─ Speech to text custom model (overage)                                            100  hours                           $60.00   
  ├─ Speech to text custom model (connected container commitment)                  50,000  hours                       $28,500.00   
  ├─ Speech to text custom model (connected container overage)                        100  hours                           $56.50   
- ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.45 per hours               
+ ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.23 per hours               
  ├─ Speech to text custom endpoint hosting                            Monthly cost depends on usage: $0.05375 per hours            
  ├─ Speech to text custom training                                    Monthly cost depends on usage: $10.00 per hours              
  ├─ Speech to text enhanced add-ons (commitment)                                  50,000  hours                        $7,500.00   
@@ -56,12 +56,12 @@
  ├─ Speech to text (overage)                                                         100  hours                           $65.00   
  ├─ Speech to text (connected container commitment)                               10,000  hours                        $6,175.00   
  ├─ Speech to text (connected container overage)                                     100  hours                           $62.00   
- ├─ Speech to text batch                                              Monthly cost depends on usage: $0.36 per hours               
+ ├─ Speech to text batch                                              Monthly cost depends on usage: $0.18 per hours               
  ├─ Speech to text custom model (commitment)                                      10,000  hours                        $7,800.00   
  ├─ Speech to text custom model (overage)                                            100  hours                           $78.00   
  ├─ Speech to text custom model (connected container commitment)                  10,000  hours                        $7,410.00   
  ├─ Speech to text custom model (connected container overage)                        100  hours                           $73.72   
- ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.45 per hours               
+ ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.23 per hours               
  ├─ Speech to text custom endpoint hosting                            Monthly cost depends on usage: $0.05375 per hours            
  ├─ Speech to text custom training                                    Monthly cost depends on usage: $10.00 per hours              
  ├─ Speech to text enhanced add-ons (commitment)                                  10,000  hours                        $1,950.00   
@@ -111,12 +111,12 @@
  ├─ Speech to text (overage)                                                         100  hours                           $80.00   
  ├─ Speech to text (connected container commitment)                                2,000  hours                        $1,520.00   
  ├─ Speech to text (connected container overage)                                     100  hours                           $76.00   
- ├─ Speech to text batch                                              Monthly cost depends on usage: $0.36 per hours               
+ ├─ Speech to text batch                                              Monthly cost depends on usage: $0.18 per hours               
  ├─ Speech to text custom model (commitment)                                       2,000  hours                        $1,920.00   
  ├─ Speech to text custom model (overage)                                            100  hours                           $96.00   
  ├─ Speech to text custom model (connected container commitment)                   2,000  hours                        $1,824.00   
  ├─ Speech to text custom model (connected container overage)                        100  hours                           $90.86   
- ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.45 per hours               
+ ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.23 per hours               
  ├─ Speech to text custom endpoint hosting                            Monthly cost depends on usage: $0.05375 per hours            
  ├─ Speech to text custom training                                    Monthly cost depends on usage: $10.00 per hours              
  ├─ Speech to text enhanced add-ons (commitment)                                   2,000  hours                          $480.00   
@@ -179,9 +179,9 @@
                                                                                                                                    
  azurerm_cognitive_account.with_usage["SpeechServices-S0"]                                                                         
  ├─ Speech to text                                                                    20  hours                           $20.00   
- ├─ Speech to text batch                                                              56  hours                           $20.16   
+ ├─ Speech to text batch                                                              56  hours                           $10.08   
  ├─ Speech to text custom model                                                       17  hours                           $20.40   
- ├─ Speech to text custom model batch                                                 44  hours                           $19.80   
+ ├─ Speech to text custom model batch                                                 44  hours                            $9.90   
  ├─ Speech to text custom endpoint hosting                                           372  hours                           $20.00   
  ├─ Speech to text custom training                                                     2  hours                           $20.00   
  ├─ Speech to text enhanced add-ons                                                   67  hours                           $20.10   
@@ -217,9 +217,9 @@
  └─ Speech requests                                                   Monthly cost depends on usage: $5.50 per 1K transactions     
                                                                                                                                    
  azurerm_cognitive_account.speech_with_commitment["invalid"]                                                                       
- ├─ Speech to text batch                                              Monthly cost depends on usage: $0.36 per hours               
+ ├─ Speech to text batch                                              Monthly cost depends on usage: $0.18 per hours               
  ├─ Speech to text custom model                                       Monthly cost depends on usage: $1.20 per hours               
- ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.45 per hours               
+ ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.23 per hours               
  ├─ Speech to text custom endpoint hosting                            Monthly cost depends on usage: $0.05375 per hours            
  ├─ Speech to text custom training                                    Monthly cost depends on usage: $10.00 per hours              
  ├─ Speech to text enhanced add-ons                                   Monthly cost depends on usage: $0.30 per hours               
@@ -251,9 +251,9 @@
                                                                                                                                    
  azurerm_cognitive_account.without_usage["SpeechServices-S0"]                                                                      
  ├─ Speech to text                                                    Monthly cost depends on usage: $1.00 per hours               
- ├─ Speech to text batch                                              Monthly cost depends on usage: $0.36 per hours               
+ ├─ Speech to text batch                                              Monthly cost depends on usage: $0.18 per hours               
  ├─ Speech to text custom model                                       Monthly cost depends on usage: $1.20 per hours               
- ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.45 per hours               
+ ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.23 per hours               
  ├─ Speech to text custom endpoint hosting                            Monthly cost depends on usage: $0.05375 per hours            
  ├─ Speech to text custom training                                    Monthly cost depends on usage: $10.00 per hours              
  ├─ Speech to text enhanced add-ons                                   Monthly cost depends on usage: $0.30 per hours               
@@ -281,7 +281,7 @@
  ├─ Customized training                                               Monthly cost depends on usage: $3.00 per hour                
  └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records         
                                                                                                                                    
- OVERALL TOTAL                                                                                                      $314,896.73 
+ OVERALL TOTAL                                                                                                      $314,876.75 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -295,7 +295,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃ $314,897      ┃ $0.00       ┃ $314,897   ┃
+┃ main                                               ┃ $314,877      ┃ $0.00       ┃ $314,877   ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/resources/azure/cognitive_account_speech.go
+++ b/internal/resources/azure/cognitive_account_speech.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/infracost/infracost/internal/logging"
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
-	"github.com/shopspring/decimal"
 )
 
 var validSpeechCommitmentTierHrs = []int64{2_000, 10_000, 50_000}
@@ -191,7 +192,7 @@ func (r *CognitiveAccountSpeech) costComponents() []*schema.CostComponent {
 	}
 
 	costComponents = append(costComponents,
-		r.s0HourlyCostComponent("Speech to text batch", "Speech to Text Batch", r.MonthlySpeechToTextBatchHrs),
+		r.s0HourlyCostComponent("Speech to text batch", "S1 Speech to Text Batch", r.MonthlySpeechToTextBatchHrs),
 	)
 
 	if r.MonthlyCommitmentSpeechToTextCustomModelHrs != nil {
@@ -205,9 +206,9 @@ func (r *CognitiveAccountSpeech) costComponents() []*schema.CostComponent {
 	}
 
 	costComponents = append(costComponents, []*schema.CostComponent{
-		r.s0HourlyCostComponent("Speech to text custom model batch", "Custom Speech to Text Batch", r.MonthlySpeechToTextCustomModelBatchHrs),
-		r.s0CostComponent("Speech to text custom endpoint hosting", "Custom Speech Model Hosting Unit", floatPtrToDecimalPtr(r.MonthlySpeechToTextCustomEndpointHrs), "hours", 1, &schema.PriceFilter{Unit: strPtr("1/Hour")}), // This uses a different unit, so we don't want to filter the price by '1 Hour'
-		r.s0HourlyCostComponent("Speech to text custom training", "Custom Speech Training", r.MonthlySpeechToTextCustomTrainingHrs),
+		r.s0HourlyCostComponent("Speech to text custom model batch", "S1 Custom Speech to Text Batch", r.MonthlySpeechToTextCustomModelBatchHrs),
+		r.s0CostComponent("Speech to text custom endpoint hosting", "S1 Custom Speech Model Hosting Unit", floatPtrToDecimalPtr(r.MonthlySpeechToTextCustomEndpointHrs), "hours", 1, &schema.PriceFilter{Unit: strPtr("1/Hour")}), // This uses a different unit, so we don't want to filter the price by '1 Hour'
+		r.s0HourlyCostComponent("Speech to text custom training", "S1 Custom Speech Training", r.MonthlySpeechToTextCustomTrainingHrs),
 	}...)
 
 	if r.MonthlyCommitmentSpeechToTextEnhancedAddOnsHrs != nil {
@@ -221,7 +222,7 @@ func (r *CognitiveAccountSpeech) costComponents() []*schema.CostComponent {
 	}
 
 	costComponents = append(costComponents,
-		r.s0HourlyCostComponent("Speech to text conversation transcription multi-channel audio", "Conversation Transcription Multichannel Audio", r.MonthlySpeechToTextConversationTranscriptionMultiChannelAudioHrs),
+		r.s0HourlyCostComponent("Speech to text conversation transcription multi-channel audio", "S1 Conversation Transcription Multichannel Audio", r.MonthlySpeechToTextConversationTranscriptionMultiChannelAudioHrs),
 	)
 
 	// Text to speech
@@ -240,14 +241,14 @@ func (r *CognitiveAccountSpeech) costComponents() []*schema.CostComponent {
 		}
 	}
 	if (r.MonthlyCommitmentTextToSpeechNeuralCommitmentChars == nil && r.MonthlyConnectedContainerCommitmentTextToSpeechNeuralCommitmentChars == nil) || r.MonthlyTextToSpeechNeuralChars != nil {
-		costComponents = append(costComponents, r.s0CostComponent("Text to speech neural", "Neural Text To Speech Characters", intPtrToDecimalPtr(r.MonthlyTextToSpeechNeuralChars), "1M chars", 1_000_000, nil))
+		costComponents = append(costComponents, r.s0CostComponent("Text to speech neural", "S1 Neural Text To Speech Characters", intPtrToDecimalPtr(r.MonthlyTextToSpeechNeuralChars), "1M chars", 1_000_000, nil))
 	}
 
 	costComponents = append(costComponents, []*schema.CostComponent{
-		r.s0HourlyCostComponent("Text to speech custom neural training", "Custom Neural Training", r.MonthlyTextToSpeechCustomNeuralTrainingHrs),
-		r.s0CostComponent("Text to speech custom neural", "Custom Neural Realtime Characters", intPtrToDecimalPtr(r.MonthlyTextToSpeechCustomNeuralChars), "1M chars", 1_000_000, nil),
-		r.s0CostComponent("Text to speech custom neural endpoint hosting", "Custom Neural Voice Model Hosting Unit", floatPtrToDecimalPtr(r.MonthlyTextToSpeechCustomNeuralEndpointHrs), "hours", 1, &schema.PriceFilter{Unit: strPtr("1/Hour")}), // This uses a different unit, so we don't want to filter the price by '1 Hour'
-		r.s0CostComponent("Text to speech long audio", "Neural Long Audio Characters", intPtrToDecimalPtr(r.MonthlyTextToSpeechLongAudioChars), "1M chars", 1_000_000, nil),
+		r.s0HourlyCostComponent("Text to speech custom neural training", "S1 Custom Neural Training", r.MonthlyTextToSpeechCustomNeuralTrainingHrs),
+		r.s0CostComponent("Text to speech custom neural", "S1 Custom Neural Realtime Characters", intPtrToDecimalPtr(r.MonthlyTextToSpeechCustomNeuralChars), "1M chars", 1_000_000, nil),
+		r.s0CostComponent("Text to speech custom neural endpoint hosting", "S1 Custom Neural Voice Model Hosting Unit", floatPtrToDecimalPtr(r.MonthlyTextToSpeechCustomNeuralEndpointHrs), "hours", 1, &schema.PriceFilter{Unit: strPtr("1/Hour")}), // This uses a different unit, so we don't want to filter the price by '1 Hour'
+		r.s0CostComponent("Text to speech long audio", "S1 Neural Long Audio Characters", intPtrToDecimalPtr(r.MonthlyTextToSpeechLongAudioChars), "1M chars", 1_000_000, nil),
 	}...)
 
 	costComponents = append(costComponents, r.personalVoiceCostComponents()...)
@@ -255,18 +256,18 @@ func (r *CognitiveAccountSpeech) costComponents() []*schema.CostComponent {
 	// Speech translation
 
 	costComponents = append(costComponents,
-		r.s0HourlyCostComponent("Speech translation", "Speech Translation", r.MonthlySpeechTranslationHrs),
+		r.s0HourlyCostComponent("Speech translation", "S1 Speech Translation", r.MonthlySpeechTranslationHrs),
 	)
 
 	// Speaker recognition
 	costComponents = append(costComponents, []*schema.CostComponent{
-		r.s0CostComponent("Speaker verification", "Speaker Verification Transactions", intPtrToDecimalPtr(r.MonthlySpeakerVerificationTransactions), "1K transactions", 1_000, nil),
-		r.s0CostComponent("Speaker identification", "Speaker Identification Transactions", intPtrToDecimalPtr(r.MonthlySpeakerIdentificationTransactions), "1K transactions", 1_000, nil),
+		r.s0CostComponent("Speaker verification", "S1 Speaker Verification Transactions", intPtrToDecimalPtr(r.MonthlySpeakerVerificationTransactions), "1K transactions", 1_000, nil),
+		r.s0CostComponent("Speaker identification", "S1 Speaker Identification Transactions", intPtrToDecimalPtr(r.MonthlySpeakerIdentificationTransactions), "1K transactions", 1_000, nil),
 	}...)
 
 	// Voice profiles
 	costComponents = append(costComponents,
-		r.s0CostComponent("Voice profiles", "Voice Storage", intPtrToDecimalPtr(r.MonthlyVoiceProfiles), "1K profiles", 1_000, nil),
+		r.s0CostComponent("Voice profiles", "S1 Voice Storage", intPtrToDecimalPtr(r.MonthlyVoiceProfiles), "1K profiles", 1_000, nil),
 	)
 
 	return costComponents
@@ -331,7 +332,7 @@ func (r *CognitiveAccountSpeech) personalVoiceCostComponents() []*schema.CostCom
 				AttributeFilters: []*schema.AttributeFilter{
 					{Key: "productName", Value: strPtr("Speech")},
 					{Key: "skuName", Value: strPtr("Text to Speech - Personal Voice")},
-					{Key: "meterName", Value: strPtr("Voice Storage")},
+					{Key: "meterName", Value: strPtr("Text to Speech - Personal Voice Voice Storage")},
 				},
 			},
 		},


### PR DESCRIPTION
Commits the extended support costs for eks cluster and lightsail instance test. Changes the Azure AI services tests meter naming to fix prices not found. This also includes minor changes to the cognitive service pricing.