### PR TITLE
Fix Terragrunt dep output mocks

### DIFF
--- a/internal/providers/terraform/testdata/hcl_provider_test/adds_source_url_from_remote_module/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/adds_source_url_from_remote_module/expected.json
@@ -103,15 +103,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 923,
-                      "endLine": 938
+                      "startLine": 924,
+                      "endLine": 939
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 938,
+                  "endLine": 939,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 923
+                  "startLine": 924
                 }
               },
               {
@@ -139,15 +139,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 912,
-                      "endLine": 921
+                      "startLine": 913,
+                      "endLine": 922
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 921,
+                  "endLine": 922,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 912
+                  "startLine": 913
                 }
               },
               {
@@ -291,15 +291,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 923,
-                      "endLine": 938
+                      "startLine": 924,
+                      "endLine": 939
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 938,
+                  "endLine": 939,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 923
+                  "startLine": 924
                 }
               },
               {
@@ -327,15 +327,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 912,
-                      "endLine": 921
+                      "startLine": 913,
+                      "endLine": 922
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 921,
+                  "endLine": 922,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 912
+                  "startLine": 913
                 }
               },
               {
@@ -544,15 +544,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 923,
-                      "endLine": 938
+                      "startLine": 924,
+                      "endLine": 939
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 938,
+                  "endLine": 939,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 923
+                  "startLine": 924
                 }
               },
               {
@@ -580,15 +580,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 912,
-                      "endLine": 921
+                      "startLine": 913,
+                      "endLine": 922
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 921,
+                  "endLine": 922,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 912
+                  "startLine": 913
                 }
               },
               {
@@ -927,15 +927,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 923,
-                    "endLine": 938
+                    "startLine": 924,
+                    "endLine": 939
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 938,
+                "endLine": 939,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 923
+                "startLine": 924
               }
             },
             {
@@ -963,15 +963,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 912,
-                    "endLine": 921
+                    "startLine": 913,
+                    "endLine": 922
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 921,
+                "endLine": 922,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 912
+                "startLine": 913
               }
             },
             {
@@ -1115,15 +1115,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 923,
-                    "endLine": 938
+                    "startLine": 924,
+                    "endLine": 939
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 938,
+                "endLine": 939,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 923
+                "startLine": 924
               }
             },
             {
@@ -1151,15 +1151,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 912,
-                    "endLine": 921
+                    "startLine": 913,
+                    "endLine": 922
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 921,
+                "endLine": 922,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 912
+                "startLine": 913
               }
             },
             {
@@ -1368,15 +1368,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 923,
-                    "endLine": 938
+                    "startLine": 924,
+                    "endLine": 939
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 938,
+                "endLine": 939,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 923
+                "startLine": 924
               }
             },
             {
@@ -1404,15 +1404,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 912,
-                    "endLine": 921
+                    "startLine": 913,
+                    "endLine": 922
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 921,
+                "endLine": 922,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 912
+                "startLine": 913
               }
             },
             {

--- a/internal/providers/terraform/testdata/hcl_provider_test/adds_source_url_from_remote_module_chdir/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/adds_source_url_from_remote_module_chdir/expected.json
@@ -103,15 +103,15 @@
                     {
                       "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 923,
-                      "endLine": 938
+                      "startLine": 924,
+                      "endLine": 939
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 938,
+                  "endLine": 939,
                   "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 923
+                  "startLine": 924
                 }
               },
               {
@@ -139,15 +139,15 @@
                     {
                       "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 912,
-                      "endLine": 921
+                      "startLine": 913,
+                      "endLine": 922
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 921,
+                  "endLine": 922,
                   "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 912
+                  "startLine": 913
                 }
               },
               {
@@ -291,15 +291,15 @@
                     {
                       "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 923,
-                      "endLine": 938
+                      "startLine": 924,
+                      "endLine": 939
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 938,
+                  "endLine": 939,
                   "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 923
+                  "startLine": 924
                 }
               },
               {
@@ -327,15 +327,15 @@
                     {
                       "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 912,
-                      "endLine": 921
+                      "startLine": 913,
+                      "endLine": 922
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 921,
+                  "endLine": 922,
                   "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 912
+                  "startLine": 913
                 }
               },
               {
@@ -544,15 +544,15 @@
                     {
                       "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 923,
-                      "endLine": 938
+                      "startLine": 924,
+                      "endLine": 939
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 938,
+                  "endLine": 939,
                   "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 923
+                  "startLine": 924
                 }
               },
               {
@@ -580,15 +580,15 @@
                     {
                       "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 912,
-                      "endLine": 921
+                      "startLine": 913,
+                      "endLine": 922
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 921,
+                  "endLine": 922,
                   "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 912
+                  "startLine": 913
                 }
               },
               {
@@ -927,15 +927,15 @@
                   {
                     "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 923,
-                    "endLine": 938
+                    "startLine": 924,
+                    "endLine": 939
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 938,
+                "endLine": 939,
                 "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 923
+                "startLine": 924
               }
             },
             {
@@ -963,15 +963,15 @@
                   {
                     "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 912,
-                    "endLine": 921
+                    "startLine": 913,
+                    "endLine": 922
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 921,
+                "endLine": 922,
                 "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 912
+                "startLine": 913
               }
             },
             {
@@ -1115,15 +1115,15 @@
                   {
                     "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 923,
-                    "endLine": 938
+                    "startLine": 924,
+                    "endLine": 939
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 938,
+                "endLine": 939,
                 "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 923
+                "startLine": 924
               }
             },
             {
@@ -1151,15 +1151,15 @@
                   {
                     "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 912,
-                    "endLine": 921
+                    "startLine": 913,
+                    "endLine": 922
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 921,
+                "endLine": 922,
                 "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 912
+                "startLine": 913
               }
             },
             {
@@ -1368,15 +1368,15 @@
                   {
                     "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 923,
-                    "endLine": 938
+                    "startLine": 924,
+                    "endLine": 939
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 938,
+                "endLine": 939,
                 "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 923
+                "startLine": 924
               }
             },
             {
@@ -1404,15 +1404,15 @@
                   {
                     "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 912,
-                    "endLine": 921
+                    "startLine": 913,
+                    "endLine": 922
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 921,
+                "endLine": 922,
                 "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 912
+                "startLine": 913
               }
             },
             {

--- a/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/renders_module_resources/expected.json
@@ -22,15 +22,21 @@
               "attributesWithUnknownKeys": [
                 {
                   "attribute": "customer_gateway_id",
-                  "missingVariables": ["module.gateway.aws_customer_gateway_id"]
+                  "missingVariables": [
+                    "module.gateway.aws_customer_gateway_id"
+                  ]
                 },
                 {
                   "attribute": "transit_gateway_id",
-                  "missingVariables": ["module.gateway.aws_ec2_transit_gateway_id"]
+                  "missingVariables": [
+                    "module.gateway.aws_ec2_transit_gateway_id"
+                  ]
                 },
                 {
                   "attribute": "type",
-                  "missingVariables": ["module.gateway.aws_customer_gateway_type"]
+                  "missingVariables": [
+                    "module.gateway.aws_customer_gateway_type"
+                  ]
                 }
               ],
               "calls": [
@@ -143,15 +149,21 @@
             "attributesWithUnknownKeys": [
               {
                 "attribute": "customer_gateway_id",
-                "missingVariables": ["module.gateway.aws_customer_gateway_id"]
+                "missingVariables": [
+                  "module.gateway.aws_customer_gateway_id"
+                ]
               },
               {
                 "attribute": "transit_gateway_id",
-                "missingVariables": ["module.gateway.aws_ec2_transit_gateway_id"]
+                "missingVariables": [
+                  "module.gateway.aws_ec2_transit_gateway_id"
+                ]
               },
               {
                 "attribute": "type",
-                "missingVariables": ["module.gateway.aws_customer_gateway_type"]
+                "missingVariables": [
+                  "module.gateway.aws_customer_gateway_type"
+                ]
               }
             ],
             "calls": [


### PR DESCRIPTION
The updates the pre-processing of Terragrunt dependencies to take into account instances where a function is called on the dependency. For example, previous we were looking for patterns like `dependency.my-mod.my-output[0]` to be able to tell if the output should be mocked as a list. Now we also look for patterns like `tolist(dependency.my-mod.my-output)[0]`.

Eventually we will want to replace the internal Terragrunt HCL decoding to use our own so that we handle mocks better, but this unblocks us for just now.

The tests were also failing because a remote module has been updated, so I had to fix a bug with the sparse checkouts to be able to update them.