### PR TITLE
fix: adds module path to errored project

### DIFF
--- a/cmd/infracost/testdata/breakdown_plan_error/breakdown_plan_error.golden
+++ b/cmd/infracost/testdata/breakdown_plan_error/breakdown_plan_error.golden
@@ -1,4 +1,5 @@
 Project: infracost/infracost/examples/terraform
+Module path: .
 
 Errors:
   terraform plan failed:

--- a/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/breakdown_terragrunt_diff_project_error.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/breakdown_terragrunt_diff_project_error.golden
@@ -1,5 +1,6 @@
 ──────────────────────────────────
-Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/example/dev
+Module path: example/dev
 Errors:
   Error processing module at 'REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/foo/terragrunt.hcl'. How this module was found:
     dependency of module at 'REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/example/dev'. Underlying error:
@@ -8,7 +9,8 @@ Errors:
           no such file or directory
 
 ──────────────────────────────────
-Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error
+Project: infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/example/prod
+Module path: example/prod
 Errors:
   Error processing module at 'REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/foo/terragrunt.hcl'. How this module was found:
     dependency of module at 'REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/example/dev'. Underlying error:

--- a/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/prior.json
+++ b/cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/prior.json
@@ -17,7 +17,7 @@
       "metadata": {
         "path": "example/dev",
         "type": "terragrunt_dir",
-        "terraformModulePath": "dev",
+        "terraformModulePath": "example/dev",
         "vcsSubPath": "cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/example/dev"
       },
       "pastBreakdown": {
@@ -302,7 +302,7 @@
       "metadata": {
         "path": "example/prod",
         "type": "terragrunt_dir",
-        "terraformModulePath": "prod",
+        "terraformModulePath": "example/prod",
         "vcsSubPath": "cmd/infracost/testdata/breakdown_terragrunt_diff_project_error/example/prod"
       },
       "pastBreakdown": {

--- a/cmd/infracost/testdata/diff_terragrunt_syntax_error/diff_terragrunt_syntax_error.golden
+++ b/cmd/infracost/testdata/diff_terragrunt_syntax_error/diff_terragrunt_syntax_error.golden
@@ -1,5 +1,6 @@
 ──────────────────────────────────
 Project: dems-ag1
+Module path: testdata/diff_terragrunt_syntax_error/terragrunt/dev
 Errors:
   Error processing module at 'REPLACED_PROJECT_PATH/infracost/infracost/cmd/infracost/testdata/diff_terragrunt_syntax_error/terragrunt/dev/terragrunt.hcl'. How this module was found:
     Terragrunt config file found in a subdirectory of testdata/diff_terragrunt_syntax_error/terragrunt/dev. Underlying error:


### PR DESCRIPTION
Adds `TerraformModulePath` to any errored project. This resolves an issue in the `diff` command. Errored projects that were discovered at a child path of the initial path provided in the config would have the same `Path` and or `Name` metadata. This would cause a `compare-to` conflict because we saw them as duplicate projects, even though these projects were actually located in different directories.