### PR TITLE
fix: propagate default provider tags to volume tags

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -85,6 +85,26 @@ func TestBreakdownFormatJsonWithTags(t *testing.T) {
 	)
 }
 
+func TestBreakdownFormatJsonWithTagsVersionLessThan5point39(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testName,
+		[]string{
+			"breakdown",
+			"--format", "json",
+			"--path", dir,
+		},
+		&GoldenFileOptions{
+			CaptureLogs: true,
+			IsJSON:      true,
+		}, func(ctx *config.RunContext) {
+			ctx.Config.TagPoliciesEnabled = true
+		},
+	)
+}
+
 func TestBreakdownFormatJsonWithTagsAftModule(t *testing.T) {
 	testName := testutil.CalcGoldenFileTestdataDirName()
 	dir := path.Join("./testdata", testName)

--- a/cmd/infracost/testdata/breakdown_format_json_with_tags/breakdown_format_json_with_tags.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags/breakdown_format_json_with_tags.golden
@@ -41,20 +41,22 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "volume_tag_overwritten",
               "volume_tags.baz": "bat"
             },
             "metadata": {
               "calls": [
                 {
                   "blockName": "aws_instance.web_app",
-                  "endLine": 88,
+                  "endLine": 89,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
                   "startLine": 67
                 }
               ],
-              "checksum": "13adebe4ed01fd707c54cf97a06980aecb52eab84fe379a941727cc1ead2a93f",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
-              "endLine": 88,
+              "checksum": "3971020356e35708e0de7df3decdd615468f858c38205a99249dd4aa4e3ccf23",
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
+              "endLine": 89,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
               "startLine": 67
             },
@@ -128,22 +130,24 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "ebs_block_device[0].foo": "ebd",
-              "root_block_device.foo": "rbd"
+              "root_block_device.foo": "rbd",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride"
             },
             "metadata": {
               "calls": [
                 {
                   "blockName": "aws_instance.web_app_block_tags",
-                  "endLine": 202,
+                  "endLine": 203,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-                  "startLine": 181
+                  "startLine": 182
                 }
               ],
               "checksum": "47efe9c1f904be19ea9a38623ebcb399b03026ba4c0436284a121e35b84ce286",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
-              "endLine": 202,
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
+              "endLine": 203,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-              "startLine": 181
+              "startLine": 182
             },
             "hourlyCost": "1.017315068493150679",
             "monthlyCost": "742.64",
@@ -219,15 +223,15 @@
               "calls": [
                 {
                   "blockName": "aws_autoscaling_group.launch_template",
-                  "endLine": 179,
+                  "endLine": 180,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-                  "startLine": 155
+                  "startLine": 156
                 }
               ],
               "checksum": "683ec0c113599563ccbf834223b61ffcc2abbd9ac8d6202036fc4fc6eb56a2d0",
-              "endLine": 179,
+              "endLine": 180,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-              "startLine": 155
+              "startLine": 156
             },
             "hourlyCost": "0.2303726027397260165",
             "monthlyCost": "168.172",
@@ -310,22 +314,24 @@
               "DefaultOverride": "defaultoverride",
               "bat": "ball",
               "fizz": "buzz",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.flip": "flop"
             },
             "metadata": {
               "calls": [
                 {
                   "blockName": "aws_instance.launch_instance",
-                  "endLine": 102,
+                  "endLine": 103,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-                  "startLine": 90
+                  "startLine": 91
                 }
               ],
               "checksum": "92d793c678fac9bf7ce08e05983f01e62665b7ea640a512f23bb3061b8c645b5",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
-              "endLine": 102,
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
+              "endLine": 103,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-              "startLine": 90
+              "startLine": 91
             },
             "hourlyCost": "0.0586890410958904025",
             "monthlyCost": "42.843",
@@ -586,16 +592,16 @@
               "calls": [
                 {
                   "blockName": "aws_launch_template.example",
-                  "endLine": 153,
+                  "endLine": 154,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-                  "startLine": 104
+                  "startLine": 105
                 }
               ],
               "checksum": "5ae555e21daf62bb42d8cfcff0473722eb04032804b064b14d474f6f8923255e",
               "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
-              "endLine": 153,
+              "endLine": 154,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-              "startLine": 104
+              "startLine": 105
             }
           }
         ],
@@ -612,20 +618,22 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "volume_tag_overwritten",
               "volume_tags.baz": "bat"
             },
             "metadata": {
               "calls": [
                 {
                   "blockName": "aws_instance.web_app",
-                  "endLine": 88,
+                  "endLine": 89,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
                   "startLine": 67
                 }
               ],
-              "checksum": "13adebe4ed01fd707c54cf97a06980aecb52eab84fe379a941727cc1ead2a93f",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
-              "endLine": 88,
+              "checksum": "3971020356e35708e0de7df3decdd615468f858c38205a99249dd4aa4e3ccf23",
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
+              "endLine": 89,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
               "startLine": 67
             },
@@ -699,22 +707,24 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "ebs_block_device[0].foo": "ebd",
-              "root_block_device.foo": "rbd"
+              "root_block_device.foo": "rbd",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride"
             },
             "metadata": {
               "calls": [
                 {
                   "blockName": "aws_instance.web_app_block_tags",
-                  "endLine": 202,
+                  "endLine": 203,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-                  "startLine": 181
+                  "startLine": 182
                 }
               ],
               "checksum": "47efe9c1f904be19ea9a38623ebcb399b03026ba4c0436284a121e35b84ce286",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
-              "endLine": 202,
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
+              "endLine": 203,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-              "startLine": 181
+              "startLine": 182
             },
             "hourlyCost": "1.017315068493150679",
             "monthlyCost": "742.64",
@@ -790,15 +800,15 @@
               "calls": [
                 {
                   "blockName": "aws_autoscaling_group.launch_template",
-                  "endLine": 179,
+                  "endLine": 180,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-                  "startLine": 155
+                  "startLine": 156
                 }
               ],
               "checksum": "683ec0c113599563ccbf834223b61ffcc2abbd9ac8d6202036fc4fc6eb56a2d0",
