### PR TITLE
fix: fix config template replace function so it works as filter

### DIFF
--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -169,7 +169,7 @@ func (p *Parser) trimSuffix(s, suffix string) string {
 }
 
 // replace returns s with all instances of old replaced by new.
-func (p *Parser) replace(s, old, new string) string {
+func (p *Parser) replace(old, new, s string) string {
 	return strings.ReplaceAll(s, old, new)
 }
 


### PR DESCRIPTION
This makes it consistent with sprig's implementation. The last argument is the src string, so using it as a filter like `"I Am Henry VIII" | replace " " "-"` works.