### PR TITLE
feat: add `RepoName` variable to config template

### DIFF
--- a/cmd/infracost/generate.go
+++ b/cmd/infracost/generate.go
@@ -146,6 +146,7 @@ func (g *generateConfigCommand) run(cmd *cobra.Command, args []string) error {
 		})
 
 		variables := template.Variables{
+			RepoName:            m.Remote.Name,
 			Branch:              m.Branch.Name,
 			DetectedProjects:    detectedProjects,
 			DetectedRootModules: detectedRootModules,

--- a/cmd/infracost/testdata/generate/repo_name/expected.golden
+++ b/cmd/infracost/testdata/generate/repo_name/expected.golden
@@ -1,0 +1,16 @@
+version: 0.1
+
+projects:
+  - path: apps/bar
+    name: apps-bar
+    terraform_vars:
+      environment: prod
+  - path: apps/foo
+    name: apps-foo-dev
+    terraform_vars:
+      environment: prod
+  - path: apps/foo
+    name: apps-foo-prod
+    terraform_vars:
+      environment: prod
+

--- a/cmd/infracost/testdata/generate/repo_name/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/repo_name/infracost.yml.tmpl
@@ -1,0 +1,11 @@
+version: 0.1
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+    terraform_vars:
+    {{- if eq $.RepoName "infracost/infracost"}}
+      environment: prod
+    {{- end}}
+{{- end }}

--- a/cmd/infracost/testdata/generate/repo_name/tree.txt
+++ b/cmd/infracost/testdata/generate/repo_name/tree.txt
@@ -1,0 +1,10 @@
+.
+└── apps
+    ├── bar
+    │   ├── backend.tf
+    │   └── terraform.tfvars
+    └── foo
+        ├── dev.tfvars
+        ├── main.tf
+        ├── prod.tfvars
+        └── terraform.tfvars

--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/infracost/infracost/internal/logging"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	pathToRegexp "github.com/soongo/path-to-regexp"
 	"gopkg.in/yaml.v2"
+
+	"github.com/infracost/infracost/internal/logging"
 )
 
 var (
@@ -35,6 +36,7 @@ type DetectedRooModule struct {
 
 // Variables hold the global variables that are passed into any template that the Parser evaluates.
 type Variables struct {
+	RepoName            string
 	Branch              string
 	BaseBranch          string
 	DetectedProjects    []DetectedProject


### PR DESCRIPTION
Adds support for use of logic gates within the config template based on the current repository name.