### PR TITLE
refactor: add `region` field to resource data

### DIFF
--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_hcl/breakdown_with_policy_data_upload_hcl-upload.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_hcl/breakdown_with_policy_data_upload_hcl-upload.golden
@@ -68,7 +68,8 @@ storePolicyResources:
             "endLine": 37,
             "filename": "testdata/breakdown_with_policy_data_upload_hcl/main.tf",
             "startLine": 16
-          }
+          },
+          "region": "us-east-1"
         }
       ]
     }
@@ -137,7 +138,8 @@ storePolicyResources:
             "endLine": 37,
             "filename": "testdata/breakdown_with_policy_data_upload_hcl/main.tf",
             "startLine": 16
-          }
+          },
+          "region": "us-east-1"
         }
       ]
     }

--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_plan_json/breakdown_with_policy_data_upload_plan_json-upload.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_plan_json/breakdown_with_policy_data_upload_plan_json-upload.golden
@@ -61,7 +61,8 @@ storePolicyResources:
             "endLine": 0,
             "filename": "",
             "startLine": 0
-          }
+          },
+          "region": "us-east-1"
         }
       ]
     }

--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_terragrunt/breakdown_with_policy_data_upload_terragrunt-upload.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_terragrunt/breakdown_with_policy_data_upload_terragrunt-upload.golden
@@ -68,7 +68,8 @@ storePolicyResources:
             "endLine": 22,
             "filename": "testdata/breakdown_with_policy_data_upload_terragrunt/main.tf",
             "startLine": 1
-          }
+          },
+          "region": "us-east-1"
         }
       ]
     }
@@ -137,7 +138,8 @@ storePolicyResources:
             "endLine": 22,
             "filename": "testdata/breakdown_with_policy_data_upload_terragrunt/main.tf",
             "startLine": 1
-          }
+          },
+          "region": "us-east-1"
         }
       ]
     }

--- a/cmd/resourcegen/embed/providers/terraform/$cloud_provider$/$filename$.go.tmpl
+++ b/cmd/resourcegen/embed/providers/terraform/$cloud_provider$/$filename$.go.tmpl
@@ -22,11 +22,7 @@ func {{.RegistryFuncName}}() *schema.RegistryItem {
 }
 
 func {{ .RFuncName }}(d *schema.ResourceData) schema.CoreResource {
-	{{- if (eq .CloudProvider "azure") }}
-	region := lookupRegion(d, []string{"resource_group_name"})
-	{{- else }}
-	region := d.Get("region").String()
-	{{- end }}
+	region := d.Region
 	{{- if .WithHelp }}
 
 	// In {{.RFuncName}} we parse the resource data coming from d

--- a/contributing/add_new_resource_guide.md
+++ b/contributing/add_new_resource_guide.md
@@ -1202,7 +1202,7 @@ If the resource has a `zone` key, if they have a zone key, use this logic to get
 
 ### Azure zone mappings
 
-Unless the resource has global or zone-based pricing, the first line of the resource function should be `region := lookupRegion(d, []string{})` where the second parameter is an optional list of parent resources where the region can be found. See the following examples of how this method is used in other Azure resources.
+Unless the resource has global or zone-based pricing, you should add a custom GetRegion function to the RegistryItem. This should use the `lookupRegion` function that has the following signature: `lookupRegion(d *schema.ResourceData, parentResourceKeys []string) string`. The second parameter for this function is an optional list of parent resources where the region can be found. See the following examples of how this method is used in other Azure resources.
 
   ```go
 	func getAppServiceCertificateBindingRegistryItem() *schema.RegistryItem {
@@ -1213,12 +1213,10 @@ Unless the resource has global or zone-based pricing, the first line of the reso
 				"certificate_id",
 				"resource_group_name",
 			},
+      GetRegion: func(d *schema.ResourceData) string {
+        return lookupRegion(d, []string{"certificate_id", "resource_group_name"})
+      },
 		}
-	}
-
-	func NewAzureRMAppServiceCertificateBinding(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-		region := lookupRegion(d, []string{"certificate_id", "resource_group_name"})
-		// ...
 	}
   ```
 

--- a/internal/apiclient/policy.go
+++ b/internal/apiclient/policy.go
@@ -142,6 +142,7 @@ type policy2Resource struct {
 	Values       json.RawMessage          `json:"values"`
 	References   []policy2Reference       `json:"references"`
 	Metadata     policy2InfracostMetadata `json:"infracostMetadata"`
+	Region       string                   `json:"region"`
 }
 
 type policy2InfracostMetadata struct {
@@ -237,6 +238,7 @@ func filterResource(rd *schema.ResourceData, al allowList) policy2Resource {
 			Filename:  rd.Metadata["filename"].String(),
 			StartLine: rd.Metadata["startLine"].Int(),
 		},
+		Region: rd.Region,
 	}
 }
 

--- a/internal/docs/generator.go
+++ b/internal/docs/generator.go
@@ -16,8 +16,7 @@ func generateSupportedResourcesDocs(docsTemplatesPath string, outputPath string)
 	if err != nil {
 		return err
 	}
-	resourceRegistryMap := terraform.GetResourceRegistryMap()
-	err = tmpl.Execute(f, resourceRegistryMap)
+	err = tmpl.Execute(f, terraform.ResourceRegistryMap)
 	if err != nil {
 		return err
 	}

--- a/internal/providers/terraform/aws/aws.go
+++ b/internal/providers/terraform/aws/aws.go
@@ -3,8 +3,6 @@ package aws
 import (
 	"strings"
 
-	"github.com/tidwall/gjson"
-
 	"github.com/infracost/infracost/internal/logging"
 	"github.com/infracost/infracost/internal/schema"
 )
@@ -70,14 +68,16 @@ func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {
 	return specialContexts
 }
 
