### PR TITLE
fix: detection of HCL attributes for *.tf.json files

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -750,6 +750,10 @@ func TestBreakdownTerraformUseState_v0_14(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "./testdata/terraform_v0.14_state.json", "--terraform-use-state"}, nil)
 }
 
+func TestBreakdownTerraformTFJSON(t *testing.T) {
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())}, nil)
+}
+
 func TestBreakdownWithPrivateTerraformRegistryModule(t *testing.T) {
 	if os.Getenv("INFRACOST_TERRAFORM_CLOUD_TOKEN") == "" {
 		t.Skip("Skipping because INFRACOST_TERRAFORM_CLOUD_TOKEN is not set and external contributors won't have this.")

--- a/cmd/infracost/testdata/breakdown_terraform_tfjson/breakdown_terraform_tfjson.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_tfjson/breakdown_terraform_tfjson.golden
@@ -1,0 +1,33 @@
+Project: main
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost   
+                                                                                                                        
+ aws_instance.web_app                                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64   
+ ├─ root_block_device                                                                                                   
+ │  └─ Storage (general purpose SSD, gp2)                                50  GB                                 $5.00   
+ └─ ebs_block_device[0]                                                                                                 
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00   
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00   
+                                                                                                                        
+ aws_lambda_function.hello_world                                                                                        
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests            
+ ├─ Ephemeral storage                                   Monthly cost depends on usage: $0.0000000309 per GB-seconds     
+ └─ Duration (first 6B)                                 Monthly cost depends on usage: $0.0000166667 per GB-seconds     
+                                                                                                                        
+ OVERALL TOTAL                                                                                               $742.64 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ main                                               ┃          $743 ┃           - ┃       $743 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terraform_tfjson/main.tf.json
+++ b/cmd/infracost/testdata/breakdown_terraform_tfjson/main.tf.json
@@ -1,0 +1,47 @@
+{
+  "output": {
+      "aws_instance_type": {
+          "value": "${aws_instance.web_app.instance_type}"
+      }
+  },
+  "provider": {
+      "aws": {
+          "access_key": "mock_access_key",
+          "region": "us-east-1",
+          "secret_key": "mock_secret_key",
+          "skip_credentials_validation": true,
+          "skip_requesting_account_id": true
+      }
+  },
+  "resource": {
+      "aws_instance": {
+          "web_app": {
+              "ami": "ami-674cbc1e",
+              "ebs_block_device": [
+                  {
+                      "device_name": "my_data",
+                      "iops": 800,
+                      "volume_size": 1000,
+                      "volume_type": "io1"
+                  }
+              ],
+              "instance_type": "m5.4xlarge",
+              "root_block_device": [
+                  {
+                      "volume_size": 50
+                  }
+              ]
+          }
+      },
+      "aws_lambda_function": {
+          "hello_world": {
+              "filename": "function.zip",
+              "function_name": "hello_world",
+              "handler": "exports.test",
+              "memory_size": 1024,
+              "role": "arn:aws:lambda:us-east-1:aws:resource-id",
+              "runtime": "nodejs12.x"
+          }
+      }
+  }
+}

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -1030,7 +1030,7 @@ func (b *Block) getHCLAttributes() hcl.Attributes {
 			return nil
 		}
 		for k := range attrs {
-			if _, ok := b.UniqueAttrs[k]; !ok {
+			if _, ok := b.UniqueAttrs[k]; ok {
 				delete(attrs, k)
 			}
 


### PR DESCRIPTION
There's a typo which means when the body of the parsed HCL file is a JSON body, we're not returning the attributes correctly.