### PR TITLE
feat: Add Google provider default labels

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -827,6 +827,7 @@ func TestBreakdownWithPrivateHttpsModulePopulatesErrors(t *testing.T) {
 
 func TestBreakdownWithPrivateTerraformRegistryModulePopulatesErrors(t *testing.T) {
 	t.Setenv("INFRACOST_TERRAFORM_CLOUD_TOKEN", "badkey")
+	_ = os.MkdirAll(fmt.Sprintf(".infracost%cterraform_modules", os.PathSeparator), 0o600)
 
 	GoldenFileCommandTest(
 		t,

--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -827,7 +827,6 @@ func TestBreakdownWithPrivateHttpsModulePopulatesErrors(t *testing.T) {
 
 func TestBreakdownWithPrivateTerraformRegistryModulePopulatesErrors(t *testing.T) {
 	t.Setenv("INFRACOST_TERRAFORM_CLOUD_TOKEN", "badkey")
-	_ = os.MkdirAll(fmt.Sprintf(".infracost%cterraform_modules", os.PathSeparator), 0o600)
 
 	GoldenFileCommandTest(
 		t,

--- a/cmd/infracost/testdata/breakdown_format_json_with_tags_google/breakdown_format_json_with_tags_google.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags_google/breakdown_format_json_with_tags_google.golden
@@ -24,7 +24,7 @@
             "name": "google",
             "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
             "startLine": 1,
-            "endLine": 5
+            "endLine": 8
           }
         ]
       },
@@ -34,24 +34,27 @@
             "name": "google_compute_disk.gcd1",
             "resourceType": "google_compute_disk",
             "tags": {
+              "DefaultLabel": "this is a default label",
               "GoogleLabel": "compute-disk-label"
             },
-            "defaultTags": {},
+            "defaultTags": {
+              "DefaultLabel": "this is a default label"
+            },
             "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
                 {
                   "blockName": "google_compute_disk.gcd1",
-                  "endLine": 14,
+                  "endLine": 17,
                   "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-                  "startLine": 7
+                  "startLine": 10
                 }
               ],
               "checksum": "167438a6d3e64b8f75d1c0f7dcbf733ed65c24b40ce19d9d05c7c42ea070c947",
-              "endLine": 14,
+              "endLine": 17,
               "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-              "startLine": 7
+              "startLine": 10
             },
             "hourlyCost": "0.027397260273972604",
             "monthlyCost": "20",
@@ -71,23 +74,27 @@
           {
             "name": "google_compute_disk.gcd2",
             "resourceType": "google_compute_disk",
-            "tags": {},
-            "defaultTags": {},
+            "tags": {
+              "DefaultLabel": "this is a default label"
+            },
+            "defaultTags": {
+              "DefaultLabel": "this is a default label"
+            },
             "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
                 {
                   "blockName": "google_compute_disk.gcd2",
-                  "endLine": 19,
+                  "endLine": 22,
                   "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-                  "startLine": 16
+                  "startLine": 19
                 }
               ],
               "checksum": "37baa7cee7077135d1b2f8c8d323cb484fcbd5be11d5fe3caafe1783113d98a4",
-              "endLine": 19,
+              "endLine": 22,
               "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-              "startLine": 16
+              "startLine": 19
             },
             "hourlyCost": "0.02328767123287671",
             "monthlyCost": "17",
@@ -108,24 +115,27 @@
             "name": "google_sql_database_instance.gsdi",
             "resourceType": "google_sql_database_instance",
             "tags": {
+              "DefaultLabel": "this is a default label",
               "GoogleSettingsUserLabel": "sql-db-label"
             },
-            "defaultTags": {},
+            "defaultTags": {
+              "DefaultLabel": "this is a default label"
+            },
             "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
                 {
                   "blockName": "google_sql_database_instance.gsdi",
-                  "endLine": 39,
+                  "endLine": 42,
                   "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-                  "startLine": 29
+                  "startLine": 32
                 }
               ],
               "checksum": "7f1731430d3c956e3e11da3378aa13ccb98e19f5889054a196bff8a068ad7d1b",
