### PR TITLE
Add more config template functions

### DIFF
--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -65,6 +65,8 @@ func NewParser(repoDir string, variables Variables) *Parser {
 		"trimPrefix": p.trimPrefix,
 		"trimSuffix": p.trimSuffix,
 		"replace":    p.replace,
+		"quote":      p.quote,
+		"squote":     p.squote,
 		"pathExists": p.pathExists,
 		"matchPaths": p.matchPaths,
 		"list":       p.list,
@@ -168,6 +170,30 @@ func (p *Parser) trimSuffix(s, suffix string) string {
 // replace returns s with all instances of old replaced by new.
 func (p *Parser) replace(s, old, new string) string {
 	return strings.ReplaceAll(s, old, new)
+}
+
+// quote wraps the provided strings in double quotes.
+// Taken from https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/strings.go#L83
+func (p *Parser) quote(str ...interface{}) string {
+	out := make([]string, 0, len(str))
+	for _, s := range str {
+		if s != nil {
+			out = append(out, fmt.Sprintf("%q", strval(s)))
+		}
+	}
+	return strings.Join(out, " ")
+}
+
+// squote wraps the provided strings in single quotes.
+// Taken from https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/strings.go#L93C1-L101C2
+func (p *Parser) squote(str ...interface{}) string {
+	out := make([]string, 0, len(str))
+	for _, s := range str {
+		if s != nil {
+			out = append(out, fmt.Sprintf("'%v'", s))
+		}
+	}
+	return strings.Join(out, " ")
 }
 
 // pathExists reports whether path is a subpath within base.
@@ -360,4 +386,21 @@ func isSubdirectory(base, target string) bool {
 	}
 
 	return !strings.HasPrefix(relPath, "..") && fileInfo.Mode()&os.ModeSymlink == 0
+}
+
+// strval returns the string representation of v.
+// Taken from https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/strings.go#L174
+func strval(v interface{}) string {
+	switch v := v.(type) {
+	case string:
+		return v
+	case []byte:
+		return string(v)
+	case error:
+		return v.Error()
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }

--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/infracost/infracost/internal/logging"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	pathToRegexp "github.com/soongo/path-to-regexp"
@@ -341,11 +342,12 @@ func (p *Parser) readFile(path string) string {
 
 // parseYaml decodes provided yaml contents and assigns decoded values into a
 // generic out value. This can be used as a simple object in the templates.
+// This returns an empty map if the yaml is invalid.
 func (p *Parser) parseYaml(contents string) map[string]interface{} {
 	var out map[string]interface{}
 	err := yaml.Unmarshal([]byte(contents), &out)
 	if err != nil {
-		panic(err)
+		logging.Logger.Error().Err(err).Msg("failed to unmarshal yaml when calling parseYaml in the config template")
 	}
 
 	return out
@@ -353,11 +355,12 @@ func (p *Parser) parseYaml(contents string) map[string]interface{} {
 
 // parseJson decodes the provided json contents and assigns decoded values into a
 // generic out value. This can be used as a simple object in the templates.
+// This returns an empty map if the json is invalid.
 func (p *Parser) parseJson(contents string) map[string]interface{} {
 	var out map[string]interface{}
 	err := jsoniter.Unmarshal([]byte(contents), &out)
 	if err != nil {
-		panic(err)
+		logging.Logger.Error().Err(err).Msg("failed to unmarshal json when calling parseJson in the config template")
 	}
 
 	return out

--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -62,6 +62,8 @@ func NewParser(repoDir string, variables Variables) *Parser {
 		"startsWith": p.startsWith,
 		"endsWith":   p.endsWith,
 		"contains":   p.contains,
+		"trimPrefix": p.trimPrefix,
+		"trimSuffix": p.trimSuffix,
 		"pathExists": p.pathExists,
 		"matchPaths": p.matchPaths,
 		"list":       p.list,
@@ -150,6 +152,16 @@ func (p *Parser) endsWith(s, suffix string) bool {
 // contains reports whether substr is within s.
 func (p *Parser) contains(s, substr string) bool {
 	return strings.Contains(s, substr)
+}
+
+// trimPrefix returns s without the provided prefix string.
+func (p *Parser) trimPrefix(s, prefix string) string {
+	return strings.TrimPrefix(s, prefix)
+}
+
+// trimSuffix returns s without the provided suffix string.
+func (p *Parser) trimSuffix(s, suffix string) string {
+	return strings.TrimSuffix(s, suffix)
 }
 
 // pathExists reports whether path is a subpath within base.

--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -64,6 +64,7 @@ func NewParser(repoDir string, variables Variables) *Parser {
 		"contains":   p.contains,
 		"trimPrefix": p.trimPrefix,
 		"trimSuffix": p.trimSuffix,
+		"replace":    p.replace,
 		"pathExists": p.pathExists,
 		"matchPaths": p.matchPaths,
 		"list":       p.list,
@@ -162,6 +163,11 @@ func (p *Parser) trimPrefix(s, prefix string) string {
 // trimSuffix returns s without the provided suffix string.
 func (p *Parser) trimSuffix(s, suffix string) string {
 	return strings.TrimSuffix(s, suffix)
+}
+
+// replace returns s with all instances of old replaced by new.
+func (p *Parser) replace(s, old, new string) string {
+	return strings.ReplaceAll(s, old, new)
 }
 
 // pathExists reports whether path is a subpath within base.


### PR DESCRIPTION
Adds some more config template functions.

Also updates the `parseJson` and `parseYaml` functions to not panic on errors. We don't want to stop the whole config template execution on this. It seems safer to log and not panic on these errors, since we shouldn't fail runs if we're unable to parse them. In the future if we want an option that does return error we can do what sprig does and create `mustParseYaml` and `mustParseJson` functions.