### PR TITLE
fix: fixup more resources to use `GetRegion` method

### DIFF
--- a/internal/providers/terraform/aws/cloudfront_distribution.go
+++ b/internal/providers/terraform/aws/cloudfront_distribution.go
@@ -13,6 +13,14 @@ func getCloudfrontDistributionRegistryItem() *schema.RegistryItem {
 			"origin.0.domain_name",
 			"origin.0.origin_id",
 		},
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			orignShieldRegion := d.Get("origin.0.origin_shield.0.origin_shield_region").String()
+			if orignShieldRegion != "" {
+				return orignShieldRegion
+			}
+
+			return defaultRegion
+		},
 	}
 }
 func newCloudfrontDistribution(d *schema.ResourceData) schema.CoreResource {

--- a/internal/providers/terraform/aws/dx_gateway_association.go
+++ b/internal/providers/terraform/aws/dx_gateway_association.go
@@ -10,6 +10,17 @@ func getDXGatewayAssociationRegistryItem() *schema.RegistryItem {
 		Name:                "aws_dx_gateway_association",
 		CoreRFunc:           NewDXGatewayAssociation,
 		ReferenceAttributes: []string{"associated_gateway_id"},
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			assocGateway := d.References("associated_gateway_id")
+			if len(assocGateway) > 0 {
+				region := assocGateway[0].Get("region").String()
+				if region != "" {
+					return region
+				}
+			}
+
+			return defaultRegion
+		},
 	}
 }
 func NewDXGatewayAssociation(d *schema.ResourceData) schema.CoreResource {

--- a/internal/providers/terraform/aws/ec2_transit_gateway_peering_attachment.go
+++ b/internal/providers/terraform/aws/ec2_transit_gateway_peering_attachment.go
@@ -12,6 +12,17 @@ func getEC2TransitGatewayPeeringAttachmentRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"transit_gateway_id",
 		},
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			transitGatewayRefs := d.References("transit_gateway_id")
+			if len(transitGatewayRefs) > 0 {
+				region := transitGatewayRefs[0].Get("region").String()
+				if region != "" {
+					return region
+				}
+			}
+
+			return defaultRegion
+		},
 	}
 }
 func NewEC2TransitGatewayPeeringAttachment(d *schema.ResourceData) schema.CoreResource {

--- a/internal/providers/terraform/aws/ec2_transit_gateway_vpc_attachment.go
+++ b/internal/providers/terraform/aws/ec2_transit_gateway_vpc_attachment.go
@@ -15,6 +15,28 @@ func getEC2TransitGatewayVpcAttachmentRegistryItem() *schema.RegistryItem {
 			"transit_gateway_id",
 			"vpc_id",
 		},
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			var region string
+			vpcRefs := d.References("vpc_id")
+			for _, ref := range vpcRefs {
+				if strings.ToLower(ref.Type) == "aws_default_vpc" || strings.ToLower(ref.Type) == "aws_vpc" {
+					region = ref.Get("region").String()
+					break
+				}
+			}
+
+			// Try to get the region from the transit gateway
+			transitGatewayRefs := d.References("transit_gateway_id")
+			if len(transitGatewayRefs) > 0 {
+				region = transitGatewayRefs[0].Get("region").String()
+			}
+
+			if region != "" {
+				return region
+			}
+
+			return defaultRegion
+		},
 	}
 }
 func NewEc2TransitGatewayVpcAttachment(d *schema.ResourceData) schema.CoreResource {

--- a/internal/providers/terraform/azure/app_service_certificate_binding.go
+++ b/internal/providers/terraform/azure/app_service_certificate_binding.go
@@ -12,7 +12,7 @@ func getAppServiceCertificateBindingRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"certificate_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"certificate_id"})
 		},
 	}

--- a/internal/providers/terraform/azure/cognitive_deployment.go
+++ b/internal/providers/terraform/azure/cognitive_deployment.go
@@ -14,7 +14,7 @@ func getCognitiveDeploymentRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"cognitive_account_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			region := lookupRegion(d, []string{"cognitive_account_id"})
 
 			cognitiveAccountRefs := d.References("cognitive_account_id")

