### PR TITLE
fix: Add tfvar files to the project dependency paths

### DIFF
--- a/cmd/infracost/testdata/generate/aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt/expected.golden
@@ -7,46 +7,70 @@ projects:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
@@ -9,6 +9,11 @@ projects:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/dev.tfvars
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
@@ -17,6 +22,11 @@ projects:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/prod.tfvars
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
@@ -25,6 +35,11 @@ projects:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/dev.tfvars
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
@@ -33,6 +48,11 @@ projects:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/prod.tfvars
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
@@ -41,6 +61,11 @@ projects:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/dev.tfvars
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
@@ -49,6 +74,11 @@ projects:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/prod.tfvars
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
@@ -57,6 +87,11 @@ projects:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/dev.tfvars
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
@@ -65,4 +100,9 @@ projects:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/prod.tfvars
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/aunt_filename_matches_project/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_filename_matches_project/expected.golden
@@ -7,31 +7,46 @@ projects:
       - ../../variables/env/dev/defaults.tfvars
       - ../../variables/env/dev/bar.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/env/dev/defaults.tfvars
+      - ../../variables/env/dev/bar.tfvars
   - path: infra/components/bar
     name: infra-components-bar-prod
     terraform_var_files:
       - ../../variables/env/prod/defaults.tfvars
       - ../../variables/env/prod/bar.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/env/prod/defaults.tfvars
+      - ../../variables/env/prod/bar.tfvars
   - path: infra/components/baz
     name: infra-components-baz-dev
     terraform_var_files:
       - ../../variables/env/dev/defaults.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/env/dev/defaults.tfvars
   - path: infra/components/baz
     name: infra-components-baz-prod
     terraform_var_files:
       - ../../variables/env/prod/defaults.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/env/prod/defaults.tfvars
   - path: infra/components/foo
     name: infra-components-foo-dev
     terraform_var_files:
       - ../../variables/env/dev/defaults.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/env/dev/defaults.tfvars
   - path: infra/components/foo
     name: infra-components-foo-prod
     terraform_var_files:
       - ../../variables/env/prod/foo.tfvars
       - ../../variables/env/prod/defaults.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/env/prod/foo.tfvars
+      - ../../variables/env/prod/defaults.tfvars
 

--- a/cmd/infracost/testdata/generate/aunt_filenames_with_env/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_filenames_with_env/expected.golden
@@ -8,24 +8,37 @@ projects:
       - ../../variables/cko-dev/age.tfvars
       - ../../variables/cko-dev/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-dev/age.tfvars
+      - ../../variables/cko-dev/dev.tfvars
   - path: components/age
     name: components-age-mgmt
     terraform_var_files:
       - ../../variables/default.tfvars
       - ../../variables/cko-mgmt/age.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-mgmt/age.tfvars
   - path: components/age
     name: components-age-playground
     terraform_var_files:
       - ../../variables/default.tfvars
       - ../../variables/cko-playground/age.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-playground/age.tfvars
   - path: components/age
     name: components-age-prod
     terraform_var_files:
       - ../../variables/default.tfvars
       - ../../variables/cko-prod/age.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-prod/age.tfvars
   - path: components/airflow
     name: components-airflow-dev
     terraform_var_files:
@@ -33,24 +46,37 @@ projects:
       - ../../variables/cko-dev/airflow.tfvars
       - ../../variables/cko-dev/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-dev/airflow.tfvars
+      - ../../variables/cko-dev/dev.tfvars
   - path: components/airflow
     name: components-airflow-mgmt
     terraform_var_files:
       - ../../variables/default.tfvars
       - ../../variables/cko-mgmt/airflow.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-mgmt/airflow.tfvars
   - path: components/airflow
     name: components-airflow-playground
     terraform_var_files:
       - ../../variables/default.tfvars
       - ../../variables/cko-playground/airflow.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-playground/airflow.tfvars
   - path: components/airflow
     name: components-airflow-prod
     terraform_var_files:
       - ../../variables/default.tfvars
       - ../../variables/cko-prod/airflow.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-prod/airflow.tfvars
   - path: components/apm-events
     name: components-apm-events-dev
     terraform_var_files:
