### PR TITLE
fix: support hidden directories in autodetect

### DIFF
--- a/cmd/infracost/diff_test.go
+++ b/cmd/infracost/diff_test.go
@@ -220,7 +220,7 @@ projects:
 		path.Join(dir, "prod"))
 
 	configFilePath := path.Join(dir, "infracost.yml")
-	err := os.WriteFile(configFilePath, []byte(configFile), os.ModePerm)
+	err := os.WriteFile(configFilePath, []byte(configFile), os.ModePerm) // nolint: gosec
 	require.NoError(t, err)
 
 	defer os.Remove(configFilePath)
@@ -245,7 +245,7 @@ projects:
 		path.Join(dir, "prod"))
 
 	configFilePath := path.Join(dir, "infracost.yml")
-	err := os.WriteFile(configFilePath, []byte(configFile), os.ModePerm)
+	err := os.WriteFile(configFilePath, []byte(configFile), os.ModePerm) // nolint: gosec
 	require.NoError(t, err)
 
 	defer os.Remove(configFilePath)

--- a/cmd/infracost/generate_test.go
+++ b/cmd/infracost/generate_test.go
@@ -136,7 +136,7 @@ func assertGoldenFile(tt *testing.T, args []string, dir string) {
 		i := buf.Bytes()
 		out.Write(i)
 
-		err := os.WriteFile(path.Join(dir, "actual.txt"), out.Bytes(), os.ModePerm)
+		err := os.WriteFile(path.Join(dir, "actual.txt"), out.Bytes(), os.ModePerm) // nolint: gosec
 		assert.NoError(tt, err)
 	}
 }

--- a/cmd/infracost/testdata/generate/include_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/include_dirs/expected.golden
@@ -3,9 +3,20 @@ autodetect:
   include_dirs:
     - apps/bat
     - apps/baz
+    - apps/.hidden
     - apps/wildcard/**
 
 projects:
+  - path: apps/.hidden
+    name: apps-.hidden-dev
+    terraform_var_files:
+      - ../default.tfvars
+      - ../dev.tfvars
+  - path: apps/.hidden
+    name: apps-.hidden-prod
+    terraform_var_files:
+      - ../default.tfvars
+      - ../prod.tfvars
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:

--- a/cmd/infracost/testdata/generate/include_dirs/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/include_dirs/infracost.yml.tmpl
@@ -3,6 +3,7 @@ autodetect:
   include_dirs:
     - apps/bat
     - apps/baz
+    - apps/.hidden
     - apps/wildcard/**
 
 projects:

--- a/cmd/infracost/testdata/generate/include_dirs/tree.txt
+++ b/cmd/infracost/testdata/generate/include_dirs/tree.txt
@@ -8,6 +8,8 @@
     │   └── foo.tf
     ├── bat
     │   └── bip.tf
+    ├── .hidden
+    │   └── main.tf
     ├── wildcard
     │   ├── one
     │   │   └── fip.tf

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -108,7 +108,7 @@ projects:
 		t.Run(tt.name, func(t *testing.T) {
 			c := Config{}
 			path := filepath.Join(tmp, fmt.Sprintf("conf-%d.yaml", i))
-			err := os.WriteFile(path, tt.contents, os.ModePerm)
+			err := os.WriteFile(path, tt.contents, os.ModePerm) // nolint: gosec
 			require.NoError(t, err)
 
 			// we need to remove INFRACOST_TERRAFORM_CLOUD_TOKEN value for these tests.

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -751,7 +751,7 @@ func createTestFile(filename, contents string) string {
 		panic(err)
 	}
 	path := filepath.Join(dir, filename)
-	if err := os.WriteFile(path, []byte(contents), os.ModePerm); err != nil {
+	if err := os.WriteFile(path, []byte(contents), os.ModePerm); err != nil { // nolint: gosec
 		panic(err)
 	}
 	return path
@@ -779,11 +779,11 @@ func createTestFileWithModule(contents string, moduleContents string, moduleName
 		}
 	}
 
-	if err := os.WriteFile(filepath.Join(rootPath, "main.tf"), []byte(contents), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(rootPath, "main.tf"), []byte(contents), os.ModePerm); err != nil { // nolint: gosec
 		panic(err)
 	}
 
-	if err := os.WriteFile(filepath.Join(modulePath, "main.tf"), []byte(moduleContents), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(modulePath, "main.tf"), []byte(moduleContents), os.ModePerm); err != nil { // nolint: gosec
 		panic(err)
 	}
 
@@ -1781,7 +1781,7 @@ func Test_DynamicBlockExpandsToCorrectLength(t *testing.T) {
 	path := createTestFile("main.tf", `
 variable "my_config" {
   default = [
-    {"location": "eu1"}, 
+    {"location": "eu1"},
     {"location": "eu2"}
   ]
 }

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -1463,11 +1463,13 @@ func (p *ProjectLocator) walkPaths(fullPath string, level int, maxSearchDepth in
 
 	for _, info := range fileInfos {
 		if info.IsDir() {
-			if strings.HasPrefix(info.Name(), ".") {
+			fullPath := filepath.Join(fullPath, info.Name())
+
+			if strings.HasPrefix(info.Name(), ".") && !p.shouldIncludeDir(fullPath) {
 				continue
 			}
 
-			p.walkPaths(filepath.Join(fullPath, info.Name()), level+1, maxSearchDepth)
+			p.walkPaths(fullPath, level+1, maxSearchDepth)
 		}
 	}
 }

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -326,7 +326,7 @@ func (p *HCLProvider) LoadPlanJSON() HCLProject {
 		module.JSON, module.Error = p.modulesToPlanJSON(module.Module)
 
 		if os.Getenv("INFRACOST_JSON_DUMP") == "true" {
-			err := os.WriteFile(fmt.Sprintf("%s-out.json", strings.ReplaceAll(module.Module.ModulePath, "/", "-")), module.JSON, os.ModePerm)
+			err := os.WriteFile(fmt.Sprintf("%s-out.json", strings.ReplaceAll(module.Module.ModulePath, "/", "-")), module.JSON, os.ModePerm) // nolint: gosec
 			if err != nil {
 				p.logger.Debug().Err(err).Msg("failed to write to json dump")
 			}

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -496,7 +496,7 @@ func copyInitCacheToPath(source, destination string) error {
 						return err
 					}
 
-					if err := os.WriteFile(destPath, srcData, os.ModePerm); err != nil {
+					if err := os.WriteFile(destPath, srcData, os.ModePerm); err != nil { // nolint: gosec
 						return err
 					}
 				}


### PR DESCRIPTION
If we specify a hidden directory in `include_dirs` in the autodetect config, it should be detected correctly.

By default, hidden directories will still be excluded.