### PR TITLE
fix: Fix config generator when env name is in the project path IC-1911

### DIFF
--- a/cmd/infracost/testdata/generate/env_names_in_path/expected.golden
+++ b/cmd/infracost/testdata/generate/env_names_in_path/expected.golden
@@ -1,0 +1,18 @@
+version: 0.1
+autodetect:
+  env_names:
+   - dev
+   - prod
+   - qa
+
+projects:
+  - path: infra/components/foo-dev
+    name: infra-components-foo-dev
+    terraform_var_files:
+      - ../../variables/defaults.tfvars
+      - ../../variables/dev/foo-dev.tfvars
+  - path: infra/components/foo-prod
+    name: infra-components-foo-prod
+    terraform_var_files:
+      - ../../variables/defaults.tfvars
+      - ../../variables/prod/foo-prod.tfvars

--- a/cmd/infracost/testdata/generate/env_names_in_path/expected.golden
+++ b/cmd/infracost/testdata/generate/env_names_in_path/expected.golden
@@ -16,3 +16,4 @@ projects:
     terraform_var_files:
       - ../../variables/defaults.tfvars
       - ../../variables/prod/foo-prod.tfvars
+

--- a/cmd/infracost/testdata/generate/env_names_in_path/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/env_names_in_path/infracost.yml.tmpl
@@ -1,0 +1,16 @@
+version: 0.1
+autodetect:
+  env_names:
+   - dev
+   - prod
+   - qa
+
+projects:
+{{- range $project := .DetectedProjects }}
+  - path: {{ $project.Path }}
+    name: {{ $project.Name }}
+    terraform_var_files:
+    {{- range $varFile := $project.TerraformVarFiles }}
+      - {{ $varFile }}
+    {{- end }}
+{{- end }}

--- a/cmd/infracost/testdata/generate/env_names_in_path/tree.txt
+++ b/cmd/infracost/testdata/generate/env_names_in_path/tree.txt
@@ -1,0 +1,15 @@
+.
+└── infra
+    ├── components
+    │   ├── foo-dev
+    │   │   └── main.tf
+    │   └── foo-prod
+    │       └── main.tf
+    └── variables
+        ├── dev
+        │   └── foo-dev.tfvars
+        ├── prod
+        │   └── foo-prod.tfvars
+        ├── qa
+        │   └── bar.tfvars
+        └── defaults.tfvars

--- a/cmd/infracost/testdata/generate/modules_and_external_tfvars/expected.golden
+++ b/cmd/infracost/testdata/generate/modules_and_external_tfvars/expected.golden
@@ -2,7 +2,7 @@ version: 0.1
 
 projects:
   - path: db/dev
-    name: db-dev-dev
+    name: db-dev
     terraform_var_files:
       - ../../default.tfvars
       - ../../envs/dev.tfvars
@@ -13,7 +13,7 @@ projects:
       - default.tfvars
       - envs/dev.tfvars
   - path: db/prod
-    name: db-prod-prod
+    name: db-prod
     terraform_var_files:
       - ../../default.tfvars
       - ../../envs/prod.tfvars

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -108,22 +108,16 @@ func makePathsRelativeToInitial(paths []string, initialPath string) []string {
 }
 
 // OptionWithModuleSuffix sets an optional module suffix which will be added to the Module after it has finished parsing
-// this can be used to augment auto-detected project path names and metadata.
-func OptionWithModuleSuffix(suffix string) Option {
-	return func(p *Parser) {
-		p.moduleSuffix = suffix
-	}
-}
-
-// OptionWithProjectEnv unsets an optional module suffix when such suffix is already part of the project name.
-func OptionWithProjectEnv(rootPath, suffix string) Option {
+// this can be used to augment auto-detected project path names and metadata. If the suffix is already part of the project name - ignore it.
+func OptionWithModuleSuffix(rootPath, suffix string) Option {
 	return func(p *Parser) {
 		pathEnv := ""
 		if p.envMatcher != nil {
 			pathEnv = p.envMatcher.PathEnv(rootPath)
 		}
-		if pathEnv != "" && suffix != "" && pathEnv == suffix {
-			p.moduleSuffix = ""
+
+		if pathEnv == "" || (suffix != "" && pathEnv != suffix) {
+			p.moduleSuffix = suffix
 		}
 	}
 }

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -115,6 +115,19 @@ func OptionWithModuleSuffix(suffix string) Option {
 	}
 }
 
+// OptionWithProjectEnv unsets an optional module suffix when such suffix is already part of the project name.
+func OptionWithProjectEnv(rootPath, suffix string) Option {
+	return func(p *Parser) {
+		pathEnv := ""
+		if p.envMatcher != nil {
+			pathEnv = p.envMatcher.PathEnv(rootPath)
+		}
+		if pathEnv != "" && suffix != "" && pathEnv == suffix {
+			p.moduleSuffix = ""
+		}
+	}
+}
+
 // OptionWithTFEnvVars takes any TF_ENV_xxx=yyy from the environment and converts them to cty.Value
 // It then sets these as the Parser starting tfEnvVars which are used at the root module evaluation.
 func OptionWithTFEnvVars(projectEnv map[string]string) Option {

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -160,6 +160,7 @@ func autodetectedRootToProviders(projectContext *config.ProjectContext, rootPath
 					options,
 					hcl.OptionWithTFVarsPaths(append(autoVarFiles.ToPaths(), env.TerraformVarFiles.ToPaths()...), true),
 					hcl.OptionWithModuleSuffix(env.Name),
+					hcl.OptionWithProjectEnv(rootPath.DetectedPath, env.Name),
 				)...)
 			if err != nil {
 				logging.Logger.Warn().Err(err).Msgf("could not initialize provider for path %q", rootPath.DetectedPath)

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -159,8 +159,7 @@ func autodetectedRootToProviders(projectContext *config.ProjectContext, rootPath
 				append(
 					options,
 					hcl.OptionWithTFVarsPaths(append(autoVarFiles.ToPaths(), env.TerraformVarFiles.ToPaths()...), true),
-					hcl.OptionWithModuleSuffix(env.Name),
-					hcl.OptionWithProjectEnv(rootPath.DetectedPath, env.Name),
+					hcl.OptionWithModuleSuffix(rootPath.DetectedPath, env.Name),
 				)...)
 			if err != nil {
 				logging.Logger.Warn().Err(err).Msgf("could not initialize provider for path %q", rootPath.DetectedPath)


### PR DESCRIPTION
When an env name is in the path already, we should ignore the other envs.