### PR TITLE
Introducing Infracost Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <img alt="Docker pulls" src="https://img.shields.io/docker/pulls/infracost/infracost?style=plastic"/>
 <a href="https://www.infracost.io/community-chat"><img alt="Community Slack channel" src="https://img.shields.io/badge/chat-slack-%234a154b"/></a>
 <a href="https://twitter.com/intent/tweet?text=Get%20cost%20estimates%20for%20Terraform%20in%20pull%20requests!&url=https://www.infracost.io&hashtags=cloud,cost,terraform"><img alt="tweet" src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social"/></a>
+<a href="https://gurubase.io/g/infracost"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Infracost%20Guru-006BFF"/></a>
 </p>
 
 ## Get started


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Infracost Guru](https://gurubase.io/g/infracost) to Gurubase. Infracost Guru uses the data from this repo and data from the [docs](https://www.infracost.io/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Infracost Guru", which highlights that Infracost now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Infracost Guru in Gurubase, just let me know that's totally fine.
