### PR TITLE
enhance: support complex remote variables

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1099,7 +1099,7 @@ func TestBreakdownWithComplexVarFlags(t *testing.T) {
 			"--terraform-var",
 			"instance_config={\"instance_type\":\"t2.micro\",\"storage\":20}",
 			"--terraform-var",
-			"lambda_configs=[{\"memory_size\":128},{\"memory_size\":256}]",
+			"lambda_configs=[{memory_size = 128},{ memory_size = 256}]",
 			"--usage-file",
 			path.Join(dir, "infracost-usage.yml"),
 		},

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -863,7 +863,8 @@ func tfVarsToMap(vars []string) map[string]interface{} {
 
 	m := make(map[string]interface{}, len(vars))
 	for _, v := range vars {
-		pieces := strings.Split(v, "=")
+		pieces := strings.SplitN(v, "=", 2)
+
 		if len(pieces) != 2 {
 			continue
 		}

--- a/internal/hcl/var.go
+++ b/internal/hcl/var.go
@@ -1,0 +1,75 @@
+package hcl
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	ctyJson "github.com/zclconf/go-cty/cty/json"
+)
+
+func ParseVariable(val interface{}) (cty.Value, error) {
+	switch v := val.(type) {
+	case string:
+		// Try to parse the string as an HCL expression. This will handle expressions
+		// passed in via the command line or env variables.
+		expr, diags := hclsyntax.ParseExpression([]byte(v), "", hcl.Pos{})
+		if !diags.HasErrors() {
+			parsedVal, moreDiags := expr.Value(nil)
+			if !moreDiags.HasErrors() {
+				return parsedVal, nil
+			}
+		}
+
+		return cty.StringVal(v), nil
+	// These cases should only be hit when the input is coming from the config file.
+	case int:
+		return cty.NumberIntVal(int64(v)), nil
+	case float64:
+		return cty.NumberFloatVal(v), nil
+	case bool:
+		return cty.BoolVal(v), nil
+	default:
+		// Try to parse complex types as JSON
+		// This will handle complex variables that have been passed into Infracost
+		// via the config file, e.g.:
+		// terraform_vars:
+		//   my_map:
+		//     key1: value1
+		//     key2: value2
+
+		// Ensure any maps with non-string keys are converted to string keys
+		m := convertToStringKeyMap(v)
+		b, err := json.Marshal(m)
+		if err != nil {
+			return cty.DynamicVal, err
+		}
+
+		simple := &ctyJson.SimpleJSONValue{}
+		err = simple.UnmarshalJSON(b)
+		if err != nil {
+			return cty.DynamicVal, err
+		}
+
+		return simple.Value, nil
+	}
+}
+
+func convertToStringKeyMap(value interface{}) interface{} {
+	switch v := value.(type) {
+	case map[interface{}]interface{}:
+		result := make(map[string]interface{})
+		for key, val := range v {
+			strKey := fmt.Sprintf("%v", key)
+			result[strKey] = convertToStringKeyMap(val)
+		}
+		return result
+	case []interface{}:
+		for i, elem := range v {
+			v[i] = convertToStringKeyMap(elem)
+		}
+	}
+	return value
+}

--- a/internal/hcl/var_test.go
+++ b/internal/hcl/var_test.go
@@ -1,0 +1,141 @@
+package hcl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestParseVariable(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   interface{}
+		want    cty.Value
+		wantErr bool
+	}{
+		{
+			name:    "string input",
+			input:   "hello",
+			want:    cty.StringVal("hello"),
+			wantErr: false,
+		},
+		{
+			name:    "integer input",
+			input:   42,
+			want:    cty.NumberIntVal(42),
+			wantErr: false,
+		},
+		{
+			name:    "float input",
+			input:   3.14,
+			want:    cty.NumberFloatVal(3.14),
+			wantErr: false,
+		},
+		{
+			name:    "boolean input",
+			input:   true,
+			want:    cty.BoolVal(true),
+			wantErr: false,
+		},
+		{
+			name:    "map with string keys input",
+			input:   map[string]interface{}{"key": "value"},
+			want:    cty.ObjectVal(map[string]cty.Value{"key": cty.StringVal("value")}),
+			wantErr: false,
+		},
+		{
+			name:    "map with integer keys input",
+			input:   map[interface{}]interface{}{1: "one", 2: "two"},
+			want:    cty.ObjectVal(map[string]cty.Value{"1": cty.StringVal("one"), "2": cty.StringVal("two")}),
+			wantErr: false,
+		},
+		{
+			name:    "nested map",
+			input:   map[string]interface{}{"outer": map[string]interface{}{"inner": "value"}},
+			want:    cty.ObjectVal(map[string]cty.Value{"outer": cty.ObjectVal(map[string]cty.Value{"inner": cty.StringVal("value")})}),
+			wantErr: false,
+		},
+		{
+			name:    "list input",
+			input:   []interface{}{"one", "two"},
+			want:    cty.TupleVal([]cty.Value{cty.StringVal("one"), cty.StringVal("two")}),
+			wantErr: false,
+		},
+		{
+			name:    "nested list",
+			input:   []interface{}{[]interface{}{"one", "two"}, "three"},
+			want:    cty.TupleVal([]cty.Value{cty.TupleVal([]cty.Value{cty.StringVal("one"), cty.StringVal("two")}), cty.StringVal("three")}),
+			wantErr: false,
+		},
+		{
+			name:    "HCL expression - simple map and list",
+			input:   `{"Hello": "world", "Foo": ["bar", "baz"]}`,
+			want:    cty.ObjectVal(map[string]cty.Value{"Hello": cty.StringVal("world"), "Foo": cty.TupleVal([]cty.Value{cty.StringVal("bar"), cty.StringVal("baz")})}),
+			wantErr: false,
+		},
+		{
+			name:    "HCL expression - map with complex keys and list",
+			input:   `{"hello": "world", "foo": ["bar", "baz"]}`,
+			want:    cty.ObjectVal(map[string]cty.Value{"hello": cty.StringVal("world"), "foo": cty.TupleVal([]cty.Value{cty.StringVal("bar"), cty.StringVal("baz")})}),
+			wantErr: false,
+		},
+		{
+			name:    "invalid input",
+			input:   func() {},
+			want:    cty.DynamicVal,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseVariable(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseVariable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !got.RawEquals(tt.want) {
+				t.Errorf("ParseVariable() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConvertToStringKeyMap(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		want  interface{}
+	}{
+		{
+			name:  "map with interface{} keys",
+			input: map[interface{}]interface{}{1: "one", "two": 2},
+			want:  map[string]interface{}{"1": "one", "two": 2},
+		},
+		{
+			name:  "nested map with interface{} keys",
+			input: map[interface{}]interface{}{"outer": map[interface{}]interface{}{1: "one"}},
+			want:  map[string]interface{}{"outer": map[string]interface{}{"1": "one"}},
+		},
+		{
+			name:  "slice of interface{}",
+			input: []interface{}{map[interface{}]interface{}{1: "one"}},
+			want:  []interface{}{map[string]interface{}{"1": "one"}},
+		},
+		{
+			name:  "non-map and non-slice input",
+			input: "string",
+			want:  "string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertToStringKeyMap(tt.input)
+			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", tt.want) {
+				t.Errorf("convertToStringKeyMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds support for variables that are specified with HCL syntax.

Previously we had supported complex variables, e.g. `--terraform-vars='custom_tags={"env": "prod", "project": "myproj"}'`, but we didn't support this if using HCL syntax, e.g. `--terraform-vars='custom_tags={env = "prod", project = "myproj"}'`.

This also updates the Terraform Cloud remote variable parsing to use the same logic as other variable parsing. It also supports loading in Terraform variables from Terraform Cloud if they are set as environment variables (i.e. with a `TF_VARS_` prefix).