### PR TITLE
fix: Take PITR enabled into account

### DIFF
--- a/cmd/infracost/testdata/breakdown_with_actual_costs_pitr_disabled/breakdown_with_actual_costs_pitr_disabled.golden
+++ b/cmd/infracost/testdata/breakdown_with_actual_costs_pitr_disabled/breakdown_with_actual_costs_pitr_disabled.golden
@@ -1,0 +1,33 @@
+Project: main
+
+ Name                                                            Monthly Qty  Unit   Monthly Cost    
+                                                                                                     
+ aws_dynamodb_table.usage                                                                            
+ ├─ Write request unit (WRU)                                         100,000  WRUs          $0.13  * 
+ ├─ Read request unit (RRU)                                          100,001  RRUs          $0.03  * 
+ ├─ Data storage                                                     100,002  GB       $25,000.50  * 
+ ├─ On-demand backup storage                                         100,004  GB       $10,000.40  * 
+ ├─ Table data restored                                              100,005  GB       $15,000.75  * 
+ └─ Streams read request unit (sRRU)                                 100,006  sRRUs         $0.02  * 
+ ├─ Actual costs Sep 15-22 (arn:aws_dynamodb_table)                                                  
+    ├─ $0.005123 per some aws thing                                    1,000  GB            $5.12    
+    └─ $0.045 per some other aws thing                                 1,000  GB           $45.00    
+ └─ Actual costs Aug 15-Sep 22 (arn:another_aws_dynamodb_table)                                      
+    └─ $0.005123 per some aws thing                                    1,000  GB            $5.12    
+                                                                                                     
+ OVERALL TOTAL                                                                         $50,001.82 
+
+*Usage costs were estimated using Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+1 cloud resource was detected:
+∙ 1 was estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ main                                               ┃ $0.00         ┃ $50,002     ┃ $50,002    ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_actual_costs_pitr_disabled/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_actual_costs_pitr_disabled/main.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+resource "aws_dynamodb_table" "usage" {
+  name         = "usage"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "usageValue"
+
+  point_in_time_recovery {
+    enabled = disabled
+  }
+}

--- a/internal/providers/terraform/aws/dynamodb_table.go
+++ b/internal/providers/terraform/aws/dynamodb_table.go
@@ -40,6 +40,13 @@ func NewDynamoDBTableResource(d *schema.ResourceData) schema.CoreResource {
 		targets = append(targets, newAppAutoscalingTarget(ref, ref.UsageData))
 	}
 
+	pitr := &aws.PointInTimeRecovery{Enabled: false}
+	if d.Get("point_in_time_recovery").Exists() {
+		pitr = &aws.PointInTimeRecovery{
+			Enabled: d.Get("point_in_time_recovery").Array()[0].Get("enabled").Bool(),
+		}
+	}
+
 	a := &aws.DynamoDBTable{
 		Address:              d.Address,
 		Region:               d.Get("region").String(),
@@ -49,6 +56,7 @@ func NewDynamoDBTableResource(d *schema.ResourceData) schema.CoreResource {
 		ReadCapacity:         intPtr(d.Get("read_capacity").Int()),
 		ReplicaRegions:       replicaRegions,
 		AppAutoscalingTarget: targets,
+		PointInTypeRecovery:  pitr,
 	}
 	return a
 }

--- a/internal/resources/aws/dynamodb_table.go
+++ b/internal/resources/aws/dynamodb_table.go
@@ -11,6 +11,10 @@ import (
 	"github.com/infracost/infracost/internal/usage/aws"
 )
 
+type PointInTimeRecovery struct {
+	Enabled bool `infracost_usage:"enabled"`
+}
+
 type DynamoDBTable struct {
 	// "required" args that can't really be missing.
 	Address        string
@@ -24,6 +28,7 @@ type DynamoDBTable struct {
 	ReadCapacity  *int64
 
 	AppAutoscalingTarget []*AppAutoscalingTarget
+	PointInTypeRecovery  *PointInTimeRecovery
 
 	// "usage" args
 	MonthlyWriteRequestUnits       *int64 `infracost_usage:"monthly_write_request_units"`
@@ -101,7 +106,10 @@ func (a *DynamoDBTable) BuildResource() *schema.Resource {
 	// Data storage
 	costComponents = append(costComponents, a.dataStorageCostComponent(a.Region, a.StorageGB))
 	// Continuous backups (PITR)
-	costComponents = append(costComponents, a.continuousBackupCostComponent(a.Region, a.PitrBackupStorageGB))
+	if a.PointInTypeRecovery.Enabled {
+		costComponents = append(costComponents, a.continuousBackupCostComponent(a.Region, a.PitrBackupStorageGB))
+	}
+
 	// OnDemand backups
 	costComponents = append(costComponents, a.onDemandBackupCostComponent(a.Region, a.OnDemandBackupStorageGB))
 	// Restoring tables


### PR DESCRIPTION
Update the DynamoDB resource to read the `point_in_time_recovery` block
to ensure that it is enabled so PITR costs aren't inadvertently added to
the cost estimate.

Add test to validate
