### PR TITLE
chore: bump terragrunt version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -265,7 +265,7 @@ replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
-replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20240909111416-82d45309175e
+replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20240920091357-980f132ffa5a
 
 replace github.com/heimdalr/dag => github.com/aliscott/dag v1.3.2-0.20231115114512-4ce18c825f94
 

--- a/go.sum
+++ b/go.sum
@@ -814,8 +814,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/infracost/go-getter v0.0.0-20240909111353-c0d2eebadfd5 h1:FiK2b8h6CezRGI6CGs7YDVG9nbF2TQGMcRK9iSM37so=
 github.com/infracost/go-getter v0.0.0-20240909111353-c0d2eebadfd5/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
-github.com/infracost/terragrunt v0.47.1-0.20240909111416-82d45309175e h1:YBOqpHRu4DHY5v9tyBR66PsdZOEL/Cs3kzhOuTbA6vM=
-github.com/infracost/terragrunt v0.47.1-0.20240909111416-82d45309175e/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
+github.com/infracost/terragrunt v0.47.1-0.20240920091357-980f132ffa5a h1:S24y2y7hdsgtT4HD/dUAiangWfPv4cz+n3f4/J2di0M=
+github.com/infracost/terragrunt v0.47.1-0.20240920091357-980f132ffa5a/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=


### PR DESCRIPTION
Bumps terragrunt pkg version so that we pull in the decoding panic changes outlined in https://github.com/infracost/terragrunt/pull/17