@@ -58,22 +84,35 @@ projects:
       - ../../variables/cko-dev/apm-events.tfvars
       - ../../variables/cko-dev/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-dev/apm-events.tfvars
+      - ../../variables/cko-dev/dev.tfvars
   - path: components/apm-events
     name: components-apm-events-mgmt
     terraform_var_files:
       - ../../variables/default.tfvars
       - ../../variables/cko-mgmt/apm-events.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-mgmt/apm-events.tfvars
   - path: components/apm-events
     name: components-apm-events-playground
     terraform_var_files:
       - ../../variables/default.tfvars
       - ../../variables/cko-playground/apm-events.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-playground/apm-events.tfvars
   - path: components/apm-events
     name: components-apm-events-prod
     terraform_var_files:
       - ../../variables/default.tfvars
       - ../../variables/cko-prod/apm-events.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/default.tfvars
+      - ../../variables/cko-prod/apm-events.tfvars
 

--- a/cmd/infracost/testdata/generate/child/expected.golden
+++ b/cmd/infracost/testdata/generate/child/expected.golden
@@ -7,22 +7,34 @@ projects:
       - envs/default.tfvars
       - envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/default.tfvars
+      - envs/dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - envs/default.tfvars
       - envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/default.tfvars
+      - envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - envs/default.tfvars
       - envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/default.tfvars
+      - envs/dev.tfvars
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - envs/default.tfvars
       - envs/staging.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/default.tfvars
+      - envs/staging.tfvars
 

--- a/cmd/infracost/testdata/generate/cousin/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin/expected.golden
@@ -6,11 +6,15 @@ projects:
     terraform_var_files:
       - ../../variables/envs/dev/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/envs/dev/dev.tfvars
   - path: infra/components/foo
     name: infra-components-foo-prod
     terraform_var_files:
       - ../../variables/envs/prod/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/envs/prod/prod.tfvars
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-dev
     terraform_var_files:
@@ -18,16 +22,26 @@ projects:
       - ../../../variables/envs/dev/dev.tfvars
       - ../../variables/envs/dev/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/envs/defaults.tfvars
+      - ../../../variables/envs/dev/dev.tfvars
+      - ../../variables/envs/dev/dev.tfvars
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-prod
     terraform_var_files:
       - ../../variables/envs/defaults.tfvars
       - ../../../variables/envs/prod/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/envs/defaults.tfvars
+      - ../../../variables/envs/prod/prod.tfvars
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-stag
     terraform_var_files:
       - ../../variables/envs/defaults.tfvars
       - ../../variables/envs/stag/stag.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/envs/defaults.tfvars
+      - ../../variables/envs/stag/stag.tfvars
 

--- a/cmd/infracost/testdata/generate/cousin_flat/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin_flat/expected.golden
@@ -7,10 +7,16 @@ projects:
       - variables/envs/defaults.tfvars
       - variables/envs/dev/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - variables/envs/defaults.tfvars
+      - variables/envs/dev/dev.tfvars
   - path: .
     name: main-prod
     terraform_var_files:
       - variables/envs/defaults.tfvars
       - variables/envs/prod/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - variables/envs/defaults.tfvars
+      - variables/envs/prod/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/env_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/env_dirs/expected.golden
@@ -7,22 +7,34 @@ projects:
       - ../../variables/defaults.tfvars
       - ../../variables/dev/bla.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/defaults.tfvars
+      - ../../variables/dev/bla.tfvars
   - path: infra/components/baz
     name: infra-components-baz-stag
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/stag/bop.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/defaults.tfvars
+      - ../../variables/stag/bop.tfvars
   - path: infra/components/foo
     name: infra-components-foo-dev
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/dev/bla.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/defaults.tfvars
+      - ../../variables/dev/bla.tfvars
   - path: infra/components/foo
     name: infra-components-foo-stag
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/stag/bop.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../variables/defaults.tfvars
+      - ../../variables/stag/bop.tfvars
 

