### PR TITLE
fix: AWS VPC Endpoint pricing tiers are wrong #3228

### DIFF
--- a/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
+++ b/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.golden
@@ -2,9 +2,9 @@
  Name                                        Monthly Qty  Unit              Monthly Cost    
                                                                                             
  aws_vpc_endpoint.interface_withBigUsage                                                    
- ├─ Data processed (first 1PB)                     1,000  GB                      $10.00  * 
- ├─ Data processed (next 4PB)                      4,000  GB                      $24.00  * 
- ├─ Data processed (over 5PB)                      2,000  GB                       $8.00  * 
+ ├─ Data processed (first 1PB)                 1,000,000  GB                  $10,000.00  * 
+ ├─ Data processed (next 4PB)                  4,000,000  GB                  $24,000.00  * 
+ ├─ Data processed (over 5PB)                  2,000,000  GB                   $8,000.00  * 
  └─ Endpoint (Interface)                             730  hours                    $7.30    
                                                                                             
  aws_vpc_endpoint.interface_withUsage                                                       
@@ -27,7 +27,7 @@
  ├─ Data processed (first 1PB)            Monthly cost depends on usage: $0.01 per GB       
  └─ Endpoint (Interface)                             730  hours                    $7.30    
                                                                                             
- OVERALL TOTAL                                                                   $110.40 
+ OVERALL TOTAL                                                                $42,068.40 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -39,5 +39,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $58 ┃         $52 ┃       $110 ┃
+┃ main                                               ┃           $58 ┃     $42,010 ┃    $42,068 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/vpc_endpoint_test/vpc_endpoint_test.usage.yml
@@ -4,4 +4,4 @@ resource_usage:
     monthly_data_processed_gb: 1000
 
   aws_vpc_endpoint.interface_withBigUsage:
-    monthly_data_processed_gb: 7000
+    monthly_data_processed_gb: 7000000

--- a/internal/resources/aws/vpc_endpoint.go
+++ b/internal/resources/aws/vpc_endpoint.go
@@ -67,7 +67,7 @@ func (r *VPCEndpoint) BuildResource() *schema.Resource {
 		endpointHours = "VpcEndpoint-Hours"
 		endpointBytes = "VpcEndpoint-Bytes"
 		if dataProcessedGB != nil {
-			gbLimits := []int{1000, 4000}
+			gbLimits := []int{1000000, 4000000}
 			tiers := usage.CalculateTierBuckets(*dataProcessedGB, gbLimits)
 
 			if tiers[0].GreaterThan(decimal.NewFromInt(0)) {


### PR DESCRIPTION
The previous configuration had 1TB and 5TB tiers instead of 1PB and 5PB.

This fix correctly computes costs at all traffic levels rather than improperly deflating costs.

See https://github.com/infracost/infracost/issues/3228