-func GetResourceRegion(resourceType string, v gjson.Result) string {
+func GetResourceRegion(d *schema.ResourceData) string {
+	v := d.RawValues
+
 	// If a region key exists in the values use that
 	if v.Get("region").Exists() && v.Get("region").String() != "" {
 		return v.Get("region").String()
 	}
 
 	// Otherwise try and parse the ARN from the values
-	arnAttr, ok := arnAttributeMap[resourceType]
+	arnAttr, ok := arnAttributeMap[d.Type]
 	if !ok {
 		arnAttr = "arn"
 	}

--- a/internal/providers/terraform/azure/active_directory_domain_service.go
+++ b/internal/providers/terraform/azure/active_directory_domain_service.go
@@ -12,6 +12,6 @@ func getActiveDirectoryDomainServiceRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewActiveDirectoryDomainService(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.ActiveDirectoryDomainService{Address: d.Address, Region: lookupRegion(d, []string{}), SKU: d.Get("sku").String()}
+	r := &azure.ActiveDirectoryDomainService{Address: d.Address, Region: d.Region, SKU: d.Get("sku").String()}
 	return r
 }

--- a/internal/providers/terraform/azure/active_directory_domain_service_replica_set.go
+++ b/internal/providers/terraform/azure/active_directory_domain_service_replica_set.go
@@ -17,7 +17,7 @@ func getActiveDirectoryDomainServiceReplicaSetRegistryItem() *schema.RegistryIte
 func NewActiveDirectoryDomainServiceReplicaSet(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.ActiveDirectoryDomainServiceReplicaSet{
 		Address: d.Address,
-		Region:  lookupRegion(d, []string{}),
+		Region:  d.Region,
 	}
 	if len(d.References("domain_service_id")) > 0 {
 		r.DomainServiceIDSKU = d.References("domain_service_id")[0].Get("sku").String()

--- a/internal/providers/terraform/azure/api_management.go
+++ b/internal/providers/terraform/azure/api_management.go
@@ -15,6 +15,6 @@ func getAPIManagementRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewAPIManagement(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.APIManagement{Address: d.Address, SKUName: d.Get("sku_name").String(), Region: lookupRegion(d, []string{})}
+	r := &azure.APIManagement{Address: d.Address, SKUName: d.Get("sku_name").String(), Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/app_configuration.go
+++ b/internal/providers/terraform/azure/app_configuration.go
@@ -18,7 +18,7 @@ func getAppConfigurationRegistryItem() *schema.RegistryItem {
 }
 
 func newAppConfiguration(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	sku := strings.ToLower(strings.TrimSpace(d.Get("sku").String()))
 	if sku == "" {
 		sku = "free"

--- a/internal/providers/terraform/azure/app_service_certificate_binding.go
+++ b/internal/providers/terraform/azure/app_service_certificate_binding.go
@@ -12,9 +12,12 @@ func getAppServiceCertificateBindingRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"certificate_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"certificate_id"})
+		},
 	}
 }
 func NewAppServiceCertificateBinding(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.AppServiceCertificateBinding{Address: d.Address, Region: lookupRegion(d, []string{"certificate_id"}), SSLState: d.Get("ssl_state").String()}
+	r := &azure.AppServiceCertificateBinding{Address: d.Address, Region: d.Region, SSLState: d.Get("ssl_state").String()}
 	return r
 }

--- a/internal/providers/terraform/azure/app_service_environment.go
+++ b/internal/providers/terraform/azure/app_service_environment.go
@@ -17,7 +17,7 @@ func getAppServiceEnvironmentRegistryItem() *schema.RegistryItem {
 func NewAppServiceEnvironment(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.AppServiceEnvironment{
 		Address:     d.Address,
-		Region:      lookupRegion(d, []string{"resource_group_name"}),
+		Region:      d.Region,
 		PricingTier: d.Get("pricing_tier").String(),
 	}
 	return r

--- a/internal/providers/terraform/azure/app_service_plan.go
+++ b/internal/providers/terraform/azure/app_service_plan.go
@@ -14,7 +14,7 @@ func getAppServicePlanRegistryItem() *schema.RegistryItem {
 func NewAppServicePlan(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.AppServicePlan{
 		Address:     d.Address,
-		Region:      lookupRegion(d, []string{}),
+		Region:      d.Region,
 		SKUSize:     d.Get("sku.0.size").String(),
 		SKUCapacity: d.Get("sku.0.capacity").Int(),
 		Kind:        d.Get("kind").String(),

--- a/internal/providers/terraform/azure/application_gateway.go
+++ b/internal/providers/terraform/azure/application_gateway.go
@@ -23,7 +23,7 @@ func NewApplicationGateway(d *schema.ResourceData) schema.CoreResource {
 		SKUName:                d.Get("sku.0.name").String(),
 		SKUCapacity:            d.Get("sku.0.capacity").Int(),
 		AutoscalingMinCapacity: autoscalingMinCapacity,
-		Region:                 lookupRegion(d, []string{}),
+		Region:                 d.Region,
 	}
 
 	return r

--- a/internal/providers/terraform/azure/application_insights.go
+++ b/internal/providers/terraform/azure/application_insights.go
@@ -14,7 +14,7 @@ func getApplicationInsightsRegistryItem() *schema.RegistryItem {
 func NewApplicationInsights(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.ApplicationInsights{
 		Address:         d.Address,
-		Region:          lookupRegion(d, []string{}),
+		Region:          d.Region,
 		RetentionInDays: d.Get("retention_in_days").Int(),
 	}
 	return r

--- a/internal/providers/terraform/azure/application_insights_standard_web_t.go
+++ b/internal/providers/terraform/azure/application_insights_standard_web_t.go
@@ -16,7 +16,7 @@ func getApplicationInsightsStandardWebTestRegistryItem() *schema.RegistryItem {
 }
 
 func newApplicationInsightsStandardWebTest(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.ApplicationInsightsStandardWebTest{
 		Address:   d.Address,
 		Region:    region,

--- a/internal/providers/terraform/azure/application_insights_web_t.go
+++ b/internal/providers/terraform/azure/application_insights_web_t.go
@@ -17,7 +17,7 @@ func getApplicationInsightsWebTestRegistryItem() *schema.RegistryItem {
 func NewApplicationInsightsWebTest(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.ApplicationInsightsWebTest{
 		Address: d.Address,
-		Region:  lookupRegion(d, []string{"resource_group_name"}),
+		Region:  d.Region,
 		Enabled: d.Get("enabled").Bool(),
 		Kind:    d.Get("kind").String(),
 	}

--- a/internal/providers/terraform/azure/automation_account.go
+++ b/internal/providers/terraform/azure/automation_account.go
@@ -12,6 +12,6 @@ func getAutomationAccountRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewAutomationAccount(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.AutomationAccount{Address: d.Address, Region: lookupRegion(d, []string{})}
+	r := &azure.AutomationAccount{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/automation_dsc_configuration.go
+++ b/internal/providers/terraform/azure/automation_dsc_configuration.go
@@ -15,6 +15,6 @@ func getAutomationDSCConfigurationRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewAutomationDSCConfiguration(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.AutomationDSCConfiguration{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.AutomationDSCConfiguration{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/automation_dsc_nodeconfiguration.go
+++ b/internal/providers/terraform/azure/automation_dsc_nodeconfiguration.go
@@ -15,6 +15,6 @@ func getAutomationDSCNodeConfigurationRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewAutomationDSCNodeConfiguration(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.AutomationDSCNodeConfiguration{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.AutomationDSCNodeConfiguration{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/automation_job_schedule.go
+++ b/internal/providers/terraform/azure/automation_job_schedule.go
@@ -15,6 +15,6 @@ func getAutomationJobScheduleRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewAutomationJobSchedule(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.AutomationJobSchedule{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.AutomationJobSchedule{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/azure.go
+++ b/internal/providers/terraform/azure/azure.go
@@ -1,8 +1,6 @@
 package azure
 
 import (
-	"github.com/tidwall/gjson"
-
 	"github.com/infracost/infracost/internal/providers/terraform/provider_schemas"
 	"github.com/infracost/infracost/internal/schema"
 )
@@ -19,10 +17,6 @@ func DefaultCloudResourceIDFunc(d *schema.ResourceData) []string {
 
 func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{}
-}
-
-func GetResourceRegion(resourceType string, v gjson.Result) string {
-	return ""
 }
 
 func ParseTags(r *schema.ResourceData) *map[string]string {

--- a/internal/providers/terraform/azure/backup_protected_vm.go
+++ b/internal/providers/terraform/azure/backup_protected_vm.go
@@ -29,7 +29,7 @@ func getBackupProtectedVmRegistryItem() *schema.RegistryItem {
 // newBackupProtectedVm returns a azure.BackupProtectedVM with attributes parsed from HCL.
 // Note: archive tier not supported https://github.com/hashicorp/terraform-provider-azurerm/issues/21051 by the provider.
 func newBackupProtectedVm(d *schema.ResourceData) *azure.BackupProtectedVM {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	vms := d.References("source_vm_id")
 	if len(vms) == 0 {
 		logging.Logger.Warn().Msgf("skipping resource %s as cannot find referenced source vm", d.Address)

--- a/internal/providers/terraform/azure/bastion_host.go
+++ b/internal/providers/terraform/azure/bastion_host.go
@@ -12,6 +12,6 @@ func getBastionHostRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewBastionHost(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.BastionHost{Address: d.Address, Region: lookupRegion(d, []string{})}
+	r := &azure.BastionHost{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/cdn_endpoint.go
+++ b/internal/providers/terraform/azure/cdn_endpoint.go
@@ -23,7 +23,7 @@ func GetAzureRMCDNEndpointRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMCDNEndpoint(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := regionToCDNZone(lookupRegion(d, []string{}))
+	region := regionToCDNZone(d.Region)
 
 	var costComponents []*schema.CostComponent
 

--- a/internal/providers/terraform/azure/cognitive_account.go
+++ b/internal/providers/terraform/azure/cognitive_account.go
@@ -19,7 +19,7 @@ func getCognitiveAccountRegistryItem() *schema.RegistryItem {
 }
 
 func newCognitiveAccount(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	kind := d.Get("kind").String()
 
 	if strings.EqualFold(kind, "speechservices") {

--- a/internal/providers/terraform/azure/cognitive_deployment.go
+++ b/internal/providers/terraform/azure/cognitive_deployment.go
@@ -14,16 +14,21 @@ func getCognitiveDeploymentRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"cognitive_account_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			region := lookupRegion(d, []string{"cognitive_account_id"})
+
+			cognitiveAccountRefs := d.References("cognitive_account_id")
+			if region == "" && len(cognitiveAccountRefs) > 0 {
+				region = lookupRegion(cognitiveAccountRefs[0], []string{"resource_group_name"})
+			}
+
+			return region
+		},
 	}
 }
 
 func newCognitiveDeployment(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"cognitive_account_id"})
-
-	cognitiveAccountRefs := d.References("cognitive_account_id")
-	if region == "" && len(cognitiveAccountRefs) > 0 {
-		region = lookupRegion(cognitiveAccountRefs[0], []string{"resource_group_name"})
-	}
+	region := d.Region
 
 	return &azure.CognitiveDeployment{
 		Address: d.Address,

--- a/internal/providers/terraform/azure/container_registry.go
+++ b/internal/providers/terraform/azure/container_registry.go
@@ -14,7 +14,7 @@ func getContainerRegistryRegistryItem() *schema.RegistryItem {
 func NewContainerRegistry(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.ContainerRegistry{
 		Address:                 d.Address,
-		Region:                  lookupRegion(d, []string{}),
+		Region:                  d.Region,
 		GeoReplicationLocations: len(d.Get("georeplications").Array()),
 		SKU:                     d.Get("sku").String(),
 	}

--- a/internal/providers/terraform/azure/cosmosdb_cassandra_keyspace.go
+++ b/internal/providers/terraform/azure/cosmosdb_cassandra_keyspace.go
@@ -19,6 +19,14 @@ func GetAzureRMCosmosdbCassandraKeyspaceRegistryItem() *schema.RegistryItem {
 			"account_name",
 			"resource_group_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			if len(d.References("account_name")) > 0 {
+				account := d.References("account_name")[0]
+				return lookupRegion(account, []string{"account_name", "resource_group_name"})
+			}
+
+			return ""
+		},
 	}
 }
 
@@ -44,7 +52,7 @@ func NewAzureRMCosmosdb(d *schema.ResourceData, u *schema.UsageData) *schema.Res
 
 func cosmosDBCostComponents(d *schema.ResourceData, u *schema.UsageData, account *schema.ResourceData) []*schema.CostComponent {
 	// Find the region in from the passed-in account
-	region := lookupRegion(account, []string{"account_name", "resource_group_name"})
+	region := d.Region
 	geoLocations := account.Get("geo_location").Array()
 
 	// The geo_location attribute is a required attribute however it can be an empty list because of

--- a/internal/providers/terraform/azure/data_factory.go
+++ b/internal/providers/terraform/azure/data_factory.go
@@ -16,7 +16,7 @@ func getDataFactoryRegistryItem() *schema.RegistryItem {
 }
 
 func newDataFactory(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	r := &azure.DataFactory{
 		Address: d.Address,

--- a/internal/providers/terraform/azure/data_factory_integration_runtime_azure.go
+++ b/internal/providers/terraform/azure/data_factory_integration_runtime_azure.go
@@ -14,25 +14,26 @@ func getDataFactoryIntegrationRuntimeAzureRegistryItem() *schema.RegistryItem {
 			"data_factory_name",
 			"resource_group_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			region := lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
+
+			dataFactoryIdRefs := d.References("data_factory_id")
+			if region == "" && len(dataFactoryIdRefs) > 0 {
+				region = lookupRegion(dataFactoryIdRefs[0], []string{"resource_group_name"})
+			}
+
+			// Old provider versions < 3 can reference data_factory_name
+			dataFactoryNameRefs := d.References("data_factory_name")
+			if region == "" && len(dataFactoryNameRefs) > 0 {
+				region = lookupRegion(dataFactoryNameRefs[0], []string{"resource_group_name"})
+			}
+
+			return region
+		},
 	}
 }
 
 func newDataFactoryIntegrationRuntimeAzure(d *schema.ResourceData) schema.CoreResource {
-	var region string
-
-	region = lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
-
-	dataFactoryIdRefs := d.References("data_factory_id")
-	if region == "" && len(dataFactoryIdRefs) > 0 {
-		region = lookupRegion(dataFactoryIdRefs[0], []string{"resource_group_name"})
-	}
-
-	// Old provider versions < 3 can reference data_factory_name
-	dataFactoryNameRefs := d.References("data_factory_name")
-	if region == "" && len(dataFactoryNameRefs) > 0 {
-		region = lookupRegion(dataFactoryNameRefs[0], []string{"resource_group_name"})
-	}
-
 	cores := d.GetInt64OrDefault("core_count", 8)
 	compute := d.GetStringOrDefault("compute_type", "General")
 
@@ -44,7 +45,7 @@ func newDataFactoryIntegrationRuntimeAzure(d *schema.ResourceData) schema.CoreRe
 
 	r := &azure.DataFactoryIntegrationRuntimeAzure{
 		Address:     d.Address,
-		Region:      region,
+		Region:      d.Region,
 		Cores:       cores,
 		ComputeType: computeType,
 	}

--- a/internal/providers/terraform/azure/data_factory_integration_runtime_managed.go
+++ b/internal/providers/terraform/azure/data_factory_integration_runtime_managed.go
@@ -19,25 +19,25 @@ func getDataFactoryIntegrationRuntimeManagedRegistryItem() *schema.RegistryItem 
 			"data_factory_name",
 			"resource_group_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			region := lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
+
+			dataFactoryIdRefs := d.References("data_factory_id")
+			if region == "" && len(dataFactoryIdRefs) > 0 {
+				region = lookupRegion(dataFactoryIdRefs[0], []string{"resource_group_name"})
+			}
+
+			// Old provider versions < 3 can reference data_factory_name
+			dataFactoryNameRefs := d.References("data_factory_name")
+			if region == "" && len(dataFactoryNameRefs) > 0 {
+				region = lookupRegion(dataFactoryNameRefs[0], []string{"resource_group_name"})
+			}
+			return region
+		},
 	}
 }
 
 func newDataFactoryIntegrationRuntimeManaged(d *schema.ResourceData) schema.CoreResource {
-	var region string
-
-	region = lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
-
-	dataFactoryIdRefs := d.References("data_factory_id")
-	if region == "" && len(dataFactoryIdRefs) > 0 {
-		region = lookupRegion(dataFactoryIdRefs[0], []string{"resource_group_name"})
-	}
-
-	// Old provider versions < 3 can reference data_factory_name
-	dataFactoryNameRefs := d.References("data_factory_name")
-	if region == "" && len(dataFactoryNameRefs) > 0 {
-		region = lookupRegion(dataFactoryNameRefs[0], []string{"resource_group_name"})
-	}
-
 	licenseType := d.GetStringOrDefault("license_type", "LicenseIncluded")
 	licenseIncluded := strings.EqualFold(licenseType, "LicenseIncluded")
 
@@ -52,7 +52,7 @@ func newDataFactoryIntegrationRuntimeManaged(d *schema.ResourceData) schema.Core
 
 	r := &azure.DataFactoryIntegrationRuntimeManaged{
 		Address:         d.Address,
-		Region:          region,
+		Region:          d.Region,
 		Enterprise:      enterprise,
 		LicenseIncluded: licenseIncluded,
 		Instances:       nodes,

--- a/internal/providers/terraform/azure/data_factory_integration_runtime_self_hosted.go
+++ b/internal/providers/terraform/azure/data_factory_integration_runtime_self_hosted.go
@@ -14,28 +14,29 @@ func getDataFactoryIntegrationRuntimeSelfHostedRegistryItem() *schema.RegistryIt
 			"data_factory_name",
 			"resource_group_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			region := lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
+
+			dataFactoryIdRefs := d.References("data_factory_id")
+			if region == "" && len(dataFactoryIdRefs) > 0 {
+				region = lookupRegion(dataFactoryIdRefs[0], []string{"resource_group_name"})
+			}
+
+			// Old provider versions < 3 can reference data_factory_name
+			dataFactoryNameRefs := d.References("data_factory_name")
+			if region == "" && len(dataFactoryNameRefs) > 0 {
+				region = lookupRegion(dataFactoryNameRefs[0], []string{"resource_group_name"})
+			}
+
+			return region
+		},
 	}
 }
 
 func newDataFactoryIntegrationRuntimeSelfHosted(d *schema.ResourceData) schema.CoreResource {
-	var region string
-
-	region = lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
-
-	dataFactoryIdRefs := d.References("data_factory_id")
-	if region == "" && len(dataFactoryIdRefs) > 0 {
-		region = lookupRegion(dataFactoryIdRefs[0], []string{"resource_group_name"})
-	}
-
-	// Old provider versions < 3 can reference data_factory_name
-	dataFactoryNameRefs := d.References("data_factory_name")
-	if region == "" && len(dataFactoryNameRefs) > 0 {
-		region = lookupRegion(dataFactoryNameRefs[0], []string{"resource_group_name"})
-	}
-
 	r := &azure.DataFactoryIntegrationRuntimeSelfHosted{
 		Address: d.Address,
-		Region:  region,
+		Region:  d.Region,
 	}
 	return r
 }

--- a/internal/providers/terraform/azure/databricks_workspace.go
+++ b/internal/providers/terraform/azure/databricks_workspace.go
@@ -12,6 +12,6 @@ func getDatabricksWorkspaceRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDatabricksWorkspace(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DatabricksWorkspace{Address: d.Address, Region: lookupRegion(d, []string{}), SKU: d.Get("sku").String()}
+	r := &azure.DatabricksWorkspace{Address: d.Address, Region: d.Region, SKU: d.Get("sku").String()}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_a_record.go
+++ b/internal/providers/terraform/azure/dns_a_record.go
@@ -15,6 +15,6 @@ func getDNSARecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDNSARecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DNSARecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.DNSARecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_aaaa_record.go
+++ b/internal/providers/terraform/azure/dns_aaaa_record.go
@@ -15,6 +15,6 @@ func getDNSAAAARecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDNSAAAARecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DNSAAAARecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.DNSAAAARecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_caa_record.go
+++ b/internal/providers/terraform/azure/dns_caa_record.go
@@ -15,6 +15,6 @@ func getDNSCAARecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDNSCAARecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DNSCAARecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.DNSCAARecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_cname_record.go
+++ b/internal/providers/terraform/azure/dns_cname_record.go
@@ -15,6 +15,6 @@ func getDNSCNameRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDNSCNameRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DNSCNameRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.DNSCNameRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_mx_record.go
+++ b/internal/providers/terraform/azure/dns_mx_record.go
@@ -15,6 +15,6 @@ func getDNSMXRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDNSMXRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DNSMXRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.DNSMXRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_ns_record.go
+++ b/internal/providers/terraform/azure/dns_ns_record.go
@@ -15,6 +15,6 @@ func getDNSNSRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDNSNSRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DNSNSRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.DNSNSRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_ptr_record.go
+++ b/internal/providers/terraform/azure/dns_ptr_record.go
@@ -15,6 +15,6 @@ func getDNSPtrRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDNSPtrRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DNSPtrRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.DNSPtrRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_srv_record.go
+++ b/internal/providers/terraform/azure/dns_srv_record.go
@@ -15,6 +15,6 @@ func getDNSSrvRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDNSSrvRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DNSSrvRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.DNSSrvRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_txt_record.go
+++ b/internal/providers/terraform/azure/dns_txt_record.go
@@ -15,6 +15,6 @@ func getDNSTxtRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewDNSTxtRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.DNSTxtRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.DNSTxtRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/dns_zone.go
+++ b/internal/providers/terraform/azure/dns_zone.go
@@ -19,7 +19,7 @@ func getDNSZoneRegistryItem() *schema.RegistryItem {
 func NewDNSZone(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.DNSZone{
 		Address: d.Address,
-		Region:  lookupRegion(d, []string{"resource_group_name"}),
+		Region:  d.Region,
 	}
 
 	return r

--- a/internal/providers/terraform/azure/event_hubs_namespace.go
+++ b/internal/providers/terraform/azure/event_hubs_namespace.go
@@ -23,7 +23,7 @@ func NewAzureRMEventHubs(d *schema.ResourceData, u *schema.UsageData) *schema.Re
 	var includedRetention decimal.Decimal
 	sku := "Basic"
 	meterName := ""
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	if d.Get("sku").Type != gjson.Null {
 		sku = d.Get("sku").String()

--- a/internal/providers/terraform/azure/eventgrid_system_topic.go
+++ b/internal/providers/terraform/azure/eventgrid_system_topic.go
@@ -11,7 +11,7 @@ func getEventgridSystemTopicRegistryItem() *schema.RegistryItem {
 		CoreRFunc: func(d *schema.ResourceData) schema.CoreResource {
 			return &azure.EventGridTopic{
 				Address: d.Address,
-				Region:  lookupRegion(d, []string{"resource_group_name"}),
+				Region:  d.Region,
 			}
 		},
 		ReferenceAttributes: []string{

--- a/internal/providers/terraform/azure/eventgrid_topic.go
+++ b/internal/providers/terraform/azure/eventgrid_topic.go
@@ -11,7 +11,7 @@ func getEventgridTopicRegistryItem() *schema.RegistryItem {
 		CoreRFunc: func(d *schema.ResourceData) schema.CoreResource {
 			return &azure.EventGridTopic{
 				Address: d.Address,
-				Region:  lookupRegion(d, []string{"resource_group_name"}),
+				Region:  d.Region,
 			}
 		},
 		ReferenceAttributes: []string{

--- a/internal/providers/terraform/azure/federated_identity_credential.go
+++ b/internal/providers/terraform/azure/federated_identity_credential.go
@@ -16,7 +16,7 @@ func getFederatedIdentityCredentialRegistryItem() *schema.RegistryItem {
 }
 
 func newFederatedIdentityCredential(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.FederatedIdentityCredential{
 		Address: d.Address,
 		Region:  region,

--- a/internal/providers/terraform/azure/firewall.go
+++ b/internal/providers/terraform/azure/firewall.go
@@ -19,7 +19,7 @@ func GetAzureRMFirewallRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMFirewall(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	var costComponents []*schema.CostComponent
 

--- a/internal/providers/terraform/azure/frontdoor.go
+++ b/internal/providers/terraform/azure/frontdoor.go
@@ -22,7 +22,7 @@ func getFrontdoorRegistryItem() *schema.RegistryItem {
 
 // newFrontdoor parses Terraform's data and uses it to build a new resource
 func newFrontdoor(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	if strings.HasPrefix(strings.ToLower(region), "usgov") {
 		region = "US Gov Zone 1"

--- a/internal/providers/terraform/azure/frontdoor_firewall_policy.go
+++ b/internal/providers/terraform/azure/frontdoor_firewall_policy.go
@@ -22,7 +22,7 @@ func getFrontdoorFirewallPolicyRegistryItem() *schema.RegistryItem {
 // newFrontdoorFirewallPolicy parses Terraform's data and uses it to build
 // a new resource
 func newFrontdoorFirewallPolicy(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	if strings.HasPrefix(strings.ToLower(region), "usgov") {
 		region = "US Gov Zone 1"

--- a/internal/providers/terraform/azure/function_app.go
+++ b/internal/providers/terraform/azure/function_app.go
@@ -22,7 +22,7 @@ func getFunctionAppRegistryItem() *schema.RegistryItem {
 func newFunctionApp(d *schema.ResourceData) *azure.FunctionApp {
 	appServicePlan := d.References("app_service_plan_id")
 	servicePlan := d.References("service_plan_id")
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	if len(appServicePlan) == 0 && len(servicePlan) == 0 {
 		return &azure.FunctionApp{
@@ -42,7 +42,7 @@ func newFunctionApp(d *schema.ResourceData) *azure.FunctionApp {
 }
 
 func newFunctionAppFromAppServicePlanRef(d *schema.ResourceData, data *schema.ResourceData) *azure.FunctionApp {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	tier := "standard"
 	// support for the legacy azurerm_app_service_plan resource. This is only applicable for the legacy azurerm_function_app resource.

--- a/internal/providers/terraform/azure/hdinsight_hadoop_cluster.go
+++ b/internal/providers/terraform/azure/hdinsight_hadoop_cluster.go
@@ -18,7 +18,7 @@ func GetAzureRMHDInsightHadoopClusterRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMHDInsightHadoopCluster(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	costComponents := []*schema.CostComponent{}
 

--- a/internal/providers/terraform/azure/hdinsight_hbase_cluster.go
+++ b/internal/providers/terraform/azure/hdinsight_hbase_cluster.go
@@ -14,7 +14,7 @@ func GetAzureRMHDInsightHBaseClusterRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMHDInsightHBaseCluster(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	costComponents := []*schema.CostComponent{}
 

--- a/internal/providers/terraform/azure/hdinsight_interactive_query_cluster.go
+++ b/internal/providers/terraform/azure/hdinsight_interactive_query_cluster.go
@@ -14,7 +14,7 @@ func GetAzureRMHDInsightInteractiveQueryClusterRegistryItem() *schema.RegistryIt
 }
 
 func NewAzureRMHDInsightInteractiveQueryCluster(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	costComponents := []*schema.CostComponent{}
 

--- a/internal/providers/terraform/azure/hdinsight_kafka_cluster.go
+++ b/internal/providers/terraform/azure/hdinsight_kafka_cluster.go
@@ -17,7 +17,7 @@ func GetAzureRMHDInsightKafkaClusterRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMHDInsightKafkaCluster(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	costComponents := []*schema.CostComponent{}
 

--- a/internal/providers/terraform/azure/hdinsight_spark_cluster.go
+++ b/internal/providers/terraform/azure/hdinsight_spark_cluster.go
@@ -14,7 +14,7 @@ func GetAzureRMHDInsightSparkClusterRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMHDInsightSparkCluster(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	costComponents := []*schema.CostComponent{}
 

--- a/internal/providers/terraform/azure/image.go
+++ b/internal/providers/terraform/azure/image.go
@@ -21,7 +21,7 @@ func getImageRegistryItem() *schema.RegistryItem {
 }
 
 func newImage(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	return &azure.Image{
 		StorageGB: imageStorageSize(d),

--- a/internal/providers/terraform/azure/integration_service_environment.go
+++ b/internal/providers/terraform/azure/integration_service_environment.go
@@ -17,7 +17,7 @@ func GetAzureRMAppIntegrationServiceEnvironmentRegistryItem() *schema.RegistryIt
 }
 
 func NewAzureRMIntegrationServiceEnvironment(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	productName := "Logic Apps Integration Service Environment"
 	skuName := d.Get("sku_name").String()

--- a/internal/providers/terraform/azure/iothub.go
+++ b/internal/providers/terraform/azure/iothub.go
@@ -20,7 +20,7 @@ func getIoTHubDPSRegistryItem() *schema.RegistryItem {
 }
 
 func newIoTHub(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	sku := d.Get("sku.0.name").String()
 	capacity := d.Get("sku.0.capacity").Int()
@@ -36,7 +36,7 @@ func newIoTHub(d *schema.ResourceData) schema.CoreResource {
 }
 
 func newIoTHubDPS(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	sku := d.Get("sku.0.name").String()
 

--- a/internal/providers/terraform/azure/key_vault_certificate.go
+++ b/internal/providers/terraform/azure/key_vault_certificate.go
@@ -16,11 +16,14 @@ func GetAzureRMKeyVaultCertificateRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"key_vault_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"key_vault_id"})
+		},
 	}
 }
 
 func NewAzureRMKeyVaultCertificate(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{"key_vault_id"})
+	region := d.Region
 
 	var costComponents []*schema.CostComponent
 

--- a/internal/providers/terraform/azure/key_vault_key.go
+++ b/internal/providers/terraform/azure/key_vault_key.go
@@ -20,11 +20,14 @@ func GetAzureRMKeyVaultKeyRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"key_vault_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"key_vault_id"})
+		},
 	}
 }
 
 func NewAzureRMKeyVaultKey(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{"key_vault_id"})
+	region := d.Region
 
 	var skuName, keyType, keySize, meterName string
 	keyVault := d.References("key_vault_id")

--- a/internal/providers/terraform/azure/key_vault_managed_hardware_security_module.go
+++ b/internal/providers/terraform/azure/key_vault_managed_hardware_security_module.go
@@ -14,7 +14,7 @@ func GetAzureRMKeyVaultManagedHSMRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMKeyVaultManagedHSM(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	var costComponents []*schema.CostComponent
 

--- a/internal/providers/terraform/azure/kubernetes_cluster.go
+++ b/internal/providers/terraform/azure/kubernetes_cluster.go
@@ -40,7 +40,7 @@ func NewKubernetesCluster(d *schema.ResourceData) schema.CoreResource {
 
 	r := &azure.KubernetesCluster{
 		Address:                       d.Address,
-		Region:                        lookupRegion(d, []string{}),
+		Region:                        d.Region,
 		SKUTier:                       d.Get("sku_tier").String(),
 		NetworkProfileLoadBalancerSKU: d.Get("network_profile.0.load_balancer_sku").String(),
 		DefaultNodePoolNodeCount:      nodeCount,

--- a/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
+++ b/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
@@ -16,6 +16,9 @@ func getKubernetesClusterNodePoolRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"kubernetes_cluster_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"kubernetes_cluster_id"})
+		},
 	}
 }
 
@@ -43,7 +46,7 @@ func NewKubernetesClusterNodePool(d *schema.ResourceData) schema.CoreResource {
 
 	r := &azure.KubernetesClusterNodePool{
 		Address:      d.Address,
-		Region:       lookupRegion(d, []string{"kubernetes_cluster_id"}),
+		Region:       d.Region,
 		VMSize:       d.Get("vm_size").String(),
 		OS:           os,
 		OSDiskType:   d.Get("os_disk_type").String(),

--- a/internal/providers/terraform/azure/lb.go
+++ b/internal/providers/terraform/azure/lb.go
@@ -18,7 +18,7 @@ func getLoadBalancerRegistryItem() *schema.RegistryItem {
 func NewLB(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.LB{
 		Address: d.Address,
-		Region:  lookupRegion(d, []string{"resource_group_name"}),
+		Region:  d.Region,
 		SKU:     d.Get("sku").String(),
 	}
 	return r

--- a/internal/providers/terraform/azure/lb_outbound_rule.go
+++ b/internal/providers/terraform/azure/lb_outbound_rule.go
@@ -14,11 +14,14 @@ func GetAzureRMLoadBalancerOutboundRuleRegistryItem() *schema.RegistryItem {
 			"loadbalancer_id",
 			"resource_group_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"loadbalancer_id", "resource_group_name"})
+		},
 	}
 }
 
 func NewAzureRMLoadBalancerOutboundRule(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{"loadbalancer_id", "resource_group_name"})
+	region := d.Region
 	region = convertRegion(region)
 
 	lbSku := getParentLbSku(d.References("loadbalancer_id"))

--- a/internal/providers/terraform/azure/lb_rule.go
+++ b/internal/providers/terraform/azure/lb_rule.go
@@ -16,11 +16,14 @@ func GetAzureRMLoadBalancerRuleRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"loadbalancer_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"loadbalancer_id"})
+		},
 	}
 }
 
 func NewAzureRMLoadBalancerRule(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{"loadbalancer_id"})
+	region := d.Region
 	region = convertRegion(region)
 
 	lbSku := getParentLbSku(d.References("loadbalancer_id"))

--- a/internal/providers/terraform/azure/linux_virtual_machine.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine.go
@@ -18,7 +18,7 @@ func getLinuxVirtualMachineRegistryItem() *schema.RegistryItem {
 func NewAzureLinuxVirtualMachine(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.LinuxVirtualMachine{
 		Address:         d.Address,
-		Region:          lookupRegion(d, []string{}),
+		Region:          d.Region,
 		Size:            d.Get("size").String(),
 		UltraSSDEnabled: d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool(),
 	}

--- a/internal/providers/terraform/azure/linux_virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/linux_virtual_machine_scale_set.go
@@ -15,7 +15,7 @@ func getLinuxVirtualMachineScaleSetRegistryItem() *schema.RegistryItem {
 func NewLinuxVirtualMachineScaleSet(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	r := &azure.LinuxVirtualMachineScaleSet{
 		Address:         d.Address,
-		Region:          lookupRegion(d, []string{}),
+		Region:          d.Region,
 		SKU:             d.Get("sku").String(),
 		UltraSSDEnabled: d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool(),
 	}

--- a/internal/providers/terraform/azure/log_analytics_workspace.go
+++ b/internal/providers/terraform/azure/log_analytics_workspace.go
@@ -30,7 +30,7 @@ func getLogAnalyticsWorkspaceRegistryItem() *schema.RegistryItem {
 }
 
 func newLogAnalyticsWorkspace(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	sku := "PerGB2018"
 	if !d.IsEmpty("sku") {
 		sku = d.Get("sku").String()

--- a/internal/providers/terraform/azure/logic_app_integration_account.go
+++ b/internal/providers/terraform/azure/logic_app_integration_account.go
@@ -16,7 +16,7 @@ func getLogicAppIntegrationAccountRegistryItem() *schema.RegistryItem {
 }
 
 func newLogicAppIntegrationAccount(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	return azure.NewLogicAppIntegrationAccount(d.Address, region, d.GetStringOrDefault("sku_name", "free"))
 }

--- a/internal/providers/terraform/azure/logic_app_standard.go
+++ b/internal/providers/terraform/azure/logic_app_standard.go
@@ -17,7 +17,7 @@ func getLogicAppStandardRegistryItem() *schema.RegistryItem {
 }
 
 func newLogicAppStandard(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	var sku *string
 	appServicePlans := d.References("app_service_plan_id")

--- a/internal/providers/terraform/azure/machine_learning_compute_cluster.go
+++ b/internal/providers/terraform/azure/machine_learning_compute_cluster.go
@@ -16,7 +16,7 @@ func getMachineLearningComputeClusterRegistryItem() *schema.RegistryItem {
 }
 
 func newMachineLearningComputeCluster(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.MachineLearningComputeCluster{
 		Address:      d.Address,
 		Region:       region,

--- a/internal/providers/terraform/azure/machine_learning_compute_instance.go
+++ b/internal/providers/terraform/azure/machine_learning_compute_instance.go
@@ -16,7 +16,7 @@ func getMachineLearningComputeInstanceRegistryItem() *schema.RegistryItem {
 }
 
 func newMachineLearningComputeInstance(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.MachineLearningComputeInstance{
 		Address:      d.Address,
 		Region:       region,

--- a/internal/providers/terraform/azure/managed_disk.go
+++ b/internal/providers/terraform/azure/managed_disk.go
@@ -15,7 +15,7 @@ func getManagedDiskRegistryItem() *schema.RegistryItem {
 func NewManagedDisk(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.ManagedDisk{
 		Address: d.Address,
-		Region:  lookupRegion(d, []string{}),
+		Region:  d.Region,
 		ManagedDiskData: azure.ManagedDiskData{
 			DiskType:          d.Get("storage_account_type").String(),
 			DiskSizeGB:        d.Get("disk_size_gb").Int(),

--- a/internal/providers/terraform/azure/mariadb_server.go
+++ b/internal/providers/terraform/azure/mariadb_server.go
@@ -18,7 +18,7 @@ func GetAzureRMMariaDBServerRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMMariaDBServer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	var costComponents []*schema.CostComponent
 	serviceName := "Azure Database for MariaDB"

--- a/internal/providers/terraform/azure/monitor_action_group.go
+++ b/internal/providers/terraform/azure/monitor_action_group.go
@@ -17,7 +17,7 @@ func getMonitorActionGroupRegistryItem() *schema.RegistryItem {
 }
 
 func newMonitorActionGroup(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	smsByCountryCode := make(map[int]int)
 	for _, sms := range d.Get("sms_receiver").Array() {

--- a/internal/providers/terraform/azure/monitor_data_collection_rule.go
+++ b/internal/providers/terraform/azure/monitor_data_collection_rule.go
@@ -16,7 +16,7 @@ func getMonitorDataCollectionRuleRegistryItem() *schema.RegistryItem {
 }
 
 func newMonitorDataCollectionRule(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.MonitorDataCollectionRule{
 		Address: d.Address,
 		Region:  region,

--- a/internal/providers/terraform/azure/monitor_diagnostic_setting.go
+++ b/internal/providers/terraform/azure/monitor_diagnostic_setting.go
@@ -12,14 +12,16 @@ func getMonitorDiagnosticSettingRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"target_resource_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"target_resource_id"})
+		},
 	}
 }
 
 func newMonitorDiagnosticSetting(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"target_resource_id"})
 	return &azure.MonitorDiagnosticSetting{
 		Address: d.Address,
-		Region:  region,
+		Region:  d.Region,
 
 		EventHubTarget:        !d.IsEmpty("eventhub_authorization_rule_id"),
 		PartnerSolutionTarget: !d.IsEmpty("partner_solution_id"),

--- a/internal/providers/terraform/azure/monitor_metric_alert.go
+++ b/internal/providers/terraform/azure/monitor_metric_alert.go
@@ -16,7 +16,7 @@ func getMonitorMetricAlertRegistryItem() *schema.RegistryItem {
 }
 
 func newMonitorMetricAlert(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	scopeCount := 1 // default scope is the azure subscription, so count == 1
 	if !d.IsEmpty("scopes") {

--- a/internal/providers/terraform/azure/monitor_scheduled_query_rules_alert.go
+++ b/internal/providers/terraform/azure/monitor_scheduled_query_rules_alert.go
@@ -16,7 +16,7 @@ func getMonitorScheduledQueryRulesAlertRegistryItem() *schema.RegistryItem {
 }
 
 func newMonitorScheduledQueryRulesAlert(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.MonitorScheduledQueryRulesAlert{
 		Address:          d.Address,
 		Region:           region,

--- a/internal/providers/terraform/azure/monitor_scheduled_query_rules_alert_v2.go
+++ b/internal/providers/terraform/azure/monitor_scheduled_query_rules_alert_v2.go
@@ -19,7 +19,7 @@ func getMonitorScheduledQueryRulesAlertV2RegistryItem() *schema.RegistryItem {
 }
 
 func newMonitorScheduledQueryRulesAlertV2(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	freq := int64(1)
 	ef, err := duration.FromString(d.Get("evaluation_frequency").String())

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -56,11 +56,14 @@ func getMSSQLDatabaseRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"server_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"server_id"})
+		},
 	}
 }
 
 func newAzureRMMSSQLDatabase(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"server_id"})
+	region := d.Region
 
 	sku := d.GetStringOrDefault("sku_name", "GP_S_Gen5_2")
 

--- a/internal/providers/terraform/azure/mssql_elasticpool.go
+++ b/internal/providers/terraform/azure/mssql_elasticpool.go
@@ -18,11 +18,14 @@ func getMSSQLElasticPoolRegistryItem() *schema.RegistryItem {
 			"server_name",
 			"resource_group_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"server_name", "resource_group_name"})
+		},
 	}
 }
 
 func newMSSQLElasticPool(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"server_name", "resource_group_name"})
+	region := d.Region
 
 	sku := d.Get("sku.0.name").String()
 	capacity := d.Get("sku.0.capacity").Int()

--- a/internal/providers/terraform/azure/mssql_managed_instance.go
+++ b/internal/providers/terraform/azure/mssql_managed_instance.go
@@ -16,7 +16,7 @@ func getAzureRMMSSQLManagedInstanceRegistryItem() *schema.RegistryItem {
 }
 
 func newMSSQLManagedInstance(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	r := &azure.MSSQLManagedInstance{
 		Address: d.Address,
 		Region:  region,

--- a/internal/providers/terraform/azure/mysql_flexible_server.go
+++ b/internal/providers/terraform/azure/mysql_flexible_server.go
@@ -17,7 +17,7 @@ func getMySQLFlexibleServerRegistryItem() *schema.RegistryItem {
 }
 
 func newMySQLFlexibleServer(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 	sku := d.Get("sku_name").String()
 	storage := d.GetInt64OrDefault("storage.0.size_gb", 0)
 	iops := d.GetInt64OrDefault("storage.0.iops", 0)

--- a/internal/providers/terraform/azure/mysql_server.go
+++ b/internal/providers/terraform/azure/mysql_server.go
@@ -18,7 +18,7 @@ func GetAzureRMMySQLServerRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMMySQLServer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	serviceName := "Azure Database for MySQL"
 	var costComponents []*schema.CostComponent

--- a/internal/providers/terraform/azure/nat_gateway.go
+++ b/internal/providers/terraform/azure/nat_gateway.go
@@ -18,7 +18,7 @@ func GetAzureRMAppNATGatewayRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMNATGateway(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	region = convertRegion(region)
 
 	var monthlyDataProcessedGb *decimal.Decimal

--- a/internal/providers/terraform/azure/network_connection_monitor.go
+++ b/internal/providers/terraform/azure/network_connection_monitor.go
@@ -27,7 +27,7 @@ func newNetworkConnectionMonitor(d *schema.ResourceData) schema.CoreResource {
 		}
 	}
 
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.NetworkConnectionMonitor{
 		Address: d.Address,
 		Region:  region,

--- a/internal/providers/terraform/azure/network_ddos_protection_plan.go
+++ b/internal/providers/terraform/azure/network_ddos_protection_plan.go
@@ -16,7 +16,7 @@ func getNetworkDdosProtectionPlanRegistryItem() *schema.RegistryItem {
 }
 
 func newNetworkDdosProtectionPlan(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.NetworkDdosProtectionPlan{
 		Address: d.Address,
 		Region:  region,

--- a/internal/providers/terraform/azure/network_watcher.go
+++ b/internal/providers/terraform/azure/network_watcher.go
@@ -16,7 +16,7 @@ func getNetworkWatcherRegistryItem() *schema.RegistryItem {
 }
 
 func newNetworkWatcher(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.NetworkWatcher{
 		Address: d.Address,
 		Region:  region,

--- a/internal/providers/terraform/azure/network_watcher_flow_log.go
+++ b/internal/providers/terraform/azure/network_watcher_flow_log.go
@@ -31,7 +31,7 @@ func newNetworkWatcherFlowLog(d *schema.ResourceData) schema.CoreResource {
 		trafficAnalyticsAcceleratedProcessing = d.Get("traffic_analytics.0.interval_in_minutes").Int() == int64(10)
 	}
 
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.NetworkWatcherFlowLog{
 		Address:                               d.Address,
 		Region:                                region,

--- a/internal/providers/terraform/azure/notification_hub_namespace.go
+++ b/internal/providers/terraform/azure/notification_hub_namespace.go
@@ -19,7 +19,7 @@ func GetAzureRMNotificationHubNamespaceRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMNotificationHubNamespace(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	var monthlyAdditionalPushes *decimal.Decimal
 	sku := "Basic"

--- a/internal/providers/terraform/azure/postgresql_flexible_server.go
+++ b/internal/providers/terraform/azure/postgresql_flexible_server.go
@@ -17,7 +17,7 @@ func getPostgreSQLFlexibleServerRegistryItem() *schema.RegistryItem {
 }
 
 func newPostgreSQLFlexibleServer(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 	sku := d.Get("sku_name").String()
 	storage := d.Get("storage_mb").Int()
 

--- a/internal/providers/terraform/azure/postgresql_server.go
+++ b/internal/providers/terraform/azure/postgresql_server.go
@@ -18,7 +18,7 @@ func GetAzureRMPostgreSQLServerRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMPostrgreSQLServer(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	var costComponents []*schema.CostComponent
 	serviceName := "Azure Database for PostgreSQL"

--- a/internal/providers/terraform/azure/powerbi_embedded.go
+++ b/internal/providers/terraform/azure/powerbi_embedded.go
@@ -16,7 +16,7 @@ func getPowerBIEmbeddedRegistryItem() *schema.RegistryItem {
 }
 
 func newPowerBIEmbedded(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.PowerBIEmbedded{
 		Address: d.Address,
 		Region:  region,

--- a/internal/providers/terraform/azure/private_dns_a_record.go
+++ b/internal/providers/terraform/azure/private_dns_a_record.go
@@ -15,6 +15,6 @@ func getPrivateDNSARecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewPrivateDNSARecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.PrivateDNSARecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.PrivateDNSARecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/private_dns_aaaa_record.go
+++ b/internal/providers/terraform/azure/private_dns_aaaa_record.go
@@ -15,6 +15,6 @@ func getPrivateDNSAAAARecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewPrivateDNSAAAARecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.PrivateDNSAAAARecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.PrivateDNSAAAARecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/private_dns_cname_record.go
+++ b/internal/providers/terraform/azure/private_dns_cname_record.go
@@ -15,6 +15,6 @@ func getPrivateDNSCNameRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewPrivateDNSCNameRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.PrivateDNSCNameRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.PrivateDNSCNameRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/private_dns_mx_record.go
+++ b/internal/providers/terraform/azure/private_dns_mx_record.go
@@ -15,6 +15,6 @@ func getPrivateDNSMXRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewPrivateDNSMXRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.PrivateDNSMXRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.PrivateDNSMXRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/private_dns_ptr_record.go
+++ b/internal/providers/terraform/azure/private_dns_ptr_record.go
@@ -15,6 +15,6 @@ func getPrivateDNSPTRRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewPrivateDNSPTRRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.PrivateDNSPTRRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.PrivateDNSPTRRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/private_dns_resolver_dns_forwarding_ruleset.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_dns_forwarding_ruleset.go
@@ -18,7 +18,7 @@ func getPrivateDnsResolverDnsForwardingRulesetRegistryItem() *schema.RegistryIte
 }
 
 func newPrivateDnsResolverDnsForwardingRuleset(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	if strings.HasPrefix(strings.ToLower(region), "usgov") {
 		region = "US Gov Zone 1"

--- a/internal/providers/terraform/azure/private_dns_resolver_inbound_endpoint.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_inbound_endpoint.go
@@ -18,7 +18,7 @@ func getPrivateDnsResolverInboundEndpointRegistryItem() *schema.RegistryItem {
 }
 
 func newPrivateDnsResolverInboundEndpoint(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	if strings.HasPrefix(strings.ToLower(region), "usgov") {
 		region = "US Gov Zone 1"

--- a/internal/providers/terraform/azure/private_dns_resolver_outbound_endpoint.go
+++ b/internal/providers/terraform/azure/private_dns_resolver_outbound_endpoint.go
@@ -18,7 +18,7 @@ func getPrivateDnsResolverOutboundEndpointRegistryItem() *schema.RegistryItem {
 }
 
 func newPrivateDnsResolverOutboundEndpoint(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	if strings.HasPrefix(strings.ToLower(region), "usgov") {
 		region = "US Gov Zone 1"

--- a/internal/providers/terraform/azure/private_dns_srv_record.go
+++ b/internal/providers/terraform/azure/private_dns_srv_record.go
@@ -15,6 +15,6 @@ func getPrivateDNSSRVRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewPrivateDNSSRVRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.PrivateDNSSRVRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.PrivateDNSSRVRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/private_dns_txt_record.go
+++ b/internal/providers/terraform/azure/private_dns_txt_record.go
@@ -15,6 +15,6 @@ func getPrivateDNSTXTRecordRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewPrivateDNSTXTRecord(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.PrivateDNSTXTRecord{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.PrivateDNSTXTRecord{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/private_dns_zone.go
+++ b/internal/providers/terraform/azure/private_dns_zone.go
@@ -16,6 +16,6 @@ func getDNSPrivateZoneRegistryItem() *schema.RegistryItem {
 	}
 }
 func NewPrivateDNSZone(d *schema.ResourceData) schema.CoreResource {
-	r := &azure.PrivateDNSZone{Address: d.Address, Region: lookupRegion(d, []string{"resource_group_name"})}
+	r := &azure.PrivateDNSZone{Address: d.Address, Region: d.Region}
 	return r
 }

--- a/internal/providers/terraform/azure/private_endpoint.go
+++ b/internal/providers/terraform/azure/private_endpoint.go
@@ -20,7 +20,7 @@ func GetAzureRMPrivateEndpointRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMPrivateEndpoint(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	region = convertRegion(region)
 
 	costComponents := make([]*schema.CostComponent, 0)

--- a/internal/providers/terraform/azure/public_ip.go
+++ b/internal/providers/terraform/azure/public_ip.go
@@ -18,7 +18,7 @@ func GetAzureRMPublicIPRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMPublicIP(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	var meterName string
 	sku := "Basic"

--- a/internal/providers/terraform/azure/public_ip_prefix.go
+++ b/internal/providers/terraform/azure/public_ip_prefix.go
@@ -14,7 +14,7 @@ func GetAzureRMPublicIPPrefixRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMPublicIPPrefix(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	costComponents := make([]*schema.CostComponent, 0)
 

--- a/internal/providers/terraform/azure/recovery_services_vault.go
+++ b/internal/providers/terraform/azure/recovery_services_vault.go
@@ -27,7 +27,7 @@ func getRecoveryServicesVaultRegistryItem() *schema.RegistryItem {
 }
 
 func newRecoveryServicesVault(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	vms := d.References("azurerm_backup_protected_vm.recovery_vault_name")
 
 	var protectedVMs []*azure.BackupProtectedVM

--- a/internal/providers/terraform/azure/redis_cache.go
+++ b/internal/providers/terraform/azure/redis_cache.go
@@ -18,7 +18,7 @@ func GetAzureRMRedisCacheRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMRedisCache(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	skuName := d.Get("sku_name").String()
 	family := d.Get("family").String()

--- a/internal/providers/terraform/azure/search_service.go
+++ b/internal/providers/terraform/azure/search_service.go
@@ -24,7 +24,7 @@ func GetAzureRMSearchServiceRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMSearchService(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 	costComponents := []*schema.CostComponent{}
 
 	sku := strings.ToLower(d.Get("sku").String())

--- a/internal/providers/terraform/azure/service_plan.go
+++ b/internal/providers/terraform/azure/service_plan.go
@@ -11,7 +11,7 @@ func getServicePlanRegistryItem() *schema.RegistryItem {
 		CoreRFunc: func(d *schema.ResourceData) schema.CoreResource {
 			return &azure.ServicePlan{
 				Address:     d.Address,
-				Region:      lookupRegion(d, []string{}),
+				Region:      d.Region,
 				SKUName:     d.Get("sku_name").String(),
 				WorkerCount: d.GetInt64OrDefault("worker_count", 1),
 				OSType:      d.Get("os_type").String(),

--- a/internal/providers/terraform/azure/servicebus_namespace.go
+++ b/internal/providers/terraform/azure/servicebus_namespace.go
@@ -16,7 +16,7 @@ func getServiceBusNamespaceRegistryItem() *schema.RegistryItem {
 }
 
 func newServiceBusNamespace(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.ServiceBusNamespace{
 		Address:  d.Address,
 		Region:   region,

--- a/internal/providers/terraform/azure/signalr_service.go
+++ b/internal/providers/terraform/azure/signalr_service.go
@@ -16,7 +16,7 @@ func getSignalRServiceRegistryItem() *schema.RegistryItem {
 }
 
 func newSignalRService(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	return &azure.SignalRService{
 		Address:     d.Address,
 		Region:      region,

--- a/internal/providers/terraform/azure/snapshot.go
+++ b/internal/providers/terraform/azure/snapshot.go
@@ -17,7 +17,7 @@ func getSnapshotRegistryItem() *schema.RegistryItem {
 }
 
 func newSnapshot(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	return &azure.Image{
 		Type:      "Snapshot",

--- a/internal/providers/terraform/azure/sql_elasticpool.go
+++ b/internal/providers/terraform/azure/sql_elasticpool.go
@@ -16,6 +16,9 @@ func getSQLElasticPoolRegistryItem() *schema.RegistryItem {
 			"server_name",
 			"resource_group_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"server_name", "resource_group_name"})
+		},
 	}
 }
 
@@ -24,7 +27,7 @@ func newSQLElasticPool(d *schema.ResourceData) schema.CoreResource {
 	sku := fmt.Sprintf("%sPool", strings.ToTitle(tier))
 	dtu := d.Get("dtu").Int()
 
-	region := lookupRegion(d, []string{"server_name", "resource_group_name"})
+	region := d.Region
 	r := &azure.MSSQLElasticPool{
 		Address:       d.Address,
 		Region:        region,

--- a/internal/providers/terraform/azure/sql_managed_instance.go
+++ b/internal/providers/terraform/azure/sql_managed_instance.go
@@ -16,7 +16,7 @@ func getSQLManagedInstanceRegistryItem() *schema.RegistryItem {
 }
 
 func newSQLManagedInstance(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 	r := &azure.SQLManagedInstance{
 		Address: d.Address,
 		Region:  region,

--- a/internal/providers/terraform/azure/storage_account.go
+++ b/internal/providers/terraform/azure/storage_account.go
@@ -21,7 +21,7 @@ func getStorageAccountRegistryItem() *schema.RegistryItem {
 }
 
 func newAzureRMStorageAccount(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{})
+	region := d.Region
 
 	accountKind := "StorageV2"
 	if !d.IsEmpty("account_kind") {

--- a/internal/providers/terraform/azure/storage_queue.go
+++ b/internal/providers/terraform/azure/storage_queue.go
@@ -15,11 +15,14 @@ func getStorageQueueRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"storage_account_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"storage_account_name"})
+		},
 	}
 }
 
 func newStorageQueue(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"storage_account_name"})
+	region := d.Region
 
 	accountReplicationType := "LRS"
 	accountKind := "StorageV2"

--- a/internal/providers/terraform/azure/storage_share.go
+++ b/internal/providers/terraform/azure/storage_share.go
@@ -15,11 +15,14 @@ func getStorageShareRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"storage_account_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"storage_account_name"})
+		},
 	}
 }
 
 func newStorageShare(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"storage_account_name"})
+	region := d.Region
 
 	accountReplicationType := "LRS"
 

--- a/internal/providers/terraform/azure/synapse_spark_pool.go
+++ b/internal/providers/terraform/azure/synapse_spark_pool.go
@@ -18,11 +18,14 @@ func GetAzureRMSynapseSparkPoolRegistryItem() *schema.RegistryItem {
 			"synapse_workspace_id",
 		},
 		Notes: []string{"the total costs consist of several resources that should be viewed as a whole"},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"synapse_workspace_id"})
+		},
 	}
 }
 
 func NewAzureRMSynapseSparkPool(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{"synapse_workspace_id"})
+	region := d.Region
 	costComponents := make([]*schema.CostComponent, 0)
 
 	nodeSize := "Small"

--- a/internal/providers/terraform/azure/synapse_sql_pool.go
+++ b/internal/providers/terraform/azure/synapse_sql_pool.go
@@ -17,11 +17,14 @@ func GetAzureRMSynapseSQLPoolRegistryItem() *schema.RegistryItem {
 			"synapse_workspace_id",
 		},
 		Notes: []string{"the total costs consist of several resources that should be viewed as a whole"},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"synapse_workspace_id"})
+		},
 	}
 }
 
 func NewAzureRMSynapseSQLPool(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{"synapse_workspace_id"})
+	region := d.Region
 
 	costComponents := make([]*schema.CostComponent, 0)
 

--- a/internal/providers/terraform/azure/synapse_workspace.go
+++ b/internal/providers/terraform/azure/synapse_workspace.go
@@ -22,7 +22,7 @@ func GetAzureRMSynapseWorkspacRegistryItem() *schema.RegistryItem {
 }
 
 func NewAzureRMSynapseWorkspace(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	costComponents := make([]*schema.CostComponent, 0)
 

--- a/internal/providers/terraform/azure/traffic_manager_azure_endpoint.go
+++ b/internal/providers/terraform/azure/traffic_manager_azure_endpoint.go
@@ -12,17 +12,24 @@ func getTrafficManagerAzureEndpointRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"profile_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			if len(d.References("profile_id")) > 0 {
+				profile := d.References("profile_id")[0]
+				return lookupRegion(profile, []string{"resource_group_name"})
+			}
+
+			return ""
+		},
 	}
 }
 
 func newTrafficManagerAzureEndpoint(d *schema.ResourceData) schema.CoreResource {
-	region := ""
+	region := d.Region
 	healthCheckInterval := int64(30)
 	profileEnabled := false
 
 	if len(d.References("profile_id")) > 0 {
 		profile := d.References("profile_id")[0]
-		region = lookupRegion(profile, []string{"resource_group_name"})
 		healthCheckInterval = profile.GetInt64OrDefault("monitor_config.0.interval_in_seconds", 30)
 		profileEnabled = trafficManagerProfileEnabled(profile)
 	}

--- a/internal/providers/terraform/azure/traffic_manager_external_endpoint.go
+++ b/internal/providers/terraform/azure/traffic_manager_external_endpoint.go
@@ -12,17 +12,24 @@ func getTrafficManagerExternalEndpointRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"profile_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			if len(d.References("profile_id")) > 0 {
+				profile := d.References("profile_id")[0]
+				return lookupRegion(profile, []string{"resource_group_name"})
+			}
+
+			return ""
+		},
 	}
 }
 
 func newTrafficManagerExternalEndpoint(d *schema.ResourceData) schema.CoreResource {
-	region := ""
+	region := d.Region
 	healthCheckInterval := int64(30)
 	profileEnabled := false
 
 	if len(d.References("profile_id")) > 0 {
 		profile := d.References("profile_id")[0]
-		region = lookupRegion(profile, []string{"resource_group_name"})
 		healthCheckInterval = profile.GetInt64OrDefault("monitor_config.0.interval_in_seconds", 30)
 		profileEnabled = trafficManagerProfileEnabled(profile)
 	}

--- a/internal/providers/terraform/azure/traffic_manager_nested_endpoint.go
+++ b/internal/providers/terraform/azure/traffic_manager_nested_endpoint.go
@@ -12,17 +12,24 @@ func getTrafficManagerNestedEndpointRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"profile_id",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			if len(d.References("profile_id")) > 0 {
+				profile := d.References("profile_id")[0]
+				return lookupRegion(profile, []string{"resource_group_name"})
+			}
+
+			return ""
+		},
 	}
 }
 
 func newTrafficManagerNestedEndpoint(d *schema.ResourceData) schema.CoreResource {
-	region := ""
+	region := d.Region
 	healthCheckInterval := int64(30)
 	profileEnabled := false
 
 	if len(d.References("profile_id")) > 0 {
 		profile := d.References("profile_id")[0]
-		region = lookupRegion(profile, []string{"resource_group_name"})
 		healthCheckInterval = profile.GetInt64OrDefault("monitor_config.0.interval_in_seconds", 30)
 		profileEnabled = trafficManagerProfileEnabled(profile)
 	}

--- a/internal/providers/terraform/azure/traffic_manager_profile.go
+++ b/internal/providers/terraform/azure/traffic_manager_profile.go
@@ -17,7 +17,7 @@ func getTrafficManagerProfileRegistryItem() *schema.RegistryItem {
 }
 
 func newTrafficManagerProfile(d *schema.ResourceData) schema.CoreResource {
-	region := lookupRegion(d, []string{"resource_group_name"})
+	region := d.Region
 
 	return &azure.TrafficManagerProfile{
 		Address:            d.Address,

--- a/internal/providers/terraform/azure/util.go
+++ b/internal/providers/terraform/azure/util.go
@@ -29,113 +29,6 @@ func toAzureCLIName(location string) string {
 	return strings.ToLower(sReg.ReplaceAllString(location, ""))
 }
 
-var lookupRegionFunctions = map[string]func(d *schema.ResourceData) string{
-	"azurerm_mssql_elasticpool": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"server_name", "resource_group_name"})
-	},
-	"azurerm_lb_rule": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"loadbalancer_id"})
-	},
-	"azurerm_data_factory_integration_runtime_azure": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
-	},
-	"azurerm_traffic_manager_external_endpoint": func(d *schema.ResourceData) string {
-		if len(d.References("profile_id")) > 0 {
-			profile := d.References("profile_id")[0]
-			return lookupRegion(profile, []string{"resource_group_name"})
-		}
-
-		return lookupRegion(d, []string{"resource_group_name"})
-	},
-	"azurerm_storage_queue": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"storage_account_name"})
-	},
-	"azurerm_data_factory_integration_runtime_azure_ssis": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
-	},
-	"azurerm_app_service_certificate_binding": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"certificate_id"})
-	},
-	"azurerm_cosmosdb_cassandra_keyspace": func(d *schema.ResourceData) string {
-		if len(d.References("account_name")) > 0 {
-			account := d.References("account_name")[0]
-			return lookupRegion(account, []string{"account_name", "resource_group_name"})
-		}
-
-		return lookupRegion(d, []string{"resource_group_name"})
-	},
-	"azurerm_monitor_diagnostic_setting": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"target_resource_id"})
-	},
-	"azurerm_sql_elasticpool": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"server_name", "resource_group_name"})
-	},
-	"azurerm_virtual_network_peering": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"virtual_network_name"})
-	},
-	"azurerm_kubernetes_cluster_node_pool": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"kubernetes_cluster_id"})
-	},
-	"azurerm_key_vault_key": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"key_vault_id"})
-	},
-	"azurerm_data_factory_integration_runtime_self_hosted": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
-	},
-	"azurerm_cognitive_deployment": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"cognitive_account_id"})
-	},
-	"azurerm_traffic_manager_nested_endpoint": func(d *schema.ResourceData) string {
-		if len(d.References("profile_id")) > 0 {
-			profile := d.References("profile_id")[0]
-			return lookupRegion(profile, []string{"resource_group_name"})
-		}
-
-		return lookupRegion(d, []string{"resource_group_name"})
-	},
-	"azurerm_lb_outbound_rule": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"loadbalancer_id", "resource_group_name"})
-	},
-	"azurerm_synapse_sql_pool": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"synapse_workspace_id"})
-	},
-	"azurerm_dns_ns_record": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"resource_group_name"})
-	},
-	"azurerm_hdinsight_hadoop_cluster": func(d *schema.ResourceData) string { //nolint:misspell
-		return lookupRegion(d, []string{})
-	},
-	"azurerm_traffic_manager_azure_endpoint": func(d *schema.ResourceData) string {
-		if len(d.References("profile_id")) > 0 {
-			profile := d.References("profile_id")[0]
-			return lookupRegion(profile, []string{"resource_group_name"})
-		}
-
-		return lookupRegion(d, []string{"resource_group_name"})
-	},
-	"azurerm_key_vault_certificate": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"key_vault_id"})
-	},
-	"azurerm_mariadb_server": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{})
-	},
-	"azurerm_postgresql_server": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{})
-	},
-	"azurerm_data_factory_integration_runtime_managed": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
-	},
-	"azurerm_storage_share": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{"storage_account_name"})
-	},
-	"azurerm_windows_virtual_machine": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{})
-	},
-	"azurerm_integration_service_environment": func(d *schema.ResourceData) string {
-		return lookupRegion(d, []string{})
-	},
-}
-
 func lookupRegion(d *schema.ResourceData, parentResourceKeys []string) string {
 	// First check for a location set directly on a resource
 	location := d.Get("location").String()
@@ -170,19 +63,13 @@ func convertRegion(region string) string {
 	}
 }
 
-// GetResourceRegion returns the region for the given azure resource data. By default,
-// this uses the "location" property, but if that is not set it will traverse the
-// references to find a location. The default references used are the resource
-// group name. However, some resources specify different resources to get the
-// location from, in which case a custom function is used that specifies which
-// references to use.
+// GetResourceRegion returns the default azure region lookup function. Many
+// resources in azure define a custom region lookup function, This can be found
+// in their RegistryItem.GetRegion field. This function is used as a fallback
+// when a custom region lookup function is not defined.
 func GetResourceRegion(d *schema.ResourceData) string {
 	if d == nil {
 		return ""
-	}
-
-	if v, ok := lookupRegionFunctions[d.Type]; ok {
-		return v(d)
 	}
 
 	return lookupRegion(d, []string{"resource_group_name"})

--- a/internal/providers/terraform/azure/virtual_machine.go
+++ b/internal/providers/terraform/azure/virtual_machine.go
@@ -14,7 +14,7 @@ func getVirtualMachineRegistryItem() *schema.RegistryItem {
 func NewVirtualMachine(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.VirtualMachine{
 		Address:                    d.Address,
-		Region:                     lookupRegion(d, []string{}),
+		Region:                     d.Region,
 		StorageImageReferenceOffer: d.Get("storage_image_reference.0.offer").String(),
 		StorageOSDiskOSType:        d.Get("storage_os_disk.0.os_type").String(),
 		LicenseType:                d.Get("license_type").String(),

--- a/internal/providers/terraform/azure/virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/virtual_machine_scale_set.go
@@ -18,7 +18,7 @@ func getVirtualMachineScaleSetRegistryItem() *schema.RegistryItem {
 func NewVirtualMachineScaleSet(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.VirtualMachineScaleSet{
 		Address:     d.Address,
-		Region:      lookupRegion(d, []string{}),
+		Region:      d.Region,
 		SKUName:     d.Get("sku.0.name").String(),
 		SKUCapacity: d.Get("sku.0.capacity").Int(),
 		LicenseType: d.Get("license_type").String(),

--- a/internal/providers/terraform/azure/virtual_network_gateway.go
+++ b/internal/providers/terraform/azure/virtual_network_gateway.go
@@ -21,7 +21,7 @@ func GetAzureRMVirtualNetworkGatewayRegistryItem() *schema.RegistryItem {
 func NewAzureRMVirtualNetworkGateway(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	var connection, dataTransfers *decimal.Decimal
 	sku := "Basic"
-	region := lookupRegion(d, []string{})
+	region := d.Region
 	zone := regionToVNETZone(region)
 
 	if d.Get("sku").Type != gjson.Null {

--- a/internal/providers/terraform/azure/virtual_network_gateway_connection.go
+++ b/internal/providers/terraform/azure/virtual_network_gateway_connection.go
@@ -31,7 +31,7 @@ func NewAzureRMVirtualNetworkGatewayConnection(d *schema.ResourceData, u *schema
 		sku = vpnGateway.Get("sku").String()
 	}
 
-	region := lookupRegion(d, []string{})
+	region := d.Region
 	if strings.ToLower(sku) == "basic" {
 		return &schema.Resource{
 			Name:      d.Address,

--- a/internal/providers/terraform/azure/virtual_network_peering.go
+++ b/internal/providers/terraform/azure/virtual_network_peering.go
@@ -16,11 +16,14 @@ func getVirtualNetworkPeeringRegistryItem() *schema.RegistryItem {
 			"remote_virtual_network_id",
 			"resource_group_name",
 		},
+		GetRegion: func(d *schema.ResourceData) string {
+			return lookupRegion(d, []string{"virtual_network_name"})
+		},
 	}
 }
 
 func newVirtualNetworkPeering(d *schema.ResourceData) schema.CoreResource {
-	sourceRegion := lookupRegion(d, []string{"virtual_network_name"})
+	sourceRegion := d.Region
 	destinationRegion := lookupRegion(d, []string{"remote_virtual_network_id"})
 
 	sourceZone := virtualNetworkPeeringConvertRegion(sourceRegion)

--- a/internal/providers/terraform/azure/windows_virtual_machine.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine.go
@@ -18,7 +18,7 @@ func getWindowsVirtualMachineRegistryItem() *schema.RegistryItem {
 func NewWindowsVirtualMachine(d *schema.ResourceData) schema.CoreResource {
 	r := &azure.WindowsVirtualMachine{
 		Address:                               d.Address,
-		Region:                                lookupRegion(d, []string{}),
+		Region:                                d.Region,
 		Size:                                  d.Get("size").String(),
 		LicenseType:                           d.Get("license_type").String(),
 		AdditionalCapabilitiesUltraSSDEnabled: d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool(),

--- a/internal/providers/terraform/azure/windows_virtual_machine_scale_set.go
+++ b/internal/providers/terraform/azure/windows_virtual_machine_scale_set.go
@@ -14,7 +14,7 @@ func getWindowsVirtualMachineScaleSetRegistryItem() *schema.RegistryItem {
 func NewWindowsVirtualMachineScaleSet(d *schema.ResourceData, u *schema.UsageData) *schema.Resource {
 	r := &azure.WindowsVirtualMachineScaleSet{
 		Address:                               d.Address,
-		Region:                                lookupRegion(d, []string{}),
+		Region:                                d.Region,
 		SKU:                                   d.Get("sku").String(),
 		LicenseType:                           d.Get("license_type").String(),
 		AdditionalCapabilitiesUltraSSDEnabled: d.Get("additional_capabilities.0.ultra_ssd_enabled").Bool(),

--- a/internal/providers/terraform/google/google.go
+++ b/internal/providers/terraform/google/google.go
@@ -1,8 +1,6 @@
 package google
 
 import (
-	"github.com/tidwall/gjson"
-
 	"github.com/infracost/infracost/internal/providers/terraform/provider_schemas"
 	"github.com/infracost/infracost/internal/schema"
 )
@@ -28,7 +26,9 @@ func GetSpecialContext(d *schema.ResourceData) map[string]interface{} {
 	return map[string]interface{}{}
 }
 
-func GetResourceRegion(resourceType string, v gjson.Result) string {
+func GetResourceRegion(d *schema.ResourceData) string {
+	v := d.RawValues
+
 	if v.Get("region").Exists() && v.Get("region").String() != "" {
 		return v.Get("region").String()
 	}

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -148,7 +148,7 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 
 	var policyClient *apiclient.PolicyAPIClient
 	if runCtx.Config.PoliciesEnabled {
-		policyClient, _ = apiclient.NewPolicyAPIClient(runCtx)
+		policyClient, err = apiclient.NewPolicyAPIClient(runCtx)
 		if err != nil {
 			logger.Err(err).Msgf("failed to initialize policy client")
 		}

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -148,7 +148,7 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 
 	var policyClient *apiclient.PolicyAPIClient
 	if runCtx.Config.PoliciesEnabled {
-		policyClient, err = apiclient.NewPolicyAPIClient(runCtx)
+		policyClient, _ = apiclient.NewPolicyAPIClient(runCtx)
 		if err != nil {
 			logger.Err(err).Msgf("failed to initialize policy client")
 		}

--- a/internal/schema/registry_item.go
+++ b/internal/schema/registry_item.go
@@ -6,6 +6,11 @@ type ReferenceIDFunc func(d *ResourceData) []string
 // CloudResourceIDFunc is used to calculate the cloud resource ids (AWS ARN, Google HREF, etc...) associated with the resource
 type CloudResourceIDFunc func(d *ResourceData) []string
 
+// RegionLookupFunc is used to look up the region of a resource, this is used to
+// calculate the region of a resource if the region requires a lookup from
+// reference attributes.
+type RegionLookupFunc func(d *ResourceData) string
+
 type RegistryItem struct {
 	Name                string
 	Notes               []string
@@ -16,4 +21,9 @@ type RegistryItem struct {
 	DefaultRefIDFunc    ReferenceIDFunc
 	CloudResourceIDFunc CloudResourceIDFunc
 	NoPrice             bool
+	// GetRegion is used to look up the region of a resource if it has a region that
+	// cannot be calculated from the default resource/provider data. If the GetRegion
+	// is nil or the return result is empty the region will be calculated from the
+	// default resource/provider data.
+	GetRegion RegionLookupFunc
 }

--- a/internal/schema/resource_data.go
+++ b/internal/schema/resource_data.go
@@ -18,6 +18,10 @@ type ResourceData struct {
 	CFResource    cloudformation.Resource
 	UsageData     *UsageData
 	Metadata      map[string]gjson.Result
+	// Region is the region of the resource. When building a resource callers should
+	// use this value instead of the deprecated d.Get("region").String() or
+	// lookupRegion method.
+	Region string
 }
 
 func NewResourceData(resourceType string, providerName string, address string, tags *map[string]string, rawValues gjson.Result) *ResourceData {

--- a/internal/schema/resource_data_test.go
+++ b/internal/schema/resource_data_test.go
@@ -8,10 +8,9 @@ import (
 )
 
 func TestResourceDataEmpty(t *testing.T) {
-	r := NewResourceData("somettype", "someprovider", "some.address", nil,
-		gjson.Result{
-			Type: gjson.JSON,
-			Raw: `{	
+	r := NewResourceData("somettype", "someprovider", "some.address", nil, gjson.Result{
+		Type: gjson.JSON,
+		Raw: `{	
 					"someresource": {
 						"number": 0,
 						"string": "string",
@@ -37,7 +36,7 @@ func TestResourceDataEmpty(t *testing.T) {
 						}
 					}
 				}`,
-		})
+	})
 
 	tests := []struct {
 		key  string


### PR DESCRIPTION
Adds a `Region` property to the `schema.ResourceData` which is set when parsing the plan and set before evaluating each individual resource. This property is meant to replace the old `d.Get` approach which sets the region directly on the `RawValues` of the json.

This new approach sets the `Region` after the references have been parsed and changes the `azure` region functionality to use the `getLocation` logic that was previously done on demand per resource.

---

Adds a resource specific `GetRegion` property to the `RegistryItem` which
can be used to override the provider default functionality for fetching a
region for a resource.

Changes usage of `lookupRegion` functions in azure resources to use the new
`ResourceData.Region` property which is computed before evaluation.

Changes the `ResourceRegistryMap` to no longer use a `sync.Once` and instead be
built as a singleton `var`. This removes the sync requirement as callers only read
from this map.