### PR TITLE
fix: add support for `task_definitions` referenced through `ecs_task_…

### DIFF
--- a/internal/providers/terraform/aws/ecs_service.go
+++ b/internal/providers/terraform/aws/ecs_service.go
@@ -15,7 +15,7 @@ func getECSServiceRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:                "aws_ecs_service",
 		CoreRFunc:           NewECSService,
-		ReferenceAttributes: []string{"cluster", "task_definition"},
+		ReferenceAttributes: []string{"cluster", "task_definition", "aws_ecs_task_set.service"},
 	}
 }
 
@@ -33,6 +33,16 @@ func NewECSService(d *schema.ResourceData) schema.CoreResource {
 		if ref.Type == "aws_ecs_task_definition" {
 			taskDefinition = ref
 			break
+		}
+	}
+
+	for _, ref := range d.References("aws_ecs_task_set.service") {
+		for _, setRef := range ref.References("task_definition") {
+			if setRef.Type == "aws_ecs_task_definition" {
+				taskDefinition = setRef
+				break
+			}
+
 		}
 	}
 

--- a/internal/providers/terraform/aws/ecs_task_set.go
+++ b/internal/providers/terraform/aws/ecs_task_set.go
@@ -1,0 +1,22 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getECSTaskSet() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name: "aws_ecs_task_set",
+		RFunc: func(d *schema.ResourceData, _ *schema.UsageData) *schema.Resource {
+			return &schema.Resource{
+				Name:         d.Address,
+				ResourceType: d.Type,
+				Tags:         d.Tags,
+				IsSkipped:    true,
+				NoPrice:      true,
+				SkipMessage:  "Free resource.",
+			}
+		},
+		ReferenceAttributes: []string{"service", "cluster", "task_definition"},
+	}
+}

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -47,6 +47,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getECSClusterRegistryItem(),
 	getECSServiceRegistryItem(),
 	getECSTaskDefinitionRegistryItem(),
+	getECSTaskSet(),
 	getEFSFileSystemRegistryItem(),
 	getEIPRegistryItem(),
 	getEIPAssociationRegistryItem(),

--- a/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.golden
+++ b/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.golden
@@ -16,6 +16,11 @@
  ├─ Per vCPU per hour                                3  CPU          $88.65   
  └─ Inference accelerator (eia2.medium)          2,190  hours       $262.80   
                                                                               
+ aws_ecs_service.task_set                                                     
+ ├─ Per GB per hour                                  8  GB           $25.96   
+ ├─ Per vCPU per hour                                4  CPU         $118.20   
+ └─ Inference accelerator (eia2.medium)          1,460  hours       $175.20   
+                                                                              
  aws_ecs_service.ecs_fargate2                                                 
  ├─ Per GB per hour                                  4  GB           $12.98   
  ├─ Per vCPU per hour                                2  CPU          $59.10   
@@ -41,17 +46,17 @@
  ├─ Per vCPU per hour                                1  CPU          $29.55   
  └─ Inference accelerator (eia2.medium)            730  hours        $87.60   
                                                                               
- OVERALL TOTAL                                                   $2,349.16 
+ OVERALL TOTAL                                                   $2,668.52 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-22 cloud resources were detected:
-∙ 8 were estimated
-∙ 14 were free
+26 cloud resources were detected:
+∙ 9 were estimated
+∙ 17 were free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃ $2,349        ┃ $0.00       ┃ $2,349     ┃
+┃ main                                               ┃ $2,669        ┃ $0.00       ┃ $2,669     ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.tf
+++ b/internal/providers/terraform/aws/testdata/ecs_service_test/ecs_service_test.tf
@@ -170,3 +170,42 @@ resource "aws_ecs_service" "ecs_no_fargate_2" {
   task_definition = aws_ecs_task_definition.ecs_task.arn
   desired_count   = 2
 }
+
+resource "aws_ecs_cluster" "task_set" {
+  name = "task-set"
+}
+
+resource "aws_ecs_service" "task_set" {
+  name          = "task-set"
+  launch_type   = "FARGATE"
+  desired_count = 2
+}
+
+resource "aws_ecs_task_definition" "task_set" {
+  requires_compatibilities = ["FARGATE"]
+  family                   = "ecs_task1"
+  memory                   = "4 GB"
+  cpu                      = "2 vCPU"
+  inference_accelerator {
+    device_name = "device1"
+    device_type = "eia2.medium"
+  }
+  container_definitions = <<TASK_DEFINITION
+			[
+				{
+						"command": ["sleep", "10"],
+						"entryPoint": ["/"],
+						"essential": true,
+						"image": "alpine",
+						"name": "alpine",
+						"network_mode": "none"
+				}
+			]
+			TASK_DEFINITION
+}
+
+resource "aws_ecs_task_set" "task_set" {
+  service         = aws_ecs_service.task_set.id
+  cluster         = aws_ecs_cluster.task_set.id
+  task_definition = aws_ecs_task_definition.task_set.arn
+}


### PR DESCRIPTION
…set`.

Adds support to fetch the associated `ecs_service` task definition by walking references through a `ecs_task_set` resource. Referencing task defitions through a task set is common and without support for this we show 0 costs on a correctly configured FARGATE `ecs_service`.

An ECS task set is described by AWS as group of tasks within an Amazon ECS service that enables the management and deployment of multiple service revisions. Notably, it is a common way to use load balancers with an ecs service.