### PR TITLE
chore: Fix linting issues detected by newer golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,10 +22,9 @@ jobs:
         run: make tf_fmt_check
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@v6.1.0
         with:
           version: latest
-          skip-pkg-cache: true
           args: --timeout 5m
 
       - name: Install Terragrunt v0.31.8

--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -83,7 +83,7 @@ func buildCommentOutput(cmd *cobra.Command, ctx *config.RunContext, paths []stri
 
 	combined, err := output.Combine(inputs)
 	if errors.As(err, &clierror.WarningError{}) {
-		logging.Logger.Warn().Msgf(err.Error())
+		logging.Logger.Warn().Msg(err.Error())
 	} else if err != nil {
 		return nil, err
 	}

--- a/cmd/infracost/comment_azure_repos.go
+++ b/cmd/infracost/comment_azure_repos.go
@@ -110,7 +110,7 @@ func commentAzureReposCmd(ctx *config.RunContext) *cobra.Command {
 					if err != nil {
 						return fmt.Errorf("failed to marshal result: %w", err)
 					}
-					cmd.Printf(string(b))
+					cmd.Print(string(b))
 				} else if res.Posted {
 					cmd.Println("Comment posted to Azure Repos")
 				} else {

--- a/cmd/infracost/comment_bitbucket.go
+++ b/cmd/infracost/comment_bitbucket.go
@@ -128,7 +128,7 @@ func commentBitbucketCmd(ctx *config.RunContext) *cobra.Command {
 					if err != nil {
 						return fmt.Errorf("failed to marshal result: %w", err)
 					}
-					cmd.Printf(string(b))
+					cmd.Print(string(b))
 				} else if res.Posted {
 					cmd.Println("Comment posted to Bitbucket")
 				} else {

--- a/cmd/infracost/comment_github.go
+++ b/cmd/infracost/comment_github.go
@@ -152,7 +152,7 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 					if err != nil {
 						return fmt.Errorf("failed to marshal result: %w", err)
 					}
-					cmd.Printf(string(b))
+					cmd.Print(string(b))
 				} else if res.Posted {
 
 					cmd.Println("Comment posted to GitHub")

--- a/cmd/infracost/comment_gitlab.go
+++ b/cmd/infracost/comment_gitlab.go
@@ -124,7 +124,7 @@ func commentGitLabCmd(ctx *config.RunContext) *cobra.Command {
 					if err != nil {
 						return fmt.Errorf("failed to marshal result: %w", err)
 					}
-					cmd.Printf(string(b))
+					cmd.Print(string(b))
 				} else if res.Posted {
 					cmd.Println("Comment posted to GitLab")
 				} else {

--- a/cmd/infracost/output.go
+++ b/cmd/infracost/output.go
@@ -96,7 +96,7 @@ func outputCmd(ctx *config.RunContext) *cobra.Command {
 			combined, err := output.Combine(inputs)
 			if errors.As(err, &clierror.WarningError{}) {
 				if format == "json" {
-					logging.Logger.Warn().Msgf(err.Error())
+					logging.Logger.Warn().Msg(err.Error())
 				}
 			} else if err != nil {
 				return err

--- a/cmd/infracost/upload.go
+++ b/cmd/infracost/upload.go
@@ -71,7 +71,7 @@ See https://infracost.io/docs/features/cli_commands/#upload-runs`,
 				if err != nil {
 					return fmt.Errorf("failed to marshal result: %w", err)
 				}
-				cmd.Printf(string(b))
+				cmd.Print(string(b))
 			} else if result.ShareURL != "" {
 				cmd.Println("Share this cost estimate: ", ui.LinkString(result.ShareURL))
 			}

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -838,7 +838,7 @@ func (b *Block) Children() Blocks {
 		children = append(children, child)
 	}
 
-	return b.childBlocks
+	return children
 }
 
 // GetAttributes returns a list of Attribute for this Block. Attributes are key value specification on a given

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -41,7 +41,7 @@ func TestFormatCost(t *testing.T) {
 
 			diff := cmp.Diff(tc.expected, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatal(diff)
 			}
 		})
 	}
@@ -78,7 +78,7 @@ func TestFormatCost2DP(t *testing.T) {
 
 			diff := cmp.Diff(tc.expected, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatal(diff)
 			}
 		})
 	}