-              "endLine": 179,
+              "endLine": 180,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-              "startLine": 155
+              "startLine": 156
             },
             "hourlyCost": "0.2303726027397260165",
             "monthlyCost": "168.172",
@@ -881,22 +891,24 @@
               "DefaultOverride": "defaultoverride",
               "bat": "ball",
               "fizz": "buzz",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.flip": "flop"
             },
             "metadata": {
               "calls": [
                 {
                   "blockName": "aws_instance.launch_instance",
-                  "endLine": 102,
+                  "endLine": 103,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-                  "startLine": 90
+                  "startLine": 91
                 }
               ],
               "checksum": "92d793c678fac9bf7ce08e05983f01e62665b7ea640a512f23bb3061b8c645b5",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
-              "endLine": 102,
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
+              "endLine": 103,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-              "startLine": 90
+              "startLine": 91
             },
             "hourlyCost": "0.0586890410958904025",
             "monthlyCost": "42.843",
@@ -1157,16 +1169,16 @@
               "calls": [
                 {
                   "blockName": "aws_launch_template.example",
-                  "endLine": 153,
+                  "endLine": 154,
                   "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-                  "startLine": 104
+                  "startLine": 105
                 }
               ],
               "checksum": "5ae555e21daf62bb42d8cfcff0473722eb04032804b064b14d474f6f8923255e",
               "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
-              "endLine": 153,
+              "endLine": 154,
               "filename": "testdata/breakdown_format_json_with_tags/main.tf",
-              "startLine": 104
+              "startLine": 105
             }
           }
         ],

