### PR TITLE
fix: fix Spacelift var loading

### DIFF
--- a/internal/hcl/remote_variables_loader.go
+++ b/internal/hcl/remote_variables_loader.go
@@ -17,6 +17,7 @@ import (
 	spaceliftSession "github.com/spacelift-io/spacectl/client/session"
 	"github.com/spacelift-io/spacectl/client/structs"
 	"github.com/zclconf/go-cty/cty"
+	ctyJson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/infracost/infracost/internal/extclient"
 	"github.com/infracost/infracost/internal/logging"
@@ -120,8 +121,9 @@ func NewTFCRemoteVariablesLoader(client *extclient.AuthedAPIClient, localWorkspa
 }
 
 type RemoteVarLoaderOptions struct {
-	Blocks  Blocks
-	EnvName string
+	Blocks      Blocks
+	ModulePath  string
+	Environment string
 }
 
 // Load fetches remote variables if terraform block contains organization and
@@ -400,8 +402,8 @@ func NewSpaceliftRemoteVariableLoader(metadata vcs.Metadata, apiKeyEndpoint, api
 // Load fetches remote variables from Spacelift by querying the stacks for the
 // provided environment name and remote name.
 func (s *SpaceliftRemoteVariableLoader) Load(options RemoteVarLoaderOptions) (map[string]cty.Value, error) {
-	if options.EnvName == "" {
-		logging.Logger.Trace().Msg("no environment name provided, skipping Spacelift remote variable loading")
+	if options.ModulePath == "" {
+		logging.Logger.Trace().Msg("no module path provided, skipping Spacelift remote variable loading")
 		return nil, nil
 	}
 
@@ -409,44 +411,83 @@ func (s *SpaceliftRemoteVariableLoader) Load(options RemoteVarLoaderOptions) (ma
 	// in future we should get all stacks for the remote name and then
 	// dynamically create projects out of the stacks returned.
 	stacks, err := s.getStacks(context.Background(), &getStackOptions{
-		count:          2, // We only want 1 stack, but want to check if there's more than 1
+		count:          10, // We only want 1 stack, but want to filter by the module suffix
 		repositoryName: s.Metadata.Remote.Name,
-		fullTextSearch: options.EnvName,
+		projectRoot:    options.ModulePath,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("could not get stacks: %w", err)
+		return nil, fmt.Errorf("could not get Spacelift stacks: %w", err)
 	}
 
 	if len(stacks) == 0 {
-		logging.Logger.Debug().Msg("no stack found, skipping Spacelift remote variable loading")
+		logging.Logger.Debug().Msgf("no Spacelift stack found for module path %q", options.ModulePath)
+		return nil, nil
+	}
+
+	// If there is a module suffix, filter the stacks by it
+	if options.Environment != "" {
+		var filteredStacks []stack
+		for _, stack := range stacks {
+			if strings.HasSuffix(stack.Name, fmt.Sprintf(":%s", options.Environment)) {
+				filteredStacks = append(filteredStacks, stack)
+			}
+		}
+		stacks = filteredStacks
+	}
+
+	if len(stacks) == 0 {
+		logging.Logger.Warn().Msgf("no Spacelift stack found for module path %q with environment %q", options.ModulePath, options.Environment)
 		return nil, nil
 	}
 
 	if len(stacks) > 1 {
-		logging.Logger.Debug().Msg("more than one stack found, skipping Spacelift remote variable loading")
+		logging.Logger.Warn().Msgf("found multiple Spacelift stacks for module path %q with environment %q, skipping Spacelift remote variable loading", options.ModulePath, options.Environment)
 		return nil, nil
 	}
 
-	logging.Logger.Debug().Msgf("found stack %s for environment %s", stacks[0].Name, options.EnvName)
-	stackEnvs := stacks[0].Config
-
-	if len(stackEnvs) == 0 {
-		logging.Logger.Debug().Msg("no stack environment variables found, skipping Spacelift remote variable loading")
-		return nil, nil
-	}
+	logging.Logger.Debug().Msgf("found Spacelift stack %q for module path %q with environment: %q", stacks[0].Name, options.ModulePath, options.Environment)
 
 	vars := map[string]cty.Value{}
-	for _, env := range stackEnvs {
-		vars[env.ID] = cty.StringVal(env.Value)
+
+	// Spacelift precedence is runtime config > config > attached contexts
+	for _, env := range stacks[0].AttachedContexts {
+		if strings.HasPrefix(env.ID, "TF_VAR_") {
+			vars[strings.TrimPrefix(env.ID, "TF_VAR_")] = cty.StringVal(env.ContextName)
+		}
+	}
+
+	for _, env := range stacks[0].Config {
+		if strings.HasPrefix(env.ID, "TF_VAR_") {
+			vars[strings.TrimPrefix(env.ID, "TF_VAR_")] = cty.StringVal(env.Value)
+		}
+	}
+
+	for _, env := range stacks[0].RuntimeConfig {
+		if strings.HasPrefix(env.Element.ID, "TF_VAR_") {
+			vars[strings.TrimPrefix(env.Element.ID, "TF_VAR_")] = cty.StringVal(env.Element.Value)
+		}
+	}
+
+	logging.Logger.Debug().Msgf("loaded %d Spacelift remote variables", len(vars))
+
+	// Only marshal and log the variables if the log level is trace
+	// Otherwise we want to skip the marshalling for performance reasons
+	if logging.Logger.GetLevel() == zerolog.TraceLevel {
+		s := ctyJson.SimpleJSONValue{Value: cty.ObjectVal(vars)}
+		b, _ := s.MarshalJSON()
+		logging.Logger.Trace().Msgf("Spacelift remote variables: %v", string(b))
 	}
 
 	return vars, nil
 }
 
 type stack struct {
-	ID     string        `graphql:"id" json:"id,omitempty"`
-	Name   string        `graphql:"name" json:"name,omitempty"`
-	Config []stackConfig `graphql:"config" json:"config,omitempty"`
+	ID               string            `graphql:"id" json:"id,omitempty"`
+	Name             string            `graphql:"name" json:"name,omitempty"`
+	ProjectRoot      string            `graphql:"projectRoot" json:"projectRoot,omitempty"`
+	Config           []stackConfig     `graphql:"config" json:"config,omitempty"`
+	RuntimeConfig    []runtimeConfig   `graphql:"runtimeConfig" json:"runtimeConfig,omitempty"`
+	AttachedContexts []attachedContext `graphql:"attachedContexts" json:"attachedContexts,omitempty"`
 }
 
 type stackConfig struct {
@@ -454,11 +495,20 @@ type stackConfig struct {
 	Value string `graphql:"value" json:"value,omitempty"`
 }
 
+type runtimeConfig struct {
+	Element stackConfig `graphql:"element" json:"element,omitempty"`
+}
+
+type attachedContext struct {
+	ID          string `graphql:"id" json:"id,omitempty"`
+	ContextName string `graphql:"contextName" json:"contextName,omitempty"`
+}
+
 type getStackOptions struct {
 	count int32
 
 	repositoryName string
-	fullTextSearch string
+	projectRoot    string
 }
 
 func (s *SpaceliftRemoteVariableLoader) getStacks(ctx context.Context, p *getStackOptions) ([]stack, error) {
@@ -483,14 +533,18 @@ func (s *SpaceliftRemoteVariableLoader) getStacks(ctx context.Context, p *getSta
 			},
 		})
 	}
+	if p.projectRoot != "" {
+		conditions = append(conditions, structs.QueryPredicate{
+			Field: graphql.String("projectRoot"),
+			Constraint: structs.QueryFieldConstraint{
+				StringMatches: &[]graphql.String{graphql.String(p.projectRoot)},
+			},
+		})
+	}
 
 	input := structs.SearchInput{
 		First:      graphql.NewInt(graphql.Int(p.count)),
 		Predicates: &conditions,
-	}
-
-	if p.fullTextSearch != "" {
-		input.FullTextSearch = graphql.NewString(graphql.String(p.fullTextSearch))
 	}
 
 	variables := map[string]interface{}{"input": input}

--- a/internal/hcl/remote_variables_loader_test.go
+++ b/internal/hcl/remote_variables_loader_test.go
@@ -1,6 +1,7 @@
 package hcl
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -9,11 +10,13 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/spacelift-io/spacectl/client"
 	"github.com/spacelift-io/spacectl/client/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/zclconf/go-cty/cty"
 
+	"github.com/infracost/infracost/internal/logging"
 	"github.com/infracost/infracost/internal/vcs"
 )
 
@@ -31,9 +34,10 @@ func TestSpaceliftRemoteVariableLoader_Load(t *testing.T) {
 		want           map[string]cty.Value
 		wantErr        assert.ErrorAssertionFunc
 		testServerFunc func(t *testing.T) http.HandlerFunc
+		verifyLog      func(t *testing.T, log string)
 	}{
 		{
-			name: "return variables from spacelift context",
+			name: "return variables from SpaceLift",
 			fields: fields{
 				Metadata: vcs.Metadata{
 					Remote: vcs.Remote{
@@ -43,30 +47,79 @@ func TestSpaceliftRemoteVariableLoader_Load(t *testing.T) {
 			},
 			args: args{
 				options: RemoteVarLoaderOptions{
-					EnvName: "dev",
+					ModulePath:  "module/path",
+					Environment: "dev",
 				},
 			},
 			want: map[string]cty.Value{
-				"test":  cty.StringVal("1"),
-				"test2": cty.StringVal("foo"),
+				"context_var": cty.StringVal("context_value"),
+				"config_var":  cty.StringVal("config_value"),
+				"runtime_var": cty.StringVal("runtime_value"),
 			},
 			wantErr: assert.NoError,
 			testServerFunc: func(t *testing.T) http.HandlerFunc {
-				// test that the /graqphl endpoint has been called and the correct query has been sent
 				return func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
 					assert.Equal(t, "POST", r.Method)
 					s, err := io.ReadAll(r.Body)
 					assert.NoError(t, err)
-					assert.JSONEq(t, `{"query":"query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,config{id,value}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}","variables":{"input":{"first":2,"after":null,"fullTextSearch":"dev","predicates":[{"field":"repository","constraint":{"booleanEquals":null,"enumEquals":null,"stringMatches":["test/test"]}}],"orderBy":null}}}`, string(s))
-					assert.Equal(t, "Bearer test", r.Header.Get("Authorization"))
 
-					_, err = w.Write([]byte(`{"data":{"searchStacks":{"edges":[{"node":{"id":"dev","name":"dev","config":[{"id":"test","value":"1"},{"id":"test2","value":"foo"}]}}],"pageInfo":{"endCursor":"MDFKNEtQMzVETjFYRDcxNTY1UkJCMzBITUQ=","hasNextPage":true,"hasPreviousPage":false}}}}`))
+					expectedJSON := `{
+						"query": "query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,projectRoot,config{id,value},runtimeConfig{element{id,value}},attachedContexts{id,contextName}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}",
+						"variables": {
+							"input": {
+								"first": 10,
+								"after": null,
+								"fullTextSearch": null,
+								"orderBy": null,
+								"predicates": [
+									{"field": "repository", "constraint": {"stringMatches": ["test/test"], "booleanEquals": null, "enumEquals": null}},
+									{"field": "projectRoot", "constraint": {"stringMatches": ["module/path"], "booleanEquals": null, "enumEquals": null}}
+								]
+							}
+						}
+					}`
+					assert.JSONEq(t, expectedJSON, string(s))
+
+					response := `{
+						"data": {
+							"searchStacks": {
+								"edges": [
+									{
+										"node": {
+											"id": "module-path-dev",
+											"name": "module-path:dev",
+											"projectRoot": "module/path",
+											"attachedContexts": [
+												{"id": "TF_VAR_context_var", "contextName": "context_value"},
+												{"id": "CONTEXT_VAR", "contextName": "non_tf_context_value"}
+											],
+											"config": [
+												{"id": "TF_VAR_config_var", "value": "config_value"},
+												{"id": "CONFIG_VAR", "value": "non_tf_config_value"}
+											],
+											"runtimeConfig": [
+												{"element": {"id": "TF_VAR_runtime_var", "value": "runtime_value"}},
+												{"element": {"id": "RUNTIME_VAR", "value": "non_tf_runtime_value"}}
+											]
+										}
+									}
+								],
+								"pageInfo": {
+									"endCursor": "MDFKNEtQMzVETjFYRDcxNTY1UkJCMzBITUQ=",
+									"hasNextPage": false,
+									"hasPreviousPage": false
+								}
+							}
+						}
+					}`
+					_, err = w.Write([]byte(response))
 					assert.NoError(t, err)
 				}
 			},
 		},
 		{
-			name: "returns empty map if no variables found",
+			name: "returns the correct variables when multiple stacks match ModulePath but only one has the correct environment",
 			fields: fields{
 				Metadata: vcs.Metadata{
 					Remote: vcs.Remote{
@@ -76,26 +129,92 @@ func TestSpaceliftRemoteVariableLoader_Load(t *testing.T) {
 			},
 			args: args{
 				options: RemoteVarLoaderOptions{
-					EnvName: "dev",
+					ModulePath:  "module/path",
+					Environment: "prod",
 				},
 			},
-			want:    nil,
+			want: map[string]cty.Value{
+				"runtime_var_prod": cty.StringVal("runtime_value_prod"),
+				"config_var_prod":  cty.StringVal("config_value_prod"),
+				"context_var_prod": cty.StringVal("context_value_prod"),
+			},
 			wantErr: assert.NoError,
 			testServerFunc: func(t *testing.T) http.HandlerFunc {
-				// test that the /graqphl endpoint has been called and the correct query has been sent
 				return func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
 					assert.Equal(t, "POST", r.Method)
 					s, err := io.ReadAll(r.Body)
 					assert.NoError(t, err)
-					assert.JSONEq(t, `{"query":"query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,config{id,value}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}","variables":{"input":{"first":2,"after":null,"fullTextSearch":"dev","predicates":[{"field":"repository","constraint":{"booleanEquals":null,"enumEquals":null,"stringMatches":["test/test"]}}],"orderBy":null}}}`, string(s))
 
-					_, err = w.Write([]byte(`{"data":{"searchStacks":{"edges":[{"node":{"id":"dev","name":"dev","config":[]}}],"pageInfo":{"endCursor":"MDFKNEtQMzVETjFYRDcxNTY1UkJCMzBITUQ=","hasNextPage":true,"hasPreviousPage":false}}}}`))
+					expectedJSON := `{
+						"query": "query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,projectRoot,config{id,value},runtimeConfig{element{id,value}},attachedContexts{id,contextName}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}",
+						"variables": {
+							"input": {
+								"first": 10,
+								"after": null,
+								"fullTextSearch": null,
+								"orderBy": null,
+								"predicates": [
+									{"field": "repository", "constraint": {"stringMatches": ["test/test"], "booleanEquals": null, "enumEquals": null}},
+									{"field": "projectRoot", "constraint": {"stringMatches": ["module/path"], "booleanEquals": null, "enumEquals": null}}
+								]
+							}
+						}
+					}`
+					assert.JSONEq(t, expectedJSON, string(s))
+
+					response := `{
+						"data": {
+							"searchStacks": {
+								"edges": [
+									{
+										"node": {
+											"id": "module-path-staging",
+											"name": "module-path-:staging",
+											"projectRoot": "module/path",
+											"attachedContexts": [
+												{"id": "TF_VAR_context_var_staging", "contextName": "context_value_staging"}
+											],
+											"config": [
+												{"id": "TF_VAR_config_var_staging", "value": "config_value_staging"}
+											],
+											"runtimeConfig": [
+												{"element": {"id": "TF_VAR_runtime_var_staging", "value": "runtime_value_staging"}}
+											]
+										}
+									},
+									{
+										"node": {
+											"id": "module-path-prod",
+											"name": "module-path:prod",
+											"projectRoot": "module/path",
+											"attachedContexts": [
+												{"id": "TF_VAR_context_var_prod", "contextName": "context_value_prod"}
+											],
+											"config": [
+												{"id": "TF_VAR_config_var_prod", "value": "config_value_prod"}
+											],
+											"runtimeConfig": [
+												{"element": {"id": "TF_VAR_runtime_var_prod", "value": "runtime_value_prod"}}
+											]
+										}
+									}
+								],
+								"pageInfo": {
+									"endCursor": "MDFKNEtQMzVETjFYRDcxNTY1UkJCMzBITUQ=",
+									"hasNextPage": false,
+									"hasPreviousPage": false
+								}
+							}
+						}
+					}`
+					_, err = w.Write([]byte(response))
 					assert.NoError(t, err)
 				}
 			},
 		},
 		{
-			name: "returns empty map if no stack is found",
+			name: "returns the correct variables according to the precedence of the config and context values",
 			fields: fields{
 				Metadata: vcs.Metadata{
 					Remote: vcs.Remote{
@@ -105,26 +224,77 @@ func TestSpaceliftRemoteVariableLoader_Load(t *testing.T) {
 			},
 			args: args{
 				options: RemoteVarLoaderOptions{
-					EnvName: "dev",
+					ModulePath:  "module/path",
+					Environment: "dev",
 				},
 			},
-			want:    nil,
+			want: map[string]cty.Value{
+				"var1": cty.StringVal("runtime_value"),
+				"var2": cty.StringVal("config_value"),
+			},
 			wantErr: assert.NoError,
 			testServerFunc: func(t *testing.T) http.HandlerFunc {
-				// test that the /graqphl endpoint has been called and the correct query has been sent
 				return func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
 					assert.Equal(t, "POST", r.Method)
 					s, err := io.ReadAll(r.Body)
 					assert.NoError(t, err)
-					assert.JSONEq(t, `{"query":"query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,config{id,value}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}","variables":{"input":{"first":2,"after":null,"fullTextSearch":"dev","predicates":[{"field":"repository","constraint":{"booleanEquals":null,"enumEquals":null,"stringMatches":["test/test"]}}],"orderBy":null}}}`, string(s))
 
-					_, err = w.Write([]byte(`{"data":{"searchStacks":{"edges":[],"pageInfo":{"endCursor":"MDFKNEtQMzVETjFYRDcxNTY1UkJCMzBITUQ=","hasNextPage":true,"hasPreviousPage":false}}}}`))
+					expectedJSON := `{
+						"query": "query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,projectRoot,config{id,value},runtimeConfig{element{id,value}},attachedContexts{id,contextName}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}",
+						"variables": {
+							"input": {
+								"first": 10,
+								"after": null,
+								"fullTextSearch": null,
+								"orderBy": null,
+								"predicates": [
+									{"field": "repository", "constraint": {"stringMatches": ["test/test"], "booleanEquals": null, "enumEquals": null}},
+									{"field": "projectRoot", "constraint": {"stringMatches": ["module/path"], "booleanEquals": null, "enumEquals": null}}
+								]
+							}
+						}
+					}`
+					assert.JSONEq(t, expectedJSON, string(s))
+
+					response := `{
+						"data": {
+							"searchStacks": {
+								"edges": [
+									{
+										"node": {
+											"id": "module-path-dev",
+											"name": "module-path:dev",
+											"projectRoot": "module/path",
+											"attachedContexts": [
+												{"id": "TF_VAR_var1", "contextName": "context_value"},
+												{"id": "TF_VAR_var2", "contextName": "context_value"}
+											],
+											"config": [
+												{"id": "TF_VAR_var1", "value": "config_value"},
+												{"id": "TF_VAR_var2", "value": "config_value"}
+											],
+											"runtimeConfig": [
+												{"element": {"id": "TF_VAR_var1", "value": "runtime_value"}}
+											]
+										}
+									}
+								],
+								"pageInfo": {
+									"endCursor": null,
+									"hasNextPage": false,
+									"hasPreviousPage": false
+								}
+							}
+						}
+					}`
+					_, err = w.Write([]byte(response))
 					assert.NoError(t, err)
 				}
 			},
 		},
 		{
-			name: "returns empty map if more than one stack is found",
+			name: "returns nil if no stacks match ModulePath",
 			fields: fields{
 				Metadata: vcs.Metadata{
 					Remote: vcs.Remote{
@@ -134,22 +304,246 @@ func TestSpaceliftRemoteVariableLoader_Load(t *testing.T) {
 			},
 			args: args{
 				options: RemoteVarLoaderOptions{
-					EnvName: "dev",
+					ModulePath:  "nonexistent/path",
+					Environment: "prod",
 				},
 			},
 			want:    nil,
 			wantErr: assert.NoError,
 			testServerFunc: func(t *testing.T) http.HandlerFunc {
-				// test that the /graqphl endpoint has been called and the correct query has been sent
 				return func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
 					assert.Equal(t, "POST", r.Method)
 					s, err := io.ReadAll(r.Body)
 					assert.NoError(t, err)
-					assert.JSONEq(t, `{"query":"query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,config{id,value}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}","variables":{"input":{"first":2,"after":null,"fullTextSearch":"dev","predicates":[{"field":"repository","constraint":{"booleanEquals":null,"enumEquals":null,"stringMatches":["test/test"]}}],"orderBy":null}}}`, string(s))
 
-					_, err = w.Write([]byte(`{"data":{"searchStacks":{"edges":[{"node":{"id":"dev-a","name":"dev-a","config":[]}},{"node":{"id":"dev-b","name":"dev-b","config":[]}}],"pageInfo":{"endCursor":"MDFKNEtQMzVETjFYRDcxNTY1UkJCMzBITUQ=","hasNextPage":true,"hasPreviousPage":false}}}}`))
+					expectedJSON := `{
+						"query": "query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,projectRoot,config{id,value},runtimeConfig{element{id,value}},attachedContexts{id,contextName}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}",
+						"variables": {
+							"input": {
+								"first": 10,
+								"after": null,
+								"fullTextSearch": null,
+								"orderBy": null,
+								"predicates": [
+									{"field": "repository", "constraint": {"stringMatches": ["test/test"], "booleanEquals": null, "enumEquals": null}},
+									{"field": "projectRoot", "constraint": {"stringMatches": ["nonexistent/path"], "booleanEquals": null, "enumEquals": null}}
+								]
+							}
+						}
+					}`
+					assert.JSONEq(t, expectedJSON, string(s))
+
+					response := `{
+						"data": {
+							"searchStacks": {
+								"edges": [],
+								"pageInfo": {
+									"endCursor": null,
+									"hasNextPage": false,
+									"hasPreviousPage": false
+								}
+							}
+						}
+					}`
+					_, err = w.Write([]byte(response))
 					assert.NoError(t, err)
 				}
+			},
+		},
+		{
+			name: "returns nil if ModulePath is missing",
+			fields: fields{
+				Metadata: vcs.Metadata{
+					Remote: vcs.Remote{
+						Name: "test/test",
+					},
+				},
+			},
+			args: args{
+				options: RemoteVarLoaderOptions{
+					ModulePath: "",
+				},
+			},
+			want:    nil,
+			wantErr: assert.NoError,
+			testServerFunc: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					// This test should not reach the server as ModulePath is empty
+					assert.FailNow(t, "HTTP server should not be called when ModulePath is empty")
+				}
+			},
+		},
+		{
+			name: "warns if ModulePath matches but no environment matches",
+			fields: fields{
+				Metadata: vcs.Metadata{
+					Remote: vcs.Remote{
+						Name: "test/test",
+					},
+				},
+			},
+			args: args{
+				options: RemoteVarLoaderOptions{
+					ModulePath:  "module/path",
+					Environment: "nonexistent-env",
+				},
+			},
+			want:    nil,
+			wantErr: assert.NoError,
+			testServerFunc: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					assert.Equal(t, "POST", r.Method)
+					s, err := io.ReadAll(r.Body)
+					assert.NoError(t, err)
+
+					expectedJSON := `{
+						"query": "query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,projectRoot,config{id,value},runtimeConfig{element{id,value}},attachedContexts{id,contextName}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}",
+						"variables": {
+							"input": {
+								"first": 10,
+								"after": null,
+								"fullTextSearch": null,
+								"orderBy": null,
+								"predicates": [
+									{"field": "repository", "constraint": {"stringMatches": ["test/test"], "booleanEquals": null, "enumEquals": null}},
+									{"field": "projectRoot", "constraint": {"stringMatches": ["module/path"], "booleanEquals": null, "enumEquals": null}}
+								]
+							}
+						}
+					}`
+					assert.JSONEq(t, expectedJSON, string(s))
+
+					response := `{
+						"data": {
+							"searchStacks": {
+								"edges": [
+									{
+										"node": {
+											"id": "module-path-dev",
+											"name": "module-path:dev",
+											"projectRoot": "module/path",
+											"attachedContexts": [
+												{"id": "TF_VAR_context_var", "contextName": "context_value"}
+											],
+											"config": [
+												{"id": "TF_VAR_config_var", "value": "config_value"}
+											],
+											"runtimeConfig": [
+												{"element": {"id": "TF_VAR_runtime_var", "value": "runtime_value"}}
+											]
+										}
+									}
+								],
+								"pageInfo": {
+									"endCursor": null,
+									"hasNextPage": false,
+									"hasPreviousPage": false
+								}
+							}
+						}
+					}`
+					_, err = w.Write([]byte(response))
+					assert.NoError(t, err)
+				}
+			},
+			verifyLog: func(t *testing.T, logOutput string) {
+				assert.Contains(t, logOutput, "no Spacelift stack found for module path")
+			},
+		},
+		{
+			name: "warns if multiple stacks are found and no environment is specified",
+			fields: fields{
+				Metadata: vcs.Metadata{
+					Remote: vcs.Remote{
+						Name: "test/test",
+					},
+				},
+			},
+			args: args{
+				options: RemoteVarLoaderOptions{
+					ModulePath:  "module/path",
+					Environment: "",
+				},
+			},
+			want:    nil,
+			wantErr: assert.NoError,
+			testServerFunc: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					assert.Equal(t, "POST", r.Method)
+					s, err := io.ReadAll(r.Body)
+					assert.NoError(t, err)
+
+					expectedJSON := `{
+						"query": "query($input:SearchInput!){searchStacks(input: $input){edges{node{id,name,projectRoot,config{id,value},runtimeConfig{element{id,value}},attachedContexts{id,contextName}}},pageInfo{endCursor,hasNextPage,hasPreviousPage}}}",
+						"variables": {
+							"input": {
+								"first": 10,
+								"after": null,
+								"fullTextSearch": null,
+								"orderBy": null,
+								"predicates": [
+									{"field": "repository", "constraint": {"stringMatches": ["test/test"], "booleanEquals": null, "enumEquals": null}},
+									{"field": "projectRoot", "constraint": {"stringMatches": ["module/path"], "booleanEquals": null, "enumEquals": null}}
+								]
+							}
+						}
+					}`
+					assert.JSONEq(t, expectedJSON, string(s))
+
+					response := `{
+						"data": {
+							"searchStacks": {
+								"edges": [
+									{
+										"node": {
+											"id": "module-path-stack1",
+											"name": "module-path-stack1",
+											"projectRoot": "module/path",
+											"attachedContexts": [
+												{"id": "TF_VAR_var1", "contextName": "context_value1"}
+											],
+											"config": [
+												{"id": "TF_VAR_var1", "value": "config_value1"}
+											],
+											"runtimeConfig": [
+												{"element": {"id": "TF_VAR_var1", "value": "runtime_value1"}}
+											]
+										}
+									},
+									{
+										"node": {
+											"id": "module-path-stack2",
+											"name": "module-path-stack2",
+											"projectRoot": "module/path",
+											"attachedContexts": [
+												{"id": "TF_VAR_var2", "contextName": "context_value2"}
+											],
+											"config": [
+												{"id": "TF_VAR_var2", "value": "config_value2"}
+											],
+											"runtimeConfig": [
+												{"element": {"id": "TF_VAR_var2", "value": "runtime_value2"}}
+											]
+										}
+									}
+								],
+								"pageInfo": {
+									"endCursor": null,
+									"hasNextPage": false,
+									"hasPreviousPage": false
+								}
+							}
+						}
+					}`
+					_, err = w.Write([]byte(response))
+					assert.NoError(t, err)
+				}
+			},
+			verifyLog: func(t *testing.T, logOutput string) {
+				assert.Contains(t, logOutput, "found multiple Spacelift stacks for module path")
 			},
 		},
 	}
@@ -157,6 +551,13 @@ func TestSpaceliftRemoteVariableLoader_Load(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(tt.testServerFunc(t))
 			defer ts.Close()
+
+			var logBuf bytes.Buffer
+			log := zerolog.New(&logBuf).With().Timestamp().Logger()
+
+			oldLogger := logging.Logger
+			logging.Logger = log
+			defer func() { logging.Logger = oldLogger }()
 
 			s := &SpaceliftRemoteVariableLoader{
 				Client: client.New(http.DefaultClient, &stubSession{
@@ -172,6 +573,10 @@ func TestSpaceliftRemoteVariableLoader_Load(t *testing.T) {
 				return
 			}
 			assert.Equalf(t, tt.want, got, "Load(%v)", tt.args.options)
+
+			if tt.verifyLog != nil {
+				tt.verifyLog(t, logBuf.String())
+			}
 		})
 	}
 }

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -174,9 +174,15 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 		options = append(options, hcl.OptionGraphEvaluator())
 	}
 
+	if ctx.ProjectConfig.Name != "" {
+		options = append(options, hcl.OptionWithProjectName(ctx.ProjectConfig.Name))
+	}
+
+	envMatcher := hcl.CreateEnvFileMatcher(ctx.RunContext.Config.Autodetect.EnvNames, ctx.RunContext.Config.Autodetect.TerraformVarFileExtensions)
+
 	return &HCLProvider{
 		policyClient:   policyClient,
-		Parser:         hcl.NewParser(rootPath, hcl.CreateEnvFileMatcher(ctx.RunContext.Config.Autodetect.EnvNames, ctx.RunContext.Config.Autodetect.TerraformVarFileExtensions), loader, logger, options...),
+		Parser:         hcl.NewParser(rootPath, envMatcher, loader, logger, options...),
 		planJSONParser: NewParser(ctx, true),
 		ctx:            ctx,
 		config:         *config,
@@ -186,14 +192,6 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 func (p *HCLProvider) Context() *config.ProjectContext { return p.ctx }
 
 func (p *HCLProvider) ProjectName() string {
-	if p.ctx.ProjectConfig.Name != "" {
-		return p.ctx.ProjectConfig.Name
-	}
-
-	if p.ctx.ProjectConfig.TerraformWorkspace != "" {
-		return p.Parser.ProjectName() + "-" + p.ctx.ProjectConfig.TerraformWorkspace
-	}
-
 	return p.Parser.ProjectName()
 }
 


### PR DESCRIPTION
1. Update the Spacelift remote variable loader to load in variables from all 3 of the locations:
    - Environment
    - Spacelift environment
    - Attached contexts.

    We should look for any key starting with `TF_VAR_`

2. Update the Spacelift remote variable loader to better match on stack name. I think the following logic would work:
    1. Match the repository name exactly
    2. Match the projectRoot exactly based on the path of the module
    3. Query for multiple results
    4. If the project has a `moduleSuffix` then match on that using what is after the `:` in the project name. If there’s no `moduleSuffix`, then skip this step.
    5. Log a warning if there’s more than one match or no matches