### PR TITLE
Configure references for the Azure Firewall Policy

### DIFF
--- a/internal/providers/terraform/azure/firewall_policy.go
+++ b/internal/providers/terraform/azure/firewall_policy.go
@@ -1,0 +1,24 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getAzureRMFirewallPolicyRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:                "azurerm_firewall_policy",
+		RFunc:               newAzureRMFirewallPolicy,
+		ReferenceAttributes: []string{"azurerm_firewall_policy_rule_collection_group.firewall_policy_id"},
+	}
+}
+
+func newAzureRMFirewallPolicy(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	return &schema.Resource{
+		Name:         d.Address,
+		ResourceType: d.Type,
+		Tags:         d.Tags,
+		IsSkipped:    true,
+		NoPrice:      true,
+		SkipMessage:  "Free resource.",
+	}
+}

--- a/internal/providers/terraform/azure/firewall_policy_rule_collection_group.go
+++ b/internal/providers/terraform/azure/firewall_policy_rule_collection_group.go
@@ -1,0 +1,24 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getAzureRMFirewallPolicyRuleCollectionGroupRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:                "azurerm_firewall_policy_rule_collection_group",
+		RFunc:               newAzureRMFirewallPolicyRuleCollectionGroup,
+		ReferenceAttributes: []string{"firewall_policy_id"},
+	}
+}
+
+func newAzureRMFirewallPolicyRuleCollectionGroup(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
+	return &schema.Resource{
+		Name:         d.Address,
+		ResourceType: d.Type,
+		Tags:         d.Tags,
+		IsSkipped:    true,
+		NoPrice:      true,
+		SkipMessage:  "Free resource.",
+	}
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -51,6 +51,8 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getExpressRouteConnectionRegistryItem(),
 	getExpressRouteGatewayRegistryItem(),
 	GetAzureRMFirewallRegistryItem(),
+	getAzureRMFirewallPolicyRegistryItem(),
+	getAzureRMFirewallPolicyRuleCollectionGroupRegistryItem(),
 	getFrontdoorFirewallPolicyRegistryItem(),
 	getFrontdoorRegistryItem(),
 	GetAzureRMHDInsightHadoopClusterRegistryItem(),
@@ -390,8 +392,6 @@ var FreeResources = []string{
 	"azurerm_firewall_application_rule_collection",
 	"azurerm_firewall_nat_rule_collection",
 	"azurerm_firewall_network_rule_collection",
-	"azurerm_firewall_policy",
-	"azurerm_firewall_policy_rule_collection_group",
 
 	// Azure Front Door
 	"azurerm_frontdoor_custom_https_configuration",


### PR DESCRIPTION
Add forward and backward references for the Azure Firewall Policy to lookup the Firewall Policy Rule Collection Group. 

This is required for the Azure Firewall Finops policy so that it can check if there are application rules associated with the Firewall Policy

<img width="1661" alt="image" src="https://github.com/infracost/infracost/assets/3049157/9a1742d5-9bf8-48c6-97c6-09baf041589c">