--- a/cmd/infracost/testdata/breakdown_format_json_with_tags/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags/main.tf
@@ -68,7 +68,8 @@ resource "aws_instance" "web_app" {
   ami           = "ami-674cbc1e"
   instance_type = "m5.4xlarge"
   volume_tags = {
-    "baz" = "bat"
+    "baz"           = "bat"
+    DefaultOverride = "volume_tag_overwritten"
   }
 
   root_block_device {

--- a/cmd/infracost/testdata/breakdown_format_json_with_tags_version_less_than5point39/breakdown_format_json_with_tags_version_less_than5point39.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags_version_less_than5point39/breakdown_format_json_with_tags_version_less_than5point39.golden
@@ -1,0 +1,1222 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "stub-branch",
+    "vcsCommitSha": "stub-sha",
+    "vcsCommitAuthorName": "stub-author",
+    "vcsCommitAuthorEmail": "stub@stub.com",
+    "vcsCommitTimestamp": "REPLACED_TIME",
+    "vcsCommitMessage": "stub-message",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost"
+  },
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "infracost/infracost/cmd/infracost/testdata/breakdown_format_json_with_tags_version_less_than5point39",
+      "displayName": "main",
+      "metadata": {
+        "path": "testdata/breakdown_format_json_with_tags_version_less_than5point39",
+        "type": "terraform_dir",
+        "vcsSubPath": "cmd/infracost/testdata/breakdown_format_json_with_tags_version_less_than5point39",
+        "providers": [
+          {
+            "name": "aws",
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+            "startLine": 1,
+            "endLine": 14
+          }
+        ]
+      },
+      "pastBreakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
+              "foo": "bar",
+              "volume_tags.DefaultOverride": "volume_tag_overwritten",
+              "volume_tags.baz": "bat"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app",
+                  "endLine": 98,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 76
+                }
+              ],
+              "checksum": "3971020356e35708e0de7df3decdd615468f858c38205a99249dd4aa4e3ccf23",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 98,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 76
+            },
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_instance.web_app_block_tags",
+            "resourceType": "aws_instance",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
+              "ebs_block_device[0].foo": "ebd",
+              "root_block_device.foo": "rbd"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app_block_tags",
+                  "endLine": 212,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 191
+                }
+              ],
+              "checksum": "47efe9c1f904be19ea9a38623ebcb399b03026ba4c0436284a121e35b84ce286",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 212,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 191
+            },
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_autoscaling_group.launch_template",
+            "resourceType": "aws_autoscaling_group",
+            "tags": {
+              "fizz": "buzz",
+              "foo": "bar"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_autoscaling_group.launch_template",
+                  "endLine": 189,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 165
+                }
+              ],
+              "checksum": "683ec0c113599563ccbf834223b61ffcc2abbd9ac8d6202036fc4fc6eb56a2d0",
+              "endLine": 189,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 165
+            },
+            "hourlyCost": "0.2303726027397260165",
+            "monthlyCost": "168.172",
+            "subresources": [
+              {
+                "name": "aws_launch_template.example",
+                "metadata": {},
+                "hourlyCost": "0.2303726027397260165",
+                "monthlyCost": "168.172",
+                "costComponents": [
+                  {
+                    "name": "Instance usage (Linux/UNIX, on-demand, t3.medium)",
+                    "unit": "hours",
+                    "hourlyQuantity": "4",
+                    "monthlyQuantity": "2920",
+                    "price": "0.0441",
+                    "hourlyCost": "0.1764",
+                    "monthlyCost": "128.772",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "EC2 detailed monitoring",
+                    "unit": "metrics",
+                    "hourlyQuantity": "0.0383561643835616",
+                    "monthlyQuantity": "28",
+                    "price": "0.3",
+                    "hourlyCost": "0.01150684931506848",
+                    "monthlyCost": "8.4",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "CPU credits",
+                    "unit": "vCPU-hours",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.05",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  }
+                ],
+                "subresources": [
+                  {
+                    "name": "block_device_mapping[0]",
+                    "metadata": {},
+                    "hourlyCost": "0.0424657534246575365",
+                    "monthlyCost": "31",
+                    "costComponents": [
+                      {
+                        "name": "Storage (provisioned IOPS SSD, io1)",
+                        "unit": "GB",
+                        "hourlyQuantity": "0.0547945205479452",
+                        "monthlyQuantity": "40",
+                        "price": "0.125",
+                        "hourlyCost": "0.00684931506849315",
+                        "monthlyCost": "5",
+                        "priceNotFound": false
+                      },
+                      {
+                        "name": "Provisioned IOPS",
+                        "unit": "IOPS",
+                        "hourlyQuantity": "0.5479452054794521",
+                        "monthlyQuantity": "400",
+                        "price": "0.065",
+                        "hourlyCost": "0.0356164383561643865",
+                        "monthlyCost": "26",
+                        "priceNotFound": false
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_instance.launch_instance",
+            "resourceType": "aws_instance",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
+              "bat": "ball",
+              "fizz": "buzz",
+              "volume_tags.flip": "flop"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.launch_instance",
+                  "endLine": 112,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 100
+                }
+              ],
+              "checksum": "92d793c678fac9bf7ce08e05983f01e62665b7ea640a512f23bb3061b8c645b5",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 112,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 100
+            },
+            "hourlyCost": "0.0586890410958904025",
+            "monthlyCost": "42.843",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, t3.medium)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.0441",
+                "hourlyCost": "0.0441",
+                "monthlyCost": "32.193",
+                "priceNotFound": false
+              },
+              {
+                "name": "EC2 detailed monitoring",
+                "unit": "metrics",
+                "hourlyQuantity": "0.0095890410958904",
+                "monthlyQuantity": "7",
+                "price": "0.3",
+                "hourlyCost": "0.00287671232876712",
+                "monthlyCost": "2.1",
+                "priceNotFound": false
+              },
+              {
+                "name": "CPU credits",
+                "unit": "vCPU-hours",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.05",
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.0010958904109589",
+                "monthlyCost": "0.8",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.010958904109589",
+                    "monthlyQuantity": "8",
+                    "price": "0.1",
+                    "hourlyCost": "0.0010958904109589",
+                    "monthlyCost": "0.8",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.0106164383561643825",
+                "monthlyCost": "7.75",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0136986301369863",
+                    "monthlyQuantity": "10",
+                    "price": "0.125",
+                    "hourlyCost": "0.0017123287671232875",
+                    "monthlyCost": "1.25",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "0.136986301369863",
+                    "monthlyQuantity": "100",
+                    "price": "0.065",
+                    "hourlyCost": "0.008904109589041095",
+                    "monthlyCost": "6.5",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_autoscaling_group.bar",
+            "resourceType": "aws_autoscaling_group",
+            "tags": {
+              "foo": "bar"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_autoscaling_group.bar",
+                  "endLine": 74,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 54
+                }
+              ],
+              "checksum": "78ad6fe00b08040616d8503e00877f13cab24fa8c7e6c6d1045d7d075e8b5940",
+              "endLine": 74,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 54
+            }
+          },
+          {
+            "name": "aws_sns_topic_subscription.sns_topic_noTags",
+            "resourceType": "aws_sns_topic_subscription",
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_sns_topic_subscription.sns_topic_noTags",
+                  "endLine": 29,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 25
+                }
+              ],
+              "checksum": "10a6feecf428a263eb621089fa1ea9ed6d36c1210906f87b858471b7efc01de0",
+              "endLine": 29,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 25
+            },
+            "costComponents": [
+              {
+                "name": "HTTP notifications",
+                "unit": "1M notifications",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.6",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true,
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_sns_topic_subscription.sns_topic_withTags",
+            "resourceType": "aws_sns_topic_subscription",
+            "tags": {
+              "DefaultOverride": "sns-def",
+              "ResourceTag": "sns-ghi"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_sns_topic_subscription.sns_topic_withTags",
+                  "endLine": 39,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 31
+                }
+              ],
+              "checksum": "6e3eb9c41d083d305c807ea3fa31a2d94182d1d406f25d249bf3cf2eb27208d5",
+              "endLine": 39,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 31
+            },
+            "costComponents": [
+              {
+                "name": "HTTP notifications",
+                "unit": "1M notifications",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.6",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true,
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_sqs_queue.sqs_noTags",
+            "resourceType": "aws_sqs_queue",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_sqs_queue.sqs_noTags",
+                  "endLine": 43,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 41
+                }
+              ],
+              "checksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 43,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 41
+            },
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.4",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true,
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_sqs_queue.sqs_withTags",
+            "resourceType": "aws_sqs_queue",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "sqs-def",
+              "ResourceTag": "sqs-hi"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_sqs_queue.sqs_withTags",
+                  "endLine": 52,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 45
+                }
+              ],
+              "checksum": "0416b121e83d6bb05bd0b744a439e336a3bd1cfdaff221bec4577c59f2f744c8",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 52,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 45
+            },
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.4",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true,
+                "priceNotFound": false
+              }
+            ]
+          }
+        ],
+        "freeResources": [
+          {
+            "name": "aws_launch_template.example",
+            "resourceType": "aws_launch_template",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
+              "tag_specifications.fizz": "buzz",
+              "tag_specifications.flip": "flop",
+              "tag_specifications.no": "cap"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_launch_template.example",
+                  "endLine": 163,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 114
+                }
+              ],
+              "checksum": "5ae555e21daf62bb42d8cfcff0473722eb04032804b064b14d474f6f8923255e",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 163,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 114
+            }
+          }
+        ],
+        "totalHourlyCost": "2.323691780821917777",
+        "totalMonthlyCost": "1696.295",
+        "totalMonthlyUsageCost": "0"
+      },
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app",
+            "resourceType": "aws_instance",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
+              "foo": "bar",
+              "volume_tags.DefaultOverride": "volume_tag_overwritten",
+              "volume_tags.baz": "bat"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app",
+                  "endLine": 98,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 76
+                }
+              ],
+              "checksum": "3971020356e35708e0de7df3decdd615468f858c38205a99249dd4aa4e3ccf23",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 98,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 76
+            },
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_instance.web_app_block_tags",
+            "resourceType": "aws_instance",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
+              "ebs_block_device[0].foo": "ebd",
+              "root_block_device.foo": "rbd"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.web_app_block_tags",
+                  "endLine": 212,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 191
+                }
+              ],
+              "checksum": "47efe9c1f904be19ea9a38623ebcb399b03026ba4c0436284a121e35b84ce286",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 212,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 191
+            },
+            "hourlyCost": "1.017315068493150679",
+            "monthlyCost": "742.64",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, m5.4xlarge)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.768",
+                "hourlyCost": "0.768",
+                "monthlyCost": "560.64",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.00684931506849315",
+                "monthlyCost": "5",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0684931506849315",
+                    "monthlyQuantity": "50",
+                    "price": "0.1",
+                    "hourlyCost": "0.00684931506849315",
+                    "monthlyCost": "5",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.242465753424657529",
+                "monthlyCost": "177",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "1.3698630136986301",
+                    "monthlyQuantity": "1000",
+                    "price": "0.125",
+                    "hourlyCost": "0.1712328767123287625",
+                    "monthlyCost": "125",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "1.0958904109589041",
+                    "monthlyQuantity": "800",
+                    "price": "0.065",
+                    "hourlyCost": "0.0712328767123287665",
+                    "monthlyCost": "52",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_autoscaling_group.launch_template",
+            "resourceType": "aws_autoscaling_group",
+            "tags": {
+              "fizz": "buzz",
+              "foo": "bar"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_autoscaling_group.launch_template",
+                  "endLine": 189,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 165
+                }
+              ],
+              "checksum": "683ec0c113599563ccbf834223b61ffcc2abbd9ac8d6202036fc4fc6eb56a2d0",
+              "endLine": 189,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 165
+            },
+            "hourlyCost": "0.2303726027397260165",
+            "monthlyCost": "168.172",
+            "subresources": [
+              {
+                "name": "aws_launch_template.example",
+                "metadata": {},
+                "hourlyCost": "0.2303726027397260165",
+                "monthlyCost": "168.172",
+                "costComponents": [
+                  {
+                    "name": "Instance usage (Linux/UNIX, on-demand, t3.medium)",
+                    "unit": "hours",
+                    "hourlyQuantity": "4",
+                    "monthlyQuantity": "2920",
+                    "price": "0.0441",
+                    "hourlyCost": "0.1764",
+                    "monthlyCost": "128.772",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "EC2 detailed monitoring",
+                    "unit": "metrics",
+                    "hourlyQuantity": "0.0383561643835616",
+                    "monthlyQuantity": "28",
+                    "price": "0.3",
+                    "hourlyCost": "0.01150684931506848",
+                    "monthlyCost": "8.4",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "CPU credits",
+                    "unit": "vCPU-hours",
+                    "hourlyQuantity": "0",
+                    "monthlyQuantity": "0",
+                    "price": "0.05",
+                    "hourlyCost": "0",
+                    "monthlyCost": "0",
+                    "priceNotFound": false
+                  }
+                ],
+                "subresources": [
+                  {
+                    "name": "block_device_mapping[0]",
+                    "metadata": {},
+                    "hourlyCost": "0.0424657534246575365",
+                    "monthlyCost": "31",
+                    "costComponents": [
+                      {
+                        "name": "Storage (provisioned IOPS SSD, io1)",
+                        "unit": "GB",
+                        "hourlyQuantity": "0.0547945205479452",
+                        "monthlyQuantity": "40",
+                        "price": "0.125",
+                        "hourlyCost": "0.00684931506849315",
+                        "monthlyCost": "5",
+                        "priceNotFound": false
+                      },
+                      {
+                        "name": "Provisioned IOPS",
+                        "unit": "IOPS",
+                        "hourlyQuantity": "0.5479452054794521",
+                        "monthlyQuantity": "400",
+                        "price": "0.065",
+                        "hourlyCost": "0.0356164383561643865",
+                        "monthlyCost": "26",
+                        "priceNotFound": false
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_instance.launch_instance",
+            "resourceType": "aws_instance",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
+              "bat": "ball",
+              "fizz": "buzz",
+              "volume_tags.flip": "flop"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_instance.launch_instance",
+                  "endLine": 112,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 100
+                }
+              ],
+              "checksum": "92d793c678fac9bf7ce08e05983f01e62665b7ea640a512f23bb3061b8c645b5",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 112,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 100
+            },
+            "hourlyCost": "0.0586890410958904025",
+            "monthlyCost": "42.843",
+            "costComponents": [
+              {
+                "name": "Instance usage (Linux/UNIX, on-demand, t3.medium)",
+                "unit": "hours",
+                "hourlyQuantity": "1",
+                "monthlyQuantity": "730",
+                "price": "0.0441",
+                "hourlyCost": "0.0441",
+                "monthlyCost": "32.193",
+                "priceNotFound": false
+              },
+              {
+                "name": "EC2 detailed monitoring",
+                "unit": "metrics",
+                "hourlyQuantity": "0.0095890410958904",
+                "monthlyQuantity": "7",
+                "price": "0.3",
+                "hourlyCost": "0.00287671232876712",
+                "monthlyCost": "2.1",
+                "priceNotFound": false
+              },
+              {
+                "name": "CPU credits",
+                "unit": "vCPU-hours",
+                "hourlyQuantity": "0",
+                "monthlyQuantity": "0",
+                "price": "0.05",
+                "hourlyCost": "0",
+                "monthlyCost": "0",
+                "priceNotFound": false
+              }
+            ],
+            "subresources": [
+              {
+                "name": "root_block_device",
+                "metadata": {},
+                "hourlyCost": "0.0010958904109589",
+                "monthlyCost": "0.8",
+                "costComponents": [
+                  {
+                    "name": "Storage (general purpose SSD, gp2)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.010958904109589",
+                    "monthlyQuantity": "8",
+                    "price": "0.1",
+                    "hourlyCost": "0.0010958904109589",
+                    "monthlyCost": "0.8",
+                    "priceNotFound": false
+                  }
+                ]
+              },
+              {
+                "name": "ebs_block_device[0]",
+                "metadata": {},
+                "hourlyCost": "0.0106164383561643825",
+                "monthlyCost": "7.75",
+                "costComponents": [
+                  {
+                    "name": "Storage (provisioned IOPS SSD, io1)",
+                    "unit": "GB",
+                    "hourlyQuantity": "0.0136986301369863",
+                    "monthlyQuantity": "10",
+                    "price": "0.125",
+                    "hourlyCost": "0.0017123287671232875",
+                    "monthlyCost": "1.25",
+                    "priceNotFound": false
+                  },
+                  {
+                    "name": "Provisioned IOPS",
+                    "unit": "IOPS",
+                    "hourlyQuantity": "0.136986301369863",
+                    "monthlyQuantity": "100",
+                    "price": "0.065",
+                    "hourlyCost": "0.008904109589041095",
+                    "monthlyCost": "6.5",
+                    "priceNotFound": false
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "aws_autoscaling_group.bar",
+            "resourceType": "aws_autoscaling_group",
+            "tags": {
+              "foo": "bar"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_autoscaling_group.bar",
+                  "endLine": 74,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 54
+                }
+              ],
+              "checksum": "78ad6fe00b08040616d8503e00877f13cab24fa8c7e6c6d1045d7d075e8b5940",
+              "endLine": 74,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 54
+            }
+          },
+          {
+            "name": "aws_sns_topic_subscription.sns_topic_noTags",
+            "resourceType": "aws_sns_topic_subscription",
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_sns_topic_subscription.sns_topic_noTags",
+                  "endLine": 29,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 25
+                }
+              ],
+              "checksum": "10a6feecf428a263eb621089fa1ea9ed6d36c1210906f87b858471b7efc01de0",
+              "endLine": 29,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 25
+            },
+            "costComponents": [
+              {
+                "name": "HTTP notifications",
+                "unit": "1M notifications",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.6",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true,
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_sns_topic_subscription.sns_topic_withTags",
+            "resourceType": "aws_sns_topic_subscription",
+            "tags": {
+              "DefaultOverride": "sns-def",
+              "ResourceTag": "sns-ghi"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_sns_topic_subscription.sns_topic_withTags",
+                  "endLine": 39,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 31
+                }
+              ],
+              "checksum": "6e3eb9c41d083d305c807ea3fa31a2d94182d1d406f25d249bf3cf2eb27208d5",
+              "endLine": 39,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 31
+            },
+            "costComponents": [
+              {
+                "name": "HTTP notifications",
+                "unit": "1M notifications",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.6",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true,
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_sqs_queue.sqs_noTags",
+            "resourceType": "aws_sqs_queue",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_sqs_queue.sqs_noTags",
+                  "endLine": 43,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 41
+                }
+              ],
+              "checksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 43,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 41
+            },
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.4",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true,
+                "priceNotFound": false
+              }
+            ]
+          },
+          {
+            "name": "aws_sqs_queue.sqs_withTags",
+            "resourceType": "aws_sqs_queue",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "sqs-def",
+              "ResourceTag": "sqs-hi"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_sqs_queue.sqs_withTags",
+                  "endLine": 52,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 45
+                }
+              ],
+              "checksum": "0416b121e83d6bb05bd0b744a439e336a3bd1cfdaff221bec4577c59f2f744c8",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 52,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 45
+            },
+            "costComponents": [
+              {
+                "name": "Requests",
+                "unit": "1M requests",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.4",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true,
+                "priceNotFound": false
+              }
+            ]
+          }
+        ],
+        "freeResources": [
+          {
+            "name": "aws_launch_template.example",
+            "resourceType": "aws_launch_template",
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
+              "tag_specifications.fizz": "buzz",
+              "tag_specifications.flip": "flop",
+              "tag_specifications.no": "cap"
+            },
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "aws_launch_template.example",
+                  "endLine": 163,
+                  "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+                  "startLine": 114
+                }
+              ],
+              "checksum": "5ae555e21daf62bb42d8cfcff0473722eb04032804b064b14d474f6f8923255e",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "endLine": 163,
+              "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
+              "startLine": 114
+            }
+          }
+        ],
+        "totalHourlyCost": "2.323691780821917777",
+        "totalMonthlyCost": "1696.295",
+        "totalMonthlyUsageCost": "0"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 10,
+        "totalSupportedResources": 9,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 9,
+        "totalNoPriceResources": 1,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {
+          "aws_launch_template": 1
+        }
+      }
+    }
+  ],
+  "totalHourlyCost": "2.323691780821917777",
+  "totalMonthlyCost": "1696.295",
+  "totalMonthlyUsageCost": "0",
+  "pastTotalHourlyCost": "2.323691780821917777",
+  "pastTotalMonthlyCost": "1696.295",
+  "pastTotalMonthlyUsageCost": "0",
+  "diffTotalHourlyCost": "0",
+  "diffTotalMonthlyCost": "0",
+  "diffTotalMonthlyUsageCost": "0",
+  "timeGenerated": "REPLACED_TIME",
+  "summary": {
+    "totalDetectedResources": 10,
+    "totalSupportedResources": 9,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 9,
+    "totalNoPriceResources": 1,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {
+      "aws_launch_template": 1
+    }
+  }
+}
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf
@@ -1,0 +1,212 @@
+provider "aws" {
+  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+
+  default_tags {
+    tags = {
+      DefaultNotOverride = "defaultnotoverride"
+      DefaultOverride    = "defaultoverride"
+    }
+  }
+}
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_sns_topic_subscription" "sns_topic_noTags" {
+  endpoint  = "some-dummy-endpoint"
+  protocol  = "http"
+  topic_arn = "arn:aws:sns:us-east-1:123456789123:sns-topic-arn"
+}
+
+resource "aws_sns_topic_subscription" "sns_topic_withTags" {
+  endpoint  = "some-dummy-endpoint"
+  protocol  = "http"
+  topic_arn = "arn:aws:sns:us-east-1:123456789123:sns-topic-arn"
+  tags = {
+    DefaultOverride = "sns-def"
+    ResourceTag     = "sns-ghi"
+  }
+}
+
+resource "aws_sqs_queue" "sqs_noTags" {
+  name = "sqs_noTags"
+}
+
+resource "aws_sqs_queue" "sqs_withTags" {
+  name = "sqs_withTags"
+
+  tags = {
+    DefaultOverride = "sqs-def"
+    ResourceTag     = "sqs-hi"
+  }
+}
+
+resource "aws_autoscaling_group" "bar" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+
+  tag {
+    key                 = "foo"
+    value               = "bar"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "lorem"
+    value               = "ipsum"
+    propagate_at_launch = false
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+  volume_tags = {
+    "baz"           = "bat"
+    DefaultOverride = "volume_tag_overwritten"
+  }
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+
+  tags = {
+    "foo" = "bar"
+  }
+}
+
+resource "aws_instance" "launch_instance" {
+  volume_tags = {
+    "flip" = "flop"
+  }
+  launch_template {
+    id = aws_launch_template.example.id
+  }
+
+  tags = {
+    "bat"  = "ball"
+    "fizz" = "buzz"
+  }
+}
+
+resource "aws_launch_template" "example" {
+  name = "example-lt"
+
+  image_id      = "fake_ami"
+  instance_type = "t3.medium"
+  ebs_optimized = true
+
+  monitoring {
+    enabled = true
+  }
+
+  credit_specification {
+    cpu_credits = "unlimited"
+  }
+
+  placement {
+    tenancy = "dedicated"
+  }
+
+  block_device_mappings {
+    device_name = "xvdc"
+
+    ebs {
+      volume_type = "io1"
+      volume_size = 10
+      iops        = 100
+    }
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      "fizz" = "buzz"
+    }
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = {
+      "flip" = "flop"
+    }
+  }
+
+  tag_specifications {
+    resource_type = "capacity-reservation"
+    tags = {
+      "no" = "cap"
+    }
+  }
+}
+
+resource "aws_autoscaling_group" "launch_template" {
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  desired_capacity          = 4
+  force_delete              = true
+
+  launch_template {
+    id = aws_launch_template.example.id
+  }
+
+  tag {
+    key                 = "foo"
+    value               = "bar"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "lorem"
+    value               = "ipsum"
+    propagate_at_launch = false
+  }
+}
+
+resource "aws_instance" "web_app_block_tags" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+
+  root_block_device {
+    volume_size = 50
+    tags = {
+      "foo" = "rbd"
+    }
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+
+    tags = {
+      "foo" = "ebd"
+    }
+  }
+}