--- a/cmd/infracost/testdata/generate/env_var_dot_extensions/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_dot_extensions/expected.golden
@@ -8,6 +8,10 @@ projects:
       - ../.dev-custom-ext
       - ../.config.dev.env.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../.dev-custom-ext
+      - ../.config.dev.env.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -15,6 +19,10 @@ projects:
       - ../.prod-custom-ext
       - ../.config.prod.env.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../.prod-custom-ext
+      - ../.config.prod.env.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -22,6 +30,10 @@ projects:
       - ../.dev-custom-ext
       - ../.config.dev.env.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../.dev-custom-ext
+      - ../.config.dev.env.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -29,4 +41,8 @@ projects:
       - ../.prod-custom-ext
       - ../.config.prod.env.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../.prod-custom-ext
+      - ../.config.prod.env.tfvars
 

--- a/cmd/infracost/testdata/generate/env_var_dots/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_dots/expected.golden
@@ -10,6 +10,12 @@ projects:
       - ../config.dev.tfvars
       - ../.dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../.network-baz.tfvars
+      - ../.network-bat.tfvars
+      - ../config.dev.tfvars
+      - ../.dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -19,6 +25,12 @@ projects:
       - ../config.prod.tfvars
       - ../.prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../.network-baz.tfvars
+      - ../.network-bat.tfvars
+      - ../config.prod.tfvars
+      - ../.prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -28,6 +40,12 @@ projects:
       - ../config.dev.tfvars
       - ../.dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../.network-baz.tfvars
+      - ../.network-bat.tfvars
+      - ../config.dev.tfvars
+      - ../.dev.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -37,4 +55,10 @@ projects:
       - ../config.prod.tfvars
       - ../.prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../.network-baz.tfvars
+      - ../.network-bat.tfvars
+      - ../config.prod.tfvars
+      - ../.prod.tfvars
 

--- a/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
@@ -8,6 +8,10 @@ projects:
       - ../common.tfvars.json
       - ../baz-custom-ext
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../common.tfvars.json
+      - ../baz-custom-ext
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:
@@ -15,6 +19,10 @@ projects:
       - ../common.tfvars.json
       - ../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../common.tfvars.json
+      - ../dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -23,6 +31,11 @@ projects:
       - ../prod.env.tfvars
       - ../prod-custom-ext
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../common.tfvars.json
+      - ../prod.env.tfvars
+      - ../prod-custom-ext
   - path: apps/foo
     name: apps-foo-baz
     terraform_var_files:
@@ -30,6 +43,10 @@ projects:
       - ../common.tfvars.json
       - ../baz-custom-ext
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../common.tfvars.json
+      - ../baz-custom-ext
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -37,6 +54,10 @@ projects:
       - ../common.tfvars.json
       - ../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../common.tfvars.json
+      - ../dev.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -45,4 +66,9 @@ projects:
       - ../prod.env.tfvars
       - ../prod-custom-ext
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../common.tfvars.json
+      - ../prod.env.tfvars
+      - ../prod-custom-ext
 

--- a/cmd/infracost/testdata/generate/external_tfvars/expected.golden
+++ b/cmd/infracost/testdata/generate/external_tfvars/expected.golden
@@ -1,0 +1,58 @@
+version: 0.1
+
+projects:
+  - path: apps/foo
+    name: apps-foo-dev
+    terraform_var_files:
+      - ../../envs/default.tfvars
+      - ../../envs/dev/dev.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev/dev.tfvars
+  - path: apps/foo
+    name: apps-foo-prod
+    terraform_var_files:
+      - ../../envs/default.tfvars
+      - ../../envs/prod/prod.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod/prod.tfvars
+  - path: apps/foo
+    name: apps-foo-test
+    terraform_var_files:
+      - ../../envs/default.tfvars
+      - ../../envs/test/test.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/test/test.tfvars
+  - path: infra/db
+    name: infra-db-dev
+    terraform_var_files:
+      - ../../envs/default.tfvars
+      - ../../envs/dev/dev.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev/dev.tfvars
+  - path: infra/db
+    name: infra-db-prod
+    terraform_var_files:
+      - ../../envs/default.tfvars
+      - ../../envs/prod/prod.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod/prod.tfvars
+  - path: infra/db
+    name: infra-db-test
+    terraform_var_files:
+      - ../../envs/default.tfvars
+      - ../../envs/test/test.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/test/test.tfvars
+

