### PR TITLE
fix: cleanup bad module download directories

### DIFF
--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -801,6 +801,7 @@ func (m *ModuleLoader) loadRemoteModule(key string, source string) (*ManifestMod
 
 	err = m.packageFetcher.Fetch(moduleAddr, dest)
 	if err != nil {
+		_ = os.RemoveAll(dest)
 		return nil, schema.NewFailedDownloadDiagnostic(source, err)
 	}
 


### PR DESCRIPTION
We need to clean up any partially downloaded modules if there is an error (e.g. if the module was downloaded but the ref couldn't be checked out), otherwise when another project tries to download the same module the `_, err = os.Stat(dest)` will decide that it has been previously downloaded successfully.