### PR TITLE
chore: Update AWS EKS Cluster resource tests

### DIFF
--- a/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
@@ -11,7 +11,7 @@
  └─ EKS cluster (extended support)                 730  hours       $438.00   
                                                                               
  aws_eks_cluster.extended_support["1.26"]                                     
- └─ EKS cluster                                    730  hours        $73.00   
+ └─ EKS cluster (extended support)                 730  hours       $438.00   
                                                                               
  aws_eks_cluster.extended_support["1.27"]                                     
  └─ EKS cluster                                    730  hours        $73.00   
@@ -25,7 +25,7 @@
  aws_eks_cluster.my_aws_eks_cluster                                           
  └─ EKS cluster                                    730  hours        $73.00   
                                                                               
- OVERALL TOTAL                                                   $1,679.00 
+ OVERALL TOTAL                                                   $2,044.00 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -36,5 +36,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃ $1,679        ┃ $0.00       ┃ $1,679     ┃
+┃ main                                               ┃ $2,044        ┃ $0.00       ┃ $2,044     ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛


### PR DESCRIPTION
v1.26 is on extended support since June 11th 2024.