### PR TITLE
fix: warn on missing Terraform workspace

### DIFF
--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref1/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref1/terragrunt.hcl
@@ -14,7 +14,7 @@ EOF
 
 inputs = {
   cluster_name    = "my-cluster"
-  cluster_version = "1.27"
+  cluster_version = "1.30"
 
   cluster_endpoint_public_access = true
 

--- a/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref2/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_with_remote_source/ref2/terragrunt.hcl
@@ -4,7 +4,7 @@ terraform {
 
 inputs = {
   cluster_name    = "my-cluster"
-  cluster_version = "1.27"
+  cluster_version = "1.30"
 
   cluster_endpoint_public_access = true
 

--- a/internal/hcl/remote_variables_loader.go
+++ b/internal/hcl/remote_variables_loader.go
@@ -117,7 +117,8 @@ func (r *RemoteVariablesLoader) Load(blocks Blocks) (map[string]cty.Value, error
 		if !config.valid() {
 			config, err = r.getBackendOrganizationWorkspace(blocks)
 			if err != nil {
-				return vars, err
+				r.logger.Warn().Err(err).Msg("could not detect Terraform Cloud organization and workspace")
+				return vars, nil
 			}
 
 			if !config.valid() {


### PR DESCRIPTION
Previously this was erroring. I think it makes more sense to warn here because the user might not have any variables specified remotely, so it doesn't make sense to block the execution. Instead this should continue and show them any warnings for missing variables.