### PR TITLE
fix: support launch templates references which use `prefix`

### DIFF
--- a/internal/providers/terraform/aws/eks_node_group_test.go
+++ b/internal/providers/terraform/aws/eks_node_group_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/shopspring/decimal"
 
+	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/schema"
 	"github.com/infracost/infracost/internal/testutil"
 
@@ -17,7 +18,9 @@ func TestEKSNodeGroupGoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "eks_node_group_test")
+	tftest.GoldenFileHCLResourceTestsWithOpts(t, "eks_node_group_test", tftest.DefaultGoldenFileOptions(), func(ctx *config.RunContext) {
+		ctx.Config.GraphEvaluator = true
+	})
 }
 
 func TestEKSNodeGroup_spot(t *testing.T) {

--- a/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.golden
@@ -9,6 +9,14 @@
     └─ block_device_mapping[0]                                                                                   
        └─ Storage (general purpose SSD, gp2)                                      60  GB                 $6.00   
                                                                                                                  
+ aws_eks_node_group.example_with_launch_template_with_prefix                                                     
+ └─ aws_launch_template.prefix                                                                                   
+    ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                        2,190  hours            $210.24   
+    ├─ EBS-optimized usage                                                     2,190  hours              $0.00   
+    ├─ Inference accelerator (eia1.medium)                                     2,190  hours            $284.70   
+    └─ block_device_mapping[0]                                                                                   
+       └─ Storage (general purpose SSD, gp3)                                     300  GB                $24.00   
+                                                                                                                 
  aws_eks_node_group.example_with_launch_template_3                                                               
  └─ aws_launch_template.foo3                                                                                     
     ├─ Instance usage (Linux/UNIX, on-demand, m5.large)                        2,190  hours            $210.24   
@@ -64,17 +72,17 @@
  ├─ Instance usage (Linux/UNIX, on-demand, t3.medium)                            730  hours             $30.37   
  └─ Storage (general purpose SSD, gp2)                                            20  GB                 $2.00   
                                                                                                                  
- OVERALL TOTAL                                                                                      $2,762.37 
+ OVERALL TOTAL                                                                                      $3,281.31 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-16 cloud resources were detected:
-∙ 11 were estimated
-∙ 5 were free
+18 cloud resources were detected:
+∙ 12 were estimated
+∙ 6 were free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃ $2,762        ┃ $0.00       ┃ $2,762     ┃
+┃ main                                               ┃ $3,281        ┃ $0.00       ┃ $3,281     ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.tf
+++ b/internal/providers/terraform/aws/testdata/eks_node_group_test/eks_node_group_test.tf
@@ -8,6 +8,10 @@ provider "aws" {
   secret_key                  = "mock_secret_key"
 }
 
+locals {
+  launch_template_name = aws_launch_template.prefix.name
+}
+
 resource "aws_eks_node_group" "example" {
   cluster_name    = "test_aws_eks_node_group"
   node_group_name = "example"
@@ -337,6 +341,102 @@ resource "aws_eks_node_group" "example_with_launch_template_3" {
 
   launch_template {
     name    = aws_launch_template.foo3.name
+    version = "default_version"
+  }
+}
+
+resource "aws_launch_template" "prefix" {
+  name        = null
+  name_prefix = "prefix-"
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_type = "gp3"
+      volume_size = 100
+    }
+  }
+
+  capacity_reservation_specification {
+    capacity_reservation_preference = "open"
+  }
+
+  cpu_options {
+    core_count       = 4
+    threads_per_core = 2
+  }
+
+  credit_specification {
+    cpu_credits = "standard"
+  }
+
+  disable_api_termination = true
+
+  ebs_optimized = true
+
+  elastic_gpu_specifications {
+    type = "test"
+  }
+
+  elastic_inference_accelerator {
+    type = "eia1.medium"
+  }
+
+  iam_instance_profile {
+    name = "test"
+  }
+
+  image_id = "ami-test"
+
+  instance_initiated_shutdown_behavior = "terminate"
+
+  instance_type = "m5.xlarge"
+
+  kernel_id = "test"
+
+  key_name = "test"
+
+  license_specification {
+    license_configuration_arn = "arn:aws:license-manager:eu-west-1:123456789012:license-configuration:lic-0123456789abcdef0123456789abcdef"
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  network_interfaces {
+    associate_public_ip_address = true
+  }
+
+  placement {
+    availability_zone = "us-west-2a"
+  }
+
+  ram_disk_id = "test"
+
+  vpc_security_group_ids = ["example"]
+
+}
+
+resource "aws_eks_node_group" "example_with_launch_template_with_prefix" {
+  cluster_name    = "test_aws_eks_node_group"
+  node_group_name = "example"
+  node_role_arn   = "node_role_arn"
+  subnet_ids      = ["subnet_id"]
+
+  instance_types = ["m5.large"]
+
+  scaling_config {
+    desired_size = 3
+    max_size     = 1
+    min_size     = 1
+  }
+
+  launch_template {
+    name    = local.launch_template_name
     version = "default_version"
   }
 }


### PR DESCRIPTION
This PR adds support for launch templates which are referenced by `name` in a resource but use a `prefix` to launch. This means that the `name` attribute can be `null` and prior to this change, references would not work. This change adds a Infracost generated `name` if it is detected that the `launch_template` has a `null` name.