### PR TITLE
feat: Add ap-southeast-5 aws region

### DIFF
--- a/internal/hcl/zones_aws.go
+++ b/internal/hcl/zones_aws.go
@@ -69,6 +69,12 @@ var awsZones = map[string]cty.Value{
 		"zone_ids":    cty.ListVal([]cty.Value{cty.StringVal("apse4-az1"), cty.StringVal("apse4-az2"), cty.StringVal("apse4-az3")}),
 		"group_names": cty.ListVal([]cty.Value{cty.StringVal("ap-southeast-4"), cty.StringVal("ap-southeast-4"), cty.StringVal("ap-southeast-4")}),
 	}),
+	"ap-southeast-5": cty.ObjectVal(map[string]cty.Value{
+		"id":          cty.StringVal("ap-southeast-5"),
+		"names":       cty.ListVal([]cty.Value{cty.StringVal("ap-southeast-5a"), cty.StringVal("ap-southeast-5b"), cty.StringVal("ap-southeast-5c")}),
+		"zone_ids":    cty.ListVal([]cty.Value{cty.StringVal("apse5-az1"), cty.StringVal("apse5-az2"), cty.StringVal("apse5-az3")}),
+		"group_names": cty.ListVal([]cty.Value{cty.StringVal("ap-southeast-5"), cty.StringVal("ap-southeast-5"), cty.StringVal("ap-southeast-5")}),
+	}),
 	"ca-central-1": cty.ObjectVal(map[string]cty.Value{
 		"id":          cty.StringVal("ca-central-1"),
 		"names":       cty.ListVal([]cty.Value{cty.StringVal("ca-central-1a"), cty.StringVal("ca-central-1b"), cty.StringVal("ca-central-1d"), cty.StringVal("ca-central-1-wl1-yto-wlz-1")}),

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -113,6 +113,14 @@
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $187.00  * 
  └─ Outbound data transfer to other regions                  750  GB          $60.00  * 
                                                                                         
+ aws_data_transfer.ap-southeast-5                                                    
+ ├─ Intra-region data transfer                             2,000  GB          $20.00 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,126.40 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,884.80 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $187.00 
+ └─ Outbound data transfer to other regions                  750  GB          $60.00 
+                                                                                     
  aws_data_transfer.us-east-2                                                            
  ├─ Intra-region data transfer                             2,000  GB          $20.00  * 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60  * 
@@ -218,16 +226,16 @@
  ├─ Outbound data transfer to US East regions                500  GB           $5.00  * 
  └─ Outbound data transfer to other regions                  750  GB          $15.00  * 
                                                                                         
- OVERALL TOTAL                                                           $363,014.51 
+ OVERALL TOTAL                                                           $375,774.31 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-27 cloud resources were detected:
-∙ 27 were estimated
+28 cloud resources were detected:
+∙ 28 were estimated
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃         $0.00 ┃    $363,015 ┃   $363,015 ┃
+┃ main                                               ┃         $0.00 ┃    $375,774 ┃   $375,774 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -120,7 +120,7 @@
  ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,557.12  * 
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $244.80  * 
  └─ Outbound data transfer to other regions                  750  GB          $60.00  * 
-                                                                                     
+                                                                                        
  aws_data_transfer.us-east-2                                                            
  ├─ Intra-region data transfer                             2,000  GB          $20.00  * 
  ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB         $921.60  * 

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -226,7 +226,7 @@
  ├─ Outbound data transfer to US East regions                500  GB           $5.00  * 
  └─ Outbound data transfer to other regions                  750  GB          $15.00  * 
                                                                                         
- OVERALL TOTAL                                                           $375,774.31 
+ OVERALL TOTAL                                                           $375,135.79 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -237,5 +237,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃         $0.00 ┃    $375,774 ┃   $375,774 ┃
+┃ main                                               ┃         $0.00 ┃    $375,136 ┃   $375,136 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.golden
@@ -113,13 +113,13 @@
  ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $187.00  * 
  └─ Outbound data transfer to other regions                  750  GB          $60.00  * 
                                                                                         
- aws_data_transfer.ap-southeast-5                                                    
- ├─ Intra-region data transfer                             2,000  GB          $20.00 
- ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,126.40 
- ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,481.60 
- ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,884.80 
- ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $187.00 
- └─ Outbound data transfer to other regions                  750  GB          $60.00 
+ aws_data_transfer.ap-southeast-5                                                       
+ ├─ Intra-region data transfer                             2,000  GB          $20.00  * 
+ ├─ Outbound data transfer to Internet (first 10TB)       10,240  GB       $1,105.92  * 
+ ├─ Outbound data transfer to Internet (next 40TB)        40,960  GB       $3,133.44  * 
+ ├─ Outbound data transfer to Internet (next 100TB)      102,400  GB       $7,557.12  * 
+ ├─ Outbound data transfer to Internet (over 150TB)        3,400  GB         $244.80  * 
+ └─ Outbound data transfer to other regions                  750  GB          $60.00  * 
                                                                                      
  aws_data_transfer.us-east-2                                                            
  ├─ Intra-region data transfer                             2,000  GB          $20.00  * 

--- a/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/data_transfer_test/data_transfer_test.usage.yml
@@ -179,3 +179,9 @@ resource_usage:
         monthly_intra_region_gb: 1000
         monthly_outbound_other_regions_gb: 750
         monthly_outbound_internet_gb: 157000
+
+    aws_data_transfer.ap-southeast-5:
+        region: ap-southeast-5
+        monthly_intra_region_gb: 1000
+        monthly_outbound_other_regions_gb: 750
+        monthly_outbound_internet_gb: 157000

--- a/internal/resources/aws/cloudfront_distribution.go
+++ b/internal/resources/aws/cloudfront_distribution.go
@@ -458,6 +458,7 @@ var regionShieldMapping = map[string]string{
 	"ap-southeast-2":  "australia",
 	"ap-southeast-3":  "indonesia",
 	"ap-southeast-4":  "australia",
+	"ap-southeast-5":  "malaysia",
 	"ap-south-1":      "india",
 	"ap-south-2":      "india",
 	"sa-east-1":       "south_america",

--- a/internal/resources/aws/global_accelerator_endpoint_group.go
+++ b/internal/resources/aws/global_accelerator_endpoint_group.go
@@ -60,6 +60,7 @@ var regionCodeMapping = map[string]string{
 	"ap-southeast-2":  "AP",
 	"ap-southeast-3":  "AP",
 	"ap-southeast-4":  "AP",
+	"ap-southeast-5":  "AP",
 	"ap-south-1":      "AP",
 	"ap-south-2":      "AP",
 	"me-central-1":    "ME",

--- a/internal/resources/aws/util.go
+++ b/internal/resources/aws/util.go
@@ -136,6 +136,7 @@ var RegionMapping = map[string]string{
 	"ap-southeast-2":  "Asia Pacific (Sydney)",
 	"ap-southeast-3":  "Asia Pacific (Jakarta)",
 	"ap-southeast-4":  "Asia Pacific (Melbourne)",
+	"ap-southeast-5":  "Asia Pacific (Malaysia)",
 	"ap-south-1":      "Asia Pacific (Mumbai)",
 	"ap-south-2":      "Asia Pacific (Hyderabad)",
 	"me-central-1":    "Middle East (UAE)",
@@ -183,6 +184,7 @@ type RegionsUsage struct {
 	EUSouth1     *float64 `infracost_usage:"eu_south_1"`
 	EUWest3      *float64 `infracost_usage:"eu_west_3"`
 	EUNorth1     *float64 `infracost_usage:"eu_north_1"`
+	ILCentral1   *float64 `infracost_usage:"il_central_1"`
 	APEast1      *float64 `infracost_usage:"ap_east_1"`
 	APNortheast1 *float64 `infracost_usage:"ap_northeast_1"`
 	APNortheast2 *float64 `infracost_usage:"ap_northeast_2"`
@@ -191,6 +193,7 @@ type RegionsUsage struct {
 	APSoutheast2 *float64 `infracost_usage:"ap_southeast_2"`
 	APSoutheast3 *float64 `infracost_usage:"ap_southeast_3"`
 	APSoutheast4 *float64 `infracost_usage:"ap_southeast_4"`
+	APSoutheast5 *float64 `infracost_usage:"ap_southeast_5"`
 	APSouth1     *float64 `infracost_usage:"ap_south_1"`
 	MESouth1     *float64 `infracost_usage:"me_south_1"`
 	SAEast1      *float64 `infracost_usage:"sa_east_1"`


### PR DESCRIPTION
NOTE: Also added `il-central-1` to the `RegionsUsage` struct as it was missing, but not sure if that was deliberate?