### PR TITLE
fix: readd autogenerated `dependency_paths` with remote module fix.

### DIFF
--- a/cmd/infracost/generate.go
+++ b/cmd/infracost/generate.go
@@ -123,6 +123,7 @@ func (g *generateConfigCommand) run(cmd *cobra.Command, args []string) error {
 				Path:              p.RelativePath(),
 				Env:               p.EnvName(),
 				TerraformVarFiles: p.VarFiles(),
+				DependencyPaths:   p.DependencyPaths(),
 			}
 
 			if v, ok := detectedPaths[p.RelativePath()]; ok {

--- a/cmd/infracost/testdata/generate/module_calls/expected.golden
+++ b/cmd/infracost/testdata/generate/module_calls/expected.golden
@@ -1,0 +1,18 @@
+version: 0.1
+
+projects:
+  - path: infra/dev
+    name: infra-dev
+    skip_autodetect: true
+    dependency_paths:
+      - infra/modules/is_also_called
+      - infra/modules/is_called
+  - path: infra/modules/is_a_project
+    name: infra-modules-is_a_project
+    skip_autodetect: true
+  - path: infra/prod
+    name: infra-prod
+    skip_autodetect: true
+    dependency_paths:
+      - infra/modules/is_called
+

--- a/cmd/infracost/testdata/generate/module_calls/tree.txt
+++ b/cmd/infracost/testdata/generate/module_calls/tree.txt
@@ -1,0 +1,13 @@
+.
+└── infra
+    ├── modules
+    │   ├── is_called
+    │   │   └── main.tf
+    │   ├── is_also_called
+    │   │   └── main.tf
+    │   └── is_a_project
+    │       └── main.tf
+    ├── dev
+    │   └── module-call|..-modules-is_called|..-modules-is_also_called.tf
+    └── prod
+        └── module-call|..-modules-is_called.tf

--- a/cmd/infracost/testdata/generate/module_calls_with_template/expected.golden
+++ b/cmd/infracost/testdata/generate/module_calls_with_template/expected.golden
@@ -1,0 +1,19 @@
+version: 0.1
+
+projects:
+  - path: infra/dev
+    name: infra-dev
+    terraform_var_files:
+    dependency_paths:
+      - infra/modules/is_also_called
+      - infra/modules/is_called
+  - path: infra/modules/is_a_project
+    name: infra-modules-is_a_project
+    terraform_var_files:
+    dependency_paths:
+  - path: infra/prod
+    name: infra-prod
+    terraform_var_files:
+    dependency_paths:
+      - infra/modules/is_called
+

--- a/cmd/infracost/testdata/generate/module_calls_with_template/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/module_calls_with_template/infracost.yml.tmpl
@@ -1,0 +1,15 @@
+version: 0.1
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+    terraform_var_files:
+    {{- range $varFile := $project.TerraformVarFiles }}
+      - {{ $varFile }}
+    {{- end }}
+    dependency_paths:
+    {{- range $dep := $project.DependencyPaths }}
+      - {{ $dep }}
+    {{- end }}
+{{- end }}

--- a/cmd/infracost/testdata/generate/module_calls_with_template/tree.txt
+++ b/cmd/infracost/testdata/generate/module_calls_with_template/tree.txt
@@ -1,0 +1,13 @@
+.
+└── infra
+    ├── modules
+    │   ├── is_called
+    │   │   └── main.tf
+    │   ├── is_also_called
+    │   │   └── main.tf
+    │   └── is_a_project
+    │       └── main.tf
+    ├── dev
+    │   └── module-call|..-modules-is_called|..-modules-is_also_called.tf
+    └── prod
+        └── module-call|..-modules-is_called.tf

--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -23,6 +23,7 @@ type DetectedProject struct {
 	Name              string
 	Path              string
 	TerraformVarFiles []string
+	DependencyPaths   []string
 	Env               string
 }
 

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -201,7 +201,7 @@ func (m *ModuleLoader) loadModules(path string, prefix string) ([]*ManifestModul
 				}
 
 				// only include non-local modules in the manifest since we don't want to cache local ones.
-				if !isLocalModule(metadata.Source) {
+				if !IsLocalModule(metadata.Source) {
 					manifestMu.Lock()
 					manifestModules = append(manifestModules, metadata)
 					manifestMu.Unlock()
@@ -272,7 +272,7 @@ func (m *ModuleLoader) loadModule(moduleCall *tfconfig.ModuleCall, parentPath st
 	} else {
 		m.logger.Debug().Msgf("module %s needs loading: %s", key, err.Error())
 	}
-	if isLocalModule(source) {
+	if IsLocalModule(source) {
 		dir, err := m.cachePathRel(filepath.Join(parentPath, source))
 		if err != nil {
 			return nil, err
@@ -478,9 +478,9 @@ func (m *ModuleLoader) cachePathRel(targetPath string) (string, error) {
 	return filepath.Rel(absCachePath, absTargetPath)
 }
 
-// isLocalModule checks if the module is a local module by checking
+// IsLocalModule checks if the module is a local module by checking
 // if the module source starts with any known local prefixes
-func isLocalModule(source string) bool {
+func IsLocalModule(source string) bool {
 	return strings.HasPrefix(source, "./") ||
 		strings.HasPrefix(source, "../") ||
 		strings.HasPrefix(source, ".\\") ||

--- a/internal/hcl/modules/manifest.go
+++ b/internal/hcl/modules/manifest.go
@@ -47,7 +47,7 @@ type ManifestModule struct {
 }
 
 func (m ManifestModule) URL() string {
-	if isLocalModule(m.Source) {
+	if IsLocalModule(m.Source) {
 		return ""
 	}
 

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -251,6 +251,7 @@ type DetectedProject interface {
 	RelativePath() string
 	VarFiles() []string
 	YAML() string
+	DependencyPaths() []string
 }
 
 // Parser is a tool for parsing terraform templates at a given file system location.
@@ -270,6 +271,7 @@ type Parser struct {
 	hasChanges            bool
 	moduleSuffix          string
 	envMatcher            *EnvFileMatcher
+	moduleCalls           []string
 }
 
 // NewParser creates a new parser for the given RootPath.
@@ -284,6 +286,7 @@ func NewParser(projectRoot RootPath, envMatcher *EnvFileMatcher, moduleLoader *m
 		startingPath:        projectRoot.StartingPath,
 		detectedProjectPath: projectRoot.DetectedPath,
 		hasChanges:          projectRoot.HasChanges,
+		moduleCalls:         projectRoot.ModuleCalls,
 		workspaceName:       defaultTerraformWorkspaceName,
 		hclParser:           hclParser,
 		blockBuilder:        BlockBuilder{SetAttributes: []SetAttributesFunc{SetUUIDAttributes}, Logger: logger, HCLParser: hclParser},
@@ -335,7 +338,37 @@ func (p *Parser) YAML() string {
 		}
 	}
 
+	calls := p.DependencyPaths()
+	if len(calls) > 0 {
+		str.WriteString("    dependency_paths:\n")
+		for _, call := range calls {
+			str.WriteString(fmt.Sprintf("      - %s\n", call))
+		}
+	}
+
 	return str.String()
+}
+
+// DependencyPaths returns the list of module calls that the project depends on.
+// These are usually local module calls that have been detected in the project.
+func (p *Parser) DependencyPaths() []string {
+	if len(p.moduleCalls) == 0 {
+		return nil
+	}
+
+	sortedCalls := make([]string, len(p.moduleCalls))
+	for i, call := range p.moduleCalls {
+		relCall := call
+		dep, err := filepath.Rel(p.startingPath, call)
+		if err == nil {
+			relCall = dep
+		}
+
+		sortedCalls[i] = relCall
+	}
+	sort.Strings(sortedCalls)
+
+	return sortedCalls
 }
 
 // ParseDirectory parses all the terraform files in the detectedProjectPath into Blocks and then passes them to an Evaluator

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -959,6 +959,7 @@ type RootPath struct {
 
 	HasChildVarFiles bool
 	IsTerragrunt     bool
+	ModuleCalls      []string
 }
 
 func (r *RootPath) RelPath() string {
@@ -1158,6 +1159,7 @@ func (p *ProjectLocator) FindRootModules(startingPath string) []RootPath {
 				StartingPath:      startingPath,
 				DetectedPath:      dir.path,
 				HasChanges:        p.hasChanges(dir.path),
+				ModuleCalls:       p.moduleCalls[dir.path],
 				TerraformVarFiles: p.discoveredVarFiles[dir.path],
 				Matcher:           p.envMatcher,
 				IsTerragrunt:      dir.isTerragrunt,
@@ -1173,6 +1175,7 @@ func (p *ProjectLocator) FindRootModules(startingPath string) []RootPath {
 					StartingPath:      startingPath,
 					DetectedPath:      dir.path,
 					HasChanges:        p.hasChanges(dir.path),
+					ModuleCalls:       p.moduleCalls[dir.path],
 					TerraformVarFiles: p.discoveredVarFiles[dir.path],
 					Matcher:           p.envMatcher,
 					IsTerragrunt:      dir.isTerragrunt,

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zclconf/go-cty/cty/gocty"
 
 	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/hcl/modules"
 )
 
 var (
@@ -1623,6 +1624,12 @@ func (p *ProjectLocator) shallowDecodeTerraformBlocks(fullPath string, files map
 				err := gocty.FromCtyValue(val, &realPath)
 				if err != nil {
 					p.logger.Debug().Err(err).Str("module", strings.Join(module.Labels, ".")).Msg("could not read source value of module as string")
+					continue
+				}
+
+				// we only care about local modules for building a dependency tree
+				// so skip any remote modules here.
+				if !modules.IsLocalModule(realPath) {
 					continue
 				}
 

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -206,6 +206,10 @@ func (p *HCLProvider) VarFiles() []string {
 	return p.Parser.VarFiles()
 }
 
+func (p *HCLProvider) DependencyPaths() []string {
+	return p.Parser.DependencyPaths()
+}
+
 func (p *HCLProvider) EnvName() string {
 	return p.Parser.EnvName()
 }

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -198,6 +198,10 @@ func (p *TerragruntHCLProvider) VarFiles() []string {
 	return nil
 }
 
+func (p *TerragruntHCLProvider) DependencyPaths() []string {
+	return nil
+}
+
 func (p *TerragruntHCLProvider) YAML() string {
 	str := strings.Builder{}
 
@@ -205,6 +209,7 @@ func (p *TerragruntHCLProvider) YAML() string {
 
 	return str.String()
 }
+
 func (p *TerragruntHCLProvider) Type() string {
 	return "terragrunt_dir"
 }

--- a/internal/testutil/generate.go
+++ b/internal/testutil/generate.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,6 +114,29 @@ instance_type = "m5.4xlarge"
 		content = `
 			# This is an empty file
 `
+	}
+
+	if strings.HasPrefix(filename, "module-call") {
+		pieces := strings.Split(filename, "|")
+		calls := pieces[1:]
+		content = `provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+`
+		for i, call := range calls {
+			call = strings.TrimSuffix(call, ".tf")
+			call = strings.ReplaceAll(call, "-", "/")
+			content += `
+module "` + fmt.Sprintf("call_%d", i) + `" {
+  source = "` + call + `"
+}
+`
+		}
 	}
 
 	return os.WriteFile(filePath, []byte(content), 0600)


### PR DESCRIPTION
Reinstates the work done in https://github.com/infracost/infracost/pull/3063 but with an additional fix that can be viewed in 0dd176e293d763c5956db78bac18d66c72e0499d, This Removes remote modules from the `ProjectLocator` moduleCall list as these module calls are only designed to build a local dependency tree. Excluding remote modules also indirectly fixes an issue with YAML parsing the generated config where remote module strings were causing errors, e.g:

```
dependency_paths:
  - golden_tests/test_https_module/git::https:/github.com/infracost/terraform-private-module-example.git
```

Would cause the YAML validate step for the infracost config file to error.