### PR TITLE
fix(aws): log a warning for unknown EBS types

### DIFF
--- a/cmd/infracost/testdata/breakdown_no_prices_warnings/breakdown_no_prices_warnings.golden
+++ b/cmd/infracost/testdata/breakdown_no_prices_warnings/breakdown_no_prices_warnings.golden
@@ -15,7 +15,7 @@ Project: main
  ├─ root_block_device                                                                                    
  │  └─ Storage (general purpose SSD, gp2)                                      50  GB            $5.00   
  └─ ebs_block_device[0]                                                                                  
-    └─ Storage (general purpose SSD, gp2)                                   1,000  GB        not found   
+    └─ Storage (unknown)                                                    1,000  GB        not found   
                                                                                                          
  aws_instance.instance_invalid                                                                           
  ├─ Instance usage (Linux/UNIX, on-demand, invalid_instance_type)             730  hours     not found   

--- a/internal/resources/aws/ebs_volume.go
+++ b/internal/resources/aws/ebs_volume.go
@@ -95,8 +95,10 @@ func (a *EBSVolume) storageCostComponent() *schema.CostComponent {
 		name = "Storage (cold HDD, sc1)"
 	case "gp3":
 		name = "Storage (general purpose SSD, gp3)"
-	default:
+	case "gp2":
 		name = "Storage (general purpose SSD, gp2)"
+	default:
+		name = "Storage (unknown)"
 	}
 
 	return &schema.CostComponent{


### PR DESCRIPTION
Otherwise it will default to gp2 and FinOps policies will fail