--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_hcl/breakdown_with_policy_data_upload_hcl-upload.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_hcl/breakdown_with_policy_data_upload_hcl-upload.golden
@@ -30,6 +30,14 @@ storePolicyResources:
               "value": "bar"
             },
             {
+              "key": "volume_tags.DefaultNotOverride",
+              "value": "defaultnotoverride"
+            },
+            {
+              "key": "volume_tags.DefaultOverride",
+              "value": "defaultoverride"
+            },
+            {
               "key": "volume_tags.baz",
               "value": "bat"
             }
@@ -89,6 +97,14 @@ storePolicyResources:
             {
               "key": "foo",
               "value": "bar"
+            },
+            {
+              "key": "volume_tags.DefaultNotOverride",
+              "value": "defaultnotoverride"
+            },
+            {
+              "key": "volume_tags.DefaultOverride",
+              "value": "defaultoverride"
             },
             {
               "key": "volume_tags.baz",

--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_hcl/breakdown_with_policy_data_upload_hcl.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_hcl/breakdown_with_policy_data_upload_hcl.golden
@@ -43,6 +43,8 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.baz": "bat"
             },
             "metadata": {
@@ -55,7 +57,7 @@
                 }
               ],
               "checksum": "f5dd035ad27e97bb0e63f5e9794406f76dec425251f3ad09176905bfe8c1b6c5",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
               "endLine": 37,
               "filename": "testdata/breakdown_with_policy_data_upload_hcl/main.tf",
               "startLine": 16