@@ -121,7 +121,7 @@ func TestCurrencyFormatCost(t *testing.T) {
 
 			diff := cmp.Diff(tc.expected, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatal(diff)
 			}
 		})
 	}
@@ -161,7 +161,7 @@ func TestFormatPrice(t *testing.T) {
 
 			diff := cmp.Diff(tc.expected, got)
 			if diff != "" {
-				t.Fatalf(diff)
+				t.Fatal(diff)
 			}
 		})
 	}

--- a/internal/providers/terraform/azure/mssql_database.go
+++ b/internal/providers/terraform/azure/mssql_database.go
@@ -98,7 +98,7 @@ func newAzureRMMSSQLDatabase(d *schema.ResourceData) schema.CoreResource {
 	} else if !dtuMap.usesDTUUnits(sku) {
 		c, err := parseMSSQLSku(d.Address, sku)
 		if err != nil {
-			logging.Logger.Warn().Msgf(err.Error())
+			logging.Logger.Warn().Msg(err.Error())
 			return nil
 		}
 

--- a/internal/providers/terraform/azure/sql_database.go
+++ b/internal/providers/terraform/azure/sql_database.go
@@ -78,7 +78,7 @@ func newSQLDatabase(d *schema.ResourceData) schema.CoreResource {
 		var err error
 		config, err = parseSKU(d.Address, sku)
 		if err != nil {
-			logging.Logger.Warn().Msgf(err.Error())
+			logging.Logger.Warn().Msg(err.Error())
 			return nil
 		}
 	}

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -109,13 +109,13 @@ func (p *DirProvider) checks() error {
 		msg := fmt.Sprintf("Terraform binary '%s' could not be found. You have two options:\n", binary)
 		msg += "1. Set a custom Terraform binary using the environment variable INFRACOST_TERRAFORM_BINARY.\n\n"
 		msg += fmt.Sprintf("2. Set --path to a Terraform plan JSON file. See %s for how to generate this.", ui.LinkString("https://infracost.io/troubleshoot"))
-		return clierror.NewCLIError(errors.Errorf(msg), "Terraform binary could not be found")
+		return clierror.NewCLIError(errors.New(msg), "Terraform binary could not be found")
 	}
 
 	out, err := exec.Command(binary, "-version").Output()
 	if err != nil {
 		msg := fmt.Sprintf("Could not get version of Terraform binary '%s'", binary)
-		return clierror.NewCLIError(errors.Errorf(msg), "Could not get version of Terraform binary")
+		return clierror.NewCLIError(errors.New(msg), "Could not get version of Terraform binary")
 	}
 
 	fullVersion := strings.SplitN(string(out), "\n", 2)[0]
@@ -521,11 +521,11 @@ func checkTerraformVersion(v string, fullV string) error {
 	}
 
 	if strings.HasPrefix(fullV, "Terraform ") && semver.Compare(v, minTerraformVer) < 0 {
-		return fmt.Errorf("Terraform %s is not supported. Please use Terraform version >= %s. Update it or set the environment variable INFRACOST_TERRAFORM_BINARY.", v, minTerraformVer) //nolint
+		return fmt.Errorf("Terraform %s is not supported. Please use Terraform version >= %s. Update it or set the environment variable INFRACOST_TERRAFORM_BINARY.", v, minTerraformVer) // nolint
 	}
 
 	if strings.HasPrefix(fullV, "terragrunt") && semver.Compare(v, minTerragruntVer) < 0 {
-		return fmt.Errorf("Terragrunt %s is not supported. Please use Terragrunt version >= %s. Update it or set the environment variable INFRACOST_TERRAFORM_BINARY.", v, minTerragruntVer) //nolint
+		return fmt.Errorf("Terragrunt %s is not supported. Please use Terragrunt version >= %s. Update it or set the environment variable INFRACOST_TERRAFORM_BINARY.", v, minTerragruntVer) // nolint
 	}
 
 	// Allow any non-terraform and non-terragrunt binaries

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -193,7 +193,7 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 		}
 		priceFilter, err = resolver.PriceFilter()
 		if err != nil {
-			logging.Logger.Warn().Msgf(err.Error())
+			logging.Logger.Warn().Msg(err.Error())
 		}
 		purchaseOptionLabel = "reserved"
 	}