--- a/internal/providers/terraform/azure/cosmosdb_cassandra_keyspace.go
+++ b/internal/providers/terraform/azure/cosmosdb_cassandra_keyspace.go
@@ -19,7 +19,7 @@ func GetAzureRMCosmosdbCassandraKeyspaceRegistryItem() *schema.RegistryItem {
 			"account_name",
 			"resource_group_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			if len(d.References("account_name")) > 0 {
 				account := d.References("account_name")[0]
 				return lookupRegion(account, []string{"account_name", "resource_group_name"})

--- a/internal/providers/terraform/azure/data_factory_integration_runtime_azure.go
+++ b/internal/providers/terraform/azure/data_factory_integration_runtime_azure.go
@@ -14,7 +14,7 @@ func getDataFactoryIntegrationRuntimeAzureRegistryItem() *schema.RegistryItem {
 			"data_factory_name",
 			"resource_group_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			region := lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
 
 			dataFactoryIdRefs := d.References("data_factory_id")

--- a/internal/providers/terraform/azure/data_factory_integration_runtime_azure_ssis.go
+++ b/internal/providers/terraform/azure/data_factory_integration_runtime_azure_ssis.go
@@ -16,7 +16,7 @@ func getDataFactoryIntegrationRuntimeAzureSSISRegistryItem() *schema.RegistryIte
 			"data_factory_name",
 			"resource_group_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			region := lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
 
 			dataFactoryIdRefs := d.References("data_factory_id")

--- a/internal/providers/terraform/azure/data_factory_integration_runtime_managed.go
+++ b/internal/providers/terraform/azure/data_factory_integration_runtime_managed.go
@@ -19,7 +19,7 @@ func getDataFactoryIntegrationRuntimeManagedRegistryItem() *schema.RegistryItem 
 			"data_factory_name",
 			"resource_group_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			region := lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
 
 			dataFactoryIdRefs := d.References("data_factory_id")

--- a/internal/providers/terraform/azure/data_factory_integration_runtime_self_hosted.go
+++ b/internal/providers/terraform/azure/data_factory_integration_runtime_self_hosted.go
@@ -14,7 +14,7 @@ func getDataFactoryIntegrationRuntimeSelfHostedRegistryItem() *schema.RegistryIt
 			"data_factory_name",
 			"resource_group_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			region := lookupRegion(d, []string{"resource_group_name", "data_factory_id", "data_factory_name"})
 
 			dataFactoryIdRefs := d.References("data_factory_id")

--- a/internal/providers/terraform/azure/key_vault_certificate.go
+++ b/internal/providers/terraform/azure/key_vault_certificate.go
@@ -16,7 +16,7 @@ func GetAzureRMKeyVaultCertificateRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"key_vault_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"key_vault_id"})
 		},
 	}

--- a/internal/providers/terraform/azure/key_vault_key.go
+++ b/internal/providers/terraform/azure/key_vault_key.go
@@ -20,7 +20,7 @@ func GetAzureRMKeyVaultKeyRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"key_vault_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"key_vault_id"})
 		},
 	}

--- a/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
+++ b/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
@@ -16,7 +16,7 @@ func getKubernetesClusterNodePoolRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"kubernetes_cluster_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"kubernetes_cluster_id"})
 		},
 	}

--- a/internal/providers/terraform/azure/lb_outbound_rule.go
+++ b/internal/providers/terraform/azure/lb_outbound_rule.go
@@ -14,7 +14,7 @@ func GetAzureRMLoadBalancerOutboundRuleRegistryItem() *schema.RegistryItem {
 			"loadbalancer_id",
 			"resource_group_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"loadbalancer_id", "resource_group_name"})
 		},
 	}

--- a/internal/providers/terraform/azure/lb_rule.go
+++ b/internal/providers/terraform/azure/lb_rule.go
@@ -16,7 +16,7 @@ func GetAzureRMLoadBalancerRuleRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"loadbalancer_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"loadbalancer_id"})
 		},
 	}

