### PR TITLE
enhance: make aws_s3_bucket_lifecycle_configuration a free resource

### DIFF
--- a/infracost-usage-defaults.large.yml
+++ b/infracost-usage-defaults.large.yml
@@ -254,66 +254,6 @@ resource_type_default_usage:
     monthly_monitored_objects: 200000000 # Monthly number of monitored objects by S3 Analytics Storage Class Analysis.
   aws_s3_bucket_inventory:
     monthly_listed_objects: 8000000000 # Monthly number of listed objects.
-  aws_s3_bucket_lifecycle_configuration:
-    object_tags: 20000000 # Total object tags.
-    standard: # Usages of S3 Standard:
-      storage_gb: 900 # Total storage in GB.
-      monthly_tier_1_requests: 4000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 50000000 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_select_data_scanned_gb: 10000 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 29000 # Monthly data returned by S3 Select in GB.
-    intelligent_tiering: # Usages of S3 Intelligent - Tiering:
-      frequent_access_storage_gb: 0 # Total storage for Frequent Access Tier in GB.
-      infrequent_access_storage_gb: 0 # Total storage for Infrequent Access Tier in GB.
-      monitored_objects: 0 # Total objects monitored by the Intelligent Tiering.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB.
-      early_delete_gb: 0 # If an archive is deleted within 1 months of being uploaded, you will be charged an early deletion fee per GB.
-    standard_infrequent_access: # Usages of S3 Standard - Infrequent Access:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_data_retrieval_gb: 0 # Monthly data retrievals in GB
-      monthly_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB.
-    one_zone_infrequent_access: # Usages of S3 One Zone - Infrequent Access:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_data_retrieval_gb: 0 # Monthly data retrievals in GB
-      monthly_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB.
-    glacier_flexible_retrieval: # Usages of S3 Glacier Flexible Retrieval:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_standard_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB (for standard level of S3 Glacier).
-      monthly_standard_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB (for standard level of S3 Glacier).
-      monthly_bulk_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB (for bulk level of S3 Glacier)
-      monthly_bulk_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB (for bulk level of S3 Glacier)
-      monthly_expedited_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB (for expedited level of S3 Glacier)
-      monthly_expedited_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB (for expedited level of S3 Glacier)
-      monthly_standard_data_retrieval_requests: 0 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      monthly_expedited_data_retrieval_requests: 0 # Monthly data Retrieval requests (for expedited level of S3 Glacier).
-      monthly_standard_data_retrieval_gb: 0 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      monthly_expedited_data_retrieval_gb: 0 # Monthly data retrievals in GB (for expedited level of S3 Glacier).
-      early_delete_gb: 0 # If an archive is deleted within 3 months of being uploaded, you will be charged an early deletion fee per GB.
-    glacier_deep_archive: # Usages of S3 Glacier Deep Archive:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_standard_data_retrieval_requests: 0 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_requests: 0 # Monthly data Retrieval requests (for bulk level of S3 Glacier).
-      monthly_standard_data_retrieval_gb: 0 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_gb: 0 # Monthly data retrievals in GB (for bulk level of S3 Glacier).
-      early_delete_gb: 0 # If an archive is deleted within 6 months of being uploaded, you will be charged an early deletion fee per GB.
   aws_s3_bucket:
     object_tags: 20000000 # Total object tags. Only for AWS provider V3.
     standard: # Usages of S3 Standard:

--- a/infracost-usage-defaults.medium.yml
+++ b/infracost-usage-defaults.medium.yml
@@ -254,66 +254,6 @@ resource_type_default_usage:
     monthly_monitored_objects: 100000000 # Monthly number of monitored objects by S3 Analytics Storage Class Analysis.
   aws_s3_bucket_inventory:
     monthly_listed_objects: 4000000000 # Monthly number of listed objects.
-  aws_s3_bucket_lifecycle_configuration:
-    object_tags: 10000000 # Total object tags.
-    standard: # Usages of S3 Standard:
-      storage_gb: 450 # Total storage in GB.
-      monthly_tier_1_requests: 2000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 25000000 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_select_data_scanned_gb: 5000 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 14500 # Monthly data returned by S3 Select in GB.
-    intelligent_tiering: # Usages of S3 Intelligent - Tiering:
-      frequent_access_storage_gb: 0 # Total storage for Frequent Access Tier in GB.
-      infrequent_access_storage_gb: 0 # Total storage for Infrequent Access Tier in GB.
-      monitored_objects: 0 # Total objects monitored by the Intelligent Tiering.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB.
-      early_delete_gb: 0 # If an archive is deleted within 1 months of being uploaded, you will be charged an early deletion fee per GB.
-    standard_infrequent_access: # Usages of S3 Standard - Infrequent Access:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_data_retrieval_gb: 0 # Monthly data retrievals in GB
-      monthly_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB.
-    one_zone_infrequent_access: # Usages of S3 One Zone - Infrequent Access:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_data_retrieval_gb: 0 # Monthly data retrievals in GB
-      monthly_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB.
-    glacier_flexible_retrieval: # Usages of S3 Glacier Flexible Retrieval:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_standard_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB (for standard level of S3 Glacier).
-      monthly_standard_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB (for standard level of S3 Glacier).
-      monthly_bulk_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB (for bulk level of S3 Glacier)
-      monthly_bulk_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB (for bulk level of S3 Glacier)
-      monthly_expedited_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB (for expedited level of S3 Glacier)
-      monthly_expedited_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB (for expedited level of S3 Glacier)
-      monthly_standard_data_retrieval_requests: 0 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      monthly_expedited_data_retrieval_requests: 0 # Monthly data Retrieval requests (for expedited level of S3 Glacier).
-      monthly_standard_data_retrieval_gb: 0 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      monthly_expedited_data_retrieval_gb: 0 # Monthly data retrievals in GB (for expedited level of S3 Glacier).
-      early_delete_gb: 0 # If an archive is deleted within 3 months of being uploaded, you will be charged an early deletion fee per GB.
-    glacier_deep_archive: # Usages of S3 Glacier Deep Archive:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_standard_data_retrieval_requests: 0 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_requests: 0 # Monthly data Retrieval requests (for bulk level of S3 Glacier).
-      monthly_standard_data_retrieval_gb: 0 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_gb: 0 # Monthly data retrievals in GB (for bulk level of S3 Glacier).
-      early_delete_gb: 0 # If an archive is deleted within 6 months of being uploaded, you will be charged an early deletion fee per GB.
   aws_s3_bucket:
     object_tags: 10000000 # Total object tags. Only for AWS provider V3.
     standard: # Usages of S3 Standard:

--- a/infracost-usage-defaults.small.yml
+++ b/infracost-usage-defaults.small.yml
@@ -254,66 +254,6 @@ resource_type_default_usage:
     monthly_monitored_objects: 50000000 # Monthly number of monitored objects by S3 Analytics Storage Class Analysis.
   aws_s3_bucket_inventory:
     monthly_listed_objects: 2000000000 # Monthly number of listed objects.
-  aws_s3_bucket_lifecycle_configuration:
-    object_tags: 5000000 # Total object tags.
-    standard: # Usages of S3 Standard:
-      storage_gb: 225 # Total storage in GB.
-      monthly_tier_1_requests: 1000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 12500000 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_select_data_scanned_gb: 2500 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 7250 # Monthly data returned by S3 Select in GB.
-    intelligent_tiering: # Usages of S3 Intelligent - Tiering:
-      frequent_access_storage_gb: 0 # Total storage for Frequent Access Tier in GB.
-      infrequent_access_storage_gb: 0 # Total storage for Infrequent Access Tier in GB.
-      monitored_objects: 0 # Total objects monitored by the Intelligent Tiering.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB.
-      early_delete_gb: 0 # If an archive is deleted within 1 months of being uploaded, you will be charged an early deletion fee per GB.
-    standard_infrequent_access: # Usages of S3 Standard - Infrequent Access:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_data_retrieval_gb: 0 # Monthly data retrievals in GB
-      monthly_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB.
-    one_zone_infrequent_access: # Usages of S3 One Zone - Infrequent Access:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_data_retrieval_gb: 0 # Monthly data retrievals in GB
-      monthly_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB.
-    glacier_flexible_retrieval: # Usages of S3 Glacier Flexible Retrieval:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_standard_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB (for standard level of S3 Glacier).
-      monthly_standard_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB (for standard level of S3 Glacier).
-      monthly_bulk_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB (for bulk level of S3 Glacier)
-      monthly_bulk_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB (for bulk level of S3 Glacier)
-      monthly_expedited_select_data_scanned_gb: 0 # Monthly data scanned by S3 Select in GB (for expedited level of S3 Glacier)
-      monthly_expedited_select_data_returned_gb: 0 # Monthly data returned by S3 Select in GB (for expedited level of S3 Glacier)
-      monthly_standard_data_retrieval_requests: 0 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      monthly_expedited_data_retrieval_requests: 0 # Monthly data Retrieval requests (for expedited level of S3 Glacier).
-      monthly_standard_data_retrieval_gb: 0 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      monthly_expedited_data_retrieval_gb: 0 # Monthly data retrievals in GB (for expedited level of S3 Glacier).
-      early_delete_gb: 0 # If an archive is deleted within 3 months of being uploaded, you will be charged an early deletion fee per GB.
-    glacier_deep_archive: # Usages of S3 Glacier Deep Archive:
-      storage_gb: 0 # Total storage in GB.
-      monthly_tier_1_requests: 0 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 0 # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 0 # Monthly Lifecycle Transition requests.
-      monthly_standard_data_retrieval_requests: 0 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_requests: 0 # Monthly data Retrieval requests (for bulk level of S3 Glacier).
-      monthly_standard_data_retrieval_gb: 0 # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_gb: 0 # Monthly data retrievals in GB (for bulk level of S3 Glacier).
-      early_delete_gb: 0 # If an archive is deleted within 6 months of being uploaded, you will be charged an early deletion fee per GB.
   aws_s3_bucket:
     object_tags: 5000000 # Total object tags. Only for AWS provider V3.
     standard: # Usages of S3 Standard:

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -365,67 +365,6 @@ resource_usage:
   aws_s3_bucket_inventory.my_inventory:
     monthly_listed_objects: 100000000 # Monthly number of listed objects.
 
-  aws_s3_bucket_lifecycle_configuration.my_bucket_lifecycle_config:
-    object_tags: 10000000 # Total object tags.
-    standard: # Usages of S3 Standard:
-      storage_gb: 10000                     # Total storage in GB.
-      monthly_tier_1_requests: 1000000      # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 100000       # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_select_data_scanned_gb: 10000 # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 1000 # Monthly data returned by S3 Select in GB.
-    intelligent_tiering: # Usages of S3 Intelligent - Tiering:
-      frequent_access_storage_gb: 20000             # Total storage for Frequent Access Tier in GB.
-      infrequent_access_storage_gb: 20000           # Total storage for Infrequent Access Tier in GB.
-      monitored_objects: 2000                       # Total objects monitored by the Intelligent Tiering.
-      monthly_tier_1_requests: 2000000              # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 200000               # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 200000 # Monthly Lifecycle Transition requests.
-      monthly_select_data_scanned_gb: 20000         # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 2000         # Monthly data returned by S3 Select in GB.
-      early_delete_gb: 200000                       # If an archive is deleted within 1 months of being uploaded, you will be charged an early deletion fee per GB.
-    standard_infrequent_access: # Usages of S3 Standard - Infrequent Access:
-      storage_gb: 30000                             # Total storage in GB.
-      monthly_tier_1_requests: 3000000              # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 300000               # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 300000 # Monthly Lifecycle Transition requests.
-      monthly_data_retrieval_gb: 30000              # Monthly data retrievals in GB
-      monthly_select_data_scanned_gb: 30000         # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 3000         # Monthly data returned by S3 Select in GB.
-    one_zone_infrequent_access: # Usages of S3 One Zone - Infrequent Access:
-      storage_gb: 40000                             # Total storage in GB.
-      monthly_tier_1_requests: 4000000              # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 400000               # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 400000 # Monthly Lifecycle Transition requests.
-      monthly_data_retrieval_gb: 40000              # Monthly data retrievals in GB
-      monthly_select_data_scanned_gb: 40000         # Monthly data scanned by S3 Select in GB.
-      monthly_select_data_returned_gb: 4000         # Monthly data returned by S3 Select in GB.
-    glacier_flexible_retrieval: # Usages of S3 Glacier Flexible Retrieval:
-      storage_gb: 50000                                 # Total storage in GB.
-      monthly_tier_1_requests: 5000000                  # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 500000                   # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 500000     # Monthly Lifecycle Transition requests.
-      monthly_standard_select_data_scanned_gb: 500000   # Monthly data scanned by S3 Select in GB (for standard level of S3 Glacier).
-      monthly_standard_select_data_returned_gb: 500000  # Monthly data returned by S3 Select in GB (for standard level of S3 Glacier).
-      monthly_bulk_select_data_scanned_gb: 500000       # Monthly data scanned by S3 Select in GB (for bulk level of S3 Glacier)
-      monthly_bulk_select_data_returned_gb: 500000      # Monthly data returned by S3 Select in GB (for bulk level of S3 Glacier)
-      monthly_expedited_select_data_scanned_gb: 500000  # Monthly data scanned by S3 Select in GB (for expedited level of S3 Glacier)
-      monthly_expedited_select_data_returned_gb: 500000 # Monthly data returned by S3 Select in GB (for expedited level of S3 Glacier)
-      monthly_standard_data_retrieval_requests: 500000  # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      monthly_expedited_data_retrieval_requests: 500000 # Monthly data Retrieval requests (for expedited level of S3 Glacier).
-      monthly_standard_data_retrieval_gb: 5000          # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      monthly_expedited_data_retrieval_gb: 5000         # Monthly data retrievals in GB (for expedited level of S3 Glacier).
-      early_delete_gb: 500000                           # If an archive is deleted within 3 months of being uploaded, you will be charged an early deletion fee per GB.
-    glacier_deep_archive: # Usages of S3 Glacier Deep Archive:
-      storage_gb: 60000                                # Total storage in GB.
-      monthly_tier_1_requests: 6000000                 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
-      monthly_tier_2_requests: 600000                  # Monthly GET, SELECT, and all other requests (Tier 2).
-      monthly_lifecycle_transition_requests: 600000    # Monthly Lifecycle Transition requests.
-      monthly_standard_data_retrieval_requests: 600000 # Monthly data Retrieval requests (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_requests: 600000     # Monthly data Retrieval requests (for bulk level of S3 Glacier).
-      monthly_standard_data_retrieval_gb: 6000         # Monthly data retrievals in GB (for standard level of S3 Glacier).
-      monthly_bulk_data_retrieval_gb: 6000             # Monthly data retrievals in GB (for bulk level of S3 Glacier).
-      early_delete_gb: 600000                          # If an archive is deleted within 6 months of being uploaded, you will be charged an early deletion fee per GB.
-
   aws_s3_bucket.my_bucket:
     object_tags: 10000000 # Total object tags. Only for AWS provider V3.
     standard: # Usages of S3 Standard:

--- a/internal/providers/terraform/aws/s3_bucket_lifecycle_configuration.go
+++ b/internal/providers/terraform/aws/s3_bucket_lifecycle_configuration.go
@@ -19,7 +19,7 @@ func NewS3BucketLifecycleConfiguration(d *schema.ResourceData, u *schema.UsageDa
 		Tags:         d.Tags,
 		DefaultTags:  d.DefaultTags,
 		IsSkipped:    true,
-		NoPrice:      false,
-		//SkipMessage:  "Free resource.",
+		NoPrice:      true,
+		SkipMessage:  "Free resource.",
 	}
 }


### PR DESCRIPTION
Usage for lifecycle transitions can be recorded directly on the s3 bucket.