### PR TITLE
fix: Calculate pricing for performance insights retention (> 7 days) for Serverless v2

### DIFF
--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
@@ -6,6 +6,11 @@
  ├─ Performance Insights Long Term Retention (db.r4.8xlarge)                                 32  vCPU-month                       $165.89    
  └─ Performance Insights API                                                Monthly cost depends on usage: $0.01 per 1000 requests           
                                                                                                                                              
+ aws_rds_cluster_instance.aurora_serverless_v2_performance_insights                                                                          
+ ├─ Aurora serverless v2                                                                  3,650  ACU-hours                        $438.00  * 
+ ├─ Performance Insights Long Term Retention (serverless)                                     5  ACUs                               $1.88    
+ └─ Performance Insights API                                                Monthly cost depends on usage: $0.01 per 1000 requests           
+                                                                                                                                             
  aws_rds_cluster_instance.aurora_serverless_v2_with_usage                                                                                    
  └─ Aurora serverless v2                                                                  3,650  ACU-hours                        $438.00  * 
                                                                                                                                              
@@ -96,16 +101,20 @@
  aws_rds_cluster_instance.aurora_serverless_v2                                                                                               
  └─ Aurora serverless v2                                                    Monthly cost depends on usage: $0.12 per ACU-hours               
                                                                                                                                              
- OVERALL TOTAL                                                                                                                  $6,255.24 
+ aws_rds_cluster_instance.aurora_serverless_v2_performance_insights_free                                                                     
+ ├─ Aurora serverless v2                                                    Monthly cost depends on usage: $0.12 per ACU-hours               
+ └─ Performance Insights API                                                Monthly cost depends on usage: $0.01 per 1000 requests           
+                                                                                                                                             
+ OVERALL TOTAL                                                                                                                  $6,695.11 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-26 cloud resources were detected:
-∙ 26 were estimated
+28 cloud resources were detected:
+∙ 28 were estimated
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,807 ┃        $448 ┃     $6,255 ┃
+┃ main                                               ┃        $5,809 ┃        $886 ┃     $6,695 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.tf
@@ -175,21 +175,21 @@ resource "aws_rds_cluster_instance" "aurora_io_optimized_instance" {
 }
 
 resource "aws_rds_cluster_instance" "aurora_serverless_v2_performance_insights" {
-  identifier         = "aurora-cluster-demo"
-  cluster_identifier = aws_rds_cluster.default.id
-  instance_class     = "db.serverless"
-  engine             = "aurora-mysql"
-  engine_version     = aws_rds_cluster.default.engine_version
-  performance_insights_enabled = true
+  identifier                            = "aurora-cluster-demo"
+  cluster_identifier                    = aws_rds_cluster.default.id
+  instance_class                        = "db.serverless"
+  engine                                = "aurora-mysql"
+  engine_version                        = aws_rds_cluster.default.engine_version
+  performance_insights_enabled          = true
   performance_insights_retention_period = 731
 }
 
 resource "aws_rds_cluster_instance" "aurora_serverless_v2_performance_insights_free" {
-  identifier         = "aurora-cluster-demo"
-  cluster_identifier = aws_rds_cluster.default.id
-  instance_class     = "db.serverless"
-  engine             = "aurora-mysql"
-  engine_version     = aws_rds_cluster.default.engine_version
-  performance_insights_enabled = true
+  identifier                            = "aurora-cluster-demo"
+  cluster_identifier                    = aws_rds_cluster.default.id
+  instance_class                        = "db.serverless"
+  engine                                = "aurora-mysql"
+  engine_version                        = aws_rds_cluster.default.engine_version
+  performance_insights_enabled          = true
   performance_insights_retention_period = 7
 }

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.tf
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.tf
@@ -173,3 +173,23 @@ resource "aws_rds_cluster_instance" "aurora_io_optimized_instance" {
   engine             = aws_rds_cluster.aurora_io_optimized.engine
   engine_version     = aws_rds_cluster.aurora_io_optimized.engine_version
 }
+
+resource "aws_rds_cluster_instance" "aurora_serverless_v2_performance_insights" {
+  identifier         = "aurora-cluster-demo"
+  cluster_identifier = aws_rds_cluster.default.id
+  instance_class     = "db.serverless"
+  engine             = "aurora-mysql"
+  engine_version     = aws_rds_cluster.default.engine_version
+  performance_insights_enabled = true
+  performance_insights_retention_period = 731
+}
+
+resource "aws_rds_cluster_instance" "aurora_serverless_v2_performance_insights_free" {
+  identifier         = "aurora-cluster-demo"
+  cluster_identifier = aws_rds_cluster.default.id
+  instance_class     = "db.serverless"
+  engine             = "aurora-mysql"
+  engine_version     = aws_rds_cluster.default.engine_version
+  performance_insights_enabled = true
+  performance_insights_retention_period = 7
+}

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.usage.yml
@@ -23,3 +23,7 @@ resource_usage:
     reserved_instance_payment_option: all_upfront
   aws_rds_cluster_instance.aurora_serverless_v2_with_usage:
     capacity_units_per_hr: 5
+  aws_rds_cluster_instance.aurora_serverless_v2_performance_insights:
+    capacity_units_per_hr: 5
+  aws_rds_cluster_instance.aurora_serverless_v2_performance_insights_scaling:
+    capacity_units_per_hr: 5

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -394,7 +394,7 @@ func performanceInsightsLongTermRetentionCostComponent(region, instanceClass, db
 			auroraCapacityUnits = decimal.NewFromFloat(*capacityUnits)
 		}
 		return &schema.CostComponent{
-			Name:            fmt.Sprintf("Performance Insights Long Term Retention (serverless)"),
+			Name:            "Performance Insights Long Term Retention (serverless)",
 			Unit:            "ACUs",
 			UnitMultiplier:  decimal.NewFromInt(1),
 			MonthlyQuantity: &auroraCapacityUnits,

--- a/internal/resources/aws/rds_cluster_instance.go
+++ b/internal/resources/aws/rds_cluster_instance.go
@@ -51,7 +51,8 @@ func (r *RDSClusterInstance) BuildResource() *schema.Resource {
 	databaseEngine := r.databaseEngineValue()
 
 	costComponents := []*schema.CostComponent{}
-	if strings.EqualFold(r.InstanceClass, "db.serverless") {
+	isServerless := strings.EqualFold(r.InstanceClass, "db.serverless")
+	if isServerless {
 		costComponents = append(costComponents, r.auroraServerlessV2CostComponent(databaseEngine))
 	} else {
 		costComponents = append(costComponents, r.dbInstanceCostComponent(databaseEngine))
@@ -79,7 +80,7 @@ func (r *RDSClusterInstance) BuildResource() *schema.Resource {
 	}
 	if r.PerformanceInsightsEnabled {
 		if r.PerformanceInsightsLongTermRetention {
-			costComponents = append(costComponents, performanceInsightsLongTermRetentionCostComponent(r.Region, r.InstanceClass))
+			costComponents = append(costComponents, performanceInsightsLongTermRetentionCostComponent(r.Region, r.InstanceClass, databaseEngine, isServerless, r.CapacityUnitsPerHr))
 		}
 
 		if r.MonthlyAdditionalPerformanceInsightsRequests == nil || *r.MonthlyAdditionalPerformanceInsightsRequests > 0 {


### PR DESCRIPTION
Cost components were not being identified for the retention of performance insights data for aurora clusters.