-              "endLine": 39,
+              "endLine": 42,
               "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-              "startLine": 29
+              "startLine": 32
             },
             "hourlyCost": "0.022828767123287671",
             "monthlyCost": "16.665",
@@ -179,24 +189,27 @@
             "name": "google_monitoring_custom_service.gmcs",
             "resourceType": "google_monitoring_custom_service",
             "tags": {
+              "DefaultLabel": "this is a default label",
               "GoogleUserLabel": "monitoring-custom-service-label"
             },
-            "defaultTags": {},
+            "defaultTags": {
+              "DefaultLabel": "this is a default label"
+            },
             "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
                 {
                   "blockName": "google_monitoring_custom_service.gmcs",
-                  "endLine": 27,
+                  "endLine": 30,
                   "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-                  "startLine": 21
+                  "startLine": 24
                 }
               ],
               "checksum": "c08c94c3110cc1279d75209519a2c8446f94b9a2b4f1f37cd79123984a379911",
-              "endLine": 27,
+              "endLine": 30,
               "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-              "startLine": 21
+              "startLine": 24
             }
           }
         ],
@@ -210,24 +223,27 @@
             "name": "google_compute_disk.gcd1",
             "resourceType": "google_compute_disk",
             "tags": {
+              "DefaultLabel": "this is a default label",
               "GoogleLabel": "compute-disk-label"
             },
-            "defaultTags": {},
+            "defaultTags": {
+              "DefaultLabel": "this is a default label"
+            },
             "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
                 {
                   "blockName": "google_compute_disk.gcd1",
-                  "endLine": 14,
+                  "endLine": 17,
                   "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-                  "startLine": 7
+                  "startLine": 10
                 }
               ],
               "checksum": "167438a6d3e64b8f75d1c0f7dcbf733ed65c24b40ce19d9d05c7c42ea070c947",
-              "endLine": 14,
+              "endLine": 17,
               "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-              "startLine": 7
+              "startLine": 10
             },
             "hourlyCost": "0.027397260273972604",
             "monthlyCost": "20",
@@ -247,23 +263,27 @@
           {
             "name": "google_compute_disk.gcd2",
             "resourceType": "google_compute_disk",
-            "tags": {},
-            "defaultTags": {},
+            "tags": {
+              "DefaultLabel": "this is a default label"
+            },
+            "defaultTags": {
+              "DefaultLabel": "this is a default label"
+            },
             "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
                 {
                   "blockName": "google_compute_disk.gcd2",
-                  "endLine": 19,
+                  "endLine": 22,
                   "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-                  "startLine": 16
+                  "startLine": 19
                 }
               ],
               "checksum": "37baa7cee7077135d1b2f8c8d323cb484fcbd5be11d5fe3caafe1783113d98a4",
-              "endLine": 19,
+              "endLine": 22,
               "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-              "startLine": 16
+              "startLine": 19
             },
             "hourlyCost": "0.02328767123287671",
             "monthlyCost": "17",
@@ -284,24 +304,27 @@
             "name": "google_sql_database_instance.gsdi",
             "resourceType": "google_sql_database_instance",
             "tags": {
+              "DefaultLabel": "this is a default label",
               "GoogleSettingsUserLabel": "sql-db-label"
             },
-            "defaultTags": {},
+            "defaultTags": {
+              "DefaultLabel": "this is a default label"
+            },
             "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
                 {
                   "blockName": "google_sql_database_instance.gsdi",
-                  "endLine": 39,
+                  "endLine": 42,
                   "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-                  "startLine": 29
+                  "startLine": 32
                 }
               ],
               "checksum": "7f1731430d3c956e3e11da3378aa13ccb98e19f5889054a196bff8a068ad7d1b",
-              "endLine": 39,
+              "endLine": 42,
               "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-              "startLine": 29