--- a/cmd/infracost/testdata/generate/external_tfvars/tree.txt
+++ b/cmd/infracost/testdata/generate/external_tfvars/tree.txt
@@ -1,0 +1,16 @@
+.
+└── ./
+    ├── apps/
+    │   └── foo/
+    │       └── main.tf
+    ├── infra/
+    │   └── db/
+    │       └── main.tf
+    └── envs/
+        ├── default.tfvars
+        ├── dev/
+        │   └── dev.tfvars
+        ├── test/
+        │   └── test.tfvars
+        └── prod/
+            └── prod.tfvars

--- a/cmd/infracost/testdata/generate/force_project_type/expected.golden
+++ b/cmd/infracost/testdata/generate/force_project_type/expected.golden
@@ -6,11 +6,15 @@ projects:
     terraform_var_files:
       - dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - dev.tfvars
   - path: dup
     name: dup-prod
     terraform_var_files:
       - prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - prod.tfvars
   - path: nondup
     name: nondup
 

--- a/cmd/infracost/testdata/generate/grandchild/expected.golden
+++ b/cmd/infracost/testdata/generate/grandchild/expected.golden
@@ -7,22 +7,34 @@ projects:
       - config/envs/default.tfvars
       - config/envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - config/envs/default.tfvars
+      - config/envs/dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - config/envs/default.tfvars
+      - config/envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - config/envs/default.tfvars
+      - config/envs/dev.tfvars
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - config/envs/default.tfvars
       - config/envs/staging.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - config/envs/default.tfvars
+      - config/envs/staging.tfvars
 

--- a/cmd/infracost/testdata/generate/grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/grandparent/expected.golden
@@ -7,46 +7,70 @@ projects:
       - ../../default.tfvars
       - ../../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../prod.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../dev.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../prod.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../dev.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../prod.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../dev.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../prod.tfvars
 

--- a/cmd/infracost/testdata/generate/great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/great_aunt/expected.golden
@@ -7,46 +7,70 @@ projects:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/dev.tfvars
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/prod.tfvars
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/dev.tfvars
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/prod.tfvars
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/dev.tfvars
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/prod.tfvars
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/dev.tfvars
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../../envs/default.tfvars
+      - ../../../envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/modules_and_external_tfvars/expected.golden
+++ b/cmd/infracost/testdata/generate/modules_and_external_tfvars/expected.golden
@@ -1,0 +1,26 @@
+version: 0.1
+
+projects:
+  - path: db/dev
+    name: db-dev-dev
+    terraform_var_files:
+      - ../../default.tfvars
+      - ../../envs/dev.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - db/dev
+      - db/modules/db_config
+      - ../../default.tfvars
+      - ../../envs/dev.tfvars
+  - path: db/prod
+    name: db-prod-prod
+    terraform_var_files:
+      - ../../default.tfvars
+      - ../../envs/prod.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - db/modules/db_config
+      - db/prod
+      - ../../default.tfvars
+      - ../../envs/prod.tfvars
+

--- a/cmd/infracost/testdata/generate/modules_and_external_tfvars/tree.txt
+++ b/cmd/infracost/testdata/generate/modules_and_external_tfvars/tree.txt
@@ -1,0 +1,13 @@
+.
+├── db/
+│   ├── modules/
+│   │   └── db_config/
+│   │       └── main.tf
+│   ├── dev/
+│   │   └── module-call|..-modules-db_config.tf
+│   └── prod/
+│       └── module-call|..-modules-db_config.tf
+├── envs/
+│   ├── dev.tfvars
+│   └── prod.tfvars
+└── default.tfvars

--- a/cmd/infracost/testdata/generate/multi_descendents/expected.golden
+++ b/cmd/infracost/testdata/generate/multi_descendents/expected.golden
@@ -7,46 +7,70 @@ projects:
       - ../envs/default.tfvars
       - envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/default.tfvars