@@ -277,6 +279,8 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.baz": "bat"
             },
             "metadata": {
@@ -289,7 +293,7 @@
                 }
               ],
               "checksum": "f5dd035ad27e97bb0e63f5e9794406f76dec425251f3ad09176905bfe8c1b6c5",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
               "endLine": 37,
               "filename": "testdata/breakdown_with_policy_data_upload_hcl/main.tf",
               "startLine": 16

--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_plan_json/breakdown_with_policy_data_upload_plan_json-upload.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_plan_json/breakdown_with_policy_data_upload_plan_json-upload.golden
@@ -30,6 +30,14 @@ storePolicyResources:
               "value": "bar"
             },
             {
+              "key": "volume_tags.DefaultNotOverride",
+              "value": "defaultnotoverride"
+            },
+            {
+              "key": "volume_tags.DefaultOverride",
+              "value": "defaultoverride"
+            },
+            {
               "key": "volume_tags.baz",
               "value": "bat"
             }

--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_plan_json/breakdown_with_policy_data_upload_plan_json.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_plan_json/breakdown_with_policy_data_upload_plan_json.golden
@@ -46,10 +46,12 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.baz": "bat"
             },
             "metadata": {
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101"
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c"
             },
             "hourlyCost": "0.91197260273972602",
             "monthlyCost": "665.74",