+              "startLine": 32
             },
             "hourlyCost": "0.022828767123287671",
             "monthlyCost": "16.665",
@@ -355,24 +378,27 @@
             "name": "google_monitoring_custom_service.gmcs",
             "resourceType": "google_monitoring_custom_service",
             "tags": {
+              "DefaultLabel": "this is a default label",
               "GoogleUserLabel": "monitoring-custom-service-label"
             },
-            "defaultTags": {},
+            "defaultTags": {
+              "DefaultLabel": "this is a default label"
+            },
             "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
                 {
                   "blockName": "google_monitoring_custom_service.gmcs",
-                  "endLine": 27,
+                  "endLine": 30,
                   "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-                  "startLine": 21
+                  "startLine": 24
                 }
               ],
               "checksum": "c08c94c3110cc1279d75209519a2c8446f94b9a2b4f1f37cd79123984a379911",
-              "endLine": 27,
+              "endLine": 30,
               "filename": "testdata/breakdown_format_json_with_tags_google/main.tf",
-              "startLine": 21
+              "startLine": 24
             }
           }
         ],

--- a/cmd/infracost/testdata/breakdown_format_json_with_tags_google/breakdown_format_json_with_tags_google.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags_google/breakdown_format_json_with_tags_google.golden
@@ -36,6 +36,8 @@
             "tags": {
               "GoogleLabel": "compute-disk-label"
             },
+            "defaultTags": {},
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
@@ -70,6 +72,8 @@
             "name": "google_compute_disk.gcd2",
             "resourceType": "google_compute_disk",
             "tags": {},
+            "defaultTags": {},
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
@@ -106,6 +110,8 @@
             "tags": {
               "GoogleSettingsUserLabel": "sql-db-label"
             },
+            "defaultTags": {},
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
@@ -175,6 +181,8 @@
             "tags": {
               "GoogleUserLabel": "monitoring-custom-service-label"
             },
+            "defaultTags": {},
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
@@ -204,6 +212,8 @@
             "tags": {
               "GoogleLabel": "compute-disk-label"
             },
+            "defaultTags": {},
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
@@ -238,6 +248,8 @@
             "name": "google_compute_disk.gcd2",
             "resourceType": "google_compute_disk",
             "tags": {},
+            "defaultTags": {},
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
@@ -274,6 +286,8 @@
             "tags": {
               "GoogleSettingsUserLabel": "sql-db-label"
             },