--- a/internal/resources/aws/ec2_host.go
+++ b/internal/resources/aws/ec2_host.go
@@ -58,7 +58,7 @@ func (r *EC2Host) BuildResource() *schema.Resource {
 		priceFilter, err = resolver.PriceFilter()
 
 		if err != nil {
-			logging.Logger.Warn().Msgf(err.Error())
+			logging.Logger.Warn().Msg(err.Error())
 		}
 
 		purchaseOptionLabel = "reserved"

--- a/internal/resources/aws/elasticache_cluster.go
+++ b/internal/resources/aws/elasticache_cluster.go
@@ -80,7 +80,7 @@ func (r *ElastiCacheCluster) elastiCacheCostComponent(autoscaling bool) *schema.
 		}
 		reservedFilter, err := resolver.PriceFilter()
 		if err != nil {
-			logging.Logger.Warn().Msgf(err.Error())
+			logging.Logger.Warn().Msg(err.Error())
 		} else {
 			priceFilter = reservedFilter
 		}

--- a/internal/resources/aws/instance.go
+++ b/internal/resources/aws/instance.go
@@ -184,7 +184,7 @@ func (a *Instance) computeCostComponent() *schema.CostComponent {
 		}
 		reservedFilter, err := resolver.PriceFilter()
 		if err != nil {
-			logging.Logger.Warn().Msgf(err.Error())
+			logging.Logger.Warn().Msg(err.Error())
 		} else {
 			priceFilter = reservedFilter
 		}

--- a/internal/resources/aws/rds_cluster_instance.go
+++ b/internal/resources/aws/rds_cluster_instance.go
@@ -123,7 +123,7 @@ func (r *RDSClusterInstance) dbInstanceCostComponent(databaseEngine string) *sch
 		}
 		priceFilter, err = resolver.PriceFilter()
 		if err != nil {
-			logging.Logger.Warn().Msgf(err.Error())
+			logging.Logger.Warn().Msg(err.Error())
 		}
 		purchaseOptionLabel = "reserved"
 	}

--- a/internal/resources/aws/s3_bucket.go
+++ b/internal/resources/aws/s3_bucket.go
@@ -160,7 +160,7 @@ func (a *S3Bucket) BuildResource() *schema.Resource {
 			if err != nil {
 				msg = fmt.Sprintf("%s: %s", msg, err)
 			}
-			logging.Logger.Debug().Msgf(msg)
+			logging.Logger.Debug().Msg(msg)
 		} else {
 			standardStorageClassUsage := u["standard"].(map[string]interface{})
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -177,7 +177,7 @@ func AssertGoldenFile(t *testing.T, goldenFilePath string, actual []byte) bool {
 
 			err := os.WriteFile(goldenFilePath, actual, 0600)
 			assert.NoError(t, err)
-			t.Logf(fmt.Sprintf("Wrote golden file %s", goldenFilePath))
+			t.Logf("Wrote golden file %s", goldenFilePath)
 		} else {
 			// Generate the diff and error message.  We don't call assert.Equal because it escapes
 			// newlines (\n) and the output looks terrible.
@@ -191,7 +191,7 @@ func AssertGoldenFile(t *testing.T, goldenFilePath string, actual []byte) bool {
 				Context:  1,
 			})
 
-			t.Errorf(fmt.Sprintf("\nOutput does not match golden file (%s): \n\n%s\n", goldenFilePath, diff))
+			t.Errorf("\nOutput does not match golden file (%s): \n\n%s\n", goldenFilePath, diff)
 		}
 	}
 


### PR DESCRIPTION
I also updated the action version as it was a few major versions out and starting to cause deprecation warnings when running the linter.