### PR TITLE
chore: update the golden tests [IC-1572]

### DIFF
--- a/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
@@ -14,7 +14,7 @@
  └─ EKS cluster (extended support)                 730  hours       $438.00   
                                                                               
  aws_eks_cluster.extended_support["1.27"]                                     
- └─ EKS cluster                                    730  hours        $73.00   
+ └─ EKS cluster (extended support)                 730  hours       $438.00   
                                                                               
  aws_eks_cluster.extended_support["1.28"]                                     
  └─ EKS cluster                                    730  hours        $73.00   
@@ -25,7 +25,7 @@
  aws_eks_cluster.my_aws_eks_cluster                                           
  └─ EKS cluster                                    730  hours        $73.00   
                                                                               
- OVERALL TOTAL                                                   $2,044.00 
+ OVERALL TOTAL                                                   $2,409.00 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -36,5 +36,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $2,044 ┃           - ┃     $2,044 ┃
+┃ main                                               ┃        $2,409 ┃           - ┃     $2,409 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
@@ -5,9 +5,9 @@
  └─ Virtual server (Linux/UNIX)          730  hours        $78.49   
                                                                     
  aws_lightsail_instance.win1                                        
- └─ Virtual server (Windows)             730  hours        $19.62   
+ └─ Virtual server (Windows)             730  hours        $21.58   
                                                                     
- OVERALL TOTAL                                            $98.11 
+ OVERALL TOTAL                                           $100.07 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -18,5 +18,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $98 ┃           - ┃        $98 ┃
+┃ main                                               ┃          $100 ┃           - ┃       $100 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
@@ -5,9 +5,9 @@
  └─ Virtual server (Linux/UNIX)          730  hours        $78.49   
                                                                     
  aws_lightsail_instance.win1                                        
- └─ Virtual server (Windows)             730  hours        $21.58   
+ └─ Virtual server (Windows)             730  hours        $19.62   
                                                                     
- OVERALL TOTAL                                           $100.07 
+ OVERALL TOTAL                                            $98.11 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -18,5 +18,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃          $100 ┃           - ┃       $100 ┃
+┃ main                                               ┃           $98 ┃           - ┃        $98 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/app_service_environment_test.go
+++ b/internal/providers/terraform/azure/app_service_environment_test.go
@@ -12,5 +12,9 @@ func TestAzureRMAppIsolatedServicePlan(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "app_service_environment_test")
+	opts := tftest.DefaultGoldenFileOptions()
+	// Ignore the CLI because the resource has been removed from the provider
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "app_service_environment_test", opts)
 }

--- a/internal/providers/terraform/azure/data_factory_integration_runtime_managed_test.go
+++ b/internal/providers/terraform/azure/data_factory_integration_runtime_managed_test.go
@@ -11,6 +11,9 @@ func TestDataFactoryIntegrationRuntimeManaged(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+	opts := tftest.DefaultGoldenFileOptions()
+	// Ignore the CLI because the resource has been removed from the provider
+	opts.IgnoreCLI = true
 
-	tftest.GoldenFileResourceTests(t, "data_factory_integration_runtime_managed_test")
+	tftest.GoldenFileResourceTestsWithOpts(t, "data_factory_integration_runtime_managed_test", opts)
 }

--- a/internal/providers/terraform/azure/integration_service_environment_test.go
+++ b/internal/providers/terraform/azure/integration_service_environment_test.go
@@ -12,5 +12,9 @@ func TestAzureRMAIntegrationServiceEnvironment(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "integration_service_environment_test")
+	opts := tftest.DefaultGoldenFileOptions()
+	// Ignore the CLI because the resource has been removed from the provider
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "integration_service_environment_test", opts)
 }

--- a/internal/providers/terraform/azure/lb_outbound_rule_test.go
+++ b/internal/providers/terraform/azure/lb_outbound_rule_test.go
@@ -11,8 +11,12 @@ func TestAzureRMLoadBalancerOutboundRuleGoldenFile(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
+	opts := tftest.DefaultGoldenFileOptions()
 
-	tftest.GoldenFileResourceTests(t, "lb_outbound_rule_test")
+	// Skip CLI diff as it yields different results
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "lb_outbound_rule_test", opts)
 }
 
 func TestAzureRMLoadBalancerOutboundRuleV2GoldenFile(t *testing.T) {
@@ -21,5 +25,10 @@ func TestAzureRMLoadBalancerOutboundRuleV2GoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "lb_outbound_rule_v2_test")
+	opts := tftest.DefaultGoldenFileOptions()
+
+	// Skip CLI diff as it yields different results
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "lb_outbound_rule_v2_test", opts)
 }

--- a/internal/providers/terraform/azure/lb_rule_test.go
+++ b/internal/providers/terraform/azure/lb_rule_test.go
@@ -12,7 +12,11 @@ func TestAzureRMLoadBalancerRuleGoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "lb_rule_test")
+	opts := tftest.DefaultGoldenFileOptions()
+	// Skip CLI diff as it yields different results
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "lb_rule_test", opts)
 }
 
 func TestAzureRMLoadBalancerRuleV2GoldenFile(t *testing.T) {
@@ -21,5 +25,9 @@ func TestAzureRMLoadBalancerRuleV2GoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "lb_rule_v2_test")
+	opts := tftest.DefaultGoldenFileOptions()
+	// Skip CLI diff as it yields different results
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "lb_rule_v2_test", opts)
 }

--- a/internal/providers/terraform/azure/lb_test.go
+++ b/internal/providers/terraform/azure/lb_test.go
@@ -12,5 +12,10 @@ func TestAzureRMLoadBalancerGoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "lb_test")
+	opts := tftest.DefaultGoldenFileOptions()
+
+	// Skip CLI diff as it yields different results
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "lb_test", opts)
 }

--- a/internal/providers/terraform/azure/mariadb_server_test.go
+++ b/internal/providers/terraform/azure/mariadb_server_test.go
@@ -12,5 +12,9 @@ func TestMariaDBServer(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "mariadb_server_test")
+	opts := tftest.DefaultGoldenFileOptions()
+	// Ignore the CLI because the resource has been removed from the provider in favour of azurerm_mysql_flexible_server
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "mariadb_server_test", opts)
 }

--- a/internal/providers/terraform/azure/mysql_server_test.go
+++ b/internal/providers/terraform/azure/mysql_server_test.go
@@ -13,5 +13,7 @@ func TestMySQLServer_usage(t *testing.T) {
 
 	opts := tftest.DefaultGoldenFileOptions()
 	opts.CaptureLogs = true
+	// ignore CLI - this has been removed from the latest provider
+	opts.IgnoreCLI = true
 	tftest.GoldenFileResourceTestsWithOpts(t, "mysql_server_test", opts)
 }

--- a/internal/providers/terraform/azure/public_ip.go
+++ b/internal/providers/terraform/azure/public_ip.go
@@ -21,14 +21,13 @@ func NewAzureRMPublicIP(d *schema.ResourceData, u *schema.UsageData) *schema.Res
 	region := d.Region
 
 	var meterName string
-	sku := "Basic"
+	sku := "Standard" // default sku is Standard
+	skuTier := "Regional"
 	allocationMethod := d.Get("allocation_method").String()
 
 	if d.Get("sku").Type != gjson.Null {
 		sku = d.Get("sku").String()
 	}
-
-	skuTier := "regional"
 
 	switch sku {
 	case "Basic":
@@ -38,8 +37,8 @@ func NewAzureRMPublicIP(d *schema.ResourceData, u *schema.UsageData) *schema.Res
 		if skuTierVal != "" {
 			skuTier = skuTierVal
 		}
-		if skuTier == "global" {
-			sku = "Global"
+		if skuTier == "Global" {
+			sku = "Standard" // When sku_tier is Global, sku is Standard
 			meterName = "Global IPv4 " + allocationMethod + " Public IP"
 		} else {
 			meterName = "Standard IPv4 " + allocationMethod + " Public IP"

--- a/internal/providers/terraform/azure/sql_database_test.go
+++ b/internal/providers/terraform/azure/sql_database_test.go
@@ -13,5 +13,7 @@ func TestSQLDatabase(t *testing.T) {
 
 	opts := tftest.DefaultGoldenFileOptions()
 	opts.CaptureLogs = true
+	// ignore CLI - this has been removed from the latest provider
+	opts.IgnoreCLI = true
 	tftest.GoldenFileResourceTestsWithOpts(t, "sql_database_test", opts)
 }

--- a/internal/providers/terraform/azure/sql_elasticpool_test.go
+++ b/internal/providers/terraform/azure/sql_elasticpool_test.go
@@ -13,5 +13,7 @@ func TestSQLElasticPool(t *testing.T) {
 
 	opts := tftest.DefaultGoldenFileOptions()
 	opts.CaptureLogs = true
+	// ignore CLI - this has been removed from the latest provider
+	opts.IgnoreCLI = true
 	tftest.GoldenFileResourceTestsWithOpts(t, "sql_elasticpool_test", opts)
 }

--- a/internal/providers/terraform/azure/sql_managed_instance_test.go
+++ b/internal/providers/terraform/azure/sql_managed_instance_test.go
@@ -12,5 +12,9 @@ func TestSQLManagedInstance(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "sql_managed_instance_test")
+	opts := tftest.DefaultGoldenFileOptions()
+	// This resource is removed from the latest provider
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "sql_managed_instance_test", opts)
 }

--- a/internal/providers/terraform/azure/testdata/application_gateway_test/application_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/application_gateway_test/application_gateway_test.golden
@@ -42,9 +42,9 @@
  └─ Data processing (0-10TB)                                       Monthly cost depends on usage: $0.00 per GB    
                                                                                                                   
  azurerm_public_ip.example                                                                                        
- └─ IP address (dynamic, regional)                                           730  hours                  $2.92    
+ └─ IP address (dynamic, regional)                                           730  hours              not found    
                                                                                                                   
- OVERALL TOTAL                                                                                       $5,914.54 
+ OVERALL TOTAL                                                                                       $5,911.62 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -56,5 +56,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $3,574 ┃      $2,340 ┃     $5,915 ┃
+┃ main                                               ┃        $3,571 ┃      $2,340 ┃     $5,912 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.golden
@@ -178,9 +178,9 @@
  └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records         
                                                                                                                                    
  azurerm_cognitive_account.with_usage["SpeechServices-S0"]                                                                         
- ├─ Speech to text                                                                    20  hours                           $20.00   
+ ├─ Speech to text                                                                    20  hours                        not found   
  ├─ Speech to text batch                                                              56  hours                           $10.08   
- ├─ Speech to text custom model                                                       17  hours                           $20.40   
+ ├─ Speech to text custom model                                                       17  hours                        not found   
  ├─ Speech to text custom model batch                                                 44  hours                            $9.90   
  ├─ Speech to text custom endpoint hosting                                           372  hours                           $20.00   
  ├─ Speech to text custom training                                                     2  hours                           $20.00   
@@ -218,7 +218,7 @@
                                                                                                                                    
  azurerm_cognitive_account.speech_with_commitment["invalid"]                                                                       
  ├─ Speech to text batch                                              Monthly cost depends on usage: $0.18 per hours               
- ├─ Speech to text custom model                                       Monthly cost depends on usage: $1.20 per hours               
+ ├─ Speech to text custom model                                       not found                                                    
  ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.23 per hours               
  ├─ Speech to text custom endpoint hosting                            Monthly cost depends on usage: $0.05375 per hours            
  ├─ Speech to text custom training                                    Monthly cost depends on usage: $10.00 per hours              
@@ -250,9 +250,9 @@
  └─ Speech requests                                                   Monthly cost depends on usage: $5.50 per 1K transactions     
                                                                                                                                    
  azurerm_cognitive_account.without_usage["SpeechServices-S0"]                                                                      
- ├─ Speech to text                                                    Monthly cost depends on usage: $1.00 per hours               
+ ├─ Speech to text                                                    not found                                                    
  ├─ Speech to text batch                                              Monthly cost depends on usage: $0.18 per hours               
- ├─ Speech to text custom model                                       Monthly cost depends on usage: $1.20 per hours               
+ ├─ Speech to text custom model                                       not found                                                    
  ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.23 per hours               
  ├─ Speech to text custom endpoint hosting                            Monthly cost depends on usage: $0.05375 per hours            
  ├─ Speech to text custom training                                    Monthly cost depends on usage: $10.00 per hours              
@@ -281,7 +281,7 @@
  ├─ Customized training                                               Monthly cost depends on usage: $3.00 per hour                
  └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records         
                                                                                                                                    
- OVERALL TOTAL                                                                                                      $314,876.75 
+ OVERALL TOTAL                                                                                                      $314,836.35 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -295,7 +295,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃      $314,877 ┃           - ┃   $314,877 ┃
+┃ main                                               ┃      $314,836 ┃           - ┃   $314,836 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.golden
+++ b/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.golden
@@ -315,6 +315,11 @@
  azurerm_cognitive_deployment.eastus_without_usage["whisper"]                                                                                  
  └─ Text to speech (whisper)                                                         Monthly cost depends on usage: $0.36 per hours            
                                                                                                                                                
+ azurerm_cognitive_deployment.free_tier                                                                                                        
+ ├─ Language input (gpt-4)                                                           Monthly cost depends on usage: $0.03 per 1K tokens        
+ ├─ Language output (gpt-4)                                                          Monthly cost depends on usage: $0.06 per 1K tokens        
+ └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                               
  azurerm_cognitive_deployment.swedencentral_without_usage["dall-e-3"]                                                                          
  ├─ Standard 1024x1024 images (dall-e-3)                                             Monthly cost depends on usage: $4.00 per 100 images       
  ├─ Standard 1024x1792 images (dall-e-3)                                             Monthly cost depends on usage: $8.00 per 100 images       
@@ -377,8 +382,8 @@
 
 ──────────────────────────────────
 116 cloud resources were detected:
-∙ 108 were estimated
-∙ 7 were free
+∙ 109 were estimated
+∙ 6 were free
 ∙ 1 is not supported yet, see https://infracost.io/requested-resources:
   ∙ 1 x azurerm_cognitive_deployment
 

--- a/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.tf
+++ b/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.tf
@@ -96,8 +96,8 @@ resource "azurerm_cognitive_deployment" "eastus_without_usage" {
     version = each.value.version
   }
 
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
 }
 
@@ -113,8 +113,8 @@ resource "azurerm_cognitive_deployment" "eastus2_without_usage" {
     version = each.value.version
   }
 
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
 }
 
@@ -130,8 +130,8 @@ resource "azurerm_cognitive_deployment" "swedencentral_without_usage" {
     version = each.value.version
   }
 
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
 }
 
@@ -147,8 +147,8 @@ resource "azurerm_cognitive_deployment" "eastus_with_usage" {
     version = each.value.version
   }
 
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
 }
 
@@ -164,8 +164,8 @@ resource "azurerm_cognitive_deployment" "eastus2_with_usage" {
     version = each.value.version
   }
 
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
 }
 
@@ -181,8 +181,8 @@ resource "azurerm_cognitive_deployment" "swedencentral_with_usage" {
     version = each.value.version
   }
 
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
 }
 
@@ -195,9 +195,8 @@ resource "azurerm_cognitive_deployment" "free_tier" {
     name   = "gpt-4"
   }
 
-  scale {
-    type = "Standard"
-    tier = "Free"
+  sku {
+    name = "Standard"
   }
 }
 
@@ -210,7 +209,7 @@ resource "azurerm_cognitive_deployment" "unsupported" {
     name   = "ada"
   }
 
-  scale {
-    type = "Standard"
+  sku {
+    name = "Standard"
   }
 }

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.golden
@@ -29,8 +29,8 @@
  └─ Restored data                                                             3,000  GB                             $450.00   
                                                                                                                               
  azurerm_cosmosdb_cassandra_keyspace.mutli-master_backup2copies                                                               
- ├─ Provisioned throughput (provisioned, West US)                                10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                             10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                                10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                             10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                                           1,000  GB                             $250.00   
  ├─ Transactional storage (Central US)                                        1,000  GB                             $250.00   
  └─ Restored data                                                Monthly cost depends on usage: $0.15 per GB                  
@@ -44,7 +44,7 @@
  ├─ Periodic backup (West US)                                    Monthly cost depends on usage: $0.15 per GB                  
  └─ Restored data                                                Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                               
- OVERALL TOTAL                                                                                                   $5,155.73 
+ OVERALL TOTAL                                                                                                   $5,038.93 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -56,5 +56,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,156 ┃           - ┃     $5,156 ┃
+┃ main                                               ┃        $5,039 ┃           - ┃     $5,039 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test/cosmosdb_cassandra_keyspace_test.tf
@@ -57,11 +57,11 @@ resource "azurerm_cosmosdb_account" "continuous_backup" {
 }
 
 resource "azurerm_cosmosdb_account" "multi-master_backup2copies" {
-  name                            = "tfex-cosmosdb-account"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test_with_blank_geo_location/cosmosdb_cassandra_keyspace_test_with_blank_geo_location.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test_with_blank_geo_location/cosmosdb_cassandra_keyspace_test_with_blank_geo_location.golden
@@ -2,7 +2,7 @@
  Name                                                              Monthly Qty  Unit                  Monthly Cost   
                                                                                                                      
  azurerm_cosmosdb_cassandra_keyspace.with_blank_geo_location                                                         
- ├─ Provisioned throughput (autoscale, East US)               Monthly cost depends on usage: $11.68 per RU/s x 100   
+ ├─ Provisioned throughput (autoscale, East US)               Monthly cost depends on usage: $5.84 per RU/s x 100    
  ├─ Transactional storage (East US)                           Monthly cost depends on usage: $0.25 per GB            
  ├─ Periodic backup (East US)                                 Monthly cost depends on usage: $0.12 per GB            
  └─ Restored data                                             Monthly cost depends on usage: $0.15 per GB            

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test_with_blank_geo_location/cosmosdb_cassandra_keyspace_test_with_blank_geo_location.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_keyspace_test_with_blank_geo_location/cosmosdb_cassandra_keyspace_test_with_blank_geo_location.tf
@@ -9,11 +9,11 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_cosmosdb_account" "with_blank_geo_location" {
-  name                            = "tfex-cosmosdb-account"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.golden
@@ -29,15 +29,15 @@
  └─ Restored data                                                             3,000  GB                             $450.00   
                                                                                                                               
  azurerm_cosmosdb_cassandra_table.mutli-master_backup2copies                                                                  
- ├─ Provisioned throughput (provisioned, West US)                                10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                             10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                                10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                             10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                                           1,000  GB                             $250.00   
  ├─ Transactional storage (Central US)                                        1,000  GB                             $250.00   
  └─ Restored data                                                Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                               
  azurerm_cosmosdb_cassandra_keyspace.mutli-master_backup2copies                                                               
- ├─ Provisioned throughput (provisioned, West US)                                10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                             10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                                10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                             10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                              Monthly cost depends on usage: $0.25 per GB                  
  ├─ Transactional storage (Central US)                           Monthly cost depends on usage: $0.25 per GB                  
  ├─ Periodic backup (West US)                                    Monthly cost depends on usage: $0.15 per GB                  
@@ -89,7 +89,7 @@
  ├─ Periodic backup (West US)                                    Monthly cost depends on usage: $0.15 per GB                  
  └─ Restored data                                                Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                               
- OVERALL TOTAL                                                                                                   $5,455.03 
+ OVERALL TOTAL                                                                                                   $5,221.43 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -104,7 +104,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,455 ┃           - ┃     $5,455 ┃
+┃ main                                               ┃        $5,221 ┃           - ┃     $5,221 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_cassandra_table_test/cosmosdb_cassandra_table_test.tf
@@ -57,11 +57,11 @@ resource "azurerm_cosmosdb_account" "continuous_backup" {
 }
 
 resource "azurerm_cosmosdb_account" "multi-master_backup2copies" {
-  name                            = "tfex-cosmosdb-account"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.golden
@@ -29,8 +29,8 @@
  └─ Restored data                                                           3,000  GB                             $450.00   
                                                                                                                             
  azurerm_cosmosdb_gremlin_database.mutli-master_backup2copies                                                               
- ├─ Provisioned throughput (provisioned, West US)                              10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                           10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                              10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                           10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                                         1,000  GB                             $250.00   
  ├─ Transactional storage (Central US)                                      1,000  GB                             $250.00   
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                  
@@ -44,7 +44,7 @@
  ├─ Periodic backup (West US)                                  Monthly cost depends on usage: $0.15 per GB                  
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                             
- OVERALL TOTAL                                                                                                 $5,155.73 
+ OVERALL TOTAL                                                                                                 $5,038.93 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -56,5 +56,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,156 ┃           - ┃     $5,156 ┃
+┃ main                                               ┃        $5,039 ┃           - ┃     $5,039 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_database_test/cosmosdb_gremlin_database_test.tf
@@ -57,11 +57,11 @@ resource "azurerm_cosmosdb_account" "continuous_backup" {
 }
 
 resource "azurerm_cosmosdb_account" "multi-master_backup2copies" {
-  name                            = "tfex-cosmosdb-account"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.golden
@@ -29,8 +29,8 @@
  └─ Restored data                                                        3,000  GB                             $450.00   
                                                                                                                          
  azurerm_cosmosdb_gremlin_graph.mutli-master_backup2copies                                                               
- ├─ Provisioned throughput (provisioned, West US)                           10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                        10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                           10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                        10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                                      1,000  GB                             $250.00   
  ├─ Transactional storage (Central US)                                   1,000  GB                             $250.00   
  └─ Restored data                                           Monthly cost depends on usage: $0.15 per GB                  
@@ -53,7 +53,7 @@
  ├─ Periodic backup (West US)                               Monthly cost depends on usage: $0.15 per GB                  
  └─ Restored data                                           Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                          
- OVERALL TOTAL                                                                                              $5,155.73 
+ OVERALL TOTAL                                                                                              $5,038.93 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -65,5 +65,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,156 ┃           - ┃     $5,156 ┃
+┃ main                                               ┃        $5,039 ┃           - ┃     $5,039 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_gremlin_graph_test/cosmosdb_gremlin_graph_test.tf
@@ -57,11 +57,11 @@ resource "azurerm_cosmosdb_account" "continuous_backup" {
 }
 
 resource "azurerm_cosmosdb_account" "multi-master_backup2copies" {
-  name                            = "tfex-cosmosdb-account"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.golden
@@ -29,15 +29,15 @@
  └─ Restored data                                                           3,000  GB                             $450.00   
                                                                                                                             
  azurerm_cosmosdb_mongo_collection.mutli-master_backup2copies                                                               
- ├─ Provisioned throughput (provisioned, West US)                              10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                           10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                              10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                           10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                                         1,000  GB                             $250.00   
  ├─ Transactional storage (Central US)                                      1,000  GB                             $250.00   
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                             
  azurerm_cosmosdb_mongo_database.mutli-master_backup2copies                                                                 
- ├─ Provisioned throughput (provisioned, West US)                              10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                           10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                              10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                           10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                            Monthly cost depends on usage: $0.25 per GB                  
  ├─ Transactional storage (Central US)                         Monthly cost depends on usage: $0.25 per GB                  
  ├─ Periodic backup (West US)                                  Monthly cost depends on usage: $0.15 per GB                  
@@ -89,7 +89,7 @@
  ├─ Periodic backup (West US)                                  Monthly cost depends on usage: $0.15 per GB                  
  └─ Restored data                                              Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                             
- OVERALL TOTAL                                                                                                 $5,455.03 
+ OVERALL TOTAL                                                                                                 $5,221.43 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -101,5 +101,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,455 ┃           - ┃     $5,455 ┃
+┃ main                                               ┃        $5,221 ┃           - ┃     $5,221 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_collection_test/cosmosdb_mongo_collection_test.tf
@@ -57,11 +57,11 @@ resource "azurerm_cosmosdb_account" "continuous_backup" {
 }
 
 resource "azurerm_cosmosdb_account" "multi-master_backup2copies" {
-  name                            = "tfex-cosmosdb-account"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.golden
@@ -29,8 +29,8 @@
  └─ Restored data                                                         3,000  GB                             $450.00   
                                                                                                                           
  azurerm_cosmosdb_mongo_database.mutli-master_backup2copies                                                               
- ├─ Provisioned throughput (provisioned, West US)                            10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                         10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                            10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                         10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                                       1,000  GB                             $250.00   
  ├─ Transactional storage (Central US)                                    1,000  GB                             $250.00   
  └─ Restored data                                            Monthly cost depends on usage: $0.15 per GB                  
@@ -44,7 +44,7 @@
  ├─ Periodic backup (West US)                                Monthly cost depends on usage: $0.15 per GB                  
  └─ Restored data                                            Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                           
- OVERALL TOTAL                                                                                               $5,155.73 
+ OVERALL TOTAL                                                                                               $5,038.93 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -56,5 +56,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,156 ┃           - ┃     $5,156 ┃
+┃ main                                               ┃        $5,039 ┃           - ┃     $5,039 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_mongo_database_test/cosmosdb_mongo_database_test.tf
@@ -57,11 +57,11 @@ resource "azurerm_cosmosdb_account" "continuous_backup" {
 }
 
 resource "azurerm_cosmosdb_account" "multi-master_backup2copies" {
-  name                            = "tfex-cosmosdb-account"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_container_test/cosmosdb_sql_container_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_container_test/cosmosdb_sql_container_test.tf
@@ -57,11 +57,11 @@ resource "azurerm_cosmosdb_account" "continuous_backup" {
 }
 
 resource "azurerm_cosmosdb_account" "multi-master_backup2copies" {
-  name                            = "tfex-cosmosdb-account"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"
@@ -95,7 +95,7 @@ resource "azurerm_cosmosdb_sql_container" "non-usage_autoscale" {
   resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
   account_name        = azurerm_cosmosdb_account.example.name
   database_name       = azurerm_cosmosdb_sql_database.example.name
-  partition_key_path  = "/definition/id"
+  partition_key_paths = ["/definition/id"]
   autoscale_settings {
     max_throughput = 4000
   }
@@ -106,7 +106,7 @@ resource "azurerm_cosmosdb_sql_container" "autoscale" {
   resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
   account_name        = azurerm_cosmosdb_account.continuous_backup.name
   database_name       = azurerm_cosmosdb_sql_database.example.name
-  partition_key_path  = "/definition/id"
+  partition_key_paths = ["/definition/id"]
   autoscale_settings {
     max_throughput = 6000
   }
@@ -117,7 +117,7 @@ resource "azurerm_cosmosdb_sql_container" "provisioned" {
   resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
   account_name        = azurerm_cosmosdb_account.continuous_backup.name
   database_name       = azurerm_cosmosdb_sql_database.example.name
-  partition_key_path  = "/definition/id"
+  partition_key_paths = ["/definition/id"]
   throughput          = 500
 }
 
@@ -126,7 +126,7 @@ resource "azurerm_cosmosdb_sql_container" "mutli-master_backup2copies" {
   resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
   account_name        = azurerm_cosmosdb_account.example.name
   database_name       = azurerm_cosmosdb_sql_database.example.name
-  partition_key_path  = "/definition/id"
+  partition_key_paths = ["/definition/id"]
   throughput          = 1000
 }
 
@@ -135,5 +135,5 @@ resource "azurerm_cosmosdb_sql_container" "serverless" {
   resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
   account_name        = azurerm_cosmosdb_account.example.name
   database_name       = azurerm_cosmosdb_sql_database.example.name
-  partition_key_path  = "/definition/id"
+  partition_key_paths = ["/definition/id"]
 }

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.golden
@@ -29,8 +29,8 @@
  └─ Restored data                                                       3,000  GB                             $450.00   
                                                                                                                         
  azurerm_cosmosdb_sql_database.mutli-master_backup2copies                                                               
- ├─ Provisioned throughput (provisioned, West US)                          10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                       10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                          10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                       10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                                     1,000  GB                             $250.00   
  ├─ Transactional storage (Central US)                                  1,000  GB                             $250.00   
  └─ Restored data                                          Monthly cost depends on usage: $0.15 per GB                  
@@ -53,7 +53,7 @@
  ├─ Periodic backup (West US)                              Monthly cost depends on usage: $0.15 per GB                  
  └─ Restored data                                          Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                         
- OVERALL TOTAL                                                                                             $5,184.93 
+ OVERALL TOTAL                                                                                             $5,068.13 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -65,5 +65,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,185 ┃           - ┃     $5,185 ┃
+┃ main                                               ┃        $5,068 ┃           - ┃     $5,068 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_sql_database_test/cosmosdb_sql_database_test.tf
@@ -57,11 +57,11 @@ resource "azurerm_cosmosdb_account" "continuous_backup" {
 }
 
 resource "azurerm_cosmosdb_account" "multi-master_backup2copies" {
-  name                            = "tfex-cosmosdb-account-backup2copies"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account-backup2copies"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"

--- a/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.golden
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.golden
@@ -29,8 +29,8 @@
  └─ Restored data                                                  3,000  GB                             $450.00   
                                                                                                                    
  azurerm_cosmosdb_table.mutli-master_backup2copies                                                                 
- ├─ Provisioned throughput (provisioned, West US)                     10  RU/s x 100                     $116.80   
- ├─ Provisioned throughput (provisioned, Central US)                  10  RU/s x 100                     $116.80   
+ ├─ Provisioned throughput (provisioned, West US)                     10  RU/s x 100                      $58.40   
+ ├─ Provisioned throughput (provisioned, Central US)                  10  RU/s x 100                      $58.40   
  ├─ Transactional storage (West US)                                1,000  GB                             $250.00   
  ├─ Transactional storage (Central US)                             1,000  GB                             $250.00   
  └─ Restored data                                     Monthly cost depends on usage: $0.15 per GB                  
@@ -44,7 +44,7 @@
  ├─ Periodic backup (West US)                         Monthly cost depends on usage: $0.15 per GB                  
  └─ Restored data                                     Monthly cost depends on usage: $0.15 per GB                  
                                                                                                                    
- OVERALL TOTAL                                                                                        $5,155.73 
+ OVERALL TOTAL                                                                                        $5,038.93 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -58,7 +58,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,156 ┃           - ┃     $5,156 ┃
+┃ main                                               ┃        $5,039 ┃           - ┃     $5,039 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.tf
+++ b/internal/providers/terraform/azure/testdata/cosmosdb_table_test/cosmosdb_table_test.tf
@@ -57,11 +57,11 @@ resource "azurerm_cosmosdb_account" "continuous_backup" {
 }
 
 resource "azurerm_cosmosdb_account" "multi-master_backup2copies" {
-  name                            = "tfex-cosmosdb-account"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  offer_type                      = "Standard"
-  enable_multiple_write_locations = true
+  name                = "tfex-cosmosdb-account"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  offer_type          = "Standard"
+
 
   consistency_policy {
     consistency_level = "Strong"

--- a/internal/providers/terraform/azure/testdata/event_hubs_namespace_test/event_hubs_namespace_test.tf
+++ b/internal/providers/terraform/azure/testdata/event_hubs_namespace_test/event_hubs_namespace_test.tf
@@ -43,8 +43,8 @@ resource "azurerm_eventhub_namespace" "premium" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "Premium"
-  zone_redundant      = true
-  capacity            = 8
+
+  capacity = 8
 }
 
 resource "azurerm_eventhub_namespace" "premiumWithoutUsage" {
@@ -52,7 +52,7 @@ resource "azurerm_eventhub_namespace" "premiumWithoutUsage" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "Premium"
-  zone_redundant      = true
+
 }
 
 resource "azurerm_eventhub_namespace" "dedicated" {

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_test/kubernetes_cluster_test.golden
@@ -4,7 +4,7 @@
  azurerm_kubernetes_cluster.windows                                                                  
  ├─ Uptime SLA                                                          730  hours         $73.00    
  └─ default_node_pool                                                                                
-    ├─ Instance usage (Windows, pay as you go, Standard_D2_v2)        3,650  hours        $919.80    
+    ├─ Instance usage (Windows, pay as you go, Standard_D2_v2)        3,650  hours        $868.70    
     └─ os_disk                                                                                       
        └─ Storage (S4, LRS)                                               5  months         $7.68    
                                                                                                      
@@ -44,7 +44,7 @@
     └─ os_disk                                                                                       
        └─ Storage (S10, LRS)                                              1  months         $5.89    
                                                                                                      
- OVERALL TOTAL                                                                          $2,835.67 
+ OVERALL TOTAL                                                                          $2,784.57 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -56,5 +56,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $2,835 ┃       $0.50 ┃     $2,836 ┃
+┃ main                                               ┃        $2,784 ┃       $0.50 ┃     $2,785 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/lb_outbound_rule_test/lb_outbound_rule_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_outbound_rule_test/lb_outbound_rule_test.golden
@@ -5,12 +5,12 @@
  └─ Rule usage                                730  hours                    $7.30   
                                                                                     
  azurerm_public_ip.example                                                          
- └─ IP address (static, regional)             730  hours                    $2.63   
+ └─ IP address (static, regional)             730  hours                    $3.65   
                                                                                     
  azurerm_lb.example                                                                 
  └─ Data processed                 Monthly cost depends on usage: $0.005 per GB     
                                                                                     
- OVERALL TOTAL                                                             $9.93 
+ OVERALL TOTAL                                                            $10.95 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -22,5 +22,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $10 ┃           - ┃        $10 ┃
+┃ main                                               ┃           $11 ┃           - ┃        $11 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/lb_outbound_rule_v2_test/lb_outbound_rule_v2_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_outbound_rule_v2_test/lb_outbound_rule_v2_test.golden
@@ -5,12 +5,12 @@
  └─ Rule usage                                730  hours                    $7.30   
                                                                                     
  azurerm_public_ip.example                                                          
- └─ IP address (static, regional)             730  hours                    $2.63   
+ └─ IP address (static, regional)             730  hours                    $3.65   
                                                                                     
  azurerm_lb.example                                                                 
  └─ Data processed                 Monthly cost depends on usage: $0.005 per GB     
                                                                                     
- OVERALL TOTAL                                                             $9.93 
+ OVERALL TOTAL                                                            $10.95 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -22,5 +22,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $10 ┃           - ┃        $10 ┃
+┃ main                                               ┃           $11 ┃           - ┃        $11 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/lb_rule_test/lb_rule_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_rule_test/lb_rule_test.golden
@@ -1,9 +1,6 @@
 
  Name                                          Monthly Qty  Unit              Monthly Cost   
                                                                                              
- azurerm_lb_rule.rules_withDefaultSku                                                        
- └─ Rule usage                                         730  hours                    $7.30   
-                                                                                             
  azurerm_lb_rule.rules_withStandardSku                                                       
  └─ Rule usage                                         730  hours                    $7.30   
                                                                                              
@@ -16,23 +13,20 @@
  azurerm_public_ip.example_withStandardSku                                                   
  └─ IP address (static, regional)                      730  hours                    $3.65   
                                                                                              
- azurerm_lb.example_withDefaultSku                                                           
- └─ Data processed                          Monthly cost depends on usage: $0.005 per GB     
-                                                                                             
  azurerm_lb.example_withStandardSku                                                          
  └─ Data processed                          Monthly cost depends on usage: $0.005 per GB     
                                                                                              
- OVERALL TOTAL                                                                     $25.55 
+ OVERALL TOTAL                                                                     $18.25 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
 10 cloud resources were detected:
-∙ 7 were estimated
-∙ 3 were free
+∙ 5 were estimated
+∙ 5 were free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $26 ┃           - ┃        $26 ┃
+┃ main                                               ┃           $18 ┃           - ┃        $18 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/lb_rule_test/lb_rule_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_rule_test/lb_rule_test.golden
@@ -1,32 +1,38 @@
 
  Name                                          Monthly Qty  Unit              Monthly Cost   
                                                                                              
+ azurerm_lb_rule.rules_withDefaultSku                                                        
+ └─ Rule usage                                         730  hours                    $7.30   
+                                                                                             
  azurerm_lb_rule.rules_withStandardSku                                                       
  └─ Rule usage                                         730  hours                    $7.30   
                                                                                              
  azurerm_public_ip.example_withBasicSku                                                      
- └─ IP address (static, regional)                      730  hours                    $2.63   
+ └─ IP address (static, regional)                      730  hours                    $3.65   
                                                                                              
  azurerm_public_ip.example_withDefaultSku                                                    
- └─ IP address (static, regional)                      730  hours                    $2.63   
+ └─ IP address (static, regional)                      730  hours                    $3.65   
                                                                                              
  azurerm_public_ip.example_withStandardSku                                                   
- └─ IP address (static, regional)                      730  hours                    $2.63   
+ └─ IP address (static, regional)                      730  hours                    $3.65   
+                                                                                             
+ azurerm_lb.example_withDefaultSku                                                           
+ └─ Data processed                          Monthly cost depends on usage: $0.005 per GB     
                                                                                              
  azurerm_lb.example_withStandardSku                                                          
  └─ Data processed                          Monthly cost depends on usage: $0.005 per GB     
                                                                                              
- OVERALL TOTAL                                                                     $15.18 
+ OVERALL TOTAL                                                                     $25.55 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
 10 cloud resources were detected:
-∙ 5 were estimated
-∙ 5 were free
+∙ 7 were estimated
+∙ 3 were free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $15 ┃           - ┃        $15 ┃
+┃ main                                               ┃           $26 ┃           - ┃        $26 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/lb_rule_v2_test/lb_rule_v2_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_rule_v2_test/lb_rule_v2_test.golden
@@ -4,19 +4,19 @@
  azurerm_lb_rule.rules_withStandardSku                                                       
  └─ Rule usage                                         730  hours                    $7.30   
                                                                                              
- azurerm_public_ip.example_withBasicSku                                                      
- └─ IP address (static, regional)                      730  hours                    $2.63   
-                                                                                             
  azurerm_public_ip.example_withDefaultSku                                                    
- └─ IP address (static, regional)                      730  hours                    $2.63   
+ └─ IP address (static, regional)                      730  hours                    $3.65   
                                                                                              
  azurerm_public_ip.example_withStandardSku                                                   
+ └─ IP address (static, regional)                      730  hours                    $3.65   
+                                                                                             
+ azurerm_public_ip.example_withBasicSku                                                      
  └─ IP address (static, regional)                      730  hours                    $2.63   
                                                                                              
  azurerm_lb.example_withStandardSku                                                          
  └─ Data processed                          Monthly cost depends on usage: $0.005 per GB     
                                                                                              
- OVERALL TOTAL                                                                     $15.18 
+ OVERALL TOTAL                                                                     $17.23 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -28,5 +28,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $15 ┃           - ┃        $15 ┃
+┃ main                                               ┃           $17 ┃           - ┃        $17 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/lb_rule_v2_test/lb_rule_v2_test.tf
+++ b/internal/providers/terraform/azure/testdata/lb_rule_v2_test/lb_rule_v2_test.tf
@@ -25,6 +25,7 @@ resource "azurerm_public_ip" "example_withDefaultSku" {
   location            = "West US"
   resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Static"
+  sku                 = "Standard"
 }
 
 resource "azurerm_lb" "example_withDefaultSku" {
@@ -53,6 +54,7 @@ resource "azurerm_public_ip" "example_withBasicSku" {
   location            = "West US"
   resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Static"
+  sku                 = "Basic"
 }
 
 resource "azurerm_lb" "example_withBasicSku" {
@@ -82,6 +84,7 @@ resource "azurerm_public_ip" "example_withStandardSku" {
   location            = "West US"
   resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Static"
+  sku                 = "Standard"
 }
 
 resource "azurerm_lb" "example_withStandardSku" {

--- a/internal/providers/terraform/azure/testdata/lb_test/lb_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_test/lb_test.golden
@@ -1,23 +1,26 @@
 
  Name                        Monthly Qty  Unit              Monthly Cost    
                                                                             
+ azurerm_lb.basic                                                           
+ └─ Data processed                   100  GB                       $0.50  * 
+                                                                            
  azurerm_lb.standard                                                        
  └─ Data processed                   100  GB                       $0.50  * 
                                                                             
  azurerm_lb.withoutUsage                                                    
  └─ Data processed        Monthly cost depends on usage: $0.005 per GB      
                                                                             
- OVERALL TOTAL                                                     $0.50 
+ OVERALL TOTAL                                                     $1.00 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
 4 cloud resources were detected:
-∙ 2 were estimated
-∙ 2 were free
+∙ 3 were estimated
+∙ 1 was free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃         $0.00 ┃       $0.50 ┃      $0.50 ┃
+┃ main                                               ┃         $0.00 ┃          $1 ┃         $1 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/lb_test/lb_test.golden
+++ b/internal/providers/terraform/azure/testdata/lb_test/lb_test.golden
@@ -1,26 +1,23 @@
 
  Name                        Monthly Qty  Unit              Monthly Cost    
                                                                             
- azurerm_lb.basic                                                           
- └─ Data processed                   100  GB                       $0.50  * 
-                                                                            
  azurerm_lb.standard                                                        
  └─ Data processed                   100  GB                       $0.50  * 
                                                                             
  azurerm_lb.withoutUsage                                                    
  └─ Data processed        Monthly cost depends on usage: $0.005 per GB      
                                                                             
- OVERALL TOTAL                                                     $1.00 
+ OVERALL TOTAL                                                     $0.50 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
 4 cloud resources were detected:
-∙ 3 were estimated
-∙ 1 was free
+∙ 2 were estimated
+∙ 2 were free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃         $0.00 ┃          $1 ┃         $1 ┃
+┃ main                                               ┃         $0.00 ┃       $0.50 ┃      $0.50 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.golden
@@ -118,9 +118,9 @@
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-22 cloud resources were detected:
+21 cloud resources were detected:
 ∙ 12 were estimated
-∙ 6 were free
+∙ 5 were free
 ∙ 4 are not supported yet, see https://infracost.io/requested-resources:
   ∙ 4 x azurerm_log_analytics_workspace
 

--- a/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
+++ b/internal/providers/terraform/azure/testdata/log_analytics_workspace_test/log_analytics_workspace_test.tf
@@ -8,13 +8,6 @@ resource "azurerm_resource_group" "example" {
   location = "West Europe"
 }
 
-resource "azurerm_log_analytics_workspace" "free_workspace" {
-  name                = "acctest-free"
-  location            = azurerm_resource_group.example.location
-  resource_group_name = azurerm_resource_group.example.name
-  sku                 = "Free"
-}
-
 resource "azurerm_log_analytics_workspace" "per_gb_data_ingestion" {
   name                = "acctest-01"
   location            = azurerm_resource_group.example.location

--- a/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.golden
+++ b/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.golden
@@ -2,58 +2,58 @@
  Name                                                                          Monthly Qty  Unit                      Monthly Cost   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_NV24"]                                                                  
- └─ Instance usage (Linux, pay as you go, Standard_NV24)                               730  hours                        $3,985.80   
+ └─ Instance usage (Linux, pay as you go, Standard_NV24)                               730  hours                        $3,328.80   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_NC24"]                                                                  
- └─ Instance usage (Linux, pay as you go, Standard_NC24)                               730  hours                        $3,406.18   
+ └─ Instance usage (Linux, pay as you go, Standard_NC24)                               730  hours                        $2,628.00   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_NV12"]                                                                  
- └─ Instance usage (Linux, pay as you go, Standard_NV12)                               730  hours                        $1,992.90   
+ └─ Instance usage (Linux, pay as you go, Standard_NV12)                               730  hours                        $1,664.40   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_NC12"]                                                                  
- └─ Instance usage (Linux, pay as you go, Standard_NC12)                               730  hours                        $1,703.09   
+ └─ Instance usage (Linux, pay as you go, Standard_NC12)                               730  hours                        $1,314.00   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_NV6"]                                                                   
- └─ Instance usage (Linux, pay as you go, Standard_NV6)                                730  hours                          $996.45   
+ └─ Instance usage (Linux, pay as you go, Standard_NV6)                                730  hours                          $832.20   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_E16s_v3"]                                                               
- └─ Instance usage (Linux, pay as you go, Standard_E16s_v3)                            730  hours                          $934.40   
+ └─ Instance usage (Linux, pay as you go, Standard_E16s_v3)                            730  hours                          $735.84   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_NC6"]                                                                   
- └─ Instance usage (Linux, pay as you go, Standard_NC6)                                730  hours                          $851.18   
+ └─ Instance usage (Linux, pay as you go, Standard_NC6)                                730  hours                          $657.00   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_D16s_v3"]                                                               
- └─ Instance usage (Linux, pay as you go, Standard_D16s_v3)                            730  hours                          $700.80   
+ └─ Instance usage (Linux, pay as you go, Standard_D16s_v3)                            730  hours                          $560.64   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_F16s_v2"]                                                               
- └─ Instance usage (Linux, pay as you go, Standard_F16s_v2)                            730  hours                          $566.48   
+ └─ Instance usage (Linux, pay as you go, Standard_F16s_v2)                            730  hours                          $494.21   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_E8s_v3"]                                                                
- └─ Instance usage (Linux, pay as you go, Standard_E8s_v3)                             730  hours                          $467.20   
+ └─ Instance usage (Linux, pay as you go, Standard_E8s_v3)                             730  hours                          $367.92   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_D8s_v3"]                                                                
- └─ Instance usage (Linux, pay as you go, Standard_D8s_v3)                             730  hours                          $350.40   
-                                                                                                                                     
- azurerm_machine_learning_compute_instance.example["Standard_F8s_v2"]                                                                
- └─ Instance usage (Linux, pay as you go, Standard_F8s_v2)                             730  hours                          $283.24   
+ └─ Instance usage (Linux, pay as you go, Standard_D8s_v3)                             730  hours                          $280.32   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_DS12_v2"]                                                               
- └─ Instance usage (Linux, pay as you go, Standard_DS12_v2)                            730  hours                          $276.67   
+ └─ Instance usage (Linux, pay as you go, Standard_DS12_v2)                            730  hours                          $270.83   
+                                                                                                                                     
+ azurerm_machine_learning_compute_instance.example["Standard_F8s_v2"]                                                                
+ └─ Instance usage (Linux, pay as you go, Standard_F8s_v2)                             730  hours                          $246.74   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_E4s_v3"]                                                                
- └─ Instance usage (Linux, pay as you go, Standard_E4s_v3)                             730  hours                          $233.60   
+ └─ Instance usage (Linux, pay as you go, Standard_E4s_v3)                             730  hours                          $183.96   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_D4s_v3"]                                                                
- └─ Instance usage (Linux, pay as you go, Standard_D4s_v3)                             730  hours                          $175.20   
+ └─ Instance usage (Linux, pay as you go, Standard_D4s_v3)                             730  hours                          $140.16   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_F4s_v2"]                                                                
- └─ Instance usage (Linux, pay as you go, Standard_F4s_v2)                             730  hours                          $141.62   
+ └─ Instance usage (Linux, pay as you go, Standard_F4s_v2)                             730  hours                          $123.37   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.example["Standard_D2s_v3"]                                                                
- └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                             730  hours                           $87.60   
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                             730  hours                           $70.08   
                                                                                                                                      
  azurerm_machine_learning_compute_instance.with_monthly_hrs                                                                          
- └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                             100  hours                           $12.00   
+ └─ Instance usage (Linux, pay as you go, Standard_D2s_v3)                             100  hours                            $9.60   
                                                                                                                                      
  azurerm_storage_account.example                                                                                                     
  ├─ Capacity                                                            Monthly cost depends on usage: $0.0392 per GB                
@@ -63,7 +63,7 @@
  ├─ All other operations                                                Monthly cost depends on usage: $0.0043 per 10k operations    
  └─ Blob index                                                          Monthly cost depends on usage: $0.075 per 10k tags           
                                                                                                                                      
- OVERALL TOTAL                                                                                                         $17,164.81 
+ OVERALL TOTAL                                                                                                         $13,908.07 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -75,5 +75,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $17,165 ┃           - ┃    $17,165 ┃
+┃ main                                               ┃       $13,908 ┃           - ┃    $13,908 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.tf
+++ b/internal/providers/terraform/azure/testdata/machine_learning_compute_instance_test/machine_learning_compute_instance_test.tf
@@ -56,7 +56,6 @@ resource "azurerm_machine_learning_compute_instance" "example" {
   for_each = toset(local.vm_sizes)
 
   name                          = "example-instance"
-  location                      = azurerm_resource_group.example.location
   machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
   virtual_machine_size          = each.value
 
@@ -64,7 +63,6 @@ resource "azurerm_machine_learning_compute_instance" "example" {
 
 resource "azurerm_machine_learning_compute_instance" "with_monthly_hrs" {
   name                          = "with-monthly-hrs"
-  location                      = azurerm_resource_group.example.location
   machine_learning_workspace_id = azurerm_machine_learning_workspace.example.id
   virtual_machine_size          = "Standard_D2s_v3"
 }

--- a/internal/providers/terraform/azure/testdata/monitor_data_collection_rule_test/monitor_data_collection_rule_test.tf
+++ b/internal/providers/terraform/azure/testdata/monitor_data_collection_rule_test/monitor_data_collection_rule_test.tf
@@ -38,6 +38,7 @@ resource "azurerm_monitor_data_collection_rule" "example" {
 
   data_sources {
     syslog {
+      streams        = ["Microsoft-Syslog"]
       facility_names = ["*"]
       log_levels     = ["*"]
       name           = "test-datasource-syslog"

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.tf
@@ -8,7 +8,7 @@ resource "azurerm_resource_group" "example" {
   location = "eastus"
 }
 
-resource "azurerm_sql_server" "example" {
+resource "azurerm_mssql_server" "example" {
   name                         = "example-sqlserver"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = "eastus"
@@ -19,116 +19,116 @@ resource "azurerm_sql_server" "example" {
 
 resource "azurerm_mssql_database" "general_purpose_gen_without_license" {
   name         = "acctest-db-d"
-  server_id    = azurerm_sql_server.example.id
+  server_id    = azurerm_mssql_server.example.id
   sku_name     = "GP_Gen5_4"
   license_type = "BasePrice"
 }
 resource "azurerm_mssql_database" "business_critical_gen" {
   name        = "acctest-db-d"
-  server_id   = azurerm_sql_server.example.id
+  server_id   = azurerm_mssql_server.example.id
   sku_name    = "BC_Gen5_8"
   max_size_gb = 10
 }
 resource "azurerm_mssql_database" "business_critical_m" {
   name        = "acctest-db-d"
-  server_id   = azurerm_sql_server.example.id
+  server_id   = azurerm_mssql_server.example.id
   sku_name    = "BC_M_8"
   max_size_gb = 50
 }
 resource "azurerm_mssql_database" "hyperscale_gen" {
   name        = "acctest-db-d"
-  server_id   = azurerm_sql_server.example.id
+  server_id   = azurerm_mssql_server.example.id
   sku_name    = "HS_Gen5_2"
   max_size_gb = 100
 }
 
 resource "azurerm_mssql_database" "hyperscale_gen_with_replicas" {
   name               = "acctest-db-d"
-  server_id          = azurerm_sql_server.example.id
+  server_id          = azurerm_mssql_server.example.id
   sku_name           = "HS_Gen5_2"
   read_replica_count = 2
 }
 
 resource "azurerm_mssql_database" "general_purpose_gen" {
   name         = "acctest-db-d"
-  server_id    = azurerm_sql_server.example.id
+  server_id    = azurerm_mssql_server.example.id
   sku_name     = "GP_Gen5_4"
   license_type = "LicenseIncluded"
 }
 
 resource "azurerm_mssql_database" "general_purpose_gen_zone" {
   name           = "acctest-db-d"
-  server_id      = azurerm_sql_server.example.id
+  server_id      = azurerm_mssql_server.example.id
   sku_name       = "GP_Gen5_4"
   zone_redundant = true
 }
 
 resource "azurerm_mssql_database" "serverless" {
   name      = "acctest-db-d"
-  server_id = azurerm_sql_server.example.id
+  server_id = azurerm_mssql_server.example.id
   sku_name  = "GP_S_Gen5_4"
 }
 
 resource "azurerm_mssql_database" "serverless_zone" {
   name           = "acctest-db-d"
-  server_id      = azurerm_sql_server.example.id
+  server_id      = azurerm_mssql_server.example.id
   sku_name       = "GP_S_Gen5_4"
   zone_redundant = true
 }
 
 resource "azurerm_mssql_database" "backup_default" {
   name      = "acctest-db-d"
-  server_id = azurerm_sql_server.example.id
+  server_id = azurerm_mssql_server.example.id
   sku_name  = "GP_Gen5_4"
 }
 
 resource "azurerm_mssql_database" "backup_geo" {
   name                 = "acctest-db-d"
-  server_id            = azurerm_sql_server.example.id
+  server_id            = azurerm_mssql_server.example.id
   sku_name             = "GP_Gen5_4"
   storage_account_type = "Geo"
 }
 
 resource "azurerm_mssql_database" "backup_zone" {
   name                 = "acctest-db-d"
-  server_id            = azurerm_sql_server.example.id
+  server_id            = azurerm_mssql_server.example.id
   sku_name             = "GP_Gen5_4"
   storage_account_type = "Zone"
 }
 
 resource "azurerm_mssql_database" "backup_local" {
   name                 = "acctest-db-d"
-  server_id            = azurerm_sql_server.example.id
+  server_id            = azurerm_mssql_server.example.id
   sku_name             = "GP_Gen5_4"
   storage_account_type = "Local"
 }
 
 resource "azurerm_mssql_database" "standard1" {
   name      = "acctest-db-d"
-  server_id = azurerm_sql_server.example.id
+  server_id = azurerm_mssql_server.example.id
   sku_name  = "S1"
 }
 
 resource "azurerm_mssql_database" "standard12" {
   name        = "acctest-db-d"
-  server_id   = azurerm_sql_server.example.id
+  server_id   = azurerm_mssql_server.example.id
   sku_name    = "S12"
   max_size_gb = 500
 }
 
 resource "azurerm_mssql_database" "premium6" {
   name      = "acctest-db-d"
-  server_id = azurerm_sql_server.example.id
+  server_id = azurerm_mssql_server.example.id
   sku_name  = "P6"
 }
 
 resource "azurerm_mssql_database" "blank_sku" {
   name      = "acctest-db-e"
-  server_id = azurerm_sql_server.example.id
+  server_id = azurerm_mssql_server.example.id
 }
 
 resource "azurerm_mssql_database" "elastic_pool" {
   name      = "acctest-db-f"
-  server_id = azurerm_sql_server.example.id
+  server_id = azurerm_mssql_server.example.id
   sku_name  = "ElasticPool"
 }

--- a/internal/providers/terraform/azure/testdata/mssql_elasticpool_test/mssql_elasticpool_test.tf
+++ b/internal/providers/terraform/azure/testdata/mssql_elasticpool_test/mssql_elasticpool_test.tf
@@ -8,7 +8,7 @@ resource "azurerm_resource_group" "example" {
   location = "West Europe"
 }
 
-resource "azurerm_sql_server" "example" {
+resource "azurerm_mssql_server" "example" {
   name                         = "myexamplesqlserver"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = "eastus"
@@ -21,7 +21,7 @@ resource "azurerm_mssql_elasticpool" "gp_gen5" {
   name                = "gp-gen5"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   license_type        = "LicenseIncluded"
   max_size_gb         = 100
 
@@ -42,7 +42,7 @@ resource "azurerm_mssql_elasticpool" "gp_gen5_zone_redundant" {
   name                = "gp-gen5"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   license_type        = "LicenseIncluded"
   zone_redundant      = true
   max_size_gb         = 100
@@ -64,7 +64,7 @@ resource "azurerm_mssql_elasticpool" "gp_gen5_zone_no_license" {
   name                = "gp-gen5"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   license_type        = "BasePrice"
   max_size_gb         = 100
 
@@ -85,7 +85,7 @@ resource "azurerm_mssql_elasticpool" "bc_dc" {
   name                = "bc-dc"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   license_type        = "LicenseIncluded"
   max_size_gb         = 100
 
@@ -106,7 +106,7 @@ resource "azurerm_mssql_elasticpool" "bc_dc_zone_redundant" {
   name                = "bc-dc-zone-redundant"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   license_type        = "LicenseIncluded"
   max_size_gb         = 100
   zone_redundant      = true
@@ -128,7 +128,7 @@ resource "azurerm_mssql_elasticpool" "basic_100" {
   name                = "basic-100"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   max_size_gb         = 9.7656250
 
   sku {
@@ -147,7 +147,7 @@ resource "azurerm_mssql_elasticpool" "standard_200" {
   name                = "standard-200"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   max_size_gb         = 300 # 100 GB extra storage
 
   sku {
@@ -166,7 +166,7 @@ resource "azurerm_mssql_elasticpool" "premium_500" {
   name                = "premium-500"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   max_size_gb         = 1024 # 274 GB extra storage
 
   sku {

--- a/internal/providers/terraform/azure/testdata/public_ip_test/public_ip_test.golden
+++ b/internal/providers/terraform/azure/testdata/public_ip_test/public_ip_test.golden
@@ -4,13 +4,13 @@
  azurerm_public_ip.example                                             
  └─ IP address (static, regional)           730  hours         $3.65   
                                                                        
- azurerm_public_ip.global                                              
- └─ IP address (static, global)             730  hours         $3.65   
-                                                                       
  azurerm_public_ip.example1                                            
  └─ IP address (dynamic, regional)          730  hours         $2.92   
                                                                        
- OVERALL TOTAL                                               $10.22 
+ azurerm_public_ip.global                                              
+ └─ IP address (static, global)             730  hours     not found   
+                                                                       
+ OVERALL TOTAL                                                $6.57 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -22,5 +22,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $10 ┃           - ┃        $10 ┃
+┃ main                                               ┃            $7 ┃           - ┃         $7 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.golden
+++ b/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.golden
@@ -466,9 +466,6 @@
  azurerm_service_plan.example["Windows.I2.1"]                                                  
  └─ Instance usage (I2)                                             730  hours       $438.00   
                                                                                                
- azurerm_service_plan.example["Windows.P0v3.3"]                                                
- └─ Instance usage (P0v3)                                         2,190  hours       $438.00   
-                                                                                               
  azurerm_service_plan.example["Windows.P1v2.3"]                                                
  └─ Instance usage (P1v2)                                         2,190  hours       $438.00   
                                                                                                
@@ -483,9 +480,6 @@
                                                                                                
  azurerm_service_plan.example["WindowsContainer.I2.1"]                                         
  └─ Instance usage (I2)                                             730  hours       $438.00   
-                                                                                               
- azurerm_service_plan.example["WindowsContainer.P0v3.3"]                                       
- └─ Instance usage (P0v3)                                         2,190  hours       $438.00   
                                                                                                
  azurerm_service_plan.example["WindowsContainer.P1v2.3"]                                       
  └─ Instance usage (P1v2)                                         2,190  hours       $438.00   
@@ -505,6 +499,12 @@
  azurerm_service_plan.example["WindowsContainer.I1v2.1"]                                       
  └─ Instance usage (I1v2)                                           730  hours       $399.31   
                                                                                                
+ azurerm_service_plan.example["Windows.P0v3.3"]                                                
+ └─ Instance usage (P0v3)                                         2,190  hours       $344.93   
+                                                                                               
+ azurerm_service_plan.example["WindowsContainer.P0v3.3"]                                       
+ └─ Instance usage (P0v3)                                         2,190  hours       $344.93   
+                                                                                               
  azurerm_service_plan.example["Linux.P1v3.3"]                                                  
  └─ Instance usage (P1v3)                                         2,190  hours       $339.45   
                                                                                                
@@ -520,9 +520,6 @@
  azurerm_service_plan.example["Linux.P3v2.1"]                                                  
  └─ Instance usage (P3v2)                                           730  hours       $294.19   
                                                                                                
- azurerm_service_plan.example["Windows.P0v3.2"]                                                
- └─ Instance usage (P0v3)                                         1,460  hours       $292.00   
-                                                                                               
  azurerm_service_plan.example["Windows.P1v2.2"]                                                
  └─ Instance usage (P1v2)                                         1,460  hours       $292.00   
                                                                                                
@@ -534,9 +531,6 @@
                                                                                                
  azurerm_service_plan.example["Windows.S3.1"]                                                  
  └─ Instance usage (S3)                                             730  hours       $292.00   
-                                                                                               
- azurerm_service_plan.example["WindowsContainer.P0v3.2"]                                       
- └─ Instance usage (P0v3)                                         1,460  hours       $292.00   
                                                                                                
  azurerm_service_plan.example["WindowsContainer.P1v2.2"]                                       
  └─ Instance usage (P1v2)                                         1,460  hours       $292.00   
@@ -571,8 +565,14 @@
  azurerm_service_plan.example["WindowsContainer.P1mv3.1"]                                      
  └─ Instance usage (P1mv3)                                          730  hours       $252.58   
                                                                                                
+ azurerm_service_plan.example["Windows.P0v3.2"]                                                
+ └─ Instance usage (P0v3)                                         1,460  hours       $229.95   
+                                                                                               
  azurerm_service_plan.example["Windows.P1v3.1"]                                                
  └─ Instance usage (P1v3)                                           730  hours       $229.95   
+                                                                                               
+ azurerm_service_plan.example["WindowsContainer.P0v3.2"]                                       
+ └─ Instance usage (P0v3)                                         1,460  hours       $229.95   
                                                                                                
  azurerm_service_plan.example["WindowsContainer.P1v3.1"]                                       
  └─ Instance usage (P1v3)                                           730  hours       $229.95   
@@ -582,9 +582,6 @@
                                                                                                
  azurerm_service_plan.example["Linux.P2v3.1"]                                                  
  └─ Instance usage (P2v3)                                           730  hours       $226.30   
-                                                                                               
- azurerm_service_plan.example["Linux.P0v3.3"]                                                  
- └─ Instance usage (P0v3)                                         2,190  hours       $221.19   
                                                                                                
  azurerm_service_plan.example["Linux.P1v2.3"]                                                  
  └─ Instance usage (P1v2)                                         2,190  hours       $221.19   
@@ -619,14 +616,14 @@
  azurerm_service_plan.example["Linux.S1.3"]                                                    
  └─ Instance usage (S1)                                           2,190  hours       $208.05   
                                                                                                
+ azurerm_service_plan.example["Linux.P0v3.3"]                                                  
+ └─ Instance usage (P0v3)                                         2,190  hours       $169.73   
+                                                                                               
  azurerm_service_plan.example["Windows.B1.3"]                                                  
  └─ Instance usage (B1)                                           2,190  hours       $164.25   
                                                                                                
  azurerm_service_plan.example["WindowsContainer.B1.3"]                                         
  └─ Instance usage (B1)                                           2,190  hours       $164.25   
-                                                                                               
- azurerm_service_plan.example["Linux.P0v3.2"]                                                  
- └─ Instance usage (P0v3)                                         1,460  hours       $147.46   
                                                                                                
  azurerm_service_plan.example["Linux.P1v2.2"]                                                  
  └─ Instance usage (P1v2)                                         1,460  hours       $147.46   
@@ -637,9 +634,6 @@
  azurerm_service_plan.example["Linux.B3.3"]                                                    
  └─ Instance usage (B3)                                           2,190  hours       $146.73   
                                                                                                
- azurerm_service_plan.example["Windows.P0v3.1"]                                                
- └─ Instance usage (P0v3)                                           730  hours       $146.00   
-                                                                                               
  azurerm_service_plan.example["Windows.P1v2.1"]                                                
  └─ Instance usage (P1v2)                                           730  hours       $146.00   
                                                                                                
@@ -648,9 +642,6 @@
                                                                                                
  azurerm_service_plan.example["Windows.S2.1"]                                                  
  └─ Instance usage (S2)                                             730  hours       $146.00   
-                                                                                               
- azurerm_service_plan.example["WindowsContainer.P0v3.1"]                                       
- └─ Instance usage (P0v3)                                           730  hours       $146.00   
                                                                                                
  azurerm_service_plan.example["WindowsContainer.P1v2.1"]                                       
  └─ Instance usage (P1v2)                                           730  hours       $146.00   
@@ -669,6 +660,15 @@
                                                                                                
  azurerm_service_plan.example["Linux.P1mv3.1"]                                                 
  └─ Instance usage (P1mv3)                                          730  hours       $135.78   
+                                                                                               
+ azurerm_service_plan.example["Windows.P0v3.1"]                                                
+ └─ Instance usage (P0v3)                                           730  hours       $114.98   
+                                                                                               
+ azurerm_service_plan.example["WindowsContainer.P0v3.1"]                                       
+ └─ Instance usage (P0v3)                                           730  hours       $114.98   
+                                                                                               
+ azurerm_service_plan.example["Linux.P0v3.2"]                                                  
+ └─ Instance usage (P0v3)                                         1,460  hours       $113.15   
                                                                                                
  azurerm_service_plan.example["Linux.P1v3.1"]                                                  
  └─ Instance usage (P1v3)                                           730  hours       $113.15   
@@ -691,9 +691,6 @@
  azurerm_service_plan.example["Linux.B2.3"]                                                    
  └─ Instance usage (B2)                                           2,190  hours        $74.46   
                                                                                                
- azurerm_service_plan.example["Linux.P0v3.1"]                                                  
- └─ Instance usage (P0v3)                                           730  hours        $73.73   
-                                                                                               
  azurerm_service_plan.example["Linux.P1v2.1"]                                                  
  └─ Instance usage (P1v2)                                           730  hours        $73.73   
                                                                                                
@@ -705,6 +702,9 @@
                                                                                                
  azurerm_service_plan.example["Linux.S1.1"]                                                    
  └─ Instance usage (S1)                                             730  hours        $69.35   
+                                                                                               
+ azurerm_service_plan.example["Linux.P0v3.1"]                                                  
+ └─ Instance usage (P0v3)                                           730  hours        $56.58   
                                                                                                
  azurerm_service_plan.example["Windows.B1.1"]                                                  
  └─ Instance usage (B1)                                             730  hours        $54.75   
@@ -811,7 +811,7 @@
  azurerm_service_plan.example["WindowsContainer.F1.3"]                                         
  └─ Instance usage (F1)                                           2,190  hours         $0.00   
                                                                                                
- OVERALL TOTAL                                                                  $611,320.98 
+ OVERALL TOTAL                                                                  $610,845.75 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -823,5 +823,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃      $611,321 ┃           - ┃   $611,321 ┃
+┃ main                                               ┃      $610,846 ┃           - ┃   $610,846 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.tf
+++ b/internal/providers/terraform/azure/testdata/synapse_spark_pool_test/synapse_spark_pool_test.tf
@@ -33,12 +33,6 @@ resource "azurerm_synapse_workspace" "example" {
   sql_administrator_login_password     = "H@Sh1CoR3!"
   managed_virtual_network_enabled      = false
 
-  aad_admin {
-    login     = "AzureAD Admin"
-    object_id = "00000000-0000-0000-0000-000000000000"
-    tenant_id = "00000000-0000-0000-0000-000000000000"
-  }
-
   identity {
     type = "SystemAssigned"
   }
@@ -53,6 +47,7 @@ resource "azurerm_synapse_spark_pool" "default" {
   synapse_workspace_id = azurerm_synapse_workspace.example.id
   node_size_family     = "MemoryOptimized"
   node_size            = "Small"
+  spark_version        = "3.4"
 
   node_count = 3
   auto_pause {
@@ -65,6 +60,7 @@ resource "azurerm_synapse_spark_pool" "autoscale" {
   synapse_workspace_id = azurerm_synapse_workspace.example.id
   node_size_family     = "MemoryOptimized"
   node_size            = "Small"
+  spark_version        = "3.4"
 
   auto_scale {
     min_node_count = 4

--- a/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.tf
+++ b/internal/providers/terraform/azure/testdata/synapse_sql_pool_test/synapse_sql_pool_test.tf
@@ -33,12 +33,6 @@ resource "azurerm_synapse_workspace" "example" {
   sql_administrator_login_password     = "H@Sh1CoR3!"
   managed_virtual_network_enabled      = false
 
-  aad_admin {
-    login     = "AzureAD Admin"
-    object_id = "00000000-0000-0000-0000-000000000000"
-    tenant_id = "00000000-0000-0000-0000-000000000000"
-  }
-
   identity {
     type = "SystemAssigned"
   }
@@ -53,6 +47,7 @@ resource "azurerm_synapse_sql_pool" "default" {
   synapse_workspace_id = azurerm_synapse_workspace.example.id
   sku_name             = "DW200c"
   create_mode          = "Default"
+  storage_account_type = "GRS"
 }
 
 resource "azurerm_synapse_sql_pool" "storage" {
@@ -60,6 +55,7 @@ resource "azurerm_synapse_sql_pool" "storage" {
   synapse_workspace_id = azurerm_synapse_workspace.example.id
   sku_name             = "DW200c"
   create_mode          = "Default"
+  storage_account_type = "GRS"
 }
 
 resource "azurerm_synapse_sql_pool" "no_backup" {
@@ -67,4 +63,5 @@ resource "azurerm_synapse_sql_pool" "no_backup" {
   synapse_workspace_id = azurerm_synapse_workspace.example.id
   sku_name             = "DW200c"
   create_mode          = "Default"
+  storage_account_type = "GRS"
 }

--- a/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.tf
+++ b/internal/providers/terraform/azure/testdata/synapse_workspace_test/synapse_workspace_test.tf
@@ -33,12 +33,6 @@ resource "azurerm_synapse_workspace" "general" {
   sql_administrator_login_password     = "H@Sh1CoR3!"
   managed_virtual_network_enabled      = false
 
-  aad_admin {
-    login     = "AzureAD Admin"
-    object_id = "00000000-0000-0000-0000-000000000000"
-    tenant_id = "00000000-0000-0000-0000-000000000000"
-  }
-
   identity {
     type = "SystemAssigned"
   }
@@ -57,12 +51,6 @@ resource "azurerm_synapse_workspace" "vnet" {
   sql_administrator_login_password     = "H@Sh1CoR3!"
   managed_virtual_network_enabled      = true
 
-  aad_admin {
-    login     = "AzureAD Admin"
-    object_id = "00000000-0000-0000-0000-000000000000"
-    tenant_id = "00000000-0000-0000-0000-000000000000"
-  }
-
   identity {
     type = "SystemAssigned"
   }
@@ -80,13 +68,6 @@ resource "azurerm_synapse_workspace" "datapipelines" {
   sql_administrator_login              = "sqladminuser"
   sql_administrator_login_password     = "H@Sh1CoR3!"
 
-
-  aad_admin {
-    login     = "AzureAD Admin"
-    object_id = "00000000-0000-0000-0000-000000000000"
-    tenant_id = "00000000-0000-0000-0000-000000000000"
-  }
-
   identity {
     type = "SystemAssigned"
   }
@@ -103,13 +84,6 @@ resource "azurerm_synapse_workspace" "dataflows" {
   storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.example.id
   sql_administrator_login              = "sqladminuser"
   sql_administrator_login_password     = "H@Sh1CoR3!"
-
-
-  aad_admin {
-    login     = "AzureAD Admin"
-    object_id = "00000000-0000-0000-0000-000000000000"
-    tenant_id = "00000000-0000-0000-0000-000000000000"
-  }
 
   identity {
     type = "SystemAssigned"

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
@@ -925,13 +925,6 @@
     ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
     └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
                                                                                                                                       
- azurerm_virtual_machine.windows_vms["Standard_D5_v2"]                                                                                
- ├─ Instance usage (Windows, pay as you go, Standard_D5_v2)                            730  hours                        $1,471.68    
- ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
- └─ storage_os_disk                                                                                                                   
-    ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
-    └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
-                                                                                                                                      
  azurerm_virtual_machine.windows_vms["Standard_DS5_v2"]                                                                               
  ├─ Instance usage (Windows, pay as you go, Standard_DS5_v2)                           730  hours                        $1,471.68    
  ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
@@ -941,6 +934,13 @@
                                                                                                                                       
  azurerm_virtual_machine.linux_vms["Standard_A9"]                                                                                     
  ├─ Instance usage (Linux, pay as you go, Standard_A9)                                 730  hours                        $1,423.50    
+ ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
+ └─ storage_os_disk                                                                                                                   
+    ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
+    └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
+                                                                                                                                      
+ azurerm_virtual_machine.windows_vms["Standard_D5_v2"]                                                                                
+ ├─ Instance usage (Windows, pay as you go, Standard_D5_v2)                            730  hours                        $1,389.92    
  ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
  └─ storage_os_disk                                                                                                                   
     ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
@@ -1693,7 +1693,7 @@
     ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
     └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
                                                                                                                                       
- OVERALL TOTAL                                                                                                       $1,039,546.32 
+ OVERALL TOTAL                                                                                                       $1,039,464.56 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -1705,5 +1705,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃    $1,039,546 ┃       $0.55 ┃ $1,039,546 ┃
+┃ main                                               ┃    $1,039,464 ┃       $0.55 ┃ $1,039,465 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/virtual_network_gateway_connection_test/virtual_network_gateway_connection_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_network_gateway_connection_test/virtual_network_gateway_connection_test.golden
@@ -55,9 +55,9 @@
  └─ VPN gateway (VpnGw5)                                          730  hours                     $10.95   
                                                                                                           
  azurerm_public_ip.example                                                                                
- └─ IP address (dynamic, regional)                                730  hours                      $2.92   
+ └─ IP address (dynamic, regional)                                730  hours                  not found   
                                                                                                           
- OVERALL TOTAL                                                                               $5,964.83 
+ OVERALL TOTAL                                                                               $5,961.91 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -69,5 +69,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,965 ┃           - ┃     $5,965 ┃
+┃ main                                               ┃        $5,962 ┃           - ┃     $5,962 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/virtual_network_gateway_test/virtual_network_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_network_gateway_test/virtual_network_gateway_test.golden
@@ -37,9 +37,9 @@
  └─ VPN gateway data tranfer               Monthly cost depends on usage: $0.035 per GB        
                                                                                                
  azurerm_public_ip.example                                                                     
- └─ IP address (dynamic, regional)                     730  hours                      $2.92   
+ └─ IP address (dynamic, regional)                     730  hours                  not found   
                                                                                                
- OVERALL TOTAL                                                                   $49,247.27 
+ OVERALL TOTAL                                                                   $49,244.35 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -51,5 +51,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $49,247 ┃           - ┃    $49,247 ┃
+┃ main                                               ┃       $49,244 ┃           - ┃    $49,244 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/google/testdata/cloudfunctions_function_test/cloudfunctions_function_test.golden
+++ b/internal/providers/terraform/google/testdata/cloudfunctions_function_test/cloudfunctions_function_test.golden
@@ -1,19 +1,19 @@
 
- Name                                               Monthly Qty  Unit                      Monthly Cost    
-                                                                                                           
- google_cloudfunctions_function.my_function                                                                
- ├─ CPU                                               1,200,000  GHz-seconds                     $12.00  * 
- ├─ Memory                                              750,000  GB-seconds                       $1.88  * 
- ├─ Invocations                                      10,000,000  invocations                      $4.00  * 
- └─ Outbound data transfer                                  100  GB                              $12.00  * 
-                                                                                                           
- google_cloudfunctions_function.function                                                                   
- ├─ CPU                                      Monthly cost depends on usage: $0.00001 per GHz-seconds       
- ├─ Memory                                   Monthly cost depends on usage: $0.0000025 per GB-seconds      
- ├─ Invocations                              Monthly cost depends on usage: $0.0000004 per invocations     
- └─ Outbound data transfer                   Monthly cost depends on usage: $0.12 per GB                   
-                                                                                                           
- OVERALL TOTAL                                                                                   $29.88 
+ Name                                        Monthly Qty  Unit         Monthly Cost    
+                                                                                       
+ google_cloudfunctions_function.my_function                                            
+ ├─ CPU                                        1,200,000  GHz-seconds     not found  * 
+ ├─ Memory                                       750,000  GB-seconds      not found  * 
+ ├─ Invocations                               10,000,000  invocations     not found  * 
+ └─ Outbound data transfer                           100  GB              not found  * 
+                                                                                       
+ google_cloudfunctions_function.function                                               
+ ├─ CPU                                      not found                                 
+ ├─ Memory                                   not found                                 
+ ├─ Invocations                              not found                                 
+ └─ Outbound data transfer                   not found                                 
+                                                                                       
+ OVERALL TOTAL                                                                $0.00 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -24,5 +24,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃         $0.00 ┃         $30 ┃        $30 ┃
+┃ main                                               ┃         $0.00 ┃           - ┃      $0.00 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛


### PR DESCRIPTION
Updating the goldens prior to a CLI release

The latest AzureRM provider (4.0.1) removes a number of resources and
changes a number.

- update tests terraform where appropriate/applicable
- ignore CLI tests where the provider change doesn't make sense to
  rework the test

