### PR TITLE
chore: add an env var for json dump path

### DIFF
--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -331,7 +331,11 @@ func (p *HCLProvider) LoadPlanJSON() HCLProject {
 		module.JSON, module.Error = p.modulesToPlanJSON(module.Module)
 
 		if os.Getenv("INFRACOST_JSON_DUMP") == "true" {
-			err := os.WriteFile(fmt.Sprintf("%s-out.json", strings.ReplaceAll(module.Module.ModulePath, "/", "-")), module.JSON, os.ModePerm) // nolint: gosec
+			targetPath := fmt.Sprintf("%s-out.json", strings.ReplaceAll(module.Module.ModulePath, "/", "-"))
+			if os.Getenv("INFRACOST_JSON_DUMP_PATH") != "" {
+				targetPath = filepath.Join(os.Getenv("INFRACOST_JSON_DUMP_PATH"), targetPath)
+			}
+			err := os.WriteFile(targetPath, module.JSON, os.ModePerm) // nolint: gosec
 			if err != nil {
 				p.logger.Debug().Err(err).Msg("failed to write to json dump")
 			}


### PR DESCRIPTION
# User description
Add a new env var `INFRACOST_JSON_DUMP_PATH` to specify a target path to
drop the plan files when the `INFRACOST_JSON_DUMP` env var has been
specified.

This is to support policy engine processing the plan file

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
<p>Introduce an environment variable <code>INFRACOST_JSON_DUMP_PATH</code> in <code>HCLProvider</code> to specify a custom path for JSON plan file dumps when <code>INFRACOST_JSON_DUMP</code> is enabled.</p>
    <table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/infracost/infracost/3240?tool=ast&topic=JSON+Dump+Path>JSON Dump Path</a>
        </td><td>Add an environment variable <code>INFRACOST_JSON_DUMP_PATH</code> to specify a custom path for JSON plan file dumps.<details><summary>Modified files (1)</summary><ul><li>internal/providers/terraform/hcl_provider.go</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>Email</th><th>Commit</th><th>Date</th></tr><tr><td>ali.scott@gmail.com</td><td>fix-fix-Spacelift-var-...</td><td>October 31, 2024</td></tr>
<tr><td>liam@infracost.io</td><td>feat-Add-information-a...</td><td>August 20, 2024</td></tr></table></details></td></tr></table>This pull request is reviewed by Baz. Join @owenrumney and the rest of your team on <a href=https://baz.co/login>(Baz)</a>.
    