### PR TITLE
test: Fix test update path issue

### DIFF
--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -26,7 +26,7 @@ var (
 	projectPathRegex = regexp.MustCompile(`(Project: .*) \(.*/infracost/examples/.*\)`)
 	versionRegex     = regexp.MustCompile(`Infracost (v|preview).*`)
 	panicRegex       = regexp.MustCompile(`runtime\serror:([\w\d\n\r\[\]\:\/\.\\(\)\+\,\{\}\*\@\s\?]*)Environment`)
-	pathRegex        = regexp.MustCompile(`(/?.*/)(infracost/cmd/infracost/testdata/.*)`)
+	pathRegex        = regexp.MustCompile(`(/?.+/)(infracost/cmd/infracost/testdata/.*)`)
 	credsRegex       = regexp.MustCompile(`/.*/credentials\.yml`)
 )
 

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -26,7 +26,7 @@ var (
 	projectPathRegex = regexp.MustCompile(`(Project: .*) \(.*/infracost/examples/.*\)`)
 	versionRegex     = regexp.MustCompile(`Infracost (v|preview).*`)
 	panicRegex       = regexp.MustCompile(`runtime\serror:([\w\d\n\r\[\]\:\/\.\\(\)\+\,\{\}\*\@\s\?]*)Environment`)
-	pathRegex        = regexp.MustCompile(`(/.*/)(infracost/cmd/infracost/testdata/.*)`)
+	pathRegex        = regexp.MustCompile(`(/?.*/)(infracost/cmd/infracost/testdata/.*)`)
 	credsRegex       = regexp.MustCompile(`/.*/credentials\.yml`)
 )
 

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -26,7 +26,7 @@ var (
 	projectPathRegex = regexp.MustCompile(`(Project: .*) \(.*/infracost/examples/.*\)`)
 	versionRegex     = regexp.MustCompile(`Infracost (v|preview).*`)
 	panicRegex       = regexp.MustCompile(`runtime\serror:([\w\d\n\r\[\]\:\/\.\\(\)\+\,\{\}\*\@\s\?]*)Environment`)
-	pathRegex        = regexp.MustCompile(`(/.*/)(infracost/infracost/cmd/infracost/testdata/.*)`)
+	pathRegex        = regexp.MustCompile(`(/.*/)(infracost/cmd/infracost/testdata/.*)`)
 	credsRegex       = regexp.MustCompile(`/.*/credentials\.yml`)
 )
 
@@ -242,7 +242,7 @@ func stripDynamicValues(actual []byte) []byte {
 	actual = projectPathRegex.ReplaceAll(actual, []byte("$1 REPLACED_PROJECT_PATH"))
 	actual = versionRegex.ReplaceAll(actual, []byte("Infracost vREPLACED_VERSION"))
 	actual = panicRegex.ReplaceAll(actual, []byte("runtime error: REPLACED ERROR\nEnvironment"))
-	actual = pathRegex.ReplaceAll(actual, []byte("REPLACED_PROJECT_PATH/$2"))
+	actual = pathRegex.ReplaceAll(actual, []byte("REPLACED_PROJECT_PATH/infracost/$2"))
 	actual = credsRegex.ReplaceAll(actual, []byte("REPLACED_CREDENTIALS_PATH"))
 
 	return actual

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -26,7 +26,7 @@ var (
 	projectPathRegex = regexp.MustCompile(`(Project: .*) \(.*/infracost/examples/.*\)`)
 	versionRegex     = regexp.MustCompile(`Infracost (v|preview).*`)
 	panicRegex       = regexp.MustCompile(`runtime\serror:([\w\d\n\r\[\]\:\/\.\\(\)\+\,\{\}\*\@\s\?]*)Environment`)
-	pathRegex        = regexp.MustCompile(`(/?.+/)(infracost/cmd/infracost/testdata/.*)`)
+	pathRegex        = regexp.MustCompile(`(/?[^ ]+/)(infracost/cmd/infracost/testdata/.*)`)
 	credsRegex       = regexp.MustCompile(`/.*/credentials\.yml`)
 )
 


### PR DESCRIPTION
The replacement was expecting the project to be cloned in a parent directory named `infracost` e.g. `~/code/infracost/infracost`, but this is sometimes not the case.