+            "defaultTags": {},
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [
@@ -343,6 +357,8 @@
             "tags": {
               "GoogleUserLabel": "monitoring-custom-service-label"
             },
+            "defaultTags": {},
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_google/main.tf:1",
             "metadata": {
               "calls": [

--- a/cmd/infracost/testdata/breakdown_format_json_with_tags_google/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags_google/main.tf
@@ -2,6 +2,9 @@ provider "google" {
   credentials = "{\"type\":\"service_account\"}"
   project     = "my-project"
   region      = "us-central1"
+  default_labels = {
+    DefaultLabel = "this is a default label"
+  }
 }
 
 resource "google_compute_disk" "gcd1" {

--- a/internal/hcl/constraints_test.go
+++ b/internal/hcl/constraints_test.go
@@ -8,10 +8,6 @@ import (
 )
 
 func TestConstraintsAllowVersionOrAbove(t *testing.T) {
-	type args struct {
-		constraints     string
-		requiredVersion *version.Version
-	}
 	tests := []struct {
 		name            string
 		constraints     string

--- a/internal/hcl/constraints_test.go
+++ b/internal/hcl/constraints_test.go
@@ -1,0 +1,113 @@
+package hcl
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestConstraintsAllowVersionOrAbove(t *testing.T) {
+	type args struct {
+		constraints     string
+		requiredVersion *version.Version
+	}
+	tests := []struct {
+		name            string
+		constraints     string
+		requiredVersion string
+		want            bool
+	}{
+		{
+			name:            "bad/empty constraints",
+			constraints:     "",
+			requiredVersion: "5.0.0",
+			want:            true,
+		},
+		{
+			name:            "multi constraints",
+			constraints:     "> 3.0.0, < 6.0.0",
+			requiredVersion: "5.0.0",
+			want:            true,
+		},
+		{
+			name:            "simple match",
+			constraints:     "5.0.0",
+			requiredVersion: "5.0.0",
+			want:            true,
+		},
+		{
+			name:            "simple match via =",
+			constraints:     "= 5.0.0",
+			requiredVersion: "5.0.0",
+			want:            true,
+		},
+		{
+			name:            "simple mismatch",
+			constraints:     "5.0.0",
+			requiredVersion: "5.0.1",
+			want:            false,
+		},
+		{
+			name:            "constraints require greater",
+			constraints:     "> 5.0.0",
+			requiredVersion: "5.0.0",
+			want:            true,
+		},
+		{
+			name:            "constraints require greater than previous version",
+			constraints:     "> 1.0.0",
+			requiredVersion: "5.0.0",
+			want:            true,
+		},
+		{
+			name:            "constraints require >= version",
+			constraints:     ">= 5.0.0",
+			requiredVersion: "5.0.0",
+			want:            true,
+		},
+		{
+			name:            "patch only match on same major",
+			constraints:     "~> 5.0.0",
+			requiredVersion: "5.0.2",
+			want:            true,
+		},
+		{
+			name:            "patch only mismatch on lower major",
+			constraints:     "~> 1.0.0",
+			requiredVersion: "5.0.2",
+			want:            false,
+		},
+		{
+			name:            "patch only match on higher major",
+			constraints:     "~> 6.0.0",
+			requiredVersion: "5.0.2",
+			want:            true,
+		},
+		{
+			name:            "simple mismatch on lower constraint",
+			constraints:     "< 5.0.0",
+			requiredVersion: "5.0.0",
+			want:            false,
+		}, {
+			name:            "simple match on <= constraint",
+			constraints:     "<= 5.0.0",
+			requiredVersion: "5.0.0",
+			want:            true,
+		},
+		{
+			name:            "simple match on lower constraint",
+			constraints:     "< 5.0.1",
+			requiredVersion: "5.0.0",
+			want:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := version.NewConstraint(tt.constraints)
+			v, err := version.NewVersion(tt.requiredVersion)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, ConstraintsAllowVersionOrAbove(c, v))
+		})
+	}
+}

--- a/internal/providers/terraform/google/google.go
+++ b/internal/providers/terraform/google/google.go
@@ -36,7 +36,7 @@ func GetResourceRegion(d *schema.ResourceData) string {
 	return ""
 }
 
-func ParseTags(r *schema.ResourceData) *map[string]string {
+func ParseTags(r *schema.ResourceData, defaultLabels *map[string]string) *map[string]string {
 	_, supportsLabels := provider_schemas.GoogleLabelsSupport[r.Type]
 	rLabels := r.Get("labels").Map()
 
@@ -53,6 +53,11 @@ func ParseTags(r *schema.ResourceData) *map[string]string {
 	}
 
 	tags := make(map[string]string)
+	if defaultLabels != nil {
+		for k, v := range *defaultLabels {
+			tags[k] = v
+		}
+	}
 	for k, v := range rLabels {
 		tags[k] = v.String()
 	}


### PR DESCRIPTION
Adds support for the Google providers `default_labels`. We only attempt to parse these when the provider version is constrained at `>= v5.0.0`.

Once default values are parsed, works in entirely the same way as AWS `default_tags`.

I added default labels to the `breakdown_format_json_with_tags_google` tests/golden file. I also refactored the contraints code to gather version constraints for Google, and to make it trivial to add further providers.

See https://www.hashicorp.com/blog/terraform-google-provider-adds-updates-to-default-labels for more info.