### PR TITLE
fix: use correct values for module calls

### DIFF
--- a/internal/apiclient/policy.go
+++ b/internal/apiclient/policy.go
@@ -233,9 +233,9 @@ func filterResource(rd *schema.ResourceData, al allowList) policy2Resource {
 	for _, c := range rd.Metadata["calls"].Array() {
 		mdCalls = append(mdCalls, policy2InfracostMetadataCall{
 			BlockName: c.Get("blockName").String(),
-			EndLine:   rd.Metadata["endLine"].Int(),
-			Filename:  rd.Metadata["filename"].String(),
-			StartLine: rd.Metadata["startLine"].Int(),
+			EndLine:   c.Get("endLine").Int(),
+			Filename:  c.Get("filename").String(),
+			StartLine: c.Get("startLine").Int(),
 		})
 	}
 


### PR DESCRIPTION
Fixes issue where parent values for filename and line numbers were being used for the `Calls` values of a block when sent to policy set API. Instead these values should come from the `ModuleMetadata` so that we can correctly infer the callstack.