### PR TITLE
enhance: Add curent and past errors to project metadata

### DIFF
--- a/cmd/infracost/testdata/breakdown_with_actual_costs/breakdown_with_actual_costs.golden
+++ b/cmd/infracost/testdata/breakdown_with_actual_costs/breakdown_with_actual_costs.golden
@@ -3,8 +3,8 @@ Project: main
  Name                                                            Monthly Qty  Unit   Monthly Cost    
                                                                                                      
  aws_dynamodb_table.usage                                                                            
- ├─ Write request unit (WRU)                                         100,000  WRUs          $0.13  * 
- ├─ Read request unit (RRU)                                          100,001  RRUs          $0.03  * 
+ ├─ Write request unit (WRU)                                         100,000  WRUs          $0.06  * 
+ ├─ Read request unit (RRU)                                          100,001  RRUs          $0.01  * 
  ├─ Data storage                                                     100,002  GB       $25,000.50  * 
  ├─ Point-In-Time Recovery (PITR) backup storage                     100,003  GB       $20,000.60  * 
  ├─ On-demand backup storage                                         100,004  GB       $10,000.40  * 
@@ -16,7 +16,7 @@ Project: main
  └─ Actual costs Aug 15-Sep 22 (arn:another_aws_dynamodb_table)                                      
     └─ $0.005123 per some aws thing                                    1,000  GB            $5.12    
                                                                                                      
- OVERALL TOTAL                                                                         $70,002.42 
+ OVERALL TOTAL                                                                         $70,002.35 
 
 *Usage costs were estimated using Infracost Cloud settings, see docs for other options.
 

--- a/cmd/infracost/testdata/breakdown_with_actual_costs_pitr_disabled/breakdown_with_actual_costs_pitr_disabled.golden
+++ b/cmd/infracost/testdata/breakdown_with_actual_costs_pitr_disabled/breakdown_with_actual_costs_pitr_disabled.golden
@@ -3,8 +3,8 @@ Project: main
  Name                                                            Monthly Qty  Unit   Monthly Cost    
                                                                                                      
  aws_dynamodb_table.usage                                                                            
- ├─ Write request unit (WRU)                                         100,000  WRUs          $0.13  * 
- ├─ Read request unit (RRU)                                          100,001  RRUs          $0.03  * 
+ ├─ Write request unit (WRU)                                         100,000  WRUs          $0.06  * 
+ ├─ Read request unit (RRU)                                          100,001  RRUs          $0.01  * 
  ├─ Data storage                                                     100,002  GB       $25,000.50  * 
  ├─ On-demand backup storage                                         100,004  GB       $10,000.40  * 
  ├─ Table data restored                                              100,005  GB       $15,000.75  * 
@@ -15,7 +15,7 @@ Project: main
  └─ Actual costs Aug 15-Sep 22 (arn:another_aws_dynamodb_table)                                      
     └─ $0.005123 per some aws thing                                    1,000  GB            $5.12    
                                                                                                      
- OVERALL TOTAL                                                                         $50,001.82 
+ OVERALL TOTAL                                                                         $50,001.75 
 
 *Usage costs were estimated using Infracost Cloud settings, see docs for other options.
 

--- a/cmd/infracost/testdata/diff_with_compare_to_with_current_and_past_project_error/diff_with_compare_to_with_current_and_past_project_error.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_current_and_past_project_error/diff_with_compare_to_with_current_and_past_project_error.golden
@@ -34,6 +34,22 @@
             "data": null,
             "isError": false
           }
+        ],
+        "currentErrors": [
+          {
+            "code": 102,
+            "message": "Error loading Terraform modules: failed to parse file REPLACED_PROJECT_PATH/testdata/diff_with_compare_to_with_current_and_past_project_error/dev/mod_with_error.tf diag: REPLACED_PROJECT_PATH/testdata/diff_with_compare_to_with_current_and_past_project_error/dev/mod_with_error.tf:1,9-10: Invalid block definition; Either a quoted string block label or an opening brace (\"{\") is expected here., and 1 other diagnostic(s)",
+            "data": null,
+            "isError": true
+          }
+        ],
+        "pastErrors": [
+          {
+            "code": 102,
+            "message": "Diff baseline error: Error loading Terraform modules: failed to inspect module path dev diag: Invalid block definition: Either a quoted string block label or an opening brace (\"{\") is expected here. (and 1 other messages)",
+            "data": null,
+            "isError": false
+          }
         ]
       },
       "pastBreakdown": {

--- a/cmd/infracost/testdata/diff_with_compare_to_with_current_project_error/diff_with_compare_to_with_current_project_error.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_current_project_error/diff_with_compare_to_with_current_project_error.golden
@@ -28,6 +28,14 @@
             "data": null,
             "isError": true
           }
