### PR TITLE
refactor: use global logger

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -258,7 +258,7 @@ func (r *parallelRunner) run() ([]projectResult, error) {
 			m := fmt.Sprintf("%s\n\n", err)
 			m += fmt.Sprintf("  Try adding a config-file to configure how Infracost should run. See %s for details and examples.", ui.LinkString("https://infracost.io/config-file"))
 
-			queue = append(queue, projectJob{index: i, err: schema.NewEmptyPathTypeError(errors.New(m)), ctx: config.NewProjectContext(r.runCtx, p, map[string]interface{}{})})
+			queue = append(queue, projectJob{index: i, err: schema.NewEmptyPathTypeError(errors.New(m)), ctx: config.NewProjectContext(r.runCtx, p)})
 			i++
 			continue
 		}

--- a/internal/apiclient/dashboard.go
+++ b/internal/apiclient/dashboard.go
@@ -69,7 +69,7 @@ type projectResultInput struct {
 
 func NewDashboardAPIClient(ctx *config.RunContext) *DashboardAPIClient {
 	client := retryablehttp.NewClient()
-	client.Logger = &LeveledLogger{Logger: logging.Logger.With().Str("library", "retryablehttp").Logger()}
+	client.Logger = &LeveledLogger{Logger: logging.Logger}
 
 	return &DashboardAPIClient{
 		APIClient: APIClient{

--- a/internal/apiclient/policy.go
+++ b/internal/apiclient/policy.go
@@ -29,7 +29,7 @@ type PolicyAPIClient struct {
 // NewPolicyAPIClient retrieves resource allow-list info from Infracost Cloud and returns a new policy client
 func NewPolicyAPIClient(ctx *config.RunContext) (*PolicyAPIClient, error) {
 	client := retryablehttp.NewClient()
-	client.Logger = &LeveledLogger{Logger: logging.Logger.With().Str("library", "retryablehttp").Logger()}
+	client.Logger = &LeveledLogger{Logger: logging.Logger}
 	c := PolicyAPIClient{
 		APIClient: APIClient{
 			httpClient: client.StandardClient(),

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -130,7 +130,7 @@ func NewPricingAPIClient(ctx *config.RunContext) *PricingAPIClient {
 	}
 
 	client := retryablehttp.NewClient()
-	client.Logger = &LeveledLogger{Logger: logging.Logger.With().Str("library", "retryablehttp").Logger()}
+	client.Logger = &LeveledLogger{Logger: logging.Logger}
 	client.HTTPClient.Transport.(*http.Transport).TLSClientConfig = &tlsConfig
 	client.HTTPClient.Timeout = time.Second * 30
 

--- a/internal/extclient/authed_client.go
+++ b/internal/extclient/authed_client.go
@@ -23,7 +23,7 @@ type AuthedAPIClient struct {
 // NewAuthedAPIClient returns a new API client.
 func NewAuthedAPIClient(host, token string) *AuthedAPIClient {
 	client := retryablehttp.NewClient()
-	client.Logger = &apiclient.LeveledLogger{Logger: logging.Logger.With().Str("library", "retryablehttp").Logger()}
+	client.Logger = &apiclient.LeveledLogger{Logger: logging.Logger}
 	client.HTTPClient.Timeout = time.Second * 30
 	return &AuthedAPIClient{
 		host:   host,

--- a/internal/hcl/context.go
+++ b/internal/hcl/context.go
@@ -4,17 +4,15 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/rs/zerolog"
 	"github.com/zclconf/go-cty/cty"
 )
 
 type Context struct {
 	ctx    *hcl.EvalContext
 	parent *Context
-	logger zerolog.Logger
 }
 
-func NewContext(ctx *hcl.EvalContext, parent *Context, logger zerolog.Logger) *Context {
+func NewContext(ctx *hcl.EvalContext, parent *Context) *Context {
 	if ctx.Variables == nil {
 		ctx.Variables = make(map[string]cty.Value)
 	}
@@ -22,12 +20,11 @@ func NewContext(ctx *hcl.EvalContext, parent *Context, logger zerolog.Logger) *C
 	return &Context{
 		ctx:    ctx,
 		parent: parent,
-		logger: logger,
 	}
 }
 
 func (c *Context) NewChild() *Context {
-	return NewContext(c.ctx.NewChild(), c, c.logger)
+	return NewContext(c.ctx.NewChild(), c)
 }
 
 func (c *Context) Parent() *Context {

--- a/internal/hcl/funcs/debug.go
+++ b/internal/hcl/funcs/debug.go
@@ -3,10 +3,11 @@ package funcs
 import (
 	"fmt"
 
-	"github.com/rs/zerolog"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	ctyJson "github.com/zclconf/go-cty/cty/json"
+
+	"github.com/infracost/infracost/internal/logging"
 )
 
 // PrintArgs prints any number of args to the std out using fmt.
@@ -72,7 +73,7 @@ func valueToBytes(v cty.Value) []byte {
 //
 //	time="2022-12-06T10:27:40Z" level=debug enable_cloud_org=false ... attribute_name=volume_size provider=terraform_dir block_name=root_block_device. sync_usage=false msg="fetching attribute value"
 //	time="2022-12-06T10:27:40Z" level=debug ... msg="terraform print "test":cty.StringVal(\"foo\")"
-func LogArgs(logger zerolog.Logger) function.Function {
+func LogArgs() function.Function {
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
 			{
@@ -92,7 +93,7 @@ func LogArgs(logger zerolog.Logger) function.Function {
 			return args[1].Type(), nil
 		},
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			logger.Debug().Msgf("terraform print %q:%s", args[0], args[1].GoString())
+			logging.Logger.Debug().Msgf("terraform print %q:%s", args[0], args[1].GoString())
 
 			return args[1], nil
 		},

--- a/internal/hcl/graph_vertex_data.go
+++ b/internal/hcl/graph_vertex_data.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rs/zerolog"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/infracost/infracost/internal/logging"
 )
 
 type VertexData struct {
-	logger        zerolog.Logger
 	moduleConfigs *ModuleConfigs
 	block         *Block
 }
@@ -83,7 +83,7 @@ func (v *VertexData) evaluate(e *Evaluator, b *Block) error {
 
 	val := e.evaluateResourceOrData(b, existingVals)
 
-	v.logger.Debug().Msgf("adding data %s to the evaluation context", v.ID())
+	logging.Logger.Trace().Msgf("adding data %s to the evaluation context", v.ID())
 	e.ctx.SetByDot(val, fmt.Sprintf("data.%s", b.TypeLabel()))
 
 	return nil

--- a/internal/hcl/graph_vertex_local.go
+++ b/internal/hcl/graph_vertex_local.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rs/zerolog"
+	"github.com/infracost/infracost/internal/logging"
 )
 
 type VertexLocal struct {
-	logger        zerolog.Logger
 	moduleConfigs *ModuleConfigs
 	block         *Block
 	attr          *Attribute
@@ -38,7 +37,7 @@ func (v *VertexLocal) Visit(mutex *sync.Mutex) error {
 	for _, moduleInstance := range moduleInstances {
 		e := moduleInstance.evaluator
 
-		v.logger.Debug().Msgf("adding attribute %s to the evaluation context", v.ID())
+		logging.Logger.Trace().Msgf("adding attribute %s to the evaluation context", v.ID())
 
 		var attrInstance *Attribute
 		for _, b := range e.module.Blocks {

--- a/internal/hcl/graph_vertex_module_call.go
+++ b/internal/hcl/graph_vertex_module_call.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/rs/zerolog"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/infracost/infracost/internal/logging"
 )
 
 var moduleCallArgs = []string{"source", "version", "for_each", "count", "providers", "depends_on", "lifecycle"}
@@ -30,7 +31,6 @@ func attrIsVarInput(name string) bool {
 }
 
 type VertexModuleCall struct {
-	logger        zerolog.Logger
 	moduleConfigs *ModuleConfigs
 	block         *Block
 }
@@ -85,7 +85,7 @@ func (v *VertexModuleCall) evaluate(e *Evaluator, b *Block, mutex *sync.Mutex) e
 		return fmt.Errorf("module block %s has no label", b.FullName())
 	}
 
-	v.logger.Debug().Msgf("adding module %s to the evaluation context", b.FullName())
+	logging.Logger.Trace().Msgf("adding module %s to the evaluation context", b.FullName())
 	e.ctx.SetByDot(b.Values(), b.LocalName())
 
 	return nil
@@ -125,7 +125,6 @@ func (v *VertexModuleCall) expand(e *Evaluator, b *Block, mutex *sync.Mutex) ([]
 			map[string]map[string]cty.Value{},
 			e.workspace,
 			e.blockBuilder,
-			e.logger,
 			e.isGraph,
 		)
 

--- a/internal/hcl/graph_vertex_module_exit.go
+++ b/internal/hcl/graph_vertex_module_exit.go
@@ -2,12 +2,9 @@ package hcl
 
 import (
 	"sync"
-
-	"github.com/rs/zerolog"
 )
 
 type VertexModuleExit struct {
-	logger        zerolog.Logger
 	moduleConfigs *ModuleConfigs
 	block         *Block
 }

--- a/internal/hcl/graph_vertex_output.go
+++ b/internal/hcl/graph_vertex_output.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rs/zerolog"
+	"github.com/infracost/infracost/internal/logging"
 )
 
 type VertexOutput struct {
-	logger        zerolog.Logger
 	moduleConfigs *ModuleConfigs
 	block         *Block
 }
@@ -51,7 +50,7 @@ func (v *VertexOutput) Visit(mutex *sync.Mutex) error {
 			return fmt.Errorf("could not evaluate output %s: %w", v.ID(), err)
 		}
 
-		v.logger.Debug().Msgf("adding output %s to the evaluation context", v.ID())
+		logging.Logger.Trace().Msgf("adding output %s to the evaluation context", v.ID())
 		e.ctx.SetByDot(val, key)
 
 		parentEvaluator := moduleInstance.parentEvaluator

--- a/internal/hcl/graph_vertex_provider.go
+++ b/internal/hcl/graph_vertex_provider.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rs/zerolog"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/infracost/infracost/internal/logging"
 )
 
 type VertexProvider struct {
-	logger        zerolog.Logger
 	moduleConfigs *ModuleConfigs
 	block         *Block
 }
@@ -66,7 +66,7 @@ func (v *VertexProvider) Visit(mutex *sync.Mutex) error {
 		// We don't care about the existing values, this is only needed by the legacy evaluator
 		val := e.evaluateProvider(blockInstance, map[string]cty.Value{})
 
-		v.logger.Debug().Msgf("adding %s to the evaluation context", v.ID())
+		logging.Logger.Trace().Msgf("adding %s to the evaluation context", v.ID())
 		e.ctx.SetByDot(val, blockInstance.Label())
 
 		e.AddFilteredBlocks(blockInstance)

--- a/internal/hcl/graph_vertex_resource.go
+++ b/internal/hcl/graph_vertex_resource.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rs/zerolog"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/infracost/infracost/internal/logging"
 )
 
 type VertexResource struct {
 	moduleConfigs *ModuleConfigs
-	logger        zerolog.Logger
 	block         *Block
 }
 
@@ -67,7 +67,7 @@ func (v *VertexResource) evaluate(e *Evaluator, b *Block) error {
 	// We don't care about the existing values, this is only needed by the legacy evaluator
 	val := e.evaluateResourceOrData(b, map[string]cty.Value{})
 
-	v.logger.Debug().Msgf("adding resource %s to the evaluation context", v.ID())
+	logging.Logger.Trace().Msgf("adding resource %s to the evaluation context", v.ID())
 	e.ctx.SetByDot(val, b.TypeLabel())
 
 	return nil

--- a/internal/hcl/graph_vertex_variable.go
+++ b/internal/hcl/graph_vertex_variable.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/rs/zerolog"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/infracost/infracost/internal/logging"
 )
 
 type VertexVariable struct {
-	logger        zerolog.Logger
 	moduleConfigs *ModuleConfigs
 	block         *Block
 }
@@ -62,7 +62,7 @@ func (v *VertexVariable) Visit(mutex *sync.Mutex) error {
 			return fmt.Errorf("could not evaluate variable %s: %w", v.ID(), err)
 		}
 
-		v.logger.Debug().Msgf("adding variable %s to the evaluation context", v.ID())
+		logging.Logger.Trace().Msgf("adding variable %s to the evaluation context", v.ID())
 		key := fmt.Sprintf("var.%s", blockInstance.Label())
 		e.ctx.SetByDot(val, key)
 

--- a/internal/hcl/modules/cache.go
+++ b/internal/hcl/modules/cache.go
@@ -7,7 +7,8 @@ import (
 
 	goversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
-	"github.com/rs/zerolog"
+
+	"github.com/infracost/infracost/internal/logging"
 )
 
 // Cache is a cache of modules that can be used to lookup modules to check if they've already been loaded.
@@ -20,14 +21,12 @@ import (
 type Cache struct {
 	keyMap sync.Map
 	disco  *Disco
-	logger zerolog.Logger
 }
 
 // NewCache creates a new cache from a module manifest
-func NewCache(disco *Disco, logger zerolog.Logger) *Cache {
+func NewCache(disco *Disco) *Cache {
 	return &Cache{
-		disco:  disco,
-		logger: logger,
+		disco: disco,
 	}
 }
 
@@ -72,7 +71,7 @@ func (c *Cache) lookupModule(key string, moduleCall *tfconfig.ModuleCall) (*Mani
 
 	url, _, err := c.disco.ModuleLocation(moduleCall.Source)
 	if err != nil {
-		c.logger.Debug().Err(err).Msgf("could not fetch module location from source. Proceeding as if source has changed.")
+		logging.Logger.Debug().Err(err).Msgf("could not fetch module location from source. Proceeding as if source has changed.")
 	}
 
 	if manifestModule.Source == url.Location {

--- a/internal/hcl/modules/cache_test.go
+++ b/internal/hcl/modules/cache_test.go
@@ -43,7 +43,7 @@ func TestLookupModule(t *testing.T) {
 	logger := zerolog.New(io.Discard)
 
 	cache := &Cache{
-		disco:  NewDisco(nil, logger),
+		disco:  NewDisco(nil),
 		logger: logger,
 	}
 

--- a/internal/hcl/modules/fetch.go
+++ b/internal/hcl/modules/fetch.go
@@ -10,7 +10,6 @@ import (
 
 	getter "github.com/hashicorp/go-getter"
 	"github.com/otiai10/copy"
-	"github.com/rs/zerolog"
 
 	"github.com/infracost/infracost/internal/logging"
 )
@@ -18,15 +17,12 @@ import (
 // PackageFetcher downloads modules from a remote source to the given destination
 // This supports all the non-local and non-Terraform registry sources listed here: https://www.terraform.io/language/modules/sources
 type PackageFetcher struct {
-	cache  sync.Map
-	logger zerolog.Logger
+	cache sync.Map
 }
 
 // NewPackageFetcher constructs a new package fetcher
-func NewPackageFetcher(logger zerolog.Logger) *PackageFetcher {
-	return &PackageFetcher{
-		logger: logger,
-	}
+func NewPackageFetcher() *PackageFetcher {
+	return &PackageFetcher{}
 }
 
 // fetch downloads the remote module using the go-getter library
@@ -35,7 +31,7 @@ func (r *PackageFetcher) fetch(moduleAddr string, dest string) error {
 	if v, ok := r.cache.Load(moduleAddr); ok {
 		prevDest, _ := v.(string)
 
-		r.logger.Debug().Msgf("module %s already downloaded, copying from '%s' to '%s'", moduleAddr, prevDest, dest)
+		logging.Logger.Trace().Msgf("module %s already downloaded, copying from '%s' to '%s'", moduleAddr, prevDest, dest)
 
 		err := os.Mkdir(dest, os.ModePerm)
 		if err != nil {
@@ -67,7 +63,7 @@ func (r *PackageFetcher) fetch(moduleAddr string, dest string) error {
 		return true
 	})
 
-	r.logger.Debug().Strs("cached_module_addresses", cached).Msgf("module %s does not exist in cache, proceeding to download", moduleAddr)
+	logging.Logger.Trace().Strs("cached_module_addresses", cached).Msgf("module %s does not exist in cache, proceeding to download", moduleAddr)
 
 	decompressors := map[string]getter.Decompressor{}
 	for k, decompressor := range getter.Decompressors {

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -11,16 +11,6 @@ import (
 var (
 	// Logger is the global logger for the logging package. Callers should use this Logger
 	// to ensure that logging functionality is consistent across the Infracost codebase.
-	//
-	// It is advised to create child Loggers as needed and pass them into packages with
-	// relevant log metadata. This can be done by using the With method:
-	//
-	//		childLogger := logging.Logger.With().Str("additional", "field")
-	//		foo := MyStruct{Logger: childLogger}
-	//		foo.DoSomething()
-	//
-	// Child loggers will inherit the parent metadata fields, unless the child logger sets metadata
-	// field information with the same key. In this case child fields will overwrite the parent field.
 	Logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
 )
 

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -33,7 +33,7 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 
 	forceCLI := project.TerraformForceCLI
 	projectType := DetectProjectType(project.Path, forceCLI)
-	projectContext := config.NewProjectContext(ctx, project, nil)
+	projectContext := config.NewProjectContext(ctx, project)
 	if projectType != ProjectTypeAutodetect {
 		projectContext.ContextValues.SetValue("project_type", projectType)
 	}
@@ -87,7 +87,7 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 		locatorConfig.WorkingDirectory = ctx.Config.WorkingDirectory()
 	}
 
-	pl := hcl.NewProjectLocator(logging.Logger, locatorConfig)
+	pl := hcl.NewProjectLocator(locatorConfig)
 	rootPaths := pl.FindRootModules(project.Path)
 	if len(rootPaths) == 0 {
 		return &DetectionOutput{}, fmt.Errorf("could not detect path type for '%s'", project.Path)
@@ -95,7 +95,7 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 
 	var autoProviders []schema.Provider
 	for _, rootPath := range rootPaths {
-		detectedProjectContext := config.NewProjectContext(ctx, project, nil)
+		detectedProjectContext := config.NewProjectContext(ctx, project)
 		if rootPath.IsTerragrunt {
 			detectedProjectContext.ContextValues.SetValue("project_type", "terragrunt_dir")
 			autoProviders = append(autoProviders, terraform.NewTerragruntHCLProvider(rootPath, detectedProjectContext))

--- a/internal/providers/terraform/cmd.go
+++ b/internal/providers/terraform/cmd.go
@@ -60,14 +60,13 @@ func Cmd(opts *CmdOptions, args ...string) ([]byte, error) {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("TF_CLI_CONFIG_FILE=%s", opts.TerraformConfigFile))
 	}
 
-	subLogger := logging.Logger.With().Str("binary", "terraform").Logger().Level(zerolog.DebugLevel)
 	logWriter := &cmdLogWriter{
-		logger: subLogger,
+		logger: logging.Logger,
 		level:  zerolog.DebugLevel,
 	}
 
 	terraformLogWriter := &cmdLogWriter{
-		logger: subLogger,
+		logger: logging.Logger,
 		level:  zerolog.DebugLevel,
 	}
 

--- a/internal/providers/terraform/plan_json_provider.go
+++ b/internal/providers/terraform/plan_json_provider.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/rs/zerolog"
-
 	"github.com/infracost/infracost/internal/apiclient"
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/logging"
@@ -17,7 +15,6 @@ type PlanJSONProvider struct {
 	Path                 string
 	includePastResources bool
 	policyClient         *apiclient.PolicyAPIClient
-	logger               zerolog.Logger
 }
 
 func NewPlanJSONProvider(ctx *config.ProjectContext, includePastResources bool) *PlanJSONProvider {
@@ -35,7 +32,6 @@ func NewPlanJSONProvider(ctx *config.ProjectContext, includePastResources bool) 
 		Path:                 ctx.ProjectConfig.Path,
 		includePastResources: includePastResources,
 		policyClient:         policyClient,
-		logger:               ctx.Logger(),
 	}
 }
 
@@ -112,7 +108,7 @@ func (p *PlanJSONProvider) LoadResourcesFromSrc(usage schema.UsageMap, j []byte)
 	if p.policyClient != nil {
 		err := p.policyClient.UploadPolicyData(project, parsedConf.CurrentResourceDatas, parsedConf.PastResourceDatas)
 		if err != nil {
-			p.logger.Err(err).Msgf("Terraform project %s failed to upload policy data", project.Name)
+			logging.Logger.Debug().Err(err).Msgf("Terraform project %s failed to upload policy data", project.Name)
 		}
 	}
 


### PR DESCRIPTION
# User description
This change removes the use of child loggers with additional metadata. Additionally it changes log levels for a number of calls from Debug to Trace. These changes have been motivated for the following reasons:

1. Performance - investigation on certain large repos has identified that the `With` functionality to create child loggers is causing an alarming amount of allocations.
2. Debugging - The previous logging logic with attributes and metadata crammed into the `Debug` level was crazy to debug. In reality much of these lines should be `Trace`, and the additional attributes were not useful for filtering.

This change should simplify logging across the codebase, speed up some repos and aid in debugging.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Refactor the logging system by replacing child loggers with a global logger across the codebase. This change affects several components, including <code>DashboardAPIClient</code>, <code>PolicyAPIClient</code>, and <code>PricingAPIClient</code>, among others. The <code>NewProjectContext</code> function has been simplified by removing the logger parameter, and the logging level for certain messages has been adjusted from <code>Debug</code> to <code>Trace</code> to improve performance and debugging clarity. These modifications aim to reduce memory allocations and enhance the debugging process by streamlining log messages and levels.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/infracost/infracost/3125?tool=ast&topic=Log+Level+Adjustment>Log Level Adjustment</a>
        </td><td>Adjust log levels from <code>Debug</code> to <code>Trace</code> for certain messages to improve performance and debugging clarity.<details><summary>Modified files (19)</summary><ul><li>internal/providers/terraform/hcl_provider.go</li>
<li>internal/hcl/parser.go</li>
<li>internal/hcl/project_locator.go</li>
<li>internal/providers/terraform/terragrunt_hcl_provider.go</li>
<li>internal/hcl/modules/fetch.go</li>
<li>internal/hcl/modules/loader.go</li>
<li>internal/hcl/context.go</li>
<li>internal/providers/terraform/plan_json_provider.go</li>
<li>internal/providers/terraform/cmd.go</li>
<li>internal/logging/logger.go</li>
<li>internal/hcl/modules/cache.go</li>
<li>internal/hcl/block.go</li>
<li>internal/hcl/remote_variables_loader.go</li>
<li>internal/hcl/attribute.go</li>
<li>internal/providers/detect.go</li>
<li>internal/hcl/modules/registry.go</li>
<li>internal/hcl/graph.go</li>
<li>internal/hcl/evaluator.go</li>
<li>internal/hcl/funcs/debug.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>ali.scott@gmail.com</td><td>fix-fix-Spacelift-var-...</td><td>October 31, 2024</td></tr>
<tr><td>owen@infracost.io</td><td>fix-No-duplicate-depen...</td><td>October 23, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/infracost/infracost/3125?tool=ast&topic=Global+Logger+Refactor>Global Logger Refactor</a>
        </td><td>Refactor the logging system by replacing child loggers with a global logger across the codebase.<details><summary>Modified files (23)</summary><ul><li>internal/providers/terraform/hcl_provider.go</li>
<li>internal/hcl/parser.go</li>
<li>internal/hcl/project_locator.go</li>
<li>internal/providers/terraform/terragrunt_hcl_provider.go</li>
<li>internal/extclient/authed_client.go</li>
<li>internal/hcl/modules/fetch.go</li>
<li>internal/hcl/modules/loader.go</li>
<li>internal/hcl/context.go</li>
<li>internal/providers/terraform/plan_json_provider.go</li>
<li>internal/providers/terraform/cmd.go</li>
<li>internal/logging/logger.go</li>
<li>internal/hcl/modules/cache.go</li>
<li>internal/apiclient/dashboard.go</li>
<li>internal/hcl/block.go</li>
<li>internal/hcl/remote_variables_loader.go</li>
<li>internal/apiclient/policy.go</li>
<li>internal/hcl/attribute.go</li>
<li>internal/providers/detect.go</li>
<li>internal/hcl/modules/registry.go</li>
<li>internal/hcl/graph.go</li>
<li>internal/apiclient/pricing.go</li>
<li>internal/hcl/evaluator.go</li>
<li>internal/hcl/funcs/debug.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>ali.scott@gmail.com</td><td>fix-fix-Spacelift-var-...</td><td>October 31, 2024</td></tr>
<tr><td>liam@infracost.io</td><td>fix-Remove-.git-from-r...</td><td>October 31, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/infracost/infracost/3125?tool=ast&topic=Project+Context+Simplification>Project Context Simplification</a>
        </td><td>Simplify the <code>NewProjectContext</code> function by removing the logger parameter and related logic.<details><summary>Modified files (3)</summary><ul><li>internal/config/project_context.go</li>
<li>cmd/infracost/run.go</li>
<li>internal/providers/detect.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>ali.scott@gmail.com</td><td>enhance-support-comple...</td><td>August 12, 2024</td></tr>
<tr><td>hugorut@gmail.com</td><td>feat-add-spacelift-rem...</td><td>August 07, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @hugorut and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    