@@ -232,6 +234,8 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.baz": "bat"
             },
             "metadata": {},

--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_terragrunt/breakdown_with_policy_data_upload_terragrunt-upload.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_terragrunt/breakdown_with_policy_data_upload_terragrunt-upload.golden
@@ -30,6 +30,14 @@ storePolicyResources:
               "value": "bar"
             },
             {
+              "key": "volume_tags.DefaultNotOverride",
+              "value": "defaultnotoverride"
+            },
+            {
+              "key": "volume_tags.DefaultOverride",
+              "value": "defaultoverride"
+            },
+            {
               "key": "volume_tags.baz",
               "value": "bat"
             }
@@ -89,6 +97,14 @@ storePolicyResources:
             {
               "key": "foo",
               "value": "bar"
+            },
+            {
+              "key": "volume_tags.DefaultNotOverride",
+              "value": "defaultnotoverride"
+            },
+            {
+              "key": "volume_tags.DefaultOverride",
+              "value": "defaultoverride"
             },
             {
               "key": "volume_tags.baz",

--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_terragrunt/breakdown_with_policy_data_upload_terragrunt.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_terragrunt/breakdown_with_policy_data_upload_terragrunt.golden
@@ -31,6 +31,8 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.baz": "bat"
             },
             "metadata": {
@@ -43,7 +45,7 @@
                 }
               ],
               "checksum": "f5dd035ad27e97bb0e63f5e9794406f76dec425251f3ad09176905bfe8c1b6c5",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
               "endLine": 22,
               "filename": "testdata/breakdown_with_policy_data_upload_terragrunt/main.tf",
               "startLine": 1