+        ],
+        "currentErrors": [
+          {
+            "code": 102,
+            "message": "Error loading Terraform modules: failed to parse file REPLACED_PROJECT_PATH/testdata/diff_with_compare_to_with_current_project_error/dev/mod_with_error.tf diag: REPLACED_PROJECT_PATH/testdata/diff_with_compare_to_with_current_project_error/dev/mod_with_error.tf:1,9-10: Invalid block definition; Either a quoted string block label or an opening brace (\"{\") is expected here., and 1 other diagnostic(s)",
+            "data": null,
+            "isError": true
+          }
         ]
       },
       "pastBreakdown": {

--- a/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error/diff_with_compare_to_with_past_project_error.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error/diff_with_compare_to_with_past_project_error.golden
@@ -29,6 +29,14 @@
             "isError": false
           }
         ],
+        "pastErrors": [
+          {
+            "code": 102,
+            "message": "Diff baseline error: Error loading Terraform modules: failed to inspect module path dev diag: Invalid block definition: Either a quoted string block label or an opening brace (\"{\") is expected here. (and 1 other messages)",
+            "data": null,
+            "isError": false
+          }
+        ],
         "providers": [
           {
             "name": "aws",

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -138,6 +138,7 @@ func CompareTo(c *config.Config, current, prior Root) (Root, error) {
 		scp.PastResources = nil
 		scp.Metadata.PastPolicySha = ""
 		scp.HasDiff = true
+		scp.Metadata.CurrentErrors = scp.Metadata.Errors
 
 		metadata := p.LabelWithMetadata()
 		if v, ok := priorProjects[metadata]; ok {
@@ -164,6 +165,8 @@ func CompareTo(c *config.Config, current, prior Root) (Root, error) {
 					// be ignored.
 					continue
 				}
+
+				scp.Metadata.PastErrors = append(scp.Metadata.PastErrors, pastE)
 
 				pastE.Message = "Diff baseline error: " + pastE.Message
 				scp.Metadata.Errors = append(scp.Metadata.Errors, pastE)

--- a/internal/providers/terraform/aws/testdata/dynamodb_table_test/dynamodb_table_test.golden
+++ b/internal/providers/terraform/aws/testdata/dynamodb_table_test/dynamodb_table_test.golden
@@ -2,17 +2,17 @@
  Name                                                            Monthly Qty  Unit                  Monthly Cost    
                                                                                                                     
  aws_dynamodb_table.my_dynamodb_table_usage                                                                         
- ├─ Write request unit (WRU)                                       3,000,000  WRUs                         $3.75  * 
- ├─ Read request unit (RRU)                                        8,000,000  RRUs                         $2.00  * 
+ ├─ Write request unit (WRU)                                       3,000,000  WRUs                         $1.88  * 
+ ├─ Read request unit (RRU)                                        8,000,000  RRUs                         $1.00  * 
  ├─ Data storage                                                         230  GB                          $57.50  * 
  ├─ Point-In-Time Recovery (PITR) backup storage                       2,300  GB                         $460.00  * 
  ├─ On-demand backup storage                                             460  GB                          $46.00  * 
  ├─ Table data restored                                                  230  GB                          $34.50  * 
  ├─ Streams read request unit (sRRU)                               2,000,000  sRRUs                        $0.40  * 
  ├─ Global table (us-east-2)                                                                                        
- │  └─ Replicated write request unit (rWRU)                       4,109.5890  rWRU                         $5.63    
+ │  └─ Replicated write request unit (rWRU)                       4,109.5890  rWRU                         $1.88    
  └─ Global table (us-west-1)                                                                                        
-    └─ Replicated write request unit (rWRU)                       4,109.5890  rWRU                         $6.27    
+    └─ Replicated write request unit (rWRU)                       4,109.5890  rWRU                         $2.09    
                                                                                                                     
  aws_dynamodb_table.autoscale_dynamodb_table_usage                                                                  
  ├─ Write capacity unit (WCU, autoscaling)                                77  WCU                         $36.54  * 
@@ -32,9 +32,9 @@
  ├─ Table data restored                                     Monthly cost depends on usage: $0.15 per GB             
  ├─ Streams read request unit (sRRU)                        Monthly cost depends on usage: $0.0000002 per sRRUs     
  ├─ Global table (us-east-2)                                                                                        
- │  └─ Replicated write capacity unit (rWCU)                              20  rWCU                        $14.24    
+ │  └─ Replicated write capacity unit (rWCU)                              20  rWCU                         $9.49    
  └─ Global table (us-west-1)                                                                                        
-    └─ Replicated write capacity unit (rWCU)                              20  rWCU                        $15.88    
+    └─ Replicated write capacity unit (rWCU)                              20  rWCU                        $10.59    
                                                                                                                     
  aws_dynamodb_table.my_dynamodb_table_with_no_billing_mode                                                          
  ├─ Write capacity unit (WCU)                                             20  WCU                          $9.49    
@@ -45,9 +45,9 @@
  ├─ Table data restored                                     Monthly cost depends on usage: $0.15 per GB             
  ├─ Streams read request unit (sRRU)                        Monthly cost depends on usage: $0.0000002 per sRRUs     
  ├─ Global table (us-east-2)                                                                                        
- │  └─ Replicated write capacity unit (rWCU)                              20  rWCU                        $14.24    
+ │  └─ Replicated write capacity unit (rWCU)                              20  rWCU                         $9.49    
  └─ Global table (us-west-1)                                                                                        
-    └─ Replicated write capacity unit (rWCU)                              20  rWCU                        $15.88    
+    └─ Replicated write capacity unit (rWCU)                              20  rWCU                        $10.59    
                                                                                                                     
  aws_dynamodb_table.autoscale_dynamodb_table_literal_ref                                                            
  ├─ Write capacity unit (WCU)                                             20  WCU                          $9.49    
@@ -67,7 +67,7 @@
  ├─ Table data restored                                     Monthly cost depends on usage: $0.15 per GB             
  └─ Streams read request unit (sRRU)                        Monthly cost depends on usage: $0.0000002 per sRRUs     
                                                                                                                     
- OVERALL TOTAL                                                                                           $762.82 
+ OVERALL TOTAL                                                                                           $731.93 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -78,5 +78,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃          $106 ┃        $657 ┃       $763 ┃
+┃ main                                               ┃           $78 ┃        $654 ┃       $732 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/schema/project.go
+++ b/internal/schema/project.go
@@ -197,7 +197,9 @@ type ProjectMetadata struct {
 	TerraformWorkspace  string             `json:"terraformWorkspace,omitempty"`
 	VCSSubPath          string             `json:"vcsSubPath,omitempty"`
 	VCSCodeChanged      *bool              `json:"vcsCodeChanged,omitempty"`
-	Errors              []*ProjectDiag     `json:"errors,omitempty"`
+	Errors              []*ProjectDiag     `json:"errors,omitempty"` // contains merged current and past errors
+	CurrentErrors       []*ProjectDiag     `json:"currentErrors,omitempty"`
+	PastErrors          []*ProjectDiag     `json:"pastErrors,omitempty"`
 	Warnings            []*ProjectDiag     `json:"warnings,omitempty"`
 	Policies            Policies           `json:"policies,omitempty"`
 	Providers           []ProviderMetadata `json:"providers,omitempty"`

--- a/schema/infracost.schema.json
+++ b/schema/infracost.schema.json
@@ -355,6 +355,18 @@
           },
           "type": "array"
         },
+        "currentErrors": {
+          "items": {
+            "$ref": "#/definitions/ProjectDiag"
+          },
+          "type": "array"
+        },
+        "pastErrors": {
+          "items": {
+            "$ref": "#/definitions/ProjectDiag"
+          },
+          "type": "array"
+        },
         "warnings": {
           "items": {
             "$ref": "#/definitions/ProjectDiag"


### PR DESCRIPTION
The project metadata previously contained a single errors field containing any errors that occurred in either side of a diff. This change makes it possible to determine which side of the diff the errors came from.