### PR TITLE
fix: don't panic if the launchTemplateData map is nil

### DIFF
--- a/cmd/infracost/testdata/breakdown_format_json_with_tags_aft_module/breakdown_format_json_with_tags_aft_module.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags_aft_module/breakdown_format_json_with_tags_aft_module.golden
@@ -1327,6 +1327,15 @@
             "defaultTags": {
               "managed_by": "AFT"
             },
+            "name": "module.aft.module.aft_backend.aws_kms_key.aft_access_logs_primary_backend_bucket",
+            "tags": {
+              "managed_by": "AFT"
+            }
+          },
+          {
+            "defaultTags": {
+              "managed_by": "AFT"
+            },
             "name": "module.aft.module.aft_backend.aws_kms_key.encrypt-primary-region",
             "tags": {
               "Name": "aft-backend-REGEX_FILTER-primary-region-kms-key",
@@ -1634,6 +1643,20 @@
             ],
             "tags": {
               "Name": "aft-backend-REGEX_FILTER",
+              "managed_by": "AFT"
+            }
+          },
+          {
+            "defaultTags": {
+              "managed_by": "AFT"
+            },
+            "name": "module.aft.module.aft_backend.aws_s3_bucket.aft_access_logs_primary_backend_bucket",
+            "subresources": [
+              {
+                "name": "Standard"
+              }
+            ],
+            "tags": {
               "managed_by": "AFT"
             }
           },

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -1379,6 +1379,10 @@ func launchTemplateValues(b *Block) cty.Value {
 	v, ok := launchTemplateData["name"]
 
 	if !ok || v.IsNull() {
+		if launchTemplateData == nil {
+			launchTemplateData = make(map[string]cty.Value)
+		}
+
 		h := sha256.New()
 		h.Write([]byte(b.FullName()))
 		addressSha := hex.EncodeToString(h.Sum(nil))


### PR DESCRIPTION
we got a prod error with this stacktrace
   /panic.go:770                                    panic()
   internal/hcl/block.go:1385                       launchTemplateValues()
   internal/hcl/block.go:1062                       (*Block).Values()
   internal/hcl/evaluator.go:962                    (*Evaluator).evaluateResourceOrData()
...