### PR TITLE
fix: Only check minor version in constraints check when patch is specified

### DIFF
--- a/cmd/infracost/testdata/breakdown_format_json_with_tags_version_less_than5point39/breakdown_format_json_with_tags_version_less_than5point39.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags_version_less_than5point39/breakdown_format_json_with_tags_version_less_than5point39.golden
@@ -38,10 +38,17 @@
             "name": "aws_instance.web_app",
             "resourceType": "aws_instance",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
               "foo": "bar",
               "volume_tags.DefaultOverride": "volume_tag_overwritten",
               "volume_tags.baz": "bat"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -53,6 +60,7 @@
                 }
               ],
               "checksum": "3971020356e35708e0de7df3decdd615468f858c38205a99249dd4aa4e3ccf23",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 98,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 76
@@ -124,9 +132,16 @@
             "name": "aws_instance.web_app_block_tags",
             "resourceType": "aws_instance",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
               "ebs_block_device[0].foo": "ebd",
               "root_block_device.foo": "rbd"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -138,6 +153,7 @@
                 }
               ],
               "checksum": "47efe9c1f904be19ea9a38623ebcb399b03026ba4c0436284a121e35b84ce286",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 212,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 191
@@ -212,6 +228,11 @@
               "fizz": "buzz",
               "foo": "bar"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -304,10 +325,17 @@
             "name": "aws_instance.launch_instance",
             "resourceType": "aws_instance",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
               "bat": "ball",
               "fizz": "buzz",
               "volume_tags.flip": "flop"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -319,6 +347,7 @@
                 }
               ],
               "checksum": "92d793c678fac9bf7ce08e05983f01e62665b7ea640a512f23bb3061b8c645b5",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 112,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 100
@@ -412,6 +441,11 @@
             "tags": {
               "foo": "bar"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -431,6 +465,11 @@
           {
             "name": "aws_sns_topic_subscription.sns_topic_noTags",
             "resourceType": "aws_sns_topic_subscription",
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -467,6 +506,11 @@
               "DefaultOverride": "sns-def",
               "ResourceTag": "sns-ghi"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -499,7 +543,15 @@
           {
             "name": "aws_sqs_queue.sqs_noTags",
             "resourceType": "aws_sqs_queue",
-            "tags": {},
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -511,6 +563,7 @@
                 }
               ],
               "checksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 43,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 41
@@ -533,9 +586,15 @@
             "name": "aws_sqs_queue.sqs_withTags",
             "resourceType": "aws_sqs_queue",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "sqs-def",
               "ResourceTag": "sqs-hi"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -547,6 +606,7 @@
                 }
               ],
               "checksum": "0416b121e83d6bb05bd0b744a439e336a3bd1cfdaff221bec4577c59f2f744c8",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 52,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 45
@@ -571,10 +631,17 @@
             "name": "aws_launch_template.example",
             "resourceType": "aws_launch_template",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
               "tag_specifications.fizz": "buzz",
               "tag_specifications.flip": "flop",
               "tag_specifications.no": "cap"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -586,6 +653,7 @@
                 }
               ],
               "checksum": "5ae555e21daf62bb42d8cfcff0473722eb04032804b064b14d474f6f8923255e",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 163,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 114
@@ -602,10 +670,17 @@
             "name": "aws_instance.web_app",
             "resourceType": "aws_instance",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
               "foo": "bar",
               "volume_tags.DefaultOverride": "volume_tag_overwritten",
               "volume_tags.baz": "bat"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -617,6 +692,7 @@
                 }
               ],
               "checksum": "3971020356e35708e0de7df3decdd615468f858c38205a99249dd4aa4e3ccf23",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 98,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 76
@@ -688,9 +764,16 @@
             "name": "aws_instance.web_app_block_tags",
             "resourceType": "aws_instance",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
               "ebs_block_device[0].foo": "ebd",
               "root_block_device.foo": "rbd"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -702,6 +785,7 @@
                 }
               ],
               "checksum": "47efe9c1f904be19ea9a38623ebcb399b03026ba4c0436284a121e35b84ce286",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 212,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 191
@@ -776,6 +860,11 @@
               "fizz": "buzz",
               "foo": "bar"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -868,10 +957,17 @@
             "name": "aws_instance.launch_instance",
             "resourceType": "aws_instance",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
               "bat": "ball",
               "fizz": "buzz",
               "volume_tags.flip": "flop"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -883,6 +979,7 @@
                 }
               ],
               "checksum": "92d793c678fac9bf7ce08e05983f01e62665b7ea640a512f23bb3061b8c645b5",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 112,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 100
@@ -976,6 +1073,11 @@
             "tags": {
               "foo": "bar"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -995,6 +1097,11 @@
           {
             "name": "aws_sns_topic_subscription.sns_topic_noTags",
             "resourceType": "aws_sns_topic_subscription",
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -1031,6 +1138,11 @@
               "DefaultOverride": "sns-def",
               "ResourceTag": "sns-ghi"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -1063,7 +1175,15 @@
           {
             "name": "aws_sqs_queue.sqs_noTags",
             "resourceType": "aws_sqs_queue",
-            "tags": {},
+            "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -1075,6 +1195,7 @@
                 }
               ],
               "checksum": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 43,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 41
@@ -1097,9 +1218,15 @@
             "name": "aws_sqs_queue.sqs_withTags",
             "resourceType": "aws_sqs_queue",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
               "DefaultOverride": "sqs-def",
               "ResourceTag": "sqs-hi"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -1111,6 +1238,7 @@
                 }
               ],
               "checksum": "0416b121e83d6bb05bd0b744a439e336a3bd1cfdaff221bec4577c59f2f744c8",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 52,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 45
