### PR TITLE
enhance: support more complex Terraform vars

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1067,6 +1067,42 @@ func TestBreakdownWithOptionalVariables(t *testing.T) {
 	)
 }
 
+func TestBreakdownWithComplexConfigFileVars(t *testing.T) {
+	dir := path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())
+
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--config-file",
+			path.Join(dir, "infracost.yml"),
+		},
+		nil,
+	)
+}
+
+func TestBreakdownWithComplexVarFlags(t *testing.T) {
+	dir := path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())
+
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path",
+			dir,
+			"--terraform-var",
+			"instance_config={\"instance_type\":\"t2.micro\",\"storage\":20}",
+			"--terraform-var",
+			"lambda_configs=[{\"memory_size\":128},{\"memory_size\":256}]",
+			"--usage-file",
+			path.Join(dir, "infracost-usage.yml"),
+		},
+		nil,
+	)
+}
+
 func TestBreakdownWithDeepMergeModule(t *testing.T) {
 	GoldenFileCommandTest(
 		t,

--- a/cmd/infracost/testdata/breakdown_help/breakdown_help.golden
+++ b/cmd/infracost/testdata/breakdown_help/breakdown_help.golden
@@ -28,7 +28,7 @@ FLAGS
       --project-name string          Name of project in the output. Defaults to path or git repo name
       --show-skipped                 List unsupported resources
       --sync-usage-file              Sync usage-file with missing resources, needs usage-file too (experimental)
-      --terraform-var strings        Set value for an input variable, similar to Terraform's -var flag
+      --terraform-var stringArray    Set value for an input variable, similar to Terraform's -var flag
       --terraform-var-file strings   Load variable files, similar to Terraform's -var-file flag. Provided files must be relative to the --path flag
       --terraform-workspace string   Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string            Path to Infracost usage file that specifies values for usage-based resources

--- a/cmd/infracost/testdata/breakdown_with_complex_config_file_vars/breakdown_with_complex_config_file_vars.golden
+++ b/cmd/infracost/testdata/breakdown_with_complex_config_file_vars/breakdown_with_complex_config_file_vars.golden
@@ -1,0 +1,34 @@
+Project: testdata-breakdown_with_complex_config_file_vars
+Module path: testdata/breakdown_with_complex_config_file_vars
+
+ Name                                                 Monthly Qty  Unit         Monthly Cost    
+                                                                                                
+ aws_lambda_function.hello_world[1]                                                             
+ ├─ Requests                                                  100  1M requests        $20.00  * 
+ └─ Duration (first 6B)                                 6,250,000  GB-seconds        $104.17  * 
+                                                                                                
+ aws_lambda_function.hello_world[0]                                                             
+ ├─ Requests                                                  100  1M requests        $20.00  * 
+ └─ Duration (first 6B)                                 3,125,000  GB-seconds         $52.08  * 
+                                                                                                
+ aws_instance.web_app                                                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours               $8.47    
+ └─ root_block_device                                                                           
+    └─ Storage (general purpose SSD, gp2)                      20  GB                  $2.00    
+                                                                                                
+ OVERALL TOTAL                                                                       $206.72 
+
+*Usage costs were estimated using infracost-usage.yml, see docs for other options.
+
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 3 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ testdata-breakdown_with_complex_config_file_vars   ┃           $10 ┃        $196 ┃       $207 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_complex_config_file_vars/infracost-usage.yml
+++ b/cmd/infracost/testdata/breakdown_with_complex_config_file_vars/infracost-usage.yml
@@ -1,0 +1,5 @@
+version: 0.1
+resource_usage:
+  aws_lambda_function.hello_world[*]:
+    monthly_requests: 100000000
+    request_duration_ms: 250

--- a/cmd/infracost/testdata/breakdown_with_complex_config_file_vars/infracost.yml
+++ b/cmd/infracost/testdata/breakdown_with_complex_config_file_vars/infracost.yml
@@ -1,0 +1,11 @@
+version: 0.1
+projects:
+  - path: "./testdata/breakdown_with_complex_config_file_vars"
+    usage_file: "./testdata/breakdown_with_complex_config_file_vars/infracost-usage.yml"
+    terraform_vars:
+      instance_config:
+        instance_type: t2.micro
+        storage: 20
+      lambda_configs:
+        - memory_size: 128
+        - memory_size: 256

--- a/cmd/infracost/testdata/breakdown_with_complex_config_file_vars/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_complex_config_file_vars/main.tf
@@ -1,0 +1,46 @@
+provider "aws" {
+  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+variable "instance_config" {
+  type = map(any)
+  default = {
+    instance_type = "m5.4xlarge"
+    storage       = 10
+  }
+}
+
+variable "lambda_configs" {
+  type = list(object({
+    memory_size = number
+  }))
+  default = [
+    {
+      memory_size = 1024
+    }
+  ]
+}
+
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_config.instance_type
+
+  root_block_device {
+    volume_size = var.instance_config.storage
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  count         = length(var.lambda_configs)
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:aws:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  filename      = "function.zip"
+  memory_size   = var.lambda_configs[count.index].memory_size
+}

--- a/cmd/infracost/testdata/breakdown_with_complex_var_flags/breakdown_with_complex_var_flags.golden
+++ b/cmd/infracost/testdata/breakdown_with_complex_var_flags/breakdown_with_complex_var_flags.golden
@@ -1,0 +1,33 @@
+Project: main
+
+ Name                                                 Monthly Qty  Unit         Monthly Cost    
+                                                                                                
+ aws_lambda_function.hello_world[1]                                                             
+ ├─ Requests                                                  100  1M requests        $20.00  * 
+ └─ Duration (first 6B)                                 6,250,000  GB-seconds        $104.17  * 
+                                                                                                
+ aws_lambda_function.hello_world[0]                                                             
+ ├─ Requests                                                  100  1M requests        $20.00  * 
+ └─ Duration (first 6B)                                 3,125,000  GB-seconds         $52.08  * 
+                                                                                                
+ aws_instance.web_app                                                                           
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours               $8.47    
+ └─ root_block_device                                                                           
+    └─ Storage (general purpose SSD, gp2)                      20  GB                  $2.00    
+                                                                                                
+ OVERALL TOTAL                                                                       $206.72 
+
+*Usage costs were estimated using infracost-usage.yml, see docs for other options.
+
+──────────────────────────────────
+3 cloud resources were detected:
+∙ 3 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ main                                               ┃           $10 ┃        $196 ┃       $207 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_with_complex_var_flags/infracost-usage.yml
+++ b/cmd/infracost/testdata/breakdown_with_complex_var_flags/infracost-usage.yml
@@ -1,0 +1,5 @@
+version: 0.1
+resource_usage:
+  aws_lambda_function.hello_world[*]:
+    monthly_requests: 100000000
+    request_duration_ms: 250

--- a/cmd/infracost/testdata/breakdown_with_complex_var_flags/main.tf
+++ b/cmd/infracost/testdata/breakdown_with_complex_var_flags/main.tf
@@ -1,0 +1,46 @@
+provider "aws" {
+  region                      = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+variable "instance_config" {
+  type = map(any)
+  default = {
+    instance_type = "m5.4xlarge"
+    storage       = 10
+  }
+}
+
+variable "lambda_configs" {
+  type = list(object({
+    memory_size = number
+  }))
+  default = [
+    {
+      memory_size = 1024
+    }
+  ]
+}
+
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_config.instance_type
+
+  root_block_device {
+    volume_size = var.instance_config.storage
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  count         = length(var.lambda_configs)
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:aws:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  filename      = "function.zip"
+  memory_size   = var.lambda_configs[count.index].memory_size
+}

--- a/cmd/infracost/testdata/diff_compare_to_error/diff_compare_to_error.golden
+++ b/cmd/infracost/testdata/diff_compare_to_error/diff_compare_to_error.golden
@@ -31,7 +31,7 @@ FLAGS
       --project-name string          Name of project in the output. Defaults to path or git repo name
       --show-skipped                 List unsupported resources
       --sync-usage-file              Sync usage-file with missing resources, needs usage-file too (experimental)
-      --terraform-var strings        Set value for an input variable, similar to Terraform's -var flag
+      --terraform-var stringArray    Set value for an input variable, similar to Terraform's -var flag
       --terraform-var-file strings   Load variable files, similar to Terraform's -var-file flag. Provided files must be relative to the --path flag
       --terraform-workspace string   Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string            Path to Infracost usage file that specifies values for usage-based resources

--- a/cmd/infracost/testdata/diff_compare_to_error_terragrunt/diff_compare_to_error_terragrunt.golden
+++ b/cmd/infracost/testdata/diff_compare_to_error_terragrunt/diff_compare_to_error_terragrunt.golden
@@ -31,7 +31,7 @@ FLAGS
       --project-name string          Name of project in the output. Defaults to path or git repo name
       --show-skipped                 List unsupported resources
       --sync-usage-file              Sync usage-file with missing resources, needs usage-file too (experimental)
-      --terraform-var strings        Set value for an input variable, similar to Terraform's -var flag
+      --terraform-var stringArray    Set value for an input variable, similar to Terraform's -var flag
       --terraform-var-file strings   Load variable files, similar to Terraform's -var-file flag. Provided files must be relative to the --path flag
       --terraform-workspace string   Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string            Path to Infracost usage file that specifies values for usage-based resources

--- a/cmd/infracost/testdata/diff_help/diff_help.golden
+++ b/cmd/infracost/testdata/diff_help/diff_help.golden
@@ -29,7 +29,7 @@ FLAGS
       --project-name string          Name of project in the output. Defaults to path or git repo name
       --show-skipped                 List unsupported resources
       --sync-usage-file              Sync usage-file with missing resources, needs usage-file too (experimental)
-      --terraform-var strings        Set value for an input variable, similar to Terraform's -var flag
+      --terraform-var stringArray    Set value for an input variable, similar to Terraform's -var flag
       --terraform-var-file strings   Load variable files, similar to Terraform's -var-file flag. Provided files must be relative to the --path flag
       --terraform-workspace string   Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string            Path to Infracost usage file that specifies values for usage-based resources

--- a/cmd/infracost/testdata/flag_errors_config_file_and_terraform_workspace/flag_errors_config_file_and_terraform_workspace.golden
+++ b/cmd/infracost/testdata/flag_errors_config_file_and_terraform_workspace/flag_errors_config_file_and_terraform_workspace.golden
@@ -30,7 +30,7 @@ FLAGS
       --project-name string          Name of project in the output. Defaults to path or git repo name
       --show-skipped                 List unsupported resources
       --sync-usage-file              Sync usage-file with missing resources, needs usage-file too (experimental)
-      --terraform-var strings        Set value for an input variable, similar to Terraform's -var flag
+      --terraform-var stringArray    Set value for an input variable, similar to Terraform's -var flag
       --terraform-var-file strings   Load variable files, similar to Terraform's -var-file flag. Provided files must be relative to the --path flag
       --terraform-workspace string   Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string            Path to Infracost usage file that specifies values for usage-based resources

--- a/cmd/infracost/testdata/flag_errors_no_path/flag_errors_no_path.golden
+++ b/cmd/infracost/testdata/flag_errors_no_path/flag_errors_no_path.golden
@@ -30,7 +30,7 @@ FLAGS
       --project-name string          Name of project in the output. Defaults to path or git repo name
       --show-skipped                 List unsupported resources
       --sync-usage-file              Sync usage-file with missing resources, needs usage-file too (experimental)
-      --terraform-var strings        Set value for an input variable, similar to Terraform's -var flag
+      --terraform-var stringArray    Set value for an input variable, similar to Terraform's -var flag
       --terraform-var-file strings   Load variable files, similar to Terraform's -var-file flag. Provided files must be relative to the --path flag
       --terraform-workspace string   Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string            Path to Infracost usage file that specifies values for usage-based resources

--- a/cmd/infracost/testdata/flag_errors_path_and_config_file/flag_errors_path_and_config_file.golden
+++ b/cmd/infracost/testdata/flag_errors_path_and_config_file/flag_errors_path_and_config_file.golden
@@ -30,7 +30,7 @@ FLAGS
       --project-name string          Name of project in the output. Defaults to path or git repo name
       --show-skipped                 List unsupported resources
       --sync-usage-file              Sync usage-file with missing resources, needs usage-file too (experimental)
-      --terraform-var strings        Set value for an input variable, similar to Terraform's -var flag
+      --terraform-var stringArray    Set value for an input variable, similar to Terraform's -var flag
       --terraform-var-file strings   Load variable files, similar to Terraform's -var-file flag. Provided files must be relative to the --path flag
       --terraform-workspace string   Terraform workspace to use. Applicable when path is a Terraform directory
       --usage-file string            Path to Infracost usage file that specifies values for usage-based resources

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,7 +75,7 @@ type Project struct {
 	// TerraformVarFiles is any var files that are to be used with the project.
 	TerraformVarFiles []string `yaml:"terraform_var_files,omitempty"`
 	// TerraformVars is a slice of input vars that are to be used with the project.
-	TerraformVars map[string]string `yaml:"terraform_vars,omitempty"`
+	TerraformVars map[string]interface{} `yaml:"terraform_vars,omitempty"`
 	// TerraformForceCLI will run a project by calling out to the terraform/terragrunt binary to generate a plan JSON file.
 	TerraformForceCLI bool `yaml:"terraform_force_cli,omitempty"`
 	// TerraformPlanFlags are flags to pass to terraform plan with Terraform directory paths

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -387,8 +387,8 @@ func (p *TerragruntHCLProvider) initTerraformVarFiles(tfVarFiles []string, extra
 	return v
 }
 
-func (p *TerragruntHCLProvider) initTerraformVars(tfVars map[string]string, inputs map[string]interface{}) map[string]string {
-	m := make(map[string]string, len(tfVars)+len(inputs))
+func (p *TerragruntHCLProvider) initTerraformVars(tfVars map[string]interface{}, inputs map[string]interface{}) map[string]interface{} {
+	m := make(map[string]interface{}, len(tfVars)+len(inputs))
 	for k, v := range tfVars {
 		m[k] = v
 	}

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -63,7 +63,7 @@
         "terraform_vars": {
           "patternProperties": {
             ".*": {
-              "type": "string"
+              "additionalProperties": true
             }
           },
           "type": "object"


### PR DESCRIPTION
This adds support for more complex shaped Terraform vars (maps, lists) passed in via the Infracost config file or the `--terraform-var` flag, like:

```
--terraform-var='instance_config={"instance_type":"t2.micro","storage":20}'
```

or in the Infracost config file like:
```yaml
    terraform_vars:
      instance_config:
        instance_type: t2.micro
        storage: 20
```

I went with the approach of using `ctyJson.SimpleJSONValue` since it seems to be the easiest and most robust way of doing this, other than recursively mapping the types ourselves.