### PR TITLE
fix: save posted comment when cloud is enabled

### DIFF
--- a/cmd/infracost/comment.go
+++ b/cmd/infracost/comment.go
@@ -119,9 +119,10 @@ func buildCommentOutput(cmd *cobra.Command, ctx *config.RunContext, paths []stri
 		// the full comment markdown has been received from the API addRun or loaded from the comment-path file,
 		// so use that instead of building the output using the output.ToMarkdown templates.
 		out = &CommentOutput{
-			Body:    commentData,
-			HasDiff: combined.HasDiff(),
-			ValidAt: &combined.TimeGenerated,
+			Body:           commentData,
+			HasDiff:        combined.HasDiff(),
+			ValidAt:        &combined.TimeGenerated,
+			AddRunResponse: result,
 		}
 	}
 

--- a/cmd/infracost/comment_github.go
+++ b/cmd/infracost/comment_github.go
@@ -134,7 +134,7 @@ func commentGitHubCmd(ctx *config.RunContext) *cobra.Command {
 					return err
 				}
 
-				if res.Posted && ctx.IsCloudUploadExplicitlyEnabled() {
+				if res.Posted && ctx.IsCloudUploadEnabled() {
 					dashboardClient := apiclient.NewDashboardAPIClient(ctx)
 					if err := dashboardClient.SavePostedPrComment(ctx, commentOut.AddRunResponse.RunID, commentOut.Body); err != nil {
 						logging.Logger.Err(err).Msg("could not save posted PR comment")

--- a/internal/apiclient/dashboard.go
+++ b/internal/apiclient/dashboard.go
@@ -124,9 +124,14 @@ func (c *DashboardAPIClient) SavePostedPrComment(ctx *config.RunContext, runId, 
 	q := `mutation SavePostedPrComment($runId: String!, $comment: String!) {
 			savePostedPrComment(runId: $runId, comment: $comment) 
 }`
-	_, err := c.DoQueries([]GraphQLQuery{{q, map[string]interface{}{"runId": runId, "comment": comment}}})
+	results, err := c.DoQueries([]GraphQLQuery{{q, map[string]interface{}{"runId": runId, "comment": comment}}})
 	if err != nil {
 		return err
+	}
+	if len(results) > 0 {
+		if results[0].Get("errors").Exists() {
+			return errors.New(results[0].Get("errors").String())
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
* make sure the AddRunResponse is returned after uploading the run
* upload the pr comment when cloud upload is enabled (either explicitly or implicitly)