### PR TITLE
fix: terraform env matching on colon separated filenames

### DIFF
--- a/cmd/infracost/testdata/generate/child_with_dot/expected.golden
+++ b/cmd/infracost/testdata/generate/child_with_dot/expected.golden
@@ -1,0 +1,24 @@
+version: 0.1
+
+projects:
+  - path: apps/foo
+    name: apps-foo-dev
+    terraform_var_files:
+      - envs/default.tfvars
+      - envs/dev.eu-west-1.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - apps/foo/**
+      - apps/foo/envs/default.tfvars
+      - apps/foo/envs/dev.eu-west-1.tfvars
+  - path: apps/foo
+    name: apps-foo-staging
+    terraform_var_files:
+      - envs/default.tfvars
+      - envs/staging.eu-west-1.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - apps/foo/**
+      - apps/foo/envs/default.tfvars
+      - apps/foo/envs/staging.eu-west-1.tfvars
+

--- a/cmd/infracost/testdata/generate/child_with_dot/tree.txt
+++ b/cmd/infracost/testdata/generate/child_with_dot/tree.txt
@@ -1,0 +1,8 @@
+.
+└── apps
+    └── foo
+        ├── main.tf
+        └── envs
+            ├── staging.eu-west-1.tfvars
+            ├── dev.eu-west-1.tfvars
+            └── default.tfvars

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -158,11 +158,15 @@ func (e *EnvFileMatcher) IsEnvName(file string) bool {
 	return false
 }
 
+// clean removes the extension from the file name and converts it to lowercase.
+// This should be used to clean the file name before matching it to an env name.
 func (e *EnvFileMatcher) clean(name string) string {
 	base := filepath.Base(name)
 
 	stem, _ := splitVarFileExt(base, e.extensions)
-	return strings.ToLower(stem)
+
+	// remove the leading . from the stem as this will affect env name matching
+	return strings.TrimPrefix(strings.ToLower(stem), ".")
 }
 
 // EnvName returns the environment name for the given var file.
@@ -216,7 +220,7 @@ func (e *EnvFileMatcher) EnvName(file string) string {
 }
 
 func (e *EnvFileMatcher) hasEnvPrefix(clean string, name string) bool {
-	return strings.HasPrefix(clean, name+"-") || strings.HasPrefix(clean, name+"_") || strings.HasPrefix(clean, "."+name)
+	return strings.HasPrefix(clean, name+"-") || strings.HasPrefix(clean, name+"_") || strings.HasPrefix(clean, name+".")
 }
 
 func (e *EnvFileMatcher) hasEnvSuffix(clean string, name string) bool {


### PR DESCRIPTION
Resolves issue where a terraform var file that started with an env name but was preceded by a `.` would fail to match an env, e.g `dev.foo.tfvars`. This was because of a typo in the prefix matching logic see [here](https://github.com/infracost/infracost/pull/3170/files#diff-169eaffd399624f8000fc1ab1f0bd319ec79ea58058f53e848ccdc16f6633710R223). Changing this logic also exposed an issue when matching hidden file var files (those starting with a `.`). As the previous typo was allowing for them to be successfully matched. Now that I've fixed the prefix matching logic, i've also changed the `clean` logic to remove `.` from the filenames so that the hidden files -> env name matching works as expected.