### PR TITLE
fix: create `dependency_paths` for auto generated config

### DIFF
--- a/cmd/infracost/generate.go
+++ b/cmd/infracost/generate.go
@@ -123,6 +123,7 @@ func (g *generateConfigCommand) run(cmd *cobra.Command, args []string) error {
 				Path:              p.RelativePath(),
 				Env:               p.EnvName(),
 				TerraformVarFiles: p.VarFiles(),
+				DependencyPaths:   p.DependencyPaths(),
 			}
 
 			if v, ok := detectedPaths[p.RelativePath()]; ok {

--- a/cmd/infracost/testdata/generate/module_calls/expected.golden
+++ b/cmd/infracost/testdata/generate/module_calls/expected.golden
@@ -1,0 +1,18 @@
+version: 0.1
+
+projects:
+  - path: infra/dev
+    name: infra-dev
+    skip_autodetect: true
+    dependency_paths:
+      - infra/modules/is_also_called
+      - infra/modules/is_called
+  - path: infra/modules/is_a_project
+    name: infra-modules-is_a_project
+    skip_autodetect: true
+  - path: infra/prod
+    name: infra-prod
+    skip_autodetect: true
+    dependency_paths:
+      - infra/modules/is_called
+

--- a/cmd/infracost/testdata/generate/module_calls/tree.txt
+++ b/cmd/infracost/testdata/generate/module_calls/tree.txt
@@ -1,0 +1,13 @@
+.
+└── infra
+    ├── modules
+    │   ├── is_called
+    │   │   └── main.tf
+    │   ├── is_also_called
+    │   │   └── main.tf
+    │   └── is_a_project
+    │       └── main.tf
+    ├── dev
+    │   └── module-call|..-modules-is_called|..-modules-is_also_called.tf
+    └── prod
+        └── module-call|..-modules-is_called.tf

--- a/cmd/infracost/testdata/generate/module_calls_with_template/expected.golden
+++ b/cmd/infracost/testdata/generate/module_calls_with_template/expected.golden
@@ -1,0 +1,19 @@
+version: 0.1
+
+projects:
+  - path: infra/dev
+    name: infra-dev
+    terraform_var_files:
+    dependency_paths:
+      - infra/modules/is_also_called
+      - infra/modules/is_called
+  - path: infra/modules/is_a_project
+    name: infra-modules-is_a_project
+    terraform_var_files:
+    dependency_paths:
+  - path: infra/prod
+    name: infra-prod
+    terraform_var_files:
+    dependency_paths:
+      - infra/modules/is_called
+

--- a/cmd/infracost/testdata/generate/module_calls_with_template/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/module_calls_with_template/infracost.yml.tmpl
@@ -1,0 +1,15 @@
+version: 0.1
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+    terraform_var_files:
+    {{- range $varFile := $project.TerraformVarFiles }}
+      - {{ $varFile }}
+    {{- end }}
+    dependency_paths:
+    {{- range $dep := $project.DependencyPaths }}
+      - {{ $dep }}
+    {{- end }}
+{{- end }}

--- a/cmd/infracost/testdata/generate/module_calls_with_template/tree.txt
+++ b/cmd/infracost/testdata/generate/module_calls_with_template/tree.txt
@@ -1,0 +1,13 @@
+.
+└── infra
+    ├── modules
+    │   ├── is_called
+    │   │   └── main.tf
+    │   ├── is_also_called
+    │   │   └── main.tf
+    │   └── is_a_project
+    │       └── main.tf
+    ├── dev
+    │   └── module-call|..-modules-is_called|..-modules-is_also_called.tf
+    └── prod
+        └── module-call|..-modules-is_called.tf

--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -23,6 +23,7 @@ type DetectedProject struct {
 	Name              string
 	Path              string
 	TerraformVarFiles []string
+	DependencyPaths   []string
 	Env               string
 }
 

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -251,6 +251,7 @@ type DetectedProject interface {
 	RelativePath() string
 	VarFiles() []string
 	YAML() string
+	DependencyPaths() []string
 }
 
 // Parser is a tool for parsing terraform templates at a given file system location.
@@ -270,6 +271,7 @@ type Parser struct {
 	hasChanges            bool
 	moduleSuffix          string
 	envMatcher            *EnvFileMatcher
+	moduleCalls           []string
 }
 
 // NewParser creates a new parser for the given RootPath.
@@ -284,6 +286,7 @@ func NewParser(projectRoot RootPath, envMatcher *EnvFileMatcher, moduleLoader *m
 		startingPath:        projectRoot.StartingPath,
 		detectedProjectPath: projectRoot.DetectedPath,
 		hasChanges:          projectRoot.HasChanges,
+		moduleCalls:         projectRoot.ModuleCalls,
 		workspaceName:       defaultTerraformWorkspaceName,
 		hclParser:           hclParser,
 		blockBuilder:        BlockBuilder{SetAttributes: []SetAttributesFunc{SetUUIDAttributes}, Logger: logger, HCLParser: hclParser},
@@ -335,7 +338,37 @@ func (p *Parser) YAML() string {
 		}
 	}
 
+	calls := p.DependencyPaths()
+	if len(calls) > 0 {
+		str.WriteString("    dependency_paths:\n")
+		for _, call := range calls {
+			str.WriteString(fmt.Sprintf("      - %s\n", call))
+		}
+	}
+
 	return str.String()
+}
+
+// DependencyPaths returns the list of module calls that the project depends on.
+// These are usually local module calls that have been detected in the project.
+func (p *Parser) DependencyPaths() []string {
+	if len(p.moduleCalls) == 0 {
+		return nil
+	}
+
+	sortedCalls := make([]string, len(p.moduleCalls))
+	for i, call := range p.moduleCalls {
+		relCall := call
+		dep, err := filepath.Rel(p.startingPath, call)
+		if err == nil {
+			relCall = dep
+		}
+
+		sortedCalls[i] = relCall
+	}
+	sort.Strings(sortedCalls)
+
+	return sortedCalls
 }
 
 // ParseDirectory parses all the terraform files in the detectedProjectPath into Blocks and then passes them to an Evaluator

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -959,6 +959,7 @@ type RootPath struct {
 
 	HasChildVarFiles bool
 	IsTerragrunt     bool
+	ModuleCalls      []string
 }
 
 func (r *RootPath) RelPath() string {
@@ -1158,6 +1159,7 @@ func (p *ProjectLocator) FindRootModules(startingPath string) []RootPath {
 				StartingPath:      startingPath,
 				DetectedPath:      dir.path,
 				HasChanges:        p.hasChanges(dir.path),
+				ModuleCalls:       p.moduleCalls[dir.path],
 				TerraformVarFiles: p.discoveredVarFiles[dir.path],
 				Matcher:           p.envMatcher,
 				IsTerragrunt:      dir.isTerragrunt,
@@ -1173,6 +1175,7 @@ func (p *ProjectLocator) FindRootModules(startingPath string) []RootPath {
 					StartingPath:      startingPath,
 					DetectedPath:      dir.path,
 					HasChanges:        p.hasChanges(dir.path),
+					ModuleCalls:       p.moduleCalls[dir.path],
 					TerraformVarFiles: p.discoveredVarFiles[dir.path],
 					Matcher:           p.envMatcher,
 					IsTerragrunt:      dir.isTerragrunt,

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -206,6 +206,10 @@ func (p *HCLProvider) VarFiles() []string {
 	return p.Parser.VarFiles()
 }
 
+func (p *HCLProvider) DependencyPaths() []string {
+	return p.Parser.DependencyPaths()
+}
+
 func (p *HCLProvider) EnvName() string {
 	return p.Parser.EnvName()
 }

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -198,6 +198,10 @@ func (p *TerragruntHCLProvider) VarFiles() []string {
 	return nil
 }
 
+func (p *TerragruntHCLProvider) DependencyPaths() []string {
+	return nil
+}
+
 func (p *TerragruntHCLProvider) YAML() string {
 	str := strings.Builder{}
 
@@ -205,6 +209,7 @@ func (p *TerragruntHCLProvider) YAML() string {
 
 	return str.String()
 }
+
 func (p *TerragruntHCLProvider) Type() string {
 	return "terragrunt_dir"
 }

--- a/internal/testutil/generate.go
+++ b/internal/testutil/generate.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,6 +114,29 @@ instance_type = "m5.4xlarge"
 		content = `
 			# This is an empty file
 `
+	}
+
+	if strings.HasPrefix(filename, "module-call") {
+		pieces := strings.Split(filename, "|")
+		calls := pieces[1:]
+		content = `provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+`
+		for i, call := range calls {
+			call = strings.TrimSuffix(call, ".tf")
+			call = strings.ReplaceAll(call, "-", "/")
+			content += `
+module "` + fmt.Sprintf("call_%d", i) + `" {
+  source = "` + call + `"
+}
+`
+		}
 	}
 
 	return os.WriteFile(filePath, []byte(content), 0600)


### PR DESCRIPTION
Resolves issues where local module changes were not triggering project reruns. This has been addressed in this PR by adding the detected module calls from the `ProjectLocator` to the `dependency_paths` for each auto detected project.

**Note:** This does not solve explicitly solve issues with dependencies and Terragrunt projects. These are more nuanced and require additional work. For example handling Terragrunt `include` blocks with a `src` that resides outside the project path.