@@ -1135,10 +1263,17 @@
             "name": "aws_launch_template.example",
             "resourceType": "aws_launch_template",
             "tags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride",
               "tag_specifications.fizz": "buzz",
               "tag_specifications.flip": "flop",
               "tag_specifications.no": "cap"
             },
+            "defaultTags": {
+              "DefaultNotOverride": "defaultnotoverride",
+              "DefaultOverride": "defaultoverride"
+            },
+            "providerSupportsDefaultTags": true,
             "providerLink": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf:1",
             "metadata": {
               "calls": [
@@ -1150,6 +1285,7 @@
                 }
               ],
               "checksum": "5ae555e21daf62bb42d8cfcff0473722eb04032804b064b14d474f6f8923255e",
+              "defaultTagsChecksum": "23ce253ad214e1f28d8a9f8cda886efe35a0731151efe7c37a22652c98fa2101",
               "endLine": 163,
               "filename": "testdata/breakdown_format_json_with_tags_version_less_than5point39/main.tf",
               "startLine": 114

--- a/internal/hcl/constraints.go
+++ b/internal/hcl/constraints.go
@@ -63,8 +63,12 @@ func ConstraintsAllowVersionOrAbove(constraints version.Constraints, requiredVer
 			if segments[0] < requiredSegments[0] {
 				return false
 			}
-			if segments[0] == requiredSegments[0] && segments[1] < requiredSegments[1] {
-				return false
+			// only check the minor version if the major version is the same AND the path version is the rightmost
+			// specified component in the ~> constraint
+			if segCount := strings.Count(ver, ".") + 1; segCount > 2 {
+				if segments[0] == requiredSegments[0] && segments[1] < requiredSegments[1] {
+					return false
+				}
 			}
 		case "<":
 			if check.LessThanOrEqual(requiredVersion) {

--- a/internal/hcl/constraints.go
+++ b/internal/hcl/constraints.go
@@ -60,14 +60,17 @@ func ConstraintsAllowVersionOrAbove(constraints version.Constraints, requiredVer
 			if len(requiredSegments) < 2 {
 				continue
 			}
-			if segments[0] < requiredSegments[0] {
-				return false
-			}
-			// only check the minor version if the major version is the same AND the path version is the rightmost
-			// specified component in the ~> constraint
-			if segCount := strings.Count(ver, ".") + 1; segCount > 2 {
-				if segments[0] == requiredSegments[0] && segments[1] < requiredSegments[1] {
+			segCount := strings.Count(ver, ".") + 1
+			if segCount > 1 {
+				if segments[0] < requiredSegments[0] {
 					return false
+				}
+				// only check the minor version if the major version is the same AND the path version is the rightmost
+				// specified component in the ~> constraint
+				if segCount > 2 {
+					if segments[0] == requiredSegments[0] && segments[1] < requiredSegments[1] {
+						return false
+					}
 				}
 			}
 		case "<":

--- a/internal/hcl/constraints_test.go
+++ b/internal/hcl/constraints_test.go
@@ -115,6 +115,18 @@ func TestConstraintsAllowVersionOrAbove(t *testing.T) {
 			requiredVersion: "3.38",
 			want:            false,
 		},
+		{
+			name:            "example",
+			constraints:     "~> 2.0",
+			requiredVersion: "3.38",
+			want:            false,
+		},
+		{
+			name:            "example",
+			constraints:     "~> 2",
+			requiredVersion: "3.38",
+			want:            true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/hcl/constraints_test.go
+++ b/internal/hcl/constraints_test.go
@@ -103,13 +103,25 @@ func TestConstraintsAllowVersionOrAbove(t *testing.T) {
 			requiredVersion: "3.38",
 			want:            true,
 		},
+		{
+			name:            "example",
+			constraints:     "~> 3.0",
+			requiredVersion: "3.38",
+			want:            true,
+		},
+		{
+			name:            "example",
+			constraints:     "~> 3.0.1",
+			requiredVersion: "3.38",
+			want:            false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c, _ := version.NewConstraint(tt.constraints)
 			v, err := version.NewVersion(tt.requiredVersion)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, ConstraintsAllowVersionOrAbove(c, v))
+			assert.Equal(t, tt.want, ConstraintsAllowVersionOrAbove(c, v), "constraint %s does not allow %s or greater", tt.constraints, tt.requiredVersion)
 		})
 	}
 }


### PR DESCRIPTION
The `~>` constraint operator should only require the rightmost _specified_ number to be greater than or equal. We were always requiring the patch version as this is the rightmost number of the actual version number. Now we check whether the user specifies a patch, minor, or major number as the rightmost level, for example: 

- `~> 3.0.1` does not allow `3.38` to be installed
- `~> 3.0` does allow `3.38` to be installed
- `~> 3` does allow `3.38` to be installed
- `~> 2.0` does not allow `3.38` to be installed
- `~> 2` does allow `3.38` to be installed
