### PR TITLE
fix: support "**" in excluded_dirs

### DIFF
--- a/cmd/infracost/testdata/breakdown_format_json_with_tags_aft_module/breakdown_format_json_with_tags_aft_module.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags_aft_module/breakdown_format_json_with_tags_aft_module.golden
@@ -1016,6 +1016,15 @@
             "defaultTags": {
               "managed_by": "AFT"
             },
+            "name": "module.aft.module.aft_ssm_parameters.aws_ssm_parameter.gitlab_selfmanaged_url",
+            "tags": {
+              "managed_by": "AFT"
+            }
+          },
+          {
+            "defaultTags": {
+              "managed_by": "AFT"
+            },
             "name": "module.aft.module.aft_ssm_parameters.aws_ssm_parameter.global_customizations_repo_branch",
             "tags": {
               "managed_by": "AFT"

--- a/cmd/infracost/testdata/breakdown_format_json_with_tags_aft_module/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_with_tags_aft_module/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 module "aft" {
-  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory"
+  source = "github.com/aws-ia/terraform-aws-control_tower_account_factory?ref=1.13.2"
   # Required Variables
   ct_management_account_id    = "1234"
   log_archive_account_id      = "1234"

--- a/cmd/infracost/testdata/generate/excluded_dirs_glob/expected.golden
+++ b/cmd/infracost/testdata/generate/excluded_dirs_glob/expected.golden
@@ -1,0 +1,10 @@
+version: 0.1
+
+projects:
+  - path: apps/bar
+    name: apps-bar
+    skip_autodetect: true
+  - path: apps/foo
+    name: apps-foo
+    skip_autodetect: true
+

--- a/cmd/infracost/testdata/generate/excluded_dirs_glob/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/excluded_dirs_glob/infracost.yml.tmpl
@@ -1,0 +1,4 @@
+version: 0.1
+autodetect:
+  exclude_dirs:
+    - "apps/foo/**"

--- a/cmd/infracost/testdata/generate/excluded_dirs_glob/tree.txt
+++ b/cmd/infracost/testdata/generate/excluded_dirs_glob/tree.txt
@@ -1,0 +1,10 @@
+.
+└── apps/
+    ├── bar/
+    │   └── main.tf
+    └── foo/
+        ├── bar/
+        │   ├── main.tf
+        │   └── bat/
+        │       └── main.tf
+        └── main.tf


### PR DESCRIPTION
`filepath.Glob` doesn't support `**` so using the same glob library we use elsewhere.