--- a/internal/providers/terraform/azure/monitor_diagnostic_setting.go
+++ b/internal/providers/terraform/azure/monitor_diagnostic_setting.go
@@ -12,7 +12,7 @@ func getMonitorDiagnosticSettingRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"target_resource_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"target_resource_id"})
 		},
 	}

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -56,7 +56,7 @@ func getMSSQLDatabaseRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"server_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"server_id"})
 		},
 	}

--- a/internal/providers/terraform/azure/mssql_elasticpool.go
+++ b/internal/providers/terraform/azure/mssql_elasticpool.go
@@ -18,7 +18,7 @@ func getMSSQLElasticPoolRegistryItem() *schema.RegistryItem {
 			"server_name",
 			"resource_group_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"server_name", "resource_group_name"})
 		},
 	}

--- a/internal/providers/terraform/azure/sql_elasticpool.go
+++ b/internal/providers/terraform/azure/sql_elasticpool.go
@@ -16,7 +16,7 @@ func getSQLElasticPoolRegistryItem() *schema.RegistryItem {
 			"server_name",
 			"resource_group_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"server_name", "resource_group_name"})
 		},
 	}

--- a/internal/providers/terraform/azure/storage_queue.go
+++ b/internal/providers/terraform/azure/storage_queue.go
@@ -15,7 +15,7 @@ func getStorageQueueRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"storage_account_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"storage_account_name"})
 		},
 	}

--- a/internal/providers/terraform/azure/storage_share.go
+++ b/internal/providers/terraform/azure/storage_share.go
@@ -15,7 +15,7 @@ func getStorageShareRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"storage_account_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"storage_account_name"})
 		},
 	}

--- a/internal/providers/terraform/azure/synapse_spark_pool.go
+++ b/internal/providers/terraform/azure/synapse_spark_pool.go
@@ -18,7 +18,7 @@ func GetAzureRMSynapseSparkPoolRegistryItem() *schema.RegistryItem {
 			"synapse_workspace_id",
 		},
 		Notes: []string{"the total costs consist of several resources that should be viewed as a whole"},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"synapse_workspace_id"})
 		},
 	}

--- a/internal/providers/terraform/azure/synapse_sql_pool.go
+++ b/internal/providers/terraform/azure/synapse_sql_pool.go
@@ -17,7 +17,7 @@ func GetAzureRMSynapseSQLPoolRegistryItem() *schema.RegistryItem {
 			"synapse_workspace_id",
 		},
 		Notes: []string{"the total costs consist of several resources that should be viewed as a whole"},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"synapse_workspace_id"})
 		},
 	}

--- a/internal/providers/terraform/azure/traffic_manager_azure_endpoint.go
+++ b/internal/providers/terraform/azure/traffic_manager_azure_endpoint.go
@@ -12,7 +12,7 @@ func getTrafficManagerAzureEndpointRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"profile_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			if len(d.References("profile_id")) > 0 {
 				profile := d.References("profile_id")[0]
 				return lookupRegion(profile, []string{"resource_group_name"})

--- a/internal/providers/terraform/azure/traffic_manager_external_endpoint.go
+++ b/internal/providers/terraform/azure/traffic_manager_external_endpoint.go
@@ -12,7 +12,7 @@ func getTrafficManagerExternalEndpointRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"profile_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			if len(d.References("profile_id")) > 0 {
 				profile := d.References("profile_id")[0]
 				return lookupRegion(profile, []string{"resource_group_name"})