@@ -265,6 +267,8 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.baz": "bat"
             },
             "metadata": {
@@ -277,7 +281,7 @@
                 }
               ],
               "checksum": "f5dd035ad27e97bb0e63f5e9794406f76dec425251f3ad09176905bfe8c1b6c5",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
               "endLine": 22,
               "filename": "testdata/breakdown_with_policy_data_upload_terragrunt/main.tf",
               "startLine": 1

--- a/cmd/infracost/testdata/diff_with_policy_data_upload/diff_with_policy_data_upload.golden
+++ b/cmd/infracost/testdata/diff_with_policy_data_upload/diff_with_policy_data_upload.golden
@@ -127,6 +127,8 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.baz": "bat"
             },
             "metadata": {
@@ -139,7 +141,7 @@
                 }
               ],
               "checksum": "f5dd035ad27e97bb0e63f5e9794406f76dec425251f3ad09176905bfe8c1b6c5",
-              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
+              "defaultTagsChecksum": "4758f4f6da3f45b86f7b9d481e2181b234a33f98aca49d98ff65d4f8bc77f24c",
               "endLine": 37,
               "filename": "testdata/diff_with_policy_data_upload/main.tf",
               "startLine": 16
@@ -211,6 +213,8 @@
               "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "defaultoverride",
               "foo": "bar",
+              "volume_tags.DefaultNotOverride": "defaultnotoverride",
+              "volume_tags.DefaultOverride": "defaultoverride",
               "volume_tags.baz": "bat"
             },
             "metadata": {},

--- a/internal/hcl/constraints.go
+++ b/internal/hcl/constraints.go
@@ -1,0 +1,109 @@
+package hcl
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/go-version"
+	"github.com/zclconf/go-cty/cty/gocty"
+)
+
+var (
+	// AWSVersionConstraintVolumeTags is the version constraint for the Terraform aws
+	// provider that supports propagating default tags to volume tags. See
+	// https://github.com/hashicorp/terraform-provider-aws/issues/19890 for more
+	// information.
+	AWSVersionConstraintVolumeTags = version.Must(version.NewVersion("5.39.0"))
+)
+
+// ProviderConstraints represents the constraints for a providers within a
+// module. This can be used to check if Infracost functionality is applicable to
+// a given run.
+type ProviderConstraints struct {
+	AWS version.Constraints
+}
+
+// UnmarshalJSON parses the JSON representation of the ProviderConstraints and
+// sets the constraints for the sub providers.
+func (p *ProviderConstraints) UnmarshalJSON(b []byte) error {
+	var out map[string]string
+	err := json.Unmarshal(b, &out)
+	if err != nil {
+		return err
+	}
+
+	if v, ok := out["aws"]; ok {
+		constraints, err := version.NewConstraint(v)
+		if err == nil {
+			p.AWS = constraints
+		}
+	}
+
+	return nil
+}
+
+// MarshalJSON returns the JSON representation of the ProviderConstraints.
+// This is used to serialize the constraints for the sub providers.
+func (p *ProviderConstraints) MarshalJSON() ([]byte, error) {
+	out := map[string]string{}
+	if p == nil {
+		return json.Marshal(&out)
+	}
+
+	if p.AWS != nil {
+		out["aws"] = p.AWS.String()
+	} else {
+		out["aws"] = ""
+	}
+
+	return json.Marshal(out)
+}
+
+// NewProviderConstraints parses the provider blocks for any Terraform
+// configuration blocks if found it will attempt to return a ProviderConstraints
+// struct from the required_providers configuration. Currently, we only support
+// AWS provider constraints.
+func NewProviderConstraints(blocks Blocks) *ProviderConstraints {
+	terraformBlocks := blocks.OfType("terraform")
+	for _, block := range terraformBlocks {
+		req := block.GetChildBlock("required_providers")
+		if req == nil {
+			continue
+		}
+
+		def := req.Values().AsValueMap()
+		for provider, body := range def {
+			if provider != "aws" {
+				continue
+			}
+
+			if body.IsNull() || !body.IsKnown() {
+				continue
+			}
+
+			var source string
+			var constraintVersion string
+			if body.Type().IsObjectType() {
+				// v0.13 required provider definition
+				constraintDef := body.AsValueMap()
+				_ = gocty.FromCtyValue(constraintDef["source"], &source)
+				if source != "hashicorp/aws" {
+					continue
+				}
+
+				_ = gocty.FromCtyValue(constraintDef["version"], &constraintVersion)
+			} else {
+				// support v0.12 provider definition
+				// https://developer.hashicorp.com/terraform/language/providers/requirements#v0-12-compatible-provider-requirements
+				_ = gocty.FromCtyValue(body, &constraintVersion)
+			}
+
+			// parse the version and return it
+			constraints, err := version.NewConstraint(constraintVersion)
+			if err == nil {
+				return &ProviderConstraints{AWS: constraints}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/hcl/module.go
+++ b/internal/hcl/module.go
@@ -48,7 +48,9 @@ type Module struct {
 	// ProviderReferences is a map of provider names (relative to the module) to
 	// the provider block that defines that provider. We keep track of this so we
 	// can re-evaluate the provider blocks when we need to.
-	ProviderReferences map[string]*Block
+	ProviderReferences  map[string]*Block
+	TerraformVersion    string
+	ProviderConstraints *ProviderConstraints
 }
 
 // Index returns the count index of the Module using the name.

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -469,6 +469,13 @@ func (p *Parser) ParseDirectory() (m *Module, err error) {
 		}
 	}
 
+	// Set the root module's provider constraints we only look to do this at the root
+	// module level for now but we might look to change this in the future to parse
+	// on a per-module basis, with the same level of inheritance as the provider
+	// blocks. However, for our current use case this is not really necessary, and
+	// would just add complexity.
+	root.ProviderConstraints = NewProviderConstraints(blocks)
+
 	root.HasChanges = p.hasChanges
 	root.TerraformVarsPaths = p.tfvarsPaths
 	root.ModuleSuffix = p.moduleSuffix

--- a/internal/providers/terraform/aws/tags.go
+++ b/internal/providers/terraform/aws/tags.go
@@ -49,6 +49,14 @@ func ParseTags(defaultTags *map[string]string, r *schema.ResourceData) *map[stri
 			keysAndValues = append(keysAndValues, k, v)
 		}
 
+		if r.Type == "aws_instance" {
+			for k, v := range *defaultTags {
+				k = fmt.Sprintf("volume_tags.%s", k)
+				tags[k] = v
+				keysAndValues = append(keysAndValues, k, v)
+			}
+		}
+
 		sort.Strings(keysAndValues)
 
 		h := sha256.New()

--- a/internal/providers/terraform/aws/tags.go
+++ b/internal/providers/terraform/aws/tags.go
@@ -29,7 +29,15 @@ func parseLaunchTemplateTags(tags map[string]string, r *schema.ResourceData) {
 	}
 }
 
-func ParseTags(defaultTags *map[string]string, r *schema.ResourceData) *map[string]string {
+// TagParsingConfig defines options that can be used to configure the ParseTags function.
+type TagParsingConfig struct {
+	// PropagateDefaultsToVolumeTags specifies whether default provider tags should be
+	// propagated to volume tags. This feature was added in Terraform AWS provider
+	// version 5.39.0.
+	PropagateDefaultsToVolumeTags bool
+}
+
+func ParseTags(defaultTags *map[string]string, r *schema.ResourceData, config TagParsingConfig) *map[string]string {
 	_, supportsTags := provider_schemas.AWSTagsSupport[r.Type]
 	_, supportsTagBlock := provider_schemas.AWSTagBlockSupport[r.Type]
 
@@ -49,7 +57,7 @@ func ParseTags(defaultTags *map[string]string, r *schema.ResourceData) *map[stri
 			keysAndValues = append(keysAndValues, k, v)
 		}
 
-		if r.Type == "aws_instance" {
+		if r.Type == "aws_instance" && config.PropagateDefaultsToVolumeTags {
 			for k, v := range *defaultTags {
 				k = fmt.Sprintf("volume_tags.%s", k)
 				tags[k] = v

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -402,6 +402,9 @@ func (p *HCLProvider) newPlanSchema() {
 
 func (p *HCLProvider) modulesToPlanJSON(rootModule *hcl.Module) ([]byte, error) {
 	p.newPlanSchema()
+	if rootModule.ProviderConstraints != nil {
+		p.schema.InfracostProviderConstraints = *rootModule.ProviderConstraints
+	}
 
 	mo := p.marshalModule(rootModule)
 	p.schema.Configuration.RootModule = mo.ModuleConfig
@@ -827,7 +830,8 @@ type PlanSchema struct {
 	// plan JSON output, but we omit adding it as the supported `resource_changes` key as this will cause plan inconsistencies.
 	// We copy this `infracost_resource_changes` key at a later date to `resource_changes` before sending to the Policy API.
 	// This means that we can evaluate the Rego ruleset on the known Terraform plan JSON structure.
-	InfracostResourceChanges []ResourceChangesJSON `json:"infracost_resource_changes"`
+	InfracostResourceChanges     []ResourceChangesJSON   `json:"infracost_resource_changes"`
+	InfracostProviderConstraints hcl.ProviderConstraints `json:"infracost_provider_constraints"`
 }
 
 type PlanModule struct {

--- a/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/builds_module_configuration_correctly_with_count/expected.json
@@ -201,5 +201,8 @@
         }
       }
     }
-  ]
+  ],
+  "infracost_provider_constraints": {
+    "aws": ""
+  }
 }

--- a/internal/providers/terraform/testdata/hcl_provider_test/does_not_panic_on_double_attribute_definition/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/does_not_panic_on_double_attribute_definition/expected.json
@@ -114,5 +114,8 @@
         }
       }
     }
-  ]
+  ],
+  "infracost_provider_constraints": {
+    "aws": ""
+  }
 }

