### PR TITLE
fix: add the project path as a dependency in generated output

### DIFF
--- a/cmd/infracost/testdata/generate/module_calls/expected.golden
+++ b/cmd/infracost/testdata/generate/module_calls/expected.golden
@@ -5,6 +5,7 @@ projects:
     name: infra-dev
     skip_autodetect: true
     dependency_paths:
+      - infra/dev
       - infra/modules/is_also_called
       - infra/modules/is_called
   - path: infra/modules/is_a_project
@@ -15,4 +16,5 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - infra/modules/is_called
+      - infra/prod
 

--- a/cmd/infracost/testdata/generate/module_calls_with_template/expected.golden
+++ b/cmd/infracost/testdata/generate/module_calls_with_template/expected.golden
@@ -5,6 +5,7 @@ projects:
     name: infra-dev
     terraform_var_files:
     dependency_paths:
+      - infra/dev
       - infra/modules/is_also_called
       - infra/modules/is_called
   - path: infra/modules/is_a_project
@@ -16,4 +17,5 @@ projects:
     terraform_var_files:
     dependency_paths:
       - infra/modules/is_called
+      - infra/prod
 

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -366,6 +366,7 @@ func (p *Parser) DependencyPaths() []string {
 
 		sortedCalls[i] = relCall
 	}
+	sortedCalls = append(sortedCalls, p.RelativePath())
 	sort.Strings(sortedCalls)
 
 	return sortedCalls


### PR DESCRIPTION
Adds the project path to the generated project `dependency_paths`. This is because `dependency_paths` are treated as a change detection override. Meaning that prior to this change Infracost hosted runners would only see a project as changed if a folder in its `dependency_paths` changed.