### PR TITLE
fix: `dependency_paths` detection issues 

### DIFF
--- a/cmd/infracost/testdata/generate/aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt/expected.golden
@@ -10,6 +10,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
+      - apps/bar/us1/**
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -19,6 +20,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
+      - apps/bar/us1/**
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -28,6 +30,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
+      - apps/bar/us2/**
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -37,6 +40,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
+      - apps/bar/us2/**
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -46,6 +50,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
+      - apps/foo/us1/**
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -55,6 +60,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
+      - apps/foo/us1/**
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -64,6 +70,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
+      - apps/foo/us2/**
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -73,4 +80,5 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
+      - apps/foo/us2/**
 

--- a/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
@@ -14,6 +14,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
+      - infra/apps/bar/us1/**
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
@@ -27,6 +28,7 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
+      - infra/apps/bar/us1/**
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
@@ -40,6 +42,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
+      - infra/apps/bar/us2/**
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
@@ -53,6 +56,7 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
+      - infra/apps/bar/us2/**
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
@@ -66,6 +70,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
+      - infra/apps/foo/us1/**
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
@@ -79,6 +84,7 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
+      - infra/apps/foo/us1/**
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
@@ -92,6 +98,7 @@ projects:
       - ../../../envs/dev.tfvars
       - ../../envs/default.tfvars
       - ../../envs/dev.tfvars
+      - infra/apps/foo/us2/**
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
@@ -105,4 +112,5 @@ projects:
       - ../../../envs/prod.tfvars
       - ../../envs/default.tfvars
       - ../../envs/prod.tfvars
+      - infra/apps/foo/us2/**
 

--- a/cmd/infracost/testdata/generate/aunt_filename_matches_project/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_filename_matches_project/expected.golden
@@ -8,8 +8,9 @@ projects:
       - ../../variables/env/dev/bar.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/env/dev/defaults.tfvars
       - ../../variables/env/dev/bar.tfvars
+      - ../../variables/env/dev/defaults.tfvars
+      - infra/components/bar/**
   - path: infra/components/bar
     name: infra-components-bar-prod
     terraform_var_files:
@@ -17,8 +18,9 @@ projects:
       - ../../variables/env/prod/bar.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/env/prod/defaults.tfvars
       - ../../variables/env/prod/bar.tfvars
+      - ../../variables/env/prod/defaults.tfvars
+      - infra/components/bar/**
   - path: infra/components/baz
     name: infra-components-baz-dev
     terraform_var_files:
@@ -26,6 +28,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../variables/env/dev/defaults.tfvars
+      - infra/components/baz/**
   - path: infra/components/baz
     name: infra-components-baz-prod
     terraform_var_files:
@@ -33,6 +36,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../variables/env/prod/defaults.tfvars
+      - infra/components/baz/**
   - path: infra/components/foo
     name: infra-components-foo-dev
     terraform_var_files:
@@ -40,6 +44,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../variables/env/dev/defaults.tfvars
+      - infra/components/foo/**
   - path: infra/components/foo
     name: infra-components-foo-prod
     terraform_var_files:
@@ -47,6 +52,7 @@ projects:
       - ../../variables/env/prod/defaults.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/env/prod/foo.tfvars
       - ../../variables/env/prod/defaults.tfvars
+      - ../../variables/env/prod/foo.tfvars
+      - infra/components/foo/**
 

--- a/cmd/infracost/testdata/generate/aunt_filenames_with_env/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_filenames_with_env/expected.golden
@@ -9,9 +9,10 @@ projects:
       - ../../variables/cko-dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-dev/age.tfvars
       - ../../variables/cko-dev/dev.tfvars
+      - ../../variables/default.tfvars
+      - components/age/**
   - path: components/age
     name: components-age-mgmt
     terraform_var_files:
@@ -19,8 +20,9 @@ projects:
       - ../../variables/cko-mgmt/age.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-mgmt/age.tfvars
+      - ../../variables/default.tfvars
+      - components/age/**
   - path: components/age
     name: components-age-playground
     terraform_var_files:
@@ -28,8 +30,9 @@ projects:
       - ../../variables/cko-playground/age.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-playground/age.tfvars
+      - ../../variables/default.tfvars
+      - components/age/**
   - path: components/age
     name: components-age-prod
     terraform_var_files:
@@ -37,8 +40,9 @@ projects:
       - ../../variables/cko-prod/age.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-prod/age.tfvars
+      - ../../variables/default.tfvars
+      - components/age/**
   - path: components/airflow
     name: components-airflow-dev
     terraform_var_files:
@@ -47,9 +51,10 @@ projects:
       - ../../variables/cko-dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-dev/airflow.tfvars
       - ../../variables/cko-dev/dev.tfvars
+      - ../../variables/default.tfvars
+      - components/airflow/**
   - path: components/airflow
     name: components-airflow-mgmt
     terraform_var_files:
@@ -57,8 +62,9 @@ projects:
       - ../../variables/cko-mgmt/airflow.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-mgmt/airflow.tfvars
+      - ../../variables/default.tfvars
+      - components/airflow/**
   - path: components/airflow
     name: components-airflow-playground
     terraform_var_files:
@@ -66,8 +72,9 @@ projects:
       - ../../variables/cko-playground/airflow.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-playground/airflow.tfvars
+      - ../../variables/default.tfvars
+      - components/airflow/**
   - path: components/airflow
     name: components-airflow-prod
     terraform_var_files:
@@ -75,8 +82,9 @@ projects:
       - ../../variables/cko-prod/airflow.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-prod/airflow.tfvars
+      - ../../variables/default.tfvars
+      - components/airflow/**
   - path: components/apm-events
     name: components-apm-events-dev
     terraform_var_files:
@@ -85,9 +93,10 @@ projects:
       - ../../variables/cko-dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-dev/apm-events.tfvars
       - ../../variables/cko-dev/dev.tfvars
+      - ../../variables/default.tfvars
+      - components/apm-events/**
   - path: components/apm-events
     name: components-apm-events-mgmt
     terraform_var_files:
@@ -95,8 +104,9 @@ projects:
       - ../../variables/cko-mgmt/apm-events.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-mgmt/apm-events.tfvars
+      - ../../variables/default.tfvars
+      - components/apm-events/**
   - path: components/apm-events
     name: components-apm-events-playground
     terraform_var_files:
@@ -104,8 +114,9 @@ projects:
       - ../../variables/cko-playground/apm-events.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-playground/apm-events.tfvars
+      - ../../variables/default.tfvars
+      - components/apm-events/**
   - path: components/apm-events
     name: components-apm-events-prod
     terraform_var_files:
@@ -113,6 +124,7 @@ projects:
       - ../../variables/cko-prod/apm-events.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/default.tfvars
       - ../../variables/cko-prod/apm-events.tfvars
+      - ../../variables/default.tfvars
+      - components/apm-events/**
 

--- a/cmd/infracost/testdata/generate/child/expected.golden
+++ b/cmd/infracost/testdata/generate/child/expected.golden
@@ -8,6 +8,7 @@ projects:
       - envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/bar/**
       - envs/default.tfvars
       - envs/dev.tfvars
   - path: apps/bar
@@ -17,6 +18,7 @@ projects:
       - envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/bar/**
       - envs/default.tfvars
       - envs/prod.tfvars
   - path: apps/foo
@@ -26,6 +28,7 @@ projects:
       - envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/foo/**
       - envs/default.tfvars
       - envs/dev.tfvars
   - path: apps/foo
@@ -35,6 +38,7 @@ projects:
       - envs/staging.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/foo/**
       - envs/default.tfvars
       - envs/staging.tfvars
 

--- a/cmd/infracost/testdata/generate/cousin/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin/expected.golden
@@ -8,6 +8,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../variables/envs/dev/dev.tfvars
+      - infra/components/foo/**
   - path: infra/components/foo
     name: infra-components-foo-prod
     terraform_var_files:
@@ -15,6 +16,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../variables/envs/prod/prod.tfvars
+      - infra/components/foo/**
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-dev
     terraform_var_files:
@@ -23,9 +25,10 @@ projects:
       - ../../variables/envs/dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/envs/defaults.tfvars
       - ../../../variables/envs/dev/dev.tfvars
+      - ../../variables/envs/defaults.tfvars
       - ../../variables/envs/dev/dev.tfvars
+      - infra/nested/components/baz/**
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-prod
     terraform_var_files:
@@ -33,8 +36,9 @@ projects:
       - ../../../variables/envs/prod/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/envs/defaults.tfvars
       - ../../../variables/envs/prod/prod.tfvars
+      - ../../variables/envs/defaults.tfvars
+      - infra/nested/components/baz/**
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-stag
     terraform_var_files:
@@ -44,4 +48,5 @@ projects:
     dependency_paths:
       - ../../variables/envs/defaults.tfvars
       - ../../variables/envs/stag/stag.tfvars
+      - infra/nested/components/baz/**
 

--- a/cmd/infracost/testdata/generate/cousin_flat/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin_flat/expected.golden
@@ -8,6 +8,7 @@ projects:
       - variables/envs/dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
+      - "**"
       - variables/envs/defaults.tfvars
       - variables/envs/dev/dev.tfvars
   - path: .
@@ -17,6 +18,7 @@ projects:
       - variables/envs/prod/prod.tfvars
     skip_autodetect: true
     dependency_paths:
+      - "**"
       - variables/envs/defaults.tfvars
       - variables/envs/prod/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/env_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/env_dirs/expected.golden
@@ -10,6 +10,7 @@ projects:
     dependency_paths:
       - ../../variables/defaults.tfvars
       - ../../variables/dev/bla.tfvars
+      - infra/components/baz/**
   - path: infra/components/baz
     name: infra-components-baz-stag
     terraform_var_files:
@@ -19,6 +20,7 @@ projects:
     dependency_paths:
       - ../../variables/defaults.tfvars
       - ../../variables/stag/bop.tfvars
+      - infra/components/baz/**
   - path: infra/components/foo
     name: infra-components-foo-dev
     terraform_var_files:
@@ -28,6 +30,7 @@ projects:
     dependency_paths:
       - ../../variables/defaults.tfvars
       - ../../variables/dev/bla.tfvars
+      - infra/components/foo/**
   - path: infra/components/foo
     name: infra-components-foo-stag
     terraform_var_files:
@@ -37,4 +40,5 @@ projects:
     dependency_paths:
       - ../../variables/defaults.tfvars
       - ../../variables/stag/bop.tfvars
+      - infra/components/foo/**
 

--- a/cmd/infracost/testdata/generate/env_var_dot_extensions/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_dot_extensions/expected.golden
@@ -9,9 +9,10 @@ projects:
       - ../.config.dev.env.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../.dev-custom-ext
       - ../.config.dev.env.tfvars
+      - ../.dev-custom-ext
+      - ../default.tfvars
+      - apps/bar/**
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -20,9 +21,10 @@ projects:
       - ../.config.prod.env.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../.prod-custom-ext
       - ../.config.prod.env.tfvars
+      - ../.prod-custom-ext
+      - ../default.tfvars
+      - apps/bar/**
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -31,9 +33,10 @@ projects:
       - ../.config.dev.env.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../.dev-custom-ext
       - ../.config.dev.env.tfvars
+      - ../.dev-custom-ext
+      - ../default.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -42,7 +45,8 @@ projects:
       - ../.config.prod.env.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../.prod-custom-ext
       - ../.config.prod.env.tfvars
+      - ../.prod-custom-ext
+      - ../default.tfvars
+      - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/env_var_dots/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_dots/expected.golden
@@ -11,11 +11,12 @@ projects:
       - ../.dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../.network-baz.tfvars
-      - ../.network-bat.tfvars
-      - ../config.dev.tfvars
       - ../.dev.tfvars
+      - ../.network-bat.tfvars
+      - ../.network-baz.tfvars
+      - ../config.dev.tfvars
+      - ../default.tfvars
+      - apps/bar/**
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -26,11 +27,12 @@ projects:
       - ../.prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../.network-baz.tfvars
       - ../.network-bat.tfvars
-      - ../config.prod.tfvars
+      - ../.network-baz.tfvars
       - ../.prod.tfvars
+      - ../config.prod.tfvars
+      - ../default.tfvars
+      - apps/bar/**
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -41,11 +43,12 @@ projects:
       - ../.dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../.network-baz.tfvars
-      - ../.network-bat.tfvars
-      - ../config.dev.tfvars
       - ../.dev.tfvars
+      - ../.network-bat.tfvars
+      - ../.network-baz.tfvars
+      - ../config.dev.tfvars
+      - ../default.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -56,9 +59,10 @@ projects:
       - ../.prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../.network-baz.tfvars
       - ../.network-bat.tfvars
-      - ../config.prod.tfvars
+      - ../.network-baz.tfvars
       - ../.prod.tfvars
+      - ../config.prod.tfvars
+      - ../default.tfvars
+      - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
@@ -9,9 +9,10 @@ projects:
       - ../baz-custom-ext
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../common.tfvars.json
       - ../baz-custom-ext
+      - ../common.tfvars.json
+      - ../default.tfvars
+      - apps/bar/**
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:
@@ -20,9 +21,10 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
       - ../common.tfvars.json
+      - ../default.tfvars
       - ../dev.tfvars
+      - apps/bar/**
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -32,10 +34,11 @@ projects:
       - ../prod-custom-ext
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
       - ../common.tfvars.json
-      - ../prod.env.tfvars
+      - ../default.tfvars
       - ../prod-custom-ext
+      - ../prod.env.tfvars
+      - apps/bar/**
   - path: apps/foo
     name: apps-foo-baz
     terraform_var_files:
@@ -44,9 +47,10 @@ projects:
       - ../baz-custom-ext
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../common.tfvars.json
       - ../baz-custom-ext
+      - ../common.tfvars.json
+      - ../default.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -55,9 +59,10 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
       - ../common.tfvars.json
+      - ../default.tfvars
       - ../dev.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -67,8 +72,9 @@ projects:
       - ../prod-custom-ext
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
       - ../common.tfvars.json
-      - ../prod.env.tfvars
+      - ../default.tfvars
       - ../prod-custom-ext
+      - ../prod.env.tfvars
+      - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/external_tfvars/expected.golden
+++ b/cmd/infracost/testdata/generate/external_tfvars/expected.golden
@@ -10,6 +10,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/dev/dev.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -19,6 +20,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/prod/prod.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-test
     terraform_var_files:
@@ -28,6 +30,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/test/test.tfvars
+      - apps/foo/**
   - path: infra/db
     name: infra-db-dev
     terraform_var_files:
@@ -37,6 +40,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/dev/dev.tfvars
+      - infra/db/**
   - path: infra/db
     name: infra-db-prod
     terraform_var_files:
@@ -46,6 +50,7 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/prod/prod.tfvars
+      - infra/db/**
   - path: infra/db
     name: infra-db-test
     terraform_var_files:
@@ -55,4 +60,5 @@ projects:
     dependency_paths:
       - ../../envs/default.tfvars
       - ../../envs/test/test.tfvars
+      - infra/db/**
 

--- a/cmd/infracost/testdata/generate/grandchild/expected.golden
+++ b/cmd/infracost/testdata/generate/grandchild/expected.golden
@@ -8,6 +8,7 @@ projects:
       - config/envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/bar/**
       - config/envs/default.tfvars
       - config/envs/dev.tfvars
   - path: apps/bar
@@ -17,6 +18,7 @@ projects:
       - config/envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/bar/**
       - config/envs/default.tfvars
       - config/envs/prod.tfvars
   - path: apps/foo
@@ -26,6 +28,7 @@ projects:
       - config/envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/foo/**
       - config/envs/default.tfvars
       - config/envs/dev.tfvars
   - path: apps/foo
@@ -35,6 +38,7 @@ projects:
       - config/envs/staging.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/foo/**
       - config/envs/default.tfvars
       - config/envs/staging.tfvars
 

--- a/cmd/infracost/testdata/generate/grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/grandparent/expected.golden
@@ -10,6 +10,7 @@ projects:
     dependency_paths:
       - ../../default.tfvars
       - ../../dev.tfvars
+      - apps/bar/us1/**
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -19,6 +20,7 @@ projects:
     dependency_paths:
       - ../../default.tfvars
       - ../../prod.tfvars
+      - apps/bar/us1/**
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -28,6 +30,7 @@ projects:
     dependency_paths:
       - ../../default.tfvars
       - ../../dev.tfvars
+      - apps/bar/us2/**
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -37,6 +40,7 @@ projects:
     dependency_paths:
       - ../../default.tfvars
       - ../../prod.tfvars
+      - apps/bar/us2/**
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -46,6 +50,7 @@ projects:
     dependency_paths:
       - ../../default.tfvars
       - ../../dev.tfvars
+      - apps/foo/us1/**
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -55,6 +60,7 @@ projects:
     dependency_paths:
       - ../../default.tfvars
       - ../../prod.tfvars
+      - apps/foo/us1/**
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -64,6 +70,7 @@ projects:
     dependency_paths:
       - ../../default.tfvars
       - ../../dev.tfvars
+      - apps/foo/us2/**
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -73,4 +80,5 @@ projects:
     dependency_paths:
       - ../../default.tfvars
       - ../../prod.tfvars
+      - apps/foo/us2/**
 

--- a/cmd/infracost/testdata/generate/great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/great_aunt/expected.golden
@@ -10,6 +10,7 @@ projects:
     dependency_paths:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
+      - infra/apps/bar/us1/**
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
@@ -19,6 +20,7 @@ projects:
     dependency_paths:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
+      - infra/apps/bar/us1/**
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
@@ -28,6 +30,7 @@ projects:
     dependency_paths:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
+      - infra/apps/bar/us2/**
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
@@ -37,6 +40,7 @@ projects:
     dependency_paths:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
+      - infra/apps/bar/us2/**
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
@@ -46,6 +50,7 @@ projects:
     dependency_paths:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
+      - infra/apps/foo/us1/**
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
@@ -55,6 +60,7 @@ projects:
     dependency_paths:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
+      - infra/apps/foo/us1/**
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
@@ -64,6 +70,7 @@ projects:
     dependency_paths:
       - ../../../envs/default.tfvars
       - ../../../envs/dev.tfvars
+      - infra/apps/foo/us2/**
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
@@ -73,4 +80,5 @@ projects:
     dependency_paths:
       - ../../../envs/default.tfvars
       - ../../../envs/prod.tfvars
+      - infra/apps/foo/us2/**
 

--- a/cmd/infracost/testdata/generate/module_calls/expected.golden
+++ b/cmd/infracost/testdata/generate/module_calls/expected.golden
@@ -5,9 +5,9 @@ projects:
     name: infra-dev
     skip_autodetect: true
     dependency_paths:
-      - infra/dev
-      - infra/modules/is_also_called
-      - infra/modules/is_called
+      - infra/dev/**
+      - infra/modules/is_also_called/**
+      - infra/modules/is_called/**
   - path: infra/modules/is_a_project
     name: infra-modules-is_a_project
     skip_autodetect: true
@@ -15,6 +15,6 @@ projects:
     name: infra-prod
     skip_autodetect: true
     dependency_paths:
-      - infra/modules/is_called
-      - infra/prod
+      - infra/modules/is_called/**
+      - infra/prod/**
 

--- a/cmd/infracost/testdata/generate/module_calls_with_template/expected.golden
+++ b/cmd/infracost/testdata/generate/module_calls_with_template/expected.golden
@@ -5,9 +5,9 @@ projects:
     name: infra-dev
     terraform_var_files:
     dependency_paths:
-      - infra/dev
-      - infra/modules/is_also_called
-      - infra/modules/is_called
+      - infra/dev/**
+      - infra/modules/is_also_called/**
+      - infra/modules/is_called/**
   - path: infra/modules/is_a_project
     name: infra-modules-is_a_project
     terraform_var_files:
@@ -16,6 +16,6 @@ projects:
     name: infra-prod
     terraform_var_files:
     dependency_paths:
-      - infra/modules/is_called
-      - infra/prod
+      - infra/modules/is_called/**
+      - infra/prod/**
 

--- a/cmd/infracost/testdata/generate/modules_and_external_tfvars/expected.golden
+++ b/cmd/infracost/testdata/generate/modules_and_external_tfvars/expected.golden
@@ -8,10 +8,10 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - db/dev
-      - db/modules/db_config
       - ../../default.tfvars
       - ../../envs/dev.tfvars
+      - db/dev/**
+      - db/modules/db_config/**
   - path: db/prod
     name: db-prod-prod
     terraform_var_files:
@@ -19,8 +19,8 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - db/modules/db_config
-      - db/prod
       - ../../default.tfvars
       - ../../envs/prod.tfvars
+      - db/modules/db_config/**
+      - db/prod/**
 

--- a/cmd/infracost/testdata/generate/multi_descendents/expected.golden
+++ b/cmd/infracost/testdata/generate/multi_descendents/expected.golden
@@ -9,6 +9,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/default.tfvars
+      - apps/bar/**
       - envs/dev.tfvars
   - path: apps/bar
     name: apps-bar-staging
@@ -18,6 +19,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/default.tfvars
+      - apps/bar/**
       - envs/staging.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-dev
@@ -27,6 +29,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../envs/default.tfvars
+      - apps/bar/us1/**
       - envs/dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
@@ -36,6 +39,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../envs/default.tfvars
+      - apps/bar/us1/**
       - envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
@@ -45,6 +49,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/default.tfvars
+      - apps/foo/**
       - envs/dev.tfvars
   - path: apps/foo
     name: apps-foo-staging
@@ -54,6 +59,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/default.tfvars
+      - apps/foo/**
       - envs/staging.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
@@ -63,6 +69,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../envs/default.tfvars
+      - apps/foo/us1/**
       - envs/dev.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-prod
@@ -72,5 +79,6 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../envs/default.tfvars
+      - apps/foo/us1/**
       - envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/parent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent/expected.golden
@@ -10,6 +10,7 @@ projects:
     dependency_paths:
       - ../default.tfvars
       - ../dev.tfvars
+      - apps/bar/**
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -19,6 +20,7 @@ projects:
     dependency_paths:
       - ../default.tfvars
       - ../prod.tfvars
+      - apps/bar/**
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -28,6 +30,7 @@ projects:
     dependency_paths:
       - ../default.tfvars
       - ../dev.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -37,4 +40,5 @@ projects:
     dependency_paths:
       - ../default.tfvars
       - ../prod.tfvars
+      - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
@@ -14,6 +14,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
+      - apps/bar/us1/**
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -27,6 +28,7 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
+      - apps/bar/us1/**
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -40,6 +42,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
+      - apps/bar/us2/**
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -53,6 +56,7 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
+      - apps/bar/us2/**
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -66,6 +70,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
+      - apps/foo/us1/**
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -79,6 +84,7 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
+      - apps/foo/us1/**
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -92,6 +98,7 @@ projects:
       - ../../dev.tfvars
       - ../default.tfvars
       - ../dev.tfvars
+      - apps/foo/us2/**
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -105,4 +112,5 @@ projects:
       - ../../prod.tfvars
       - ../default.tfvars
       - ../prod.tfvars
+      - apps/foo/us2/**
 

--- a/cmd/infracost/testdata/generate/parent_filename_matches_project/expected.golden
+++ b/cmd/infracost/testdata/generate/parent_filename_matches_project/expected.golden
@@ -8,8 +8,9 @@ projects:
       - ../bar.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../defaults.tfvars
       - ../bar.tfvars
+      - ../defaults.tfvars
+      - infra/components/bar/**
   - path: infra/components/baz
     name: infra-components-baz
     terraform_var_files:
@@ -19,6 +20,7 @@ projects:
     dependency_paths:
       - ../../baz.tfvars
       - ../defaults.tfvars
+      - infra/components/baz/**
   - path: infra/components/foo
     name: infra-components-foo
     terraform_var_files:
@@ -28,6 +30,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../../foo.tfvars
-      - ../foo.tfvars
       - ../defaults.tfvars
+      - ../foo.tfvars
+      - infra/components/foo/**
 

--- a/cmd/infracost/testdata/generate/path_overrides/expected.golden
+++ b/cmd/infracost/testdata/generate/path_overrides/expected.golden
@@ -8,8 +8,9 @@ projects:
       - ../../bip.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
       - ../../bip.tfvars
+      - ../../default.tfvars
+      - infra/components/bar/**
   - path: infra/components/blah
     name: infra-components-blah-bat
     terraform_var_files:
@@ -18,9 +19,10 @@ projects:
       - ../../bat.tfvars
     skip_autodetect: true
     dependency_paths:
+      - ../../bat.tfvars
       - ../../default.tfvars
       - ../../network-bat.tfvars
-      - ../../bat.tfvars
+      - infra/components/blah/**
   - path: infra/components/blah
     name: infra-components-blah-bip
     terraform_var_files:
@@ -28,8 +30,9 @@ projects:
       - ../../bip.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
       - ../../bip.tfvars
+      - ../../default.tfvars
+      - infra/components/blah/**
   - path: infra/components/foo
     name: infra-components-foo-baz
     terraform_var_files:
@@ -39,8 +42,9 @@ projects:
       - var.auto.tfvars
     skip_autodetect: true
     dependency_paths:
+      - ../../baz.tfvars
       - ../../default.tfvars
       - ../../network-baz.tfvars
-      - ../../baz.tfvars
+      - infra/components/foo/**
       - var.auto.tfvars
 

--- a/cmd/infracost/testdata/generate/root_paths/expected.golden
+++ b/cmd/infracost/testdata/generate/root_paths/expected.golden
@@ -7,6 +7,7 @@ projects:
       - terraform.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/bar/**
       - terraform.tfvars
   - path: apps/foo
     name: apps-foo-dev
@@ -15,8 +16,9 @@ projects:
       - dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - terraform.tfvars
+      - apps/foo/**
       - dev.tfvars
+      - terraform.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -24,6 +26,7 @@ projects:
       - prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - terraform.tfvars
+      - apps/foo/**
       - prod.tfvars
+      - terraform.tfvars
 

--- a/cmd/infracost/testdata/generate/root_with_leafs/expected.golden
+++ b/cmd/infracost/testdata/generate/root_with_leafs/expected.golden
@@ -8,6 +8,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - config/dev/terraform.tfvars
+      - terraform/**
   - path: terraform
     name: terraform-prod
     terraform_var_files:
@@ -15,6 +16,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - config/prod/terraform.tfvars
+      - terraform/**
   - path: terraform/foo
     name: terraform-foo-dev
     terraform_var_files:
@@ -22,6 +24,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - dev/terraform.tfvars
+      - terraform/foo/**
   - path: terraform/foo
     name: terraform-foo-prod
     terraform_var_files:
@@ -29,4 +32,5 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - prod/terraform.tfvars
+      - terraform/foo/**
 

--- a/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
+++ b/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
@@ -11,6 +11,7 @@ projects:
     dependency_paths:
       - ../default.tfvars
       - ../dev-default.tfvars
+      - apps/bar/**
       - dev.tfvars
   - path: apps/bar
     name: apps-bar-staging
@@ -22,6 +23,7 @@ projects:
     dependency_paths:
       - ../default.tfvars
       - ../staging-default.tfvars
+      - apps/bar/**
       - staging.tfvars
   - path: apps/foo
     name: apps-foo-dev
@@ -32,6 +34,7 @@ projects:
     dependency_paths:
       - ../default.tfvars
       - ../dev-default.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -41,6 +44,7 @@ projects:
     dependency_paths:
       - ../default.tfvars
       - ../prod-default.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
@@ -50,4 +54,5 @@ projects:
     dependency_paths:
       - ../default.tfvars
       - ../staging-default.tfvars
+      - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling/expected.golden
@@ -8,8 +8,9 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/shared.tfvars
       - ../envs/dev.tfvars
+      - ../envs/shared.tfvars
+      - apps/bar/**
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -17,8 +18,9 @@ projects:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/shared.tfvars
       - ../envs/prod.tfvars
+      - ../envs/shared.tfvars
+      - apps/bar/**
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -26,8 +28,9 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/shared.tfvars
       - ../envs/dev.tfvars
+      - ../envs/shared.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -35,6 +38,7 @@ projects:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/shared.tfvars
       - ../envs/prod.tfvars
+      - ../envs/shared.tfvars
+      - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
@@ -14,6 +14,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
+      - apps/bar/us1/**
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -27,6 +28,7 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
+      - apps/bar/us1/**
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -40,6 +42,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
+      - apps/bar/us2/**
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -53,6 +56,7 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
+      - apps/bar/us2/**
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -66,6 +70,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
+      - apps/foo/us1/**
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -79,6 +84,7 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
+      - apps/foo/us1/**
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -92,6 +98,7 @@ projects:
       - ../../envs/dev.tfvars
       - ../envs/default.tfvars
       - ../envs/dev.tfvars
+      - apps/foo/us2/**
   - path: apps/foo/us2
     name: apps-foo-us2-prod
     terraform_var_files:
@@ -105,4 +112,5 @@ projects:
       - ../../envs/prod.tfvars
       - ../envs/default.tfvars
       - ../envs/prod.tfvars
+      - apps/foo/us2/**
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
@@ -7,6 +7,7 @@ projects:
       - envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/**
       - envs/dev.tfvars
   - path: apps
     name: apps-prod
@@ -14,6 +15,7 @@ projects:
       - envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/**
       - envs/prod.tfvars
   - path: apps/bar
     name: apps-bar

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
@@ -7,6 +7,7 @@ projects:
       - envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/**
       - envs/dev.tfvars
   - path: apps
     name: apps-prod
@@ -14,6 +15,7 @@ projects:
       - envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/**
       - envs/prod.tfvars
   - path: apps/bar
     name: apps-bar-prod
@@ -21,6 +23,7 @@ projects:
       - envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/bar/**
       - envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
@@ -28,5 +31,6 @@ projects:
       - envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
+      - apps/foo/**
       - envs/dev.tfvars
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
@@ -8,6 +8,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/dev.tfvars
+      - apps/**
   - path: apps
     name: apps-prod
     terraform_var_files:
@@ -15,6 +16,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/prod.tfvars
+      - apps/**
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:
@@ -22,6 +24,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/dev.tfvars
+      - apps/bar/**
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
@@ -29,6 +32,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/staging.tfvars
+      - apps/bar/**
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -36,6 +40,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/dev.tfvars
+      - apps/foo/**
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
@@ -43,4 +48,5 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/staging.tfvars
+      - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/single_project/expected.golden
+++ b/cmd/infracost/testdata/generate/single_project/expected.golden
@@ -1,22 +1,20 @@
 version: 0.1
 
 projects:
-  - path: dup
-    name: dup-dev
+  - path: .
+    name: main-dev
     terraform_var_files:
       - dev.tfvars
     skip_autodetect: true
     dependency_paths:
+      - "**"
       - dev.tfvars
-      - dup/**
-  - path: dup
-    name: dup-prod
+  - path: .
+    name: main-prod
     terraform_var_files:
       - prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - dup/**
+      - "**"
       - prod.tfvars
-  - path: nondup
-    name: nondup
 

--- a/cmd/infracost/testdata/generate/single_project/tree.txt
+++ b/cmd/infracost/testdata/generate/single_project/tree.txt
@@ -1,0 +1,4 @@
+.
+├── main.tf
+├── prod.tfvars
+└── dev.tfvars

--- a/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/expected.golden
+++ b/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/expected.golden
@@ -12,6 +12,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/dev.tfvars
+      - apps/fez/**
   - path: apps/fez
     name: apps-fez-prod
     terraform_var_files:
@@ -19,6 +20,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../envs/prod.tfvars
+      - apps/fez/**
   - path: apps/foo
     name: apps-foo
 

--- a/cmd/infracost/testdata/generate/tfvar_json/expected.golden
+++ b/cmd/infracost/testdata/generate/tfvar_json/expected.golden
@@ -8,6 +8,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../variables/env/dev/tfvars.json
+      - terraform/**
   - path: terraform
     name: terraform-prod
     terraform_var_files:
@@ -15,4 +16,5 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - ../variables/env/prod/tfvars.json
+      - terraform/**
 

--- a/cmd/infracost/testdata/generate/wildcard_env_names/expected.golden
+++ b/cmd/infracost/testdata/generate/wildcard_env_names/expected.golden
@@ -8,6 +8,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - env/conf-dev-foo.tfvars
+      - terraform/**
   - path: terraform
     name: terraform-conf-prod-foo
     terraform_var_files:
@@ -15,6 +16,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - env/conf-prod-foo.tfvars
+      - terraform/**
   - path: terraform
     name: terraform-dev
     terraform_var_files:
@@ -22,6 +24,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - env/dev.tfvars
+      - terraform/**
   - path: terraform
     name: terraform-ops-dev
     terraform_var_files:
@@ -29,6 +32,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - env/ops-dev.tfvars
+      - terraform/**
   - path: terraform
     name: terraform-ops-prod-bar
     terraform_var_files:
@@ -36,6 +40,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - env/ops-prod-bar.tfvars
+      - terraform/**
   - path: terraform
     name: terraform-ops-prod-foo
     terraform_var_files:
@@ -43,4 +48,5 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - env/ops-prod-foo.tfvars
+      - terraform/**
 

--- a/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
+++ b/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
@@ -8,6 +8,7 @@ projects:
       - env/prod.tfvars
     skip_autodetect: true
     dependency_paths:
+      - app1/**
       - defaults.tfvars
       - env/prod.tfvars
   - path: app1
@@ -17,6 +18,7 @@ projects:
       - env/test.tfvars
     skip_autodetect: true
     dependency_paths:
+      - app1/**
       - defaults.tfvars
       - env/test.tfvars
   - path: app1/app3
@@ -25,6 +27,7 @@ projects:
       - qa.tfvars
     skip_autodetect: true
     dependency_paths:
+      - app1/app3/**
       - qa.tfvars
   - path: app2
     name: app2-prod
@@ -33,6 +36,7 @@ projects:
       - env/prod.tfvars
     skip_autodetect: true
     dependency_paths:
+      - app2/**
       - env/defaults.tfvars
       - env/prod.tfvars
   - path: app2
@@ -42,6 +46,7 @@ projects:
       - env/staging.tfvars
     skip_autodetect: true
     dependency_paths:
+      - app2/**
       - env/defaults.tfvars
       - env/staging.tfvars
 


### PR DESCRIPTION
Fixes two issues with the `dependency_paths` logic

* Adds wildcard suffix to the generated `dependency_paths` for autodetect. This
is done so that changes in nested files are detected on Infracost's hosted services.
* Merges the tfvars into the `DependencyPaths` method, this resolves an issue where
if no module calls were detected then only tfvars would be added to the `dependency_paths`
config key. This would omit the project from the changes and therefore only tfvar changes
would cause a rerun on hosted services. This also standardises things for those users
who use a template, as now the tfvars are part of the `.DependencyPaths` project template
variable.