--- a/internal/providers/terraform/testdata/hcl_provider_test/populates_warnings_on_missing_vars/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/populates_warnings_on_missing_vars/expected.json
@@ -114,5 +114,8 @@
         }
       }
     }
-  ]
+  ],
+  "infracost_provider_constraints": {
+    "aws": ""
+  }
 }

--- a/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/expected.json
@@ -343,5 +343,8 @@
         }
       }
     }
-  ]
+  ],
+  "infracost_provider_constraints": {
+    "aws": ""
+  }
 }

--- a/internal/providers/terraform/testdata/hcl_provider_test/renders_multiple_count_resources_correctly/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/renders_multiple_count_resources_correctly/expected.json
@@ -868,5 +868,8 @@
         }
       }
     }
-  ]
+  ],
+  "infracost_provider_constraints": {
+    "aws": ""
+  }
 }

--- a/internal/providers/terraform/testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/shows_correct_duplicate_variable_warning/expected.json
@@ -157,5 +157,8 @@
         }
       }
     }
-  ]
+  ],
+  "infracost_provider_constraints": {
+    "aws": ""
+  }
 }

--- a/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/structures_module_expressions_correctly_with_count/expected.json
@@ -599,5 +599,8 @@
         }
       }
     }
-  ]
+  ],
+  "infracost_provider_constraints": {
+    "aws": ""
+  }
 }


### PR DESCRIPTION
Fixes issue where provider tags were not being used as defaults in volume tags. Provider defaults propagating to `volume_tags` was introduced in version `v5.39.0` of the aws provider https://github.com/hashicorp/terraform-provider-aws/issues/19890. 

To accomodate this functionality we add any of the default tags with the `volume_tags` prefix if the current resource supports `volume_tags` (currently just `aws_instance`). This is only done if the version constraint specified at the root level `terraform` `require_providers` block is compatible with the `5.39.0` version. e.g. `>= 5.0`. Versions which specify a maximum version, e.g. `~> 3.0` below `5.39` will not have the default tags passed to volume tags. If no version constraint is found/can be parsed we add default tags to volume_tags by default. This is to ensure we have no false positive tagging policy failures.