### PR TITLE
fix: don't use existing context when evaluating resources, data or provider blocks

### DIFF
--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -881,13 +881,17 @@ func (e *Evaluator) getValuesByBlockType(blockType string) cty.Value {
 			}
 
 			e.logger.Debug().Msgf("adding %s %s to the evaluation context", b.Type(), b.Label())
-			values[b.Labels()[0]] = e.evaluateResource(b, values)
+			values[b.Labels()[0]] = e.evaluateResourceOrData(b, values)
 		}
 
 	}
 
 	return cty.ObjectVal(values)
 }
+
+// evaluateProvider evaluates a provider block.
+// The values map is used to pass in the current context values. This is only needed
+// for the legacy evaluator and is not used for the graph evaluator.
 func (e *Evaluator) evaluateProvider(b *Block, values map[string]cty.Value) cty.Value {
 	provider := b.Label()
 	v, exists := values[provider]
@@ -921,7 +925,10 @@ func (e *Evaluator) evaluateProvider(b *Block, values map[string]cty.Value) cty.
 	return cty.ObjectVal(ob)
 }
 
-func (e *Evaluator) evaluateResource(b *Block, values map[string]cty.Value) cty.Value {
+// evaluateResourceOrData evaluates a resource or data block.
+// The values map is used to pass in the current context values. This is only needed
+// for the legacy evaluator and is not used for the graph evaluator.
+func (e *Evaluator) evaluateResourceOrData(b *Block, values map[string]cty.Value) cty.Value {
 	labels := b.Labels()
 
 	blockMap, ok := values[labels[0]]

--- a/internal/hcl/graph_vertex_data.go
+++ b/internal/hcl/graph_vertex_data.go
@@ -81,7 +81,7 @@ func (v *VertexData) evaluate(e *Evaluator, b *Block) error {
 		existingVals = make(map[string]cty.Value)
 	}
 
-	val := e.evaluateResource(b, existingVals)
+	val := e.evaluateResourceOrData(b, existingVals)
 
 	v.logger.Debug().Msgf("adding data %s to the evaluation context", v.ID())
 	e.ctx.SetByDot(val, fmt.Sprintf("data.%s", b.TypeLabel()))

--- a/internal/hcl/graph_vertex_provider.go
+++ b/internal/hcl/graph_vertex_provider.go
@@ -63,18 +63,11 @@ func (v *VertexProvider) Visit(mutex *sync.Mutex) error {
 			return fmt.Errorf("could not find block %q in module %q", v.ID(), moduleInstance.name)
 		}
 
-		var existingVals map[string]cty.Value
-		existingCtx := e.ctx.Get(blockInstance.TypeLabel())
-		if !existingCtx.IsNull() {
-			existingVals = existingCtx.AsValueMap()
-		} else {
-			existingVals = make(map[string]cty.Value)
-		}
-
-		val := e.evaluateProvider(blockInstance, existingVals)
+		// We don't care about the existing values, this is only needed by the legacy evaluator
+		val := e.evaluateProvider(blockInstance, map[string]cty.Value{})
 
 		v.logger.Debug().Msgf("adding %s to the evaluation context", v.ID())
-		e.ctx.Set(val, blockInstance.Label())
+		e.ctx.SetByDot(val, blockInstance.Label())
 
 		e.AddFilteredBlocks(blockInstance)
 	}

--- a/internal/hcl/graph_vertex_resource.go
+++ b/internal/hcl/graph_vertex_resource.go
@@ -64,15 +64,8 @@ func (v *VertexResource) evaluate(e *Evaluator, b *Block) error {
 		return fmt.Errorf("resource block %s has no label", v.ID())
 	}
 
-	var existingVals map[string]cty.Value
-	existingCtx := e.ctx.Get(b.TypeLabel())
-	if !existingCtx.IsNull() {
-		existingVals = existingCtx.AsValueMap()
-	} else {
-		existingVals = make(map[string]cty.Value)
-	}
-
-	val := e.evaluateResource(b, existingVals)
+	// We don't care about the existing values, this is only needed by the legacy evaluator
+	val := e.evaluateResourceOrData(b, map[string]cty.Value{})
 
 	v.logger.Debug().Msgf("adding resource %s to the evaluation context", v.ID())
 	e.ctx.SetByDot(val, b.TypeLabel())


### PR DESCRIPTION
The `SetByDot` function handles the merging anyway, so we don't need to pull out the existing values. I've left the old functionality in the `evaluateResource` and `evaluatorProvider` functions because the legacy evaluator needs it.

This also fixes an issue where the data blocks were using `e.ctx.Get(b.TypeLabel())` which was getting the wrong context. The correct functionality would have been to use `e.ctx.Get("data")`. Otherwise, this caused issues where the type of a data block matched the name of a resource, e.g. `data.aws_lb.anything` and `aws_lb.aws_lb`. In this case it would pull the context of the resource, which could cause a panic if the resource had been expanded, because it would be an array instead of the expected map.