+      - envs/dev.tfvars
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/staging.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/default.tfvars
+      - envs/staging.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - envs/dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/default.tfvars
+      - envs/dev.tfvars
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - ../envs/default.tfvars
       - envs/staging.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/default.tfvars
+      - envs/staging.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - envs/dev.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
       - ../../envs/default.tfvars
       - envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/parent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent/expected.golden
@@ -7,22 +7,34 @@ projects:
       - ../default.tfvars
       - ../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../default.tfvars
       - ../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../dev.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../prod.tfvars
 

--- a/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
@@ -9,6 +9,11 @@ projects:
       - ../default.tfvars
       - ../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../dev.tfvars
+      - ../default.tfvars
+      - ../dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -17,6 +22,11 @@ projects:
       - ../default.tfvars
       - ../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../prod.tfvars
+      - ../default.tfvars
+      - ../prod.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -25,6 +35,11 @@ projects:
       - ../default.tfvars
       - ../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../dev.tfvars
+      - ../default.tfvars
+      - ../dev.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -33,6 +48,11 @@ projects:
       - ../default.tfvars
       - ../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../prod.tfvars
+      - ../default.tfvars
+      - ../prod.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -41,6 +61,11 @@ projects:
       - ../default.tfvars
       - ../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../dev.tfvars
+      - ../default.tfvars
+      - ../dev.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -49,6 +74,11 @@ projects:
       - ../default.tfvars
       - ../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../prod.tfvars
+      - ../default.tfvars
+      - ../prod.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -57,6 +87,11 @@ projects:
       - ../default.tfvars
       - ../dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../dev.tfvars
+      - ../default.tfvars
+      - ../dev.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -65,4 +100,9 @@ projects:
       - ../default.tfvars
       - ../prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../prod.tfvars
+      - ../default.tfvars
+      - ../prod.tfvars
 

--- a/cmd/infracost/testdata/generate/parent_filename_matches_project/expected.golden
+++ b/cmd/infracost/testdata/generate/parent_filename_matches_project/expected.golden
@@ -7,12 +7,18 @@ projects:
       - ../defaults.tfvars
       - ../bar.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../defaults.tfvars
+      - ../bar.tfvars
   - path: infra/components/baz
     name: infra-components-baz
     terraform_var_files:
       - ../../baz.tfvars
       - ../defaults.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../baz.tfvars
+      - ../defaults.tfvars
   - path: infra/components/foo
     name: infra-components-foo
     terraform_var_files:
@@ -20,4 +26,8 @@ projects:
       - ../foo.tfvars
       - ../defaults.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../foo.tfvars
+      - ../foo.tfvars
+      - ../defaults.tfvars
 

--- a/cmd/infracost/testdata/generate/path_overrides/expected.golden
+++ b/cmd/infracost/testdata/generate/path_overrides/expected.golden
@@ -7,6 +7,9 @@ projects:
       - ../../default.tfvars
       - ../../bip.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../bip.tfvars
   - path: infra/components/blah
     name: infra-components-blah-bat
     terraform_var_files:
@@ -14,12 +17,19 @@ projects:
       - ../../network-bat.tfvars
       - ../../bat.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../network-bat.tfvars
+      - ../../bat.tfvars
   - path: infra/components/blah
     name: infra-components-blah-bip
     terraform_var_files:
       - ../../default.tfvars
       - ../../bip.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../bip.tfvars
   - path: infra/components/foo
     name: infra-components-foo-baz
     terraform_var_files:
@@ -28,4 +38,9 @@ projects:
       - ../../baz.tfvars
       - var.auto.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../default.tfvars
+      - ../../network-baz.tfvars
+      - ../../baz.tfvars
+      - var.auto.tfvars
 

--- a/cmd/infracost/testdata/generate/root_paths/expected.golden
+++ b/cmd/infracost/testdata/generate/root_paths/expected.golden
@@ -6,16 +6,24 @@ projects:
     terraform_var_files:
       - terraform.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - terraform.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - terraform.tfvars
       - dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - terraform.tfvars
+      - dev.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - terraform.tfvars
       - prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - terraform.tfvars
+      - prod.tfvars
 

--- a/cmd/infracost/testdata/generate/root_with_leafs/expected.golden
+++ b/cmd/infracost/testdata/generate/root_with_leafs/expected.golden
@@ -6,19 +6,27 @@ projects:
     terraform_var_files:
       - config/dev/terraform.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - config/dev/terraform.tfvars
   - path: terraform
     name: terraform-prod
     terraform_var_files:
       - config/prod/terraform.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - config/prod/terraform.tfvars
   - path: terraform/foo
     name: terraform-foo-dev
     terraform_var_files:
       - dev/terraform.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - dev/terraform.tfvars
   - path: terraform/foo
     name: terraform-foo-prod
     terraform_var_files:
       - prod/terraform.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - prod/terraform.tfvars
 

--- a/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
+++ b/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
@@ -8,6 +8,10 @@ projects:
       - ../dev-default.tfvars
       - dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../dev-default.tfvars
+      - dev.tfvars
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
@@ -15,22 +19,35 @@ projects:
       - ../staging-default.tfvars
       - staging.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../staging-default.tfvars
+      - staging.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../default.tfvars
       - ../dev-default.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../dev-default.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../default.tfvars
       - ../prod-default.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../prod-default.tfvars
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - ../default.tfvars
       - ../staging-default.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../default.tfvars
+      - ../staging-default.tfvars
 

--- a/cmd/infracost/testdata/generate/sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling/expected.golden
@@ -7,22 +7,34 @@ projects:
       - ../envs/shared.tfvars
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/shared.tfvars
+      - ../envs/dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/shared.tfvars
+      - ../envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/shared.tfvars
+      - ../envs/dev.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
       - ../envs/shared.tfvars
       - ../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/shared.tfvars
+      - ../envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
@@ -9,6 +9,11 @@ projects:
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
+      - ../envs/default.tfvars
+      - ../envs/dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -17,6 +22,11 @@ projects:
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
+      - ../envs/default.tfvars
+      - ../envs/prod.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -25,6 +35,11 @@ projects:
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
+      - ../envs/default.tfvars
+      - ../envs/dev.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -33,6 +48,11 @@ projects:
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
+      - ../envs/default.tfvars
+      - ../envs/prod.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -41,6 +61,11 @@ projects:
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
+      - ../envs/default.tfvars
+      - ../envs/dev.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -49,6 +74,11 @@ projects:
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
+      - ../envs/default.tfvars
+      - ../envs/prod.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -57,6 +87,11 @@ projects:
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/dev.tfvars
+      - ../envs/default.tfvars
+      - ../envs/dev.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -65,4 +100,9 @@ projects:
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../../envs/default.tfvars
+      - ../../envs/prod.tfvars
+      - ../envs/default.tfvars
+      - ../envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
@@ -6,11 +6,15 @@ projects:
     terraform_var_files:
       - envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/dev.tfvars
   - path: apps
     name: apps-prod
     terraform_var_files:
       - envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/prod.tfvars
   - path: apps/bar
     name: apps-bar
     skip_autodetect: true

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
@@ -6,19 +6,27 @@ projects:
     terraform_var_files:
       - envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/dev.tfvars
   - path: apps
     name: apps-prod
     terraform_var_files:
       - envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/prod.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
       - envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - envs/dev.tfvars
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
@@ -6,29 +6,41 @@ projects:
     terraform_var_files:
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/dev.tfvars
   - path: apps
     name: apps-prod
     terraform_var_files:
       - ../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/prod.tfvars
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/dev.tfvars
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
       - ../envs/staging.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/staging.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/dev.tfvars
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
       - ../envs/staging.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/staging.tfvars
 

--- a/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/expected.golden
+++ b/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/expected.golden
@@ -10,11 +10,15 @@ projects:
     terraform_var_files:
       - ../envs/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/dev.tfvars
   - path: apps/fez
     name: apps-fez-prod
     terraform_var_files:
       - ../envs/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - ../envs/prod.tfvars
   - path: apps/foo
     name: apps-foo
 

--- a/cmd/infracost/testdata/generate/tfvar_json/expected.golden
+++ b/cmd/infracost/testdata/generate/tfvar_json/expected.golden
@@ -6,9 +6,13 @@ projects:
     terraform_var_files:
       - ../variables/env/dev/tfvars.json
     skip_autodetect: true
+    dependency_paths:
+      - ../variables/env/dev/tfvars.json
   - path: terraform
     name: terraform-prod
     terraform_var_files:
       - ../variables/env/prod/tfvars.json
     skip_autodetect: true
+    dependency_paths:
+      - ../variables/env/prod/tfvars.json
 

--- a/cmd/infracost/testdata/generate/wildcard_env_names/expected.golden
+++ b/cmd/infracost/testdata/generate/wildcard_env_names/expected.golden
@@ -6,29 +6,41 @@ projects:
     terraform_var_files:
       - env/conf-dev-foo.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - env/conf-dev-foo.tfvars
   - path: terraform
     name: terraform-conf-prod-foo
     terraform_var_files:
       - env/conf-prod-foo.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - env/conf-prod-foo.tfvars
   - path: terraform
     name: terraform-dev
     terraform_var_files:
       - env/dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - env/dev.tfvars
   - path: terraform
     name: terraform-ops-dev
     terraform_var_files:
       - env/ops-dev.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - env/ops-dev.tfvars
   - path: terraform
     name: terraform-ops-prod-bar
     terraform_var_files:
       - env/ops-prod-bar.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - env/ops-prod-bar.tfvars
   - path: terraform
     name: terraform-ops-prod-foo
     terraform_var_files:
       - env/ops-prod-foo.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - env/ops-prod-foo.tfvars
 

--- a/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
+++ b/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
@@ -7,27 +7,41 @@ projects:
       - defaults.tfvars
       - env/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - defaults.tfvars
+      - env/prod.tfvars
   - path: app1
     name: app1-test
     terraform_var_files:
       - defaults.tfvars
       - env/test.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - defaults.tfvars
+      - env/test.tfvars
   - path: app1/app3
     name: app1-app3-qa
     terraform_var_files:
       - qa.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - qa.tfvars
   - path: app2
     name: app2-prod
     terraform_var_files:
       - env/defaults.tfvars
       - env/prod.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - env/defaults.tfvars
+      - env/prod.tfvars
   - path: app2
     name: app2-staging
     terraform_var_files:
       - env/defaults.tfvars
       - env/staging.tfvars
     skip_autodetect: true
+    dependency_paths:
+      - env/defaults.tfvars
+      - env/staging.tfvars
 

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -338,11 +338,11 @@ func (p *Parser) YAML() string {
 		}
 	}
 
-	calls := p.DependencyPaths()
-	if len(calls) > 0 {
+	dependencyFiles := append(p.DependencyPaths(), p.VarFiles()...)
+	if len(dependencyFiles) > 0 {
 		str.WriteString("    dependency_paths:\n")
-		for _, call := range calls {
-			str.WriteString(fmt.Sprintf("      - %s\n", call))
+		for _, depFile := range dependencyFiles {
+			str.WriteString(fmt.Sprintf("      - %s\n", depFile))
 		}
 	}
 
@@ -569,7 +569,6 @@ func (p *Parser) loadVars(blocks Blocks, filenames []string) (map[string]cty.Val
 
 	if p.remoteVariablesLoader != nil {
 		remoteVars, err := p.remoteVariablesLoader.Load(blocks)
-
 		if err != nil {
 			p.logger.Debug().Msgf("could not load vars from Terraform Cloud: %s", err)
 			return combinedVars, err


### PR DESCRIPTION
- ensure that the tfvars files are included with the modules in the
  dependency paths block of the config file
- add tests to explicitly test modules and tfvars to ensure both are
  included
- update the the existing tests expected.golden files

```
  - path: db/prod
    name: db-prod-prod
    terraform_var_files:
      - ../../default.tfvars
      - ../../envs/prod.tfvars
    skip_autodetect: true
    dependency_paths:
      - db/modules/db_config
      - db/prod
      - ../../default.tfvars
      - ../../envs/prod.tfvars
```