--- a/internal/providers/terraform/azure/traffic_manager_nested_endpoint.go
+++ b/internal/providers/terraform/azure/traffic_manager_nested_endpoint.go
@@ -12,7 +12,7 @@ func getTrafficManagerNestedEndpointRegistryItem() *schema.RegistryItem {
 		ReferenceAttributes: []string{
 			"profile_id",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			if len(d.References("profile_id")) > 0 {
 				profile := d.References("profile_id")[0]
 				return lookupRegion(profile, []string{"resource_group_name"})

--- a/internal/providers/terraform/azure/virtual_network_peering.go
+++ b/internal/providers/terraform/azure/virtual_network_peering.go
@@ -16,7 +16,7 @@ func getVirtualNetworkPeeringRegistryItem() *schema.RegistryItem {
 			"remote_virtual_network_id",
 			"resource_group_name",
 		},
-		GetRegion: func(d *schema.ResourceData) string {
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
 			return lookupRegion(d, []string{"virtual_network_name"})
 		},
 	}

--- a/internal/providers/terraform/google/artifact_registry_repository.go
+++ b/internal/providers/terraform/google/artifact_registry_repository.go
@@ -9,24 +9,29 @@ func getArtifactRegistryRepositoryRegistryItem() *schema.RegistryItem {
 	return &schema.RegistryItem{
 		Name:      "google_artifact_registry_repository",
 		CoreRFunc: newArtifactRegistryRepository,
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			region := d.Get("region").String()
+
+			zone := d.Get("zone").String()
+			if zone != "" {
+				region = zoneToRegion(zone)
+			}
+
+			location := d.Get("location").String()
+			if location != "" {
+				region = location
+			}
+
+			return region
+		},
 	}
 }
 
 func newArtifactRegistryRepository(d *schema.ResourceData) schema.CoreResource {
-	region := d.Get("region").String()
-	zone := d.Get("zone").String()
-	if zone != "" {
-		region = zoneToRegion(zone)
-	}
-
-	location := d.Get("location").String()
-	if location != "" {
-		region = location
-	}
-
 	r := &google.ArtifactRegistryRepository{
 		Address: d.Address,
-		Region:  region,
+		Region:  d.Region,
 	}
+
 	return r
 }

--- a/internal/providers/terraform/google/compute_disk.go
+++ b/internal/providers/terraform/google/compute_disk.go
@@ -12,17 +12,20 @@ func getComputeDiskRegistryItem() *schema.RegistryItem {
 		Name:                "google_compute_disk",
 		CoreRFunc:           newComputeDisk,
 		ReferenceAttributes: []string{"image", "snapshot"},
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			region := d.Get("region").String()
+
+			zone := d.Get("zone").String()
+			if zone != "" {
+				region = zoneToRegion(zone)
+			}
+
+			return region
+		},
 	}
 }
 
 func newComputeDisk(d *schema.ResourceData) schema.CoreResource {
-	region := d.Get("region").String()
-
-	zone := d.Get("zone").String()
-	if zone != "" {
-		region = zoneToRegion(zone)
-	}
-
 	diskType := d.Get("type").String()
 	size := computeDiskSize(d)
 
@@ -30,7 +33,7 @@ func newComputeDisk(d *schema.ResourceData) schema.CoreResource {
 
 	r := &google.ComputeDisk{
 		Address: d.Address,
-		Region:  region,
+		Region:  d.Region,
 		Type:    diskType,
 		Size:    size,
 		IOPS:    iops,

--- a/internal/providers/terraform/google/compute_instance.go
+++ b/internal/providers/terraform/google/compute_instance.go
@@ -20,19 +20,24 @@ func getComputeInstanceRegistryItem() *schema.RegistryItem {
 			"Custom machine types are not supported.",
 			"Sole-tenant VMs are not supported.",
 		},
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			region := d.Get("region").String()
+
+			zone := d.Get("zone").String()
+			if zone != "" {
+				region = zoneToRegion(zone)
+			}
+
+			return region
+		},
 	}
 }
 
 func newComputeInstance(d *schema.ResourceData) schema.CoreResource {
 	machineType := d.Get("machine_type").String()
 
-	region := d.Get("region").String()
+	region := d.Region
 	size := int64(1)
-
-	zone := d.Get("zone").String()
-	if zone != "" {
-		region = zoneToRegion(zone)
-	}
 
 	purchaseOption := getComputePurchaseOption(d.RawValues)
 

--- a/internal/providers/terraform/google/compute_instance_group_manager.go
+++ b/internal/providers/terraform/google/compute_instance_group_manager.go
@@ -14,16 +14,20 @@ func getComputeInstanceGroupManagerRegistryItem() *schema.RegistryItem {
 		CustomRefIDFunc: func(d *schema.ResourceData) []string {
 			return []string{d.Get("name").String()}
 		},
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			var region string
+
+			zone := d.Get("zone").String()
+			if zone != "" {
+				region = zoneToRegion(zone)
+			}
+
+			return region
+		},
 	}
 }
 
 func newComputeInstanceGroupManager(d *schema.ResourceData) schema.CoreResource {
-	var region string
-	zone := d.Get("zone").String()
-	if zone != "" {
-		region = zoneToRegion(zone)
-	}
-
 	targetSize := int64(1)
 	if d.Get("target_size").Exists() {
 		targetSize = d.Get("target_size").Int()
@@ -72,7 +76,7 @@ func newComputeInstanceGroupManager(d *schema.ResourceData) schema.CoreResource 
 
 	r := &google.ComputeInstanceGroupManager{
 		Address:           d.Address,
-		Region:            region,
+		Region:            d.Region,
 		MachineType:       machineType,
 		PurchaseOption:    purchaseOption,
 		TargetSize:        targetSize,

--- a/internal/providers/terraform/google/container_cluster.go
+++ b/internal/providers/terraform/google/container_cluster.go
@@ -30,16 +30,22 @@ func getContainerClusterRegistryItem() *schema.RegistryItem {
 			"Costs associated with non-standard Linux images, such as Windows and RHEL are not supported.",
 			"Custom machine types are not supported.",
 		},
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			region := d.Get("location").String()
+			isZone := isZone(region)
+
+			if isZone {
+				region = zoneToRegion(region)
+			}
+
+			return region
+		},
 	}
 }
 
 func newContainerCluster(d *schema.ResourceData) schema.CoreResource {
-	region := d.Get("location").String()
+	region := d.Region
 	isZone := isZone(region)
-
-	if isZone {
-		region = zoneToRegion(region)
-	}
 
 	autopilotEnabled := d.Get("enable_autopilot").Bool()
 

--- a/internal/providers/terraform/google/container_node_pool.go
+++ b/internal/providers/terraform/google/container_node_pool.go
@@ -20,6 +20,29 @@ func getContainerNodePoolRegistryItem() *schema.RegistryItem {
 			"Costs associated with non-standard Linux images, such as Windows and RHEL are not supported.",
 			"Custom machine types are not supported.",
 		},
+		GetRegion: func(defaultRegion string, d *schema.ResourceData) string {
+			var location string
+
+			var cluster *schema.ResourceData
+			if len(d.References("cluster")) > 0 {
+				cluster = d.References("cluster")[0]
+			}
+
+			if cluster != nil {
+				location = cluster.Get("location").String()
+			}
+
+			if d.Get("location").String() != "" {
+				location = d.Get("location").String()
+			}
+
+			region := location
+			if isZone(location) {
+				region = zoneToRegion(location)
+			}
+
+			return region
+		},
 	}
 }
 

--- a/internal/schema/registry_item.go
+++ b/internal/schema/registry_item.go
@@ -9,7 +9,7 @@ type CloudResourceIDFunc func(d *ResourceData) []string
 // RegionLookupFunc is used to look up the region of a resource, this is used to
 // calculate the region of a resource if the region requires a lookup from
 // reference attributes.
-type RegionLookupFunc func(d *ResourceData) string
+type RegionLookupFunc func(defaultRegion string, d *ResourceData) string
 
 type RegistryItem struct {
 	Name                string


### PR DESCRIPTION
Adds support for more resources to use the `GetRegion` method. This function defines a resource specific way of fetching the "region" data. I've changed the signature of the method so that it we fetch the default region first and pass this to the more specific resource function.