### PR TITLE
Terragrunt speed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -271,4 +271,4 @@ replace github.com/heimdalr/dag => github.com/aliscott/dag v1.3.2-0.202311151145
 
 replace github.com/shurcooL/graphql => github.com/spacelift-io/graphql v1.2.0
 
-replace github.com/hashicorp/go-getter => github.com/infracost/go-getter v0.0.0-20240822113104-39b0696ac026
+replace github.com/hashicorp/go-getter => github.com/infracost/go-getter v0.0.0-20240904124147-19d7e5faed63

--- a/go.mod
+++ b/go.mod
@@ -265,10 +265,10 @@ replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
-replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20240823104233-816ab8a80d32
+replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20240909111416-82d45309175e
 
 replace github.com/heimdalr/dag => github.com/aliscott/dag v1.3.2-0.20231115114512-4ce18c825f94
 
 replace github.com/shurcooL/graphql => github.com/spacelift-io/graphql v1.2.0
 
-replace github.com/hashicorp/go-getter => github.com/infracost/go-getter v0.0.0-20240904124147-19d7e5faed63
+replace github.com/hashicorp/go-getter => github.com/infracost/go-getter v0.0.0-20240909111353-c0d2eebadfd5

--- a/go.mod
+++ b/go.mod
@@ -270,3 +270,5 @@ replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0
 replace github.com/heimdalr/dag => github.com/aliscott/dag v1.3.2-0.20231115114512-4ce18c825f94
 
 replace github.com/shurcooL/graphql => github.com/spacelift-io/graphql v1.2.0
+
+replace github.com/hashicorp/go-getter => github.com/infracost/go-getter v0.0.0-20240822113104-39b0696ac026

--- a/go.mod
+++ b/go.mod
@@ -181,6 +181,7 @@ require (
 	github.com/hashicorp/vault/api v1.14.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 // indirect
 	github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef // indirect
+	github.com/huandu/go-clone v1.7.2 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jessevdk/go-flags v1.5.0 // indirect
 	github.com/jstemmer/go-junit-report v1.0.0 // indirect
@@ -264,8 +265,7 @@ replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
-//replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20231211141424-6a52de9a284a
-replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20240501143558-4c01e72103df
+replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20240823104233-816ab8a80d32
 
 replace github.com/heimdalr/dag => github.com/aliscott/dag v1.3.2-0.20231115114512-4ce18c825f94
 

--- a/go.sum
+++ b/go.sum
@@ -719,7 +719,6 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-cty-funcs v0.0.0-20230405223818-a090f58aa992 h1:fYOrSfO5C9PmFGtmRWSYGqq52SOoE2dXMtAn2Xzh1LQ=
 github.com/hashicorp/go-cty-funcs v0.0.0-20230405223818-a090f58aa992/go.mod h1:Abjk0jbRkDaNCzsRhOv2iDCofYpX1eVsjozoiK63qLA=
-github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.15.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
@@ -813,10 +812,10 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/infracost/go-getter v0.0.0-20240904124147-19d7e5faed63 h1:EJaOxMKTC3yg+m7rS8OezKPKKP6hbIJIjW/PF6/dDA4=
-github.com/infracost/go-getter v0.0.0-20240904124147-19d7e5faed63/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
-github.com/infracost/terragrunt v0.47.1-0.20240823104233-816ab8a80d32 h1:OUzb9sYmVDj1T/81naN4c1EevgkJHAJVFIbeJUPkFLI=
-github.com/infracost/terragrunt v0.47.1-0.20240823104233-816ab8a80d32/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
+github.com/infracost/go-getter v0.0.0-20240909111353-c0d2eebadfd5 h1:FiK2b8h6CezRGI6CGs7YDVG9nbF2TQGMcRK9iSM37so=
+github.com/infracost/go-getter v0.0.0-20240909111353-c0d2eebadfd5/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
+github.com/infracost/terragrunt v0.47.1-0.20240909111416-82d45309175e h1:YBOqpHRu4DHY5v9tyBR66PsdZOEL/Cs3kzhOuTbA6vM=
+github.com/infracost/terragrunt v0.47.1-0.20240909111416-82d45309175e/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
@@ -928,7 +927,6 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-linereader v0.0.0-20190213213312-1b945b3263eb/go.mod h1:OaY7UOoTkkrX3wRwjpYRKafIkkyeD0UtweSHAWWiqQM=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
-github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=

--- a/go.sum
+++ b/go.sum
@@ -813,8 +813,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/infracost/go-getter v0.0.0-20240822113104-39b0696ac026 h1:5pKP8qiQhcKrvf61knWyCuTHxgwxQYV9XYYIKFRclyw=
-github.com/infracost/go-getter v0.0.0-20240822113104-39b0696ac026/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
+github.com/infracost/go-getter v0.0.0-20240904124147-19d7e5faed63 h1:EJaOxMKTC3yg+m7rS8OezKPKKP6hbIJIjW/PF6/dDA4=
+github.com/infracost/go-getter v0.0.0-20240904124147-19d7e5faed63/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
 github.com/infracost/terragrunt v0.47.1-0.20240823104233-816ab8a80d32 h1:OUzb9sYmVDj1T/81naN4c1EevgkJHAJVFIbeJUPkFLI=
 github.com/infracost/terragrunt v0.47.1-0.20240823104233-816ab8a80d32/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=

--- a/go.sum
+++ b/go.sum
@@ -313,7 +313,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.44.122 h1:p6mw01WBaNpbdP2xrisz5tIkcNwzj/HysobNoaAHjgo=
@@ -720,9 +719,7 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-cty-funcs v0.0.0-20230405223818-a090f58aa992 h1:fYOrSfO5C9PmFGtmRWSYGqq52SOoE2dXMtAn2Xzh1LQ=
 github.com/hashicorp/go-cty-funcs v0.0.0-20230405223818-a090f58aa992/go.mod h1:Abjk0jbRkDaNCzsRhOv2iDCofYpX1eVsjozoiK63qLA=
-github.com/hashicorp/go-getter v1.5.1/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
-github.com/hashicorp/go-getter v1.7.6 h1:5jHuM+aH373XNtXl9TNTUH5Qd69Trve11tHIrB+6yj4=
-github.com/hashicorp/go-getter v1.7.6/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.15.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
@@ -760,7 +757,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
@@ -813,6 +809,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/infracost/go-getter v0.0.0-20240822113104-39b0696ac026 h1:5pKP8qiQhcKrvf61knWyCuTHxgwxQYV9XYYIKFRclyw=
+github.com/infracost/go-getter v0.0.0-20240822113104-39b0696ac026/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
 github.com/infracost/terragrunt v0.47.1-0.20240501143558-4c01e72103df h1:aGlX6621I8AM6Rza0QorcAzABpYtMP9KV8yfgBX08VU=
 github.com/infracost/terragrunt v0.47.1-0.20240501143558-4c01e72103df/go.mod h1:xmRpWI+M4KlZbMQp1pj20CdXlZf5eIkRND5ybNkdnus=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -821,7 +819,6 @@ github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LF
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
-github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -1132,7 +1129,6 @@ github.com/tombuildsstuff/giovanni v0.15.1/go.mod h1:0TZugJPEtqzPlMpuJHYfXY6Dq2u
 github.com/turbot/terraform-components v0.0.0-20231213122222-1f3526cab7a7 h1:qDMxFVd8Zo0rIhnEBdCIbR+T6WgjwkxpFZMN8zZmmjg=
 github.com/turbot/terraform-components v0.0.0-20231213122222-1f3526cab7a7/go.mod h1:5hzpfalEjfcJWp9yq75/EZoEu2Mzm34eJAPm3HOW2tw=
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
-github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/go.sum
+++ b/go.sum
@@ -796,6 +796,10 @@ github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87/go.mod h1:CtWFDAQg
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/huandu/go-assert v1.1.5 h1:fjemmA7sSfYHJD7CUqs9qTwwfdNAx7/j2/ZlHXzNB3c=
+github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0JrPVhn/06U=
+github.com/huandu/go-clone v1.7.2 h1:3+Aq0Ed8XK+zKkLjE2dfHg0XrpIfcohBE1K+c8Usxoo=
+github.com/huandu/go-clone v1.7.2/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
@@ -811,8 +815,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/infracost/go-getter v0.0.0-20240822113104-39b0696ac026 h1:5pKP8qiQhcKrvf61knWyCuTHxgwxQYV9XYYIKFRclyw=
 github.com/infracost/go-getter v0.0.0-20240822113104-39b0696ac026/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
-github.com/infracost/terragrunt v0.47.1-0.20240501143558-4c01e72103df h1:aGlX6621I8AM6Rza0QorcAzABpYtMP9KV8yfgBX08VU=
-github.com/infracost/terragrunt v0.47.1-0.20240501143558-4c01e72103df/go.mod h1:xmRpWI+M4KlZbMQp1pj20CdXlZf5eIkRND5ybNkdnus=
+github.com/infracost/terragrunt v0.47.1-0.20240823104233-816ab8a80d32 h1:OUzb9sYmVDj1T/81naN4c1EevgkJHAJVFIbeJUPkFLI=
+github.com/infracost/terragrunt v0.47.1-0.20240823104233-816ab8a80d32/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -425,6 +425,16 @@ func (m *ModuleLoader) loadRemoteModule(key string, source string) (*ManifestMod
 		return nil, err
 	}
 
+	// Parse the URL, add the subdir as a param
+	u, err := url.Parse(moduleAddr)
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("subdir", submodulePath)
+	u.RawQuery = q.Encode()
+	moduleAddr = u.String()
+
 	dest := m.downloadDest(moduleAddr, "")
 	moduleDownloadDir, err := m.cachePathRel(dest)
 	if err != nil {

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -290,7 +290,7 @@ func (m *ModuleLoader) loadModule(moduleCall *tfconfig.ModuleCall, parentPath st
 
 		// If the module is a in a git repo we need to check that it has been checked out.
 		// If it hasn't been checked out then we need to add it to the sparse-checkout file list.
-		m.logger.Debug().Msgf("finding git repo root for path %s", parentPath)
+		m.logger.Trace().Msgf("finding git repo root for path %s", parentPath)
 		repoRoot, err := findGitRepoRoot(parentPath)
 		if err == nil {
 			// Get the dir relative to the repoRoot
@@ -353,12 +353,12 @@ func (m *ModuleLoader) checkoutPathIfRequired(repoRoot string, dirs string) erro
 	defer unlock()
 
 	// Get the list of sparse checkout directories (and assume sparse checkout is enabled if this succeeds)
-	m.logger.Debug().Msgf("getting sparse checkout directories for path %s", repoRoot)
+	m.logger.Trace().Msgf("getting sparse checkout directories for path %s", repoRoot)
 	existingDirs, err := getSparseCheckoutDirs(repoRoot)
 	if err != nil {
 		// If the error indicates that sparse checkout is not enabled, just return nil
 		if err.Error() == "sparse-checkout not enabled" {
-			m.logger.Debug().Msgf("sparse-checkout not enabled for path %s", repoRoot)
+			m.logger.Trace().Msgf("sparse-checkout not enabled for path %s", repoRoot)
 			return nil
 		}
 		return err
@@ -396,7 +396,7 @@ func RecursivelyAddDirsToSparseCheckout(repoRoot string, existingDirs []string, 
 		return nil
 	}
 
-	logger.Debug().Msgf("adding dirs to sparse-checkout for repo %s: %v", repoRoot, newDirs)
+	logger.Trace().Msgf("adding dirs to sparse-checkout for repo %s: %v", repoRoot, newDirs)
 	mu.Lock()
 	err := setSparseCheckoutDirs(repoRoot, existingDirs)
 	mu.Unlock()
@@ -423,7 +423,7 @@ func RecursivelyAddDirsToSparseCheckout(repoRoot string, existingDirs []string, 
 	}
 
 	if len(additionalDirs) > 0 {
-		logger.Debug().Msgf("recursively adding symlinked dirs to sparse-checkout for repo %s: %v", repoRoot, additionalDirs)
+		logger.Trace().Msgf("recursively adding symlinked dirs to sparse-checkout for repo %s: %v", repoRoot, additionalDirs)
 		return RecursivelyAddDirsToSparseCheckout(repoRoot, existingDirs, additionalDirs, mu, logger, depth+1)
 	}
 

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -647,15 +647,18 @@ func (m *ModuleLoader) loadRemoteModule(key string, source string) (*ManifestMod
 		return nil, err
 	}
 
-	// Parse the URL, add the subdir as a param
-	u, err := url.Parse(moduleAddr)
-	if err != nil {
-		return nil, err
+	// If sparse checkout is enabled add the subdir to the module URL as a query param
+	// so go-getter only downloads the required directory.
+	if os.Getenv("INFRACOST_SPARSE_CHECKOUT") == "true" {
+		u, err := url.Parse(moduleAddr)
+		if err != nil {
+			return nil, err
+		}
+		q := u.Query()
+		q.Set("subdir", submodulePath)
+		u.RawQuery = q.Encode()
+		moduleAddr = u.String()
 	}
-	q := u.Query()
-	q.Set("subdir", submodulePath)
-	u.RawQuery = q.Encode()
-	moduleAddr = u.String()
 
 	dest := m.downloadDest(moduleAddr, "")
 	moduleDownloadDir, err := m.cachePathRel(dest)

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -650,15 +650,18 @@ func downloadSourceOnce(sourceURL string, opts *tgoptions.TerragruntOptions, ter
 		return "", err
 	}
 
-	// Parse the URL, add the subdir as a param
-	u, err := url.Parse(sourceURL)
-	if err != nil {
-		return "", err
+	// If sparse checkout is enabled add the subdir to the Source URL as a query param
+	// so go-getter only downloads the required directory.
+	if os.Getenv("INFRACOST_SPARSE_CHECKOUT") == "true" {
+		u, err := url.Parse(sourceURL)
+		if err != nil {
+			return "", err
+		}
+		q := u.Query()
+		q.Set("subdir", modAddr)
+		u.RawQuery = q.Encode()
+		sourceURL = u.String()
 	}
-	q := u.Query()
-	q.Set("subdir", modAddr)
-	u.RawQuery = q.Encode()
-	sourceURL = u.String()
 
 	source, err := tfsource.NewSource(sourceURL, opts.DownloadDir, opts.WorkingDir, terragruntConfig.GenerateConfigs, opts.Logger)
 	if err != nil {

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -633,8 +633,32 @@ func (p *TerragruntHCLProvider) runTerragrunt(opts *tgoptions.TerragruntOptions)
 	return info
 }
 
+func splitModuleSubDir(moduleSource string) (string, string, error) {
+	moduleAddr, submodulePath := getter.SourceDirSubdir(moduleSource)
+	if strings.HasPrefix(submodulePath, "../") {
+		return "", "", fmt.Errorf("invalid submodule path '%s'", submodulePath)
+	}
+
+	return moduleAddr, submodulePath, nil
+}
+
 // downloadSourceOnce thread-safely makes sure the sourceURL is only downloaded once
 func downloadSourceOnce(sourceURL string, opts *tgoptions.TerragruntOptions, terragruntConfig *tgconfig.TerragruntConfig) (string, error) {
+	_, modAddr, err := splitModuleSubDir(sourceURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Parse the URL, add the subdir as a param
+	u, err := url.Parse(sourceURL)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("subdir", modAddr)
+	u.RawQuery = q.Encode()
+	sourceURL = u.String()
+
 	source, err := tfsource.NewSource(sourceURL, opts.DownloadDir, opts.WorkingDir, terragruntConfig.GenerateConfigs, opts.Logger)
 	if err != nil {
 		return "", err

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -700,7 +700,7 @@ func downloadSourceOnce(sourceURL string, opts *tgoptions.TerragruntOptions, ter
 
 		if len(symlinkedDirs) > 0 {
 			mu := &sync.Mutex{}
-			logger.Debug().Msgf("recursively adding symlinked dirs to sparse-checkout for repo %s: %v", dir, symlinkedDirs)
+			logger.Trace().Msgf("recursively adding symlinked dirs to sparse-checkout for repo %s: %v", dir, symlinkedDirs)
 			// Using a depth of 1 here since the submodule directory is already downloaded, so only need
 			// to add the symlinked directories to the sparse-checkout.
 			err := modules.RecursivelyAddDirsToSparseCheckout(dir, []string{modAddr}, symlinkedDirs, mu, logger, 1)

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -426,6 +426,7 @@ func (p *TerragruntHCLProvider) prepWorkingDirs() ([]*terragruntWorkingDirInfo, 
 		Env:                        p.env,
 		IgnoreExternalDependencies: true,
 		SourceMap:                  p.ctx.RunContext.Config.TerraformSourceMap,
+		UsePartialParseConfigCache: true,
 		RunTerragrunt: func(opts *tgoptions.TerragruntOptions) (err error) {
 			defer func() {
 				unexpectedErr := recover()


### PR DESCRIPTION
This implements a two changes for improving the speed of Terragrunt repos which reference sources within large monorepos.

1. Enables the partial parse config cache (https://terragrunt.gruntwork.io/docs/reference/cli-options/#terragrunt-use-partial-parse-config-cache)
2. Adds an option to use `git sparse-checkout` for downloading only specific subdirectories of remote modules. This also handles special cases for local references to other subdirectories of that module, or symlinks within that module.