### PR TITLE
fix Get the relative path based on the starting path for var files

### DIFF
--- a/cmd/infracost/testdata/generate/aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
       - apps/bar/us1/**
+      - apps/envs/default.tfvars
+      - apps/envs/dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -18,9 +18,9 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
       - apps/bar/us1/**
+      - apps/envs/default.tfvars
+      - apps/envs/prod.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -28,9 +28,9 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
       - apps/bar/us2/**
+      - apps/envs/default.tfvars
+      - apps/envs/dev.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -38,9 +38,9 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
       - apps/bar/us2/**
+      - apps/envs/default.tfvars
+      - apps/envs/prod.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -48,8 +48,8 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
+      - apps/envs/default.tfvars
+      - apps/envs/dev.tfvars
       - apps/foo/us1/**
   - path: apps/foo/us1
     name: apps-foo-us1-prod
@@ -58,8 +58,8 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
+      - apps/envs/default.tfvars
+      - apps/envs/prod.tfvars
       - apps/foo/us1/**
   - path: apps/foo/us2
     name: apps-foo-us2-dev
@@ -68,8 +68,8 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
+      - apps/envs/default.tfvars
+      - apps/envs/dev.tfvars
       - apps/foo/us2/**
   - path: apps/foo/us2
     name: apps-foo-us2-prod
@@ -78,7 +78,7 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
+      - apps/envs/default.tfvars
+      - apps/envs/prod.tfvars
       - apps/foo/us2/**
 

--- a/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_and_great_aunt/expected.golden
@@ -10,11 +10,11 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/dev.tfvars
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
       - infra/apps/bar/us1/**
+      - infra/apps/envs/default.tfvars
+      - infra/apps/envs/dev.tfvars
+      - infra/envs/default.tfvars
+      - infra/envs/dev.tfvars
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
@@ -24,11 +24,11 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/prod.tfvars
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
       - infra/apps/bar/us1/**
+      - infra/apps/envs/default.tfvars
+      - infra/apps/envs/prod.tfvars
+      - infra/envs/default.tfvars
+      - infra/envs/prod.tfvars
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
@@ -38,11 +38,11 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/dev.tfvars
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
       - infra/apps/bar/us2/**
+      - infra/apps/envs/default.tfvars
+      - infra/apps/envs/dev.tfvars
+      - infra/envs/default.tfvars
+      - infra/envs/dev.tfvars
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
@@ -52,11 +52,11 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/prod.tfvars
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
       - infra/apps/bar/us2/**
+      - infra/apps/envs/default.tfvars
+      - infra/apps/envs/prod.tfvars
+      - infra/envs/default.tfvars
+      - infra/envs/prod.tfvars
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
@@ -66,11 +66,11 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/dev.tfvars
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
+      - infra/apps/envs/default.tfvars
+      - infra/apps/envs/dev.tfvars
       - infra/apps/foo/us1/**
+      - infra/envs/default.tfvars
+      - infra/envs/dev.tfvars
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
@@ -80,11 +80,11 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/prod.tfvars
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
+      - infra/apps/envs/default.tfvars
+      - infra/apps/envs/prod.tfvars
       - infra/apps/foo/us1/**
+      - infra/envs/default.tfvars
+      - infra/envs/prod.tfvars
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
@@ -94,11 +94,11 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/dev.tfvars
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
+      - infra/apps/envs/default.tfvars
+      - infra/apps/envs/dev.tfvars
       - infra/apps/foo/us2/**
+      - infra/envs/default.tfvars
+      - infra/envs/dev.tfvars
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
@@ -108,9 +108,9 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/prod.tfvars
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
+      - infra/apps/envs/default.tfvars
+      - infra/apps/envs/prod.tfvars
       - infra/apps/foo/us2/**
+      - infra/envs/default.tfvars
+      - infra/envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/aunt_filename_matches_project/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_filename_matches_project/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../../variables/env/dev/bar.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/env/dev/bar.tfvars
-      - ../../variables/env/dev/defaults.tfvars
       - infra/components/bar/**
+      - infra/variables/env/dev/bar.tfvars
+      - infra/variables/env/dev/defaults.tfvars
   - path: infra/components/bar
     name: infra-components-bar-prod
     terraform_var_files:
@@ -18,33 +18,33 @@ projects:
       - ../../variables/env/prod/bar.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/env/prod/bar.tfvars
-      - ../../variables/env/prod/defaults.tfvars
       - infra/components/bar/**
+      - infra/variables/env/prod/bar.tfvars
+      - infra/variables/env/prod/defaults.tfvars
   - path: infra/components/baz
     name: infra-components-baz-dev
     terraform_var_files:
       - ../../variables/env/dev/defaults.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/env/dev/defaults.tfvars
       - infra/components/baz/**
+      - infra/variables/env/dev/defaults.tfvars
   - path: infra/components/baz
     name: infra-components-baz-prod
     terraform_var_files:
       - ../../variables/env/prod/defaults.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/env/prod/defaults.tfvars
       - infra/components/baz/**
+      - infra/variables/env/prod/defaults.tfvars
   - path: infra/components/foo
     name: infra-components-foo-dev
     terraform_var_files:
       - ../../variables/env/dev/defaults.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/env/dev/defaults.tfvars
       - infra/components/foo/**
+      - infra/variables/env/dev/defaults.tfvars
   - path: infra/components/foo
     name: infra-components-foo-prod
     terraform_var_files:
@@ -52,7 +52,7 @@ projects:
       - ../../variables/env/prod/defaults.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/env/prod/defaults.tfvars
-      - ../../variables/env/prod/foo.tfvars
       - infra/components/foo/**
+      - infra/variables/env/prod/defaults.tfvars
+      - infra/variables/env/prod/foo.tfvars
 

--- a/cmd/infracost/testdata/generate/aunt_filenames_with_env/expected.golden
+++ b/cmd/infracost/testdata/generate/aunt_filenames_with_env/expected.golden
@@ -9,10 +9,10 @@ projects:
       - ../../variables/cko-dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-dev/age.tfvars
-      - ../../variables/cko-dev/dev.tfvars
-      - ../../variables/default.tfvars
       - components/age/**
+      - variables/cko-dev/age.tfvars
+      - variables/cko-dev/dev.tfvars
+      - variables/default.tfvars
   - path: components/age
     name: components-age-mgmt
     terraform_var_files:
@@ -20,9 +20,9 @@ projects:
       - ../../variables/cko-mgmt/age.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-mgmt/age.tfvars
-      - ../../variables/default.tfvars
       - components/age/**
+      - variables/cko-mgmt/age.tfvars
+      - variables/default.tfvars
   - path: components/age
     name: components-age-playground
     terraform_var_files:
@@ -30,9 +30,9 @@ projects:
       - ../../variables/cko-playground/age.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-playground/age.tfvars
-      - ../../variables/default.tfvars
       - components/age/**
+      - variables/cko-playground/age.tfvars
+      - variables/default.tfvars
   - path: components/age
     name: components-age-prod
     terraform_var_files:
@@ -40,9 +40,9 @@ projects:
       - ../../variables/cko-prod/age.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-prod/age.tfvars
-      - ../../variables/default.tfvars
       - components/age/**
+      - variables/cko-prod/age.tfvars
+      - variables/default.tfvars
   - path: components/airflow
     name: components-airflow-dev
     terraform_var_files:
@@ -51,10 +51,10 @@ projects:
       - ../../variables/cko-dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-dev/airflow.tfvars
-      - ../../variables/cko-dev/dev.tfvars
-      - ../../variables/default.tfvars
       - components/airflow/**
+      - variables/cko-dev/airflow.tfvars
+      - variables/cko-dev/dev.tfvars
+      - variables/default.tfvars
   - path: components/airflow
     name: components-airflow-mgmt
     terraform_var_files:
@@ -62,9 +62,9 @@ projects:
       - ../../variables/cko-mgmt/airflow.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-mgmt/airflow.tfvars
-      - ../../variables/default.tfvars
       - components/airflow/**
+      - variables/cko-mgmt/airflow.tfvars
+      - variables/default.tfvars
   - path: components/airflow
     name: components-airflow-playground
     terraform_var_files:
@@ -72,9 +72,9 @@ projects:
       - ../../variables/cko-playground/airflow.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-playground/airflow.tfvars
-      - ../../variables/default.tfvars
       - components/airflow/**
+      - variables/cko-playground/airflow.tfvars
+      - variables/default.tfvars
   - path: components/airflow
     name: components-airflow-prod
     terraform_var_files:
@@ -82,9 +82,9 @@ projects:
       - ../../variables/cko-prod/airflow.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-prod/airflow.tfvars
-      - ../../variables/default.tfvars
       - components/airflow/**
+      - variables/cko-prod/airflow.tfvars
+      - variables/default.tfvars
   - path: components/apm-events
     name: components-apm-events-dev
     terraform_var_files:
@@ -93,10 +93,10 @@ projects:
       - ../../variables/cko-dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-dev/apm-events.tfvars
-      - ../../variables/cko-dev/dev.tfvars
-      - ../../variables/default.tfvars
       - components/apm-events/**
+      - variables/cko-dev/apm-events.tfvars
+      - variables/cko-dev/dev.tfvars
+      - variables/default.tfvars
   - path: components/apm-events
     name: components-apm-events-mgmt
     terraform_var_files:
@@ -104,9 +104,9 @@ projects:
       - ../../variables/cko-mgmt/apm-events.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-mgmt/apm-events.tfvars
-      - ../../variables/default.tfvars
       - components/apm-events/**
+      - variables/cko-mgmt/apm-events.tfvars
+      - variables/default.tfvars
   - path: components/apm-events
     name: components-apm-events-playground
     terraform_var_files:
@@ -114,9 +114,9 @@ projects:
       - ../../variables/cko-playground/apm-events.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-playground/apm-events.tfvars
-      - ../../variables/default.tfvars
       - components/apm-events/**
+      - variables/cko-playground/apm-events.tfvars
+      - variables/default.tfvars
   - path: components/apm-events
     name: components-apm-events-prod
     terraform_var_files:
@@ -124,7 +124,7 @@ projects:
       - ../../variables/cko-prod/apm-events.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/cko-prod/apm-events.tfvars
-      - ../../variables/default.tfvars
       - components/apm-events/**
+      - variables/cko-prod/apm-events.tfvars
+      - variables/default.tfvars
 

--- a/cmd/infracost/testdata/generate/child/expected.golden
+++ b/cmd/infracost/testdata/generate/child/expected.golden
@@ -9,8 +9,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/bar/**
-      - envs/default.tfvars
-      - envs/dev.tfvars
+      - apps/bar/envs/default.tfvars
+      - apps/bar/envs/dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -19,8 +19,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/bar/**
-      - envs/default.tfvars
-      - envs/prod.tfvars
+      - apps/bar/envs/default.tfvars
+      - apps/bar/envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -29,8 +29,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/foo/**
-      - envs/default.tfvars
-      - envs/dev.tfvars
+      - apps/foo/envs/default.tfvars
+      - apps/foo/envs/dev.tfvars
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
@@ -39,6 +39,6 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/foo/**
-      - envs/default.tfvars
-      - envs/staging.tfvars
+      - apps/foo/envs/default.tfvars
+      - apps/foo/envs/staging.tfvars
 

--- a/cmd/infracost/testdata/generate/cousin/expected.golden
+++ b/cmd/infracost/testdata/generate/cousin/expected.golden
@@ -7,16 +7,16 @@ projects:
       - ../../variables/envs/dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/envs/dev/dev.tfvars
       - infra/components/foo/**
+      - infra/variables/envs/dev/dev.tfvars
   - path: infra/components/foo
     name: infra-components-foo-prod
     terraform_var_files:
       - ../../variables/envs/prod/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/envs/prod/prod.tfvars
       - infra/components/foo/**
+      - infra/variables/envs/prod/prod.tfvars
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-dev
     terraform_var_files:
@@ -25,10 +25,10 @@ projects:
       - ../../variables/envs/dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../variables/envs/dev/dev.tfvars
-      - ../../variables/envs/defaults.tfvars
-      - ../../variables/envs/dev/dev.tfvars
       - infra/nested/components/baz/**
+      - infra/nested/variables/envs/defaults.tfvars
+      - infra/nested/variables/envs/dev/dev.tfvars
+      - infra/variables/envs/dev/dev.tfvars
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-prod
     terraform_var_files:
@@ -36,9 +36,9 @@ projects:
       - ../../../variables/envs/prod/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../variables/envs/prod/prod.tfvars
-      - ../../variables/envs/defaults.tfvars
       - infra/nested/components/baz/**
+      - infra/nested/variables/envs/defaults.tfvars
+      - infra/variables/envs/prod/prod.tfvars
   - path: infra/nested/components/baz
     name: infra-nested-components-baz-stag
     terraform_var_files:
@@ -46,7 +46,7 @@ projects:
       - ../../variables/envs/stag/stag.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/envs/defaults.tfvars
-      - ../../variables/envs/stag/stag.tfvars
       - infra/nested/components/baz/**
+      - infra/nested/variables/envs/defaults.tfvars
+      - infra/nested/variables/envs/stag/stag.tfvars
 

--- a/cmd/infracost/testdata/generate/env_dirs/expected.golden
+++ b/cmd/infracost/testdata/generate/env_dirs/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../../variables/dev/bla.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/defaults.tfvars
-      - ../../variables/dev/bla.tfvars
       - infra/components/baz/**
+      - infra/variables/defaults.tfvars
+      - infra/variables/dev/bla.tfvars
   - path: infra/components/baz
     name: infra-components-baz-stag
     terraform_var_files:
@@ -18,9 +18,9 @@ projects:
       - ../../variables/stag/bop.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/defaults.tfvars
-      - ../../variables/stag/bop.tfvars
       - infra/components/baz/**
+      - infra/variables/defaults.tfvars
+      - infra/variables/stag/bop.tfvars
   - path: infra/components/foo
     name: infra-components-foo-dev
     terraform_var_files:
@@ -28,9 +28,9 @@ projects:
       - ../../variables/dev/bla.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/defaults.tfvars
-      - ../../variables/dev/bla.tfvars
       - infra/components/foo/**
+      - infra/variables/defaults.tfvars
+      - infra/variables/dev/bla.tfvars
   - path: infra/components/foo
     name: infra-components-foo-stag
     terraform_var_files:
@@ -38,7 +38,7 @@ projects:
       - ../../variables/stag/bop.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../variables/defaults.tfvars
-      - ../../variables/stag/bop.tfvars
       - infra/components/foo/**
+      - infra/variables/defaults.tfvars
+      - infra/variables/stag/bop.tfvars
 

--- a/cmd/infracost/testdata/generate/env_var_dot_extensions/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_dot_extensions/expected.golden
@@ -9,10 +9,10 @@ projects:
       - ../.config.dev.env.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../.config.dev.env.tfvars
-      - ../.dev-custom-ext
-      - ../default.tfvars
+      - apps/.config.dev.env.tfvars
+      - apps/.dev-custom-ext
       - apps/bar/**
+      - apps/default.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -21,10 +21,10 @@ projects:
       - ../.config.prod.env.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../.config.prod.env.tfvars
-      - ../.prod-custom-ext
-      - ../default.tfvars
+      - apps/.config.prod.env.tfvars
+      - apps/.prod-custom-ext
       - apps/bar/**
+      - apps/default.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -33,9 +33,9 @@ projects:
       - ../.config.dev.env.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../.config.dev.env.tfvars
-      - ../.dev-custom-ext
-      - ../default.tfvars
+      - apps/.config.dev.env.tfvars
+      - apps/.dev-custom-ext
+      - apps/default.tfvars
       - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
@@ -45,8 +45,8 @@ projects:
       - ../.config.prod.env.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../.config.prod.env.tfvars
-      - ../.prod-custom-ext
-      - ../default.tfvars
+      - apps/.config.prod.env.tfvars
+      - apps/.prod-custom-ext
+      - apps/default.tfvars
       - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/env_var_dots/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_dots/expected.golden
@@ -11,12 +11,12 @@ projects:
       - ../.dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../.dev.tfvars
-      - ../.network-bat.tfvars
-      - ../.network-baz.tfvars
-      - ../config.dev.tfvars
-      - ../default.tfvars
+      - apps/.dev.tfvars
+      - apps/.network-bat.tfvars
+      - apps/.network-baz.tfvars
       - apps/bar/**
+      - apps/config.dev.tfvars
+      - apps/default.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -27,12 +27,12 @@ projects:
       - ../.prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../.network-bat.tfvars
-      - ../.network-baz.tfvars
-      - ../.prod.tfvars
-      - ../config.prod.tfvars
-      - ../default.tfvars
+      - apps/.network-bat.tfvars
+      - apps/.network-baz.tfvars
+      - apps/.prod.tfvars
       - apps/bar/**
+      - apps/config.prod.tfvars
+      - apps/default.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -43,11 +43,11 @@ projects:
       - ../.dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../.dev.tfvars
-      - ../.network-bat.tfvars
-      - ../.network-baz.tfvars
-      - ../config.dev.tfvars
-      - ../default.tfvars
+      - apps/.dev.tfvars
+      - apps/.network-bat.tfvars
+      - apps/.network-baz.tfvars
+      - apps/config.dev.tfvars
+      - apps/default.tfvars
       - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
@@ -59,10 +59,10 @@ projects:
       - ../.prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../.network-bat.tfvars
-      - ../.network-baz.tfvars
-      - ../.prod.tfvars
-      - ../config.prod.tfvars
-      - ../default.tfvars
+      - apps/.network-bat.tfvars
+      - apps/.network-baz.tfvars
+      - apps/.prod.tfvars
+      - apps/config.prod.tfvars
+      - apps/default.tfvars
       - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
+++ b/cmd/infracost/testdata/generate/env_var_extensions/expected.golden
@@ -9,10 +9,10 @@ projects:
       - ../baz-custom-ext
     skip_autodetect: true
     dependency_paths:
-      - ../baz-custom-ext
-      - ../common.tfvars.json
-      - ../default.tfvars
       - apps/bar/**
+      - apps/baz-custom-ext
+      - apps/common.tfvars.json
+      - apps/default.tfvars
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:
@@ -21,10 +21,10 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../common.tfvars.json
-      - ../default.tfvars
-      - ../dev.tfvars
       - apps/bar/**
+      - apps/common.tfvars.json
+      - apps/default.tfvars
+      - apps/dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -34,11 +34,11 @@ projects:
       - ../prod-custom-ext
     skip_autodetect: true
     dependency_paths:
-      - ../common.tfvars.json
-      - ../default.tfvars
-      - ../prod-custom-ext
-      - ../prod.env.tfvars
       - apps/bar/**
+      - apps/common.tfvars.json
+      - apps/default.tfvars
+      - apps/prod-custom-ext
+      - apps/prod.env.tfvars
   - path: apps/foo
     name: apps-foo-baz
     terraform_var_files:
@@ -47,9 +47,9 @@ projects:
       - ../baz-custom-ext
     skip_autodetect: true
     dependency_paths:
-      - ../baz-custom-ext
-      - ../common.tfvars.json
-      - ../default.tfvars
+      - apps/baz-custom-ext
+      - apps/common.tfvars.json
+      - apps/default.tfvars
       - apps/foo/**
   - path: apps/foo
     name: apps-foo-dev
@@ -59,9 +59,9 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../common.tfvars.json
-      - ../default.tfvars
-      - ../dev.tfvars
+      - apps/common.tfvars.json
+      - apps/default.tfvars
+      - apps/dev.tfvars
       - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
@@ -72,9 +72,9 @@ projects:
       - ../prod-custom-ext
     skip_autodetect: true
     dependency_paths:
-      - ../common.tfvars.json
-      - ../default.tfvars
-      - ../prod-custom-ext
-      - ../prod.env.tfvars
+      - apps/common.tfvars.json
+      - apps/default.tfvars
       - apps/foo/**
+      - apps/prod-custom-ext
+      - apps/prod.env.tfvars
 

--- a/cmd/infracost/testdata/generate/external_tfvars/expected.golden
+++ b/cmd/infracost/testdata/generate/external_tfvars/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../../envs/dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev/dev.tfvars
       - apps/foo/**
+      - envs/default.tfvars
+      - envs/dev/dev.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -18,9 +18,9 @@ projects:
       - ../../envs/prod/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod/prod.tfvars
       - apps/foo/**
+      - envs/default.tfvars
+      - envs/prod/prod.tfvars
   - path: apps/foo
     name: apps-foo-test
     terraform_var_files:
@@ -28,9 +28,9 @@ projects:
       - ../../envs/test/test.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/test/test.tfvars
       - apps/foo/**
+      - envs/default.tfvars
+      - envs/test/test.tfvars
   - path: infra/db
     name: infra-db-dev
     terraform_var_files:
@@ -38,8 +38,8 @@ projects:
       - ../../envs/dev/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev/dev.tfvars
+      - envs/default.tfvars
+      - envs/dev/dev.tfvars
       - infra/db/**
   - path: infra/db
     name: infra-db-prod
@@ -48,8 +48,8 @@ projects:
       - ../../envs/prod/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod/prod.tfvars
+      - envs/default.tfvars
+      - envs/prod/prod.tfvars
       - infra/db/**
   - path: infra/db
     name: infra-db-test
@@ -58,7 +58,7 @@ projects:
       - ../../envs/test/test.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/test/test.tfvars
+      - envs/default.tfvars
+      - envs/test/test.tfvars
       - infra/db/**
 

--- a/cmd/infracost/testdata/generate/force_project_type/expected.golden
+++ b/cmd/infracost/testdata/generate/force_project_type/expected.golden
@@ -7,8 +7,8 @@ projects:
       - dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - dev.tfvars
       - dup/**
+      - dup/dev.tfvars
   - path: dup
     name: dup-prod
     terraform_var_files:
@@ -16,7 +16,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - dup/**
-      - prod.tfvars
+      - dup/prod.tfvars
   - path: nondup
     name: nondup
 

--- a/cmd/infracost/testdata/generate/grandchild/expected.golden
+++ b/cmd/infracost/testdata/generate/grandchild/expected.golden
@@ -9,8 +9,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/bar/**
-      - config/envs/default.tfvars
-      - config/envs/dev.tfvars
+      - apps/bar/config/envs/default.tfvars
+      - apps/bar/config/envs/dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -19,8 +19,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/bar/**
-      - config/envs/default.tfvars
-      - config/envs/prod.tfvars
+      - apps/bar/config/envs/default.tfvars
+      - apps/bar/config/envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -29,8 +29,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/foo/**
-      - config/envs/default.tfvars
-      - config/envs/dev.tfvars
+      - apps/foo/config/envs/default.tfvars
+      - apps/foo/config/envs/dev.tfvars
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
@@ -39,6 +39,6 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/foo/**
-      - config/envs/default.tfvars
-      - config/envs/staging.tfvars
+      - apps/foo/config/envs/default.tfvars
+      - apps/foo/config/envs/staging.tfvars
 

--- a/cmd/infracost/testdata/generate/grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/grandparent/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../dev.tfvars
       - apps/bar/us1/**
+      - apps/default.tfvars
+      - apps/dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -18,9 +18,9 @@ projects:
       - ../../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../prod.tfvars
       - apps/bar/us1/**
+      - apps/default.tfvars
+      - apps/prod.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -28,9 +28,9 @@ projects:
       - ../../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../dev.tfvars
       - apps/bar/us2/**
+      - apps/default.tfvars
+      - apps/dev.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -38,9 +38,9 @@ projects:
       - ../../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../prod.tfvars
       - apps/bar/us2/**
+      - apps/default.tfvars
+      - apps/prod.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -48,8 +48,8 @@ projects:
       - ../../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../dev.tfvars
+      - apps/default.tfvars
+      - apps/dev.tfvars
       - apps/foo/us1/**
   - path: apps/foo/us1
     name: apps-foo-us1-prod
@@ -58,9 +58,9 @@ projects:
       - ../../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../prod.tfvars
+      - apps/default.tfvars
       - apps/foo/us1/**
+      - apps/prod.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -68,8 +68,8 @@ projects:
       - ../../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../dev.tfvars
+      - apps/default.tfvars
+      - apps/dev.tfvars
       - apps/foo/us2/**
   - path: apps/foo/us2
     name: apps-foo-us2-prod
@@ -78,7 +78,7 @@ projects:
       - ../../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../prod.tfvars
+      - apps/default.tfvars
       - apps/foo/us2/**
+      - apps/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/great_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/great_aunt/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/dev.tfvars
       - infra/apps/bar/us1/**
+      - infra/envs/default.tfvars
+      - infra/envs/dev.tfvars
   - path: infra/apps/bar/us1
     name: infra-apps-bar-us1-prod
     terraform_var_files:
@@ -18,9 +18,9 @@ projects:
       - ../../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/prod.tfvars
       - infra/apps/bar/us1/**
+      - infra/envs/default.tfvars
+      - infra/envs/prod.tfvars
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-dev
     terraform_var_files:
@@ -28,9 +28,9 @@ projects:
       - ../../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/dev.tfvars
       - infra/apps/bar/us2/**
+      - infra/envs/default.tfvars
+      - infra/envs/dev.tfvars
   - path: infra/apps/bar/us2
     name: infra-apps-bar-us2-prod
     terraform_var_files:
@@ -38,9 +38,9 @@ projects:
       - ../../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/prod.tfvars
       - infra/apps/bar/us2/**
+      - infra/envs/default.tfvars
+      - infra/envs/prod.tfvars
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-dev
     terraform_var_files:
@@ -48,9 +48,9 @@ projects:
       - ../../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/dev.tfvars
       - infra/apps/foo/us1/**
+      - infra/envs/default.tfvars
+      - infra/envs/dev.tfvars
   - path: infra/apps/foo/us1
     name: infra-apps-foo-us1-prod
     terraform_var_files:
@@ -58,9 +58,9 @@ projects:
       - ../../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/prod.tfvars
       - infra/apps/foo/us1/**
+      - infra/envs/default.tfvars
+      - infra/envs/prod.tfvars
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-dev
     terraform_var_files:
@@ -68,9 +68,9 @@ projects:
       - ../../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/dev.tfvars
       - infra/apps/foo/us2/**
+      - infra/envs/default.tfvars
+      - infra/envs/dev.tfvars
   - path: infra/apps/foo/us2
     name: infra-apps-foo-us2-prod
     terraform_var_files:
@@ -78,7 +78,7 @@ projects:
       - ../../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../../envs/default.tfvars
-      - ../../../envs/prod.tfvars
       - infra/apps/foo/us2/**
+      - infra/envs/default.tfvars
+      - infra/envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/modules_and_external_tfvars/expected.golden
+++ b/cmd/infracost/testdata/generate/modules_and_external_tfvars/expected.golden
@@ -8,10 +8,10 @@ projects:
       - ../../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../envs/dev.tfvars
       - db/dev/**
       - db/modules/db_config/**
+      - default.tfvars
+      - envs/dev.tfvars
   - path: db/prod
     name: db-prod-prod
     terraform_var_files:
@@ -19,8 +19,8 @@ projects:
       - ../../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../envs/prod.tfvars
       - db/modules/db_config/**
       - db/prod/**
+      - default.tfvars
+      - envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/multi_descendents/expected.golden
+++ b/cmd/infracost/testdata/generate/multi_descendents/expected.golden
@@ -8,9 +8,9 @@ projects:
       - envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/default.tfvars
       - apps/bar/**
-      - envs/dev.tfvars
+      - apps/bar/envs/dev.tfvars
+      - apps/envs/default.tfvars
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
@@ -18,9 +18,9 @@ projects:
       - envs/staging.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/default.tfvars
       - apps/bar/**
-      - envs/staging.tfvars
+      - apps/bar/envs/staging.tfvars
+      - apps/envs/default.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-dev
     terraform_var_files:
@@ -28,9 +28,9 @@ projects:
       - envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
       - apps/bar/us1/**
-      - envs/dev.tfvars
+      - apps/bar/us1/envs/dev.tfvars
+      - apps/envs/default.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -38,9 +38,9 @@ projects:
       - envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
       - apps/bar/us1/**
-      - envs/prod.tfvars
+      - apps/bar/us1/envs/prod.tfvars
+      - apps/envs/default.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -48,9 +48,9 @@ projects:
       - envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/default.tfvars
+      - apps/envs/default.tfvars
       - apps/foo/**
-      - envs/dev.tfvars
+      - apps/foo/envs/dev.tfvars
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
@@ -58,9 +58,9 @@ projects:
       - envs/staging.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/default.tfvars
+      - apps/envs/default.tfvars
       - apps/foo/**
-      - envs/staging.tfvars
+      - apps/foo/envs/staging.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -68,9 +68,9 @@ projects:
       - envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
+      - apps/envs/default.tfvars
       - apps/foo/us1/**
-      - envs/dev.tfvars
+      - apps/foo/us1/envs/dev.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-prod
     terraform_var_files:
@@ -78,7 +78,7 @@ projects:
       - envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
+      - apps/envs/default.tfvars
       - apps/foo/us1/**
-      - envs/prod.tfvars
+      - apps/foo/us1/envs/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/parent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../dev.tfvars
       - apps/bar/**
+      - apps/default.tfvars
+      - apps/dev.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -18,9 +18,9 @@ projects:
       - ../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../prod.tfvars
       - apps/bar/**
+      - apps/default.tfvars
+      - apps/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -28,8 +28,8 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../dev.tfvars
+      - apps/default.tfvars
+      - apps/dev.tfvars
       - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
@@ -38,7 +38,7 @@ projects:
       - ../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../prod.tfvars
+      - apps/default.tfvars
       - apps/foo/**
+      - apps/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
+++ b/cmd/infracost/testdata/generate/parent_and_grandparent/expected.golden
@@ -10,11 +10,11 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../dev.tfvars
-      - ../default.tfvars
-      - ../dev.tfvars
+      - apps/bar/default.tfvars
+      - apps/bar/dev.tfvars
       - apps/bar/us1/**
+      - apps/default.tfvars
+      - apps/dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -24,11 +24,11 @@ projects:
       - ../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../prod.tfvars
-      - ../default.tfvars
-      - ../prod.tfvars
+      - apps/bar/default.tfvars
+      - apps/bar/prod.tfvars
       - apps/bar/us1/**
+      - apps/default.tfvars
+      - apps/prod.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -38,11 +38,11 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../dev.tfvars
-      - ../default.tfvars
-      - ../dev.tfvars
+      - apps/bar/default.tfvars
+      - apps/bar/dev.tfvars
       - apps/bar/us2/**
+      - apps/default.tfvars
+      - apps/dev.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -52,11 +52,11 @@ projects:
       - ../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../prod.tfvars
-      - ../default.tfvars
-      - ../prod.tfvars
+      - apps/bar/default.tfvars
+      - apps/bar/prod.tfvars
       - apps/bar/us2/**
+      - apps/default.tfvars
+      - apps/prod.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -66,10 +66,10 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../dev.tfvars
-      - ../default.tfvars
-      - ../dev.tfvars
+      - apps/default.tfvars
+      - apps/dev.tfvars
+      - apps/foo/default.tfvars
+      - apps/foo/dev.tfvars
       - apps/foo/us1/**
   - path: apps/foo/us1
     name: apps-foo-us1-prod
@@ -80,11 +80,11 @@ projects:
       - ../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../prod.tfvars
-      - ../default.tfvars
-      - ../prod.tfvars
+      - apps/default.tfvars
+      - apps/foo/default.tfvars
+      - apps/foo/prod.tfvars
       - apps/foo/us1/**
+      - apps/prod.tfvars
   - path: apps/foo/us2
     name: apps-foo-us2-dev
     terraform_var_files:
@@ -94,10 +94,10 @@ projects:
       - ../dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../dev.tfvars
-      - ../default.tfvars
-      - ../dev.tfvars
+      - apps/default.tfvars
+      - apps/dev.tfvars
+      - apps/foo/default.tfvars
+      - apps/foo/dev.tfvars
       - apps/foo/us2/**
   - path: apps/foo/us2
     name: apps-foo-us2-prod
@@ -108,9 +108,9 @@ projects:
       - ../prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../default.tfvars
-      - ../../prod.tfvars
-      - ../default.tfvars
-      - ../prod.tfvars
+      - apps/default.tfvars
+      - apps/foo/default.tfvars
+      - apps/foo/prod.tfvars
       - apps/foo/us2/**
+      - apps/prod.tfvars
 

--- a/cmd/infracost/testdata/generate/parent_filename_matches_project/expected.golden
+++ b/cmd/infracost/testdata/generate/parent_filename_matches_project/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../bar.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../bar.tfvars
-      - ../defaults.tfvars
+      - infra/components/bar.tfvars
       - infra/components/bar/**
+      - infra/components/defaults.tfvars
   - path: infra/components/baz
     name: infra-components-baz
     terraform_var_files:
@@ -18,9 +18,9 @@ projects:
       - ../defaults.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../baz.tfvars
-      - ../defaults.tfvars
+      - infra/baz.tfvars
       - infra/components/baz/**
+      - infra/components/defaults.tfvars
   - path: infra/components/foo
     name: infra-components-foo
     terraform_var_files:
@@ -29,8 +29,8 @@ projects:
       - ../defaults.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../foo.tfvars
-      - ../defaults.tfvars
-      - ../foo.tfvars
+      - infra/components/defaults.tfvars
+      - infra/components/foo.tfvars
       - infra/components/foo/**
+      - infra/foo.tfvars
 

--- a/cmd/infracost/testdata/generate/path_overrides/expected.golden
+++ b/cmd/infracost/testdata/generate/path_overrides/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../../bip.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../bip.tfvars
-      - ../../default.tfvars
+      - infra/bip.tfvars
       - infra/components/bar/**
+      - infra/default.tfvars
   - path: infra/components/blah
     name: infra-components-blah-bat
     terraform_var_files:
@@ -19,10 +19,10 @@ projects:
       - ../../bat.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../bat.tfvars
-      - ../../default.tfvars
-      - ../../network-bat.tfvars
+      - infra/bat.tfvars
       - infra/components/blah/**
+      - infra/default.tfvars
+      - infra/network-bat.tfvars
   - path: infra/components/blah
     name: infra-components-blah-bip
     terraform_var_files:
@@ -30,9 +30,9 @@ projects:
       - ../../bip.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../bip.tfvars
-      - ../../default.tfvars
+      - infra/bip.tfvars
       - infra/components/blah/**
+      - infra/default.tfvars
   - path: infra/components/foo
     name: infra-components-foo-baz
     terraform_var_files:
@@ -42,9 +42,9 @@ projects:
       - var.auto.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../baz.tfvars
-      - ../../default.tfvars
-      - ../../network-baz.tfvars
+      - infra/baz.tfvars
       - infra/components/foo/**
-      - var.auto.tfvars
+      - infra/components/foo/var.auto.tfvars
+      - infra/default.tfvars
+      - infra/network-baz.tfvars
 

--- a/cmd/infracost/testdata/generate/root_paths/expected.golden
+++ b/cmd/infracost/testdata/generate/root_paths/expected.golden
@@ -8,7 +8,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/bar/**
-      - terraform.tfvars
+      - apps/bar/terraform.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -17,8 +17,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/foo/**
-      - dev.tfvars
-      - terraform.tfvars
+      - apps/foo/dev.tfvars
+      - apps/foo/terraform.tfvars
   - path: apps/foo
     name: apps-foo-prod
     terraform_var_files:
@@ -27,6 +27,6 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/foo/**
-      - prod.tfvars
-      - terraform.tfvars
+      - apps/foo/prod.tfvars
+      - apps/foo/terraform.tfvars
 

--- a/cmd/infracost/testdata/generate/root_with_leafs/expected.golden
+++ b/cmd/infracost/testdata/generate/root_with_leafs/expected.golden
@@ -7,30 +7,30 @@ projects:
       - config/dev/terraform.tfvars
     skip_autodetect: true
     dependency_paths:
-      - config/dev/terraform.tfvars
       - terraform/**
+      - terraform/config/dev/terraform.tfvars
   - path: terraform
     name: terraform-prod
     terraform_var_files:
       - config/prod/terraform.tfvars
     skip_autodetect: true
     dependency_paths:
-      - config/prod/terraform.tfvars
       - terraform/**
+      - terraform/config/prod/terraform.tfvars
   - path: terraform/foo
     name: terraform-foo-dev
     terraform_var_files:
       - dev/terraform.tfvars
     skip_autodetect: true
     dependency_paths:
-      - dev/terraform.tfvars
       - terraform/foo/**
+      - terraform/foo/dev/terraform.tfvars
   - path: terraform/foo
     name: terraform-foo-prod
     terraform_var_files:
       - prod/terraform.tfvars
     skip_autodetect: true
     dependency_paths:
-      - prod/terraform.tfvars
       - terraform/foo/**
+      - terraform/foo/prod/terraform.tfvars
 

--- a/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
+++ b/cmd/infracost/testdata/generate/shared_env_var_files/expected.golden
@@ -9,10 +9,10 @@ projects:
       - dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../dev-default.tfvars
       - apps/bar/**
-      - dev.tfvars
+      - apps/bar/dev.tfvars
+      - apps/default.tfvars
+      - apps/dev-default.tfvars
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
@@ -21,10 +21,10 @@ projects:
       - staging.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../staging-default.tfvars
       - apps/bar/**
-      - staging.tfvars
+      - apps/bar/staging.tfvars
+      - apps/default.tfvars
+      - apps/staging-default.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -32,8 +32,8 @@ projects:
       - ../dev-default.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../dev-default.tfvars
+      - apps/default.tfvars
+      - apps/dev-default.tfvars
       - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
@@ -42,9 +42,9 @@ projects:
       - ../prod-default.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../prod-default.tfvars
+      - apps/default.tfvars
       - apps/foo/**
+      - apps/prod-default.tfvars
   - path: apps/foo
     name: apps-foo-staging
     terraform_var_files:
@@ -52,7 +52,7 @@ projects:
       - ../staging-default.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../default.tfvars
-      - ../staging-default.tfvars
+      - apps/default.tfvars
       - apps/foo/**
+      - apps/staging-default.tfvars
 

--- a/cmd/infracost/testdata/generate/sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling/expected.golden
@@ -8,9 +8,9 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/dev.tfvars
-      - ../envs/shared.tfvars
       - apps/bar/**
+      - apps/envs/dev.tfvars
+      - apps/envs/shared.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -18,9 +18,9 @@ projects:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/prod.tfvars
-      - ../envs/shared.tfvars
       - apps/bar/**
+      - apps/envs/prod.tfvars
+      - apps/envs/shared.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -28,8 +28,8 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/dev.tfvars
-      - ../envs/shared.tfvars
+      - apps/envs/dev.tfvars
+      - apps/envs/shared.tfvars
       - apps/foo/**
   - path: apps/foo
     name: apps-foo-prod
@@ -38,7 +38,7 @@ projects:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/prod.tfvars
-      - ../envs/shared.tfvars
+      - apps/envs/prod.tfvars
+      - apps/envs/shared.tfvars
       - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_aunt/expected.golden
@@ -10,11 +10,11 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
-      - ../envs/default.tfvars
-      - ../envs/dev.tfvars
+      - apps/bar/envs/default.tfvars
+      - apps/bar/envs/dev.tfvars
       - apps/bar/us1/**
+      - apps/envs/default.tfvars
+      - apps/envs/dev.tfvars
   - path: apps/bar/us1
     name: apps-bar-us1-prod
     terraform_var_files:
@@ -24,11 +24,11 @@ projects:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
-      - ../envs/default.tfvars
-      - ../envs/prod.tfvars
+      - apps/bar/envs/default.tfvars
+      - apps/bar/envs/prod.tfvars
       - apps/bar/us1/**
+      - apps/envs/default.tfvars
+      - apps/envs/prod.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-dev
     terraform_var_files:
@@ -38,11 +38,11 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
-      - ../envs/default.tfvars
-      - ../envs/dev.tfvars
+      - apps/bar/envs/default.tfvars
+      - apps/bar/envs/dev.tfvars
       - apps/bar/us2/**
+      - apps/envs/default.tfvars
+      - apps/envs/dev.tfvars
   - path: apps/bar/us2
     name: apps-bar-us2-prod
     terraform_var_files:
@@ -52,11 +52,11 @@ projects:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
-      - ../envs/default.tfvars
-      - ../envs/prod.tfvars
+      - apps/bar/envs/default.tfvars
+      - apps/bar/envs/prod.tfvars
       - apps/bar/us2/**
+      - apps/envs/default.tfvars
+      - apps/envs/prod.tfvars
   - path: apps/foo/us1
     name: apps-foo-us1-dev
     terraform_var_files:
@@ -66,10 +66,10 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
-      - ../envs/default.tfvars
-      - ../envs/dev.tfvars
+      - apps/envs/default.tfvars
+      - apps/envs/dev.tfvars
+      - apps/foo/envs/default.tfvars
+      - apps/foo/envs/dev.tfvars
       - apps/foo/us1/**
   - path: apps/foo/us1
     name: apps-foo-us1-prod
@@ -80,10 +80,10 @@ projects:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
-      - ../envs/default.tfvars
-      - ../envs/prod.tfvars
+      - apps/envs/default.tfvars
+      - apps/envs/prod.tfvars
+      - apps/foo/envs/default.tfvars
+      - apps/foo/envs/prod.tfvars
       - apps/foo/us1/**
   - path: apps/foo/us2
     name: apps-foo-us2-dev
@@ -94,10 +94,10 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/dev.tfvars
-      - ../envs/default.tfvars
-      - ../envs/dev.tfvars
+      - apps/envs/default.tfvars
+      - apps/envs/dev.tfvars
+      - apps/foo/envs/default.tfvars
+      - apps/foo/envs/dev.tfvars
       - apps/foo/us2/**
   - path: apps/foo/us2
     name: apps-foo-us2-prod
@@ -108,9 +108,9 @@ projects:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../../envs/default.tfvars
-      - ../../envs/prod.tfvars
-      - ../envs/default.tfvars
-      - ../envs/prod.tfvars
+      - apps/envs/default.tfvars
+      - apps/envs/prod.tfvars
+      - apps/foo/envs/default.tfvars
+      - apps/foo/envs/prod.tfvars
       - apps/foo/us2/**
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_default/expected.golden
@@ -8,7 +8,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/**
-      - envs/dev.tfvars
+      - apps/envs/dev.tfvars
   - path: apps
     name: apps-prod
     terraform_var_files:
@@ -16,7 +16,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/**
-      - envs/prod.tfvars
+      - apps/envs/prod.tfvars
   - path: apps/bar
     name: apps-bar
     skip_autodetect: true

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_child/expected.golden
@@ -8,7 +8,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/**
-      - envs/dev.tfvars
+      - apps/envs/dev.tfvars
   - path: apps
     name: apps-prod
     terraform_var_files:
@@ -16,7 +16,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/**
-      - envs/prod.tfvars
+      - apps/envs/prod.tfvars
   - path: apps/bar
     name: apps-bar-prod
     terraform_var_files:
@@ -24,7 +24,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/bar/**
-      - envs/prod.tfvars
+      - apps/bar/envs/prod.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
@@ -32,5 +32,5 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - apps/foo/**
-      - envs/dev.tfvars
+      - apps/foo/envs/dev.tfvars
 

--- a/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
+++ b/cmd/infracost/testdata/generate/sibling_and_child_prefer_sibling/expected.golden
@@ -7,39 +7,39 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/dev.tfvars
       - apps/**
+      - envs/dev.tfvars
   - path: apps
     name: apps-prod
     terraform_var_files:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/prod.tfvars
       - apps/**
+      - envs/prod.tfvars
   - path: apps/bar
     name: apps-bar-dev
     terraform_var_files:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/dev.tfvars
       - apps/bar/**
+      - apps/envs/dev.tfvars
   - path: apps/bar
     name: apps-bar-staging
     terraform_var_files:
       - ../envs/staging.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/staging.tfvars
       - apps/bar/**
+      - apps/envs/staging.tfvars
   - path: apps/foo
     name: apps-foo-dev
     terraform_var_files:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/dev.tfvars
+      - apps/envs/dev.tfvars
       - apps/foo/**
   - path: apps/foo
     name: apps-foo-staging
@@ -47,6 +47,6 @@ projects:
       - ../envs/staging.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/staging.tfvars
+      - apps/envs/staging.tfvars
       - apps/foo/**
 

--- a/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/expected.golden
+++ b/cmd/infracost/testdata/generate/terragrunt_and_terraform_mixed/expected.golden
@@ -11,7 +11,7 @@ projects:
       - ../envs/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/dev.tfvars
+      - apps/envs/dev.tfvars
       - apps/fez/**
   - path: apps/fez
     name: apps-fez-prod
@@ -19,7 +19,7 @@ projects:
       - ../envs/prod.tfvars
     skip_autodetect: true
     dependency_paths:
-      - ../envs/prod.tfvars
+      - apps/envs/prod.tfvars
       - apps/fez/**
   - path: apps/foo
     name: apps-foo

--- a/cmd/infracost/testdata/generate/tfvar_json/expected.golden
+++ b/cmd/infracost/testdata/generate/tfvar_json/expected.golden
@@ -7,14 +7,14 @@ projects:
       - ../variables/env/dev/tfvars.json
     skip_autodetect: true
     dependency_paths:
-      - ../variables/env/dev/tfvars.json
       - terraform/**
+      - variables/env/dev/tfvars.json
   - path: terraform
     name: terraform-prod
     terraform_var_files:
       - ../variables/env/prod/tfvars.json
     skip_autodetect: true
     dependency_paths:
-      - ../variables/env/prod/tfvars.json
       - terraform/**
+      - variables/env/prod/tfvars.json
 

--- a/cmd/infracost/testdata/generate/wildcard_env_names/expected.golden
+++ b/cmd/infracost/testdata/generate/wildcard_env_names/expected.golden
@@ -7,46 +7,46 @@ projects:
       - env/conf-dev-foo.tfvars
     skip_autodetect: true
     dependency_paths:
-      - env/conf-dev-foo.tfvars
       - terraform/**
+      - terraform/env/conf-dev-foo.tfvars
   - path: terraform
     name: terraform-conf-prod-foo
     terraform_var_files:
       - env/conf-prod-foo.tfvars
     skip_autodetect: true
     dependency_paths:
-      - env/conf-prod-foo.tfvars
       - terraform/**
+      - terraform/env/conf-prod-foo.tfvars
   - path: terraform
     name: terraform-dev
     terraform_var_files:
       - env/dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - env/dev.tfvars
       - terraform/**
+      - terraform/env/dev.tfvars
   - path: terraform
     name: terraform-ops-dev
     terraform_var_files:
       - env/ops-dev.tfvars
     skip_autodetect: true
     dependency_paths:
-      - env/ops-dev.tfvars
       - terraform/**
+      - terraform/env/ops-dev.tfvars
   - path: terraform
     name: terraform-ops-prod-bar
     terraform_var_files:
       - env/ops-prod-bar.tfvars
     skip_autodetect: true
     dependency_paths:
-      - env/ops-prod-bar.tfvars
       - terraform/**
+      - terraform/env/ops-prod-bar.tfvars
   - path: terraform
     name: terraform-ops-prod-foo
     terraform_var_files:
       - env/ops-prod-foo.tfvars
     skip_autodetect: true
     dependency_paths:
-      - env/ops-prod-foo.tfvars
       - terraform/**
+      - terraform/env/ops-prod-foo.tfvars
 

--- a/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
+++ b/cmd/infracost/testdata/generate_config_auto_detect_with_nested_tfvars/generate_config_auto_detect_with_nested_tfvars.golden
@@ -9,8 +9,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - app1/**
-      - defaults.tfvars
-      - env/prod.tfvars
+      - app1/defaults.tfvars
+      - app1/env/prod.tfvars
   - path: app1
     name: app1-test
     terraform_var_files:
@@ -19,8 +19,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - app1/**
-      - defaults.tfvars
-      - env/test.tfvars
+      - app1/defaults.tfvars
+      - app1/env/test.tfvars
   - path: app1/app3
     name: app1-app3-qa
     terraform_var_files:
@@ -28,7 +28,7 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - app1/app3/**
-      - qa.tfvars
+      - app1/app3/qa.tfvars
   - path: app2
     name: app2-prod
     terraform_var_files:
@@ -37,8 +37,8 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - app2/**
-      - env/defaults.tfvars
-      - env/prod.tfvars
+      - app2/env/defaults.tfvars
+      - app2/env/prod.tfvars
   - path: app2
     name: app2-staging
     terraform_var_files:
@@ -47,6 +47,6 @@ projects:
     skip_autodetect: true
     dependency_paths:
       - app2/**
-      - env/defaults.tfvars
-      - env/staging.tfvars
+      - app2/env/defaults.tfvars
+      - app2/env/staging.tfvars
 

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -368,7 +368,12 @@ func (p *Parser) DependencyPaths() []string {
 		sortedCalls = append(sortedCalls, relCall+"/**")
 	}
 
-	sortedCalls = append(sortedCalls, p.VarFiles()...)
+	for _, varFile := range p.tfvarsPaths {
+		relVarFile, err := filepath.Rel(p.startingPath, varFile)
+		if err == nil {
+			sortedCalls = append(sortedCalls, relVarFile)
+		}
+	}
 
 	if p.RelativePath() == "." {
 		sortedCalls = append(sortedCalls, `"**"`)


### PR DESCRIPTION
Pattern matching doesn't work for the tfvar dependency paths when they're relative but works okay when they're relative to the starting path like module calls


