### PR TITLE
enhance: multiple price handling

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -243,7 +243,7 @@ func newParallelRunner(cmd *cobra.Command, runCtx *config.RunContext) (*parallel
 		cmd:            cmd,
 		pathMuxs:       pathMuxs,
 		prior:          prior,
-		pricingFetcher: prices.NewPriceFetcher(runCtx),
+		pricingFetcher: prices.NewPriceFetcher(runCtx, false),
 	}, nil
 }
 

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -17,7 +17,6 @@ import (
 	"github.com/infracost/infracost/internal/ui"
 
 	"github.com/shopspring/decimal"
-	"github.com/tidwall/gjson"
 )
 
 var (
@@ -256,10 +255,14 @@ func (p *PriceFetcher) getPrices(req apiclient.BatchRequest) error {
 	return nil
 }
 
+type productPrice struct {
+	Hash  string
+	Price decimal.Decimal
+}
+
 func (p *PriceFetcher) setCostComponentPrice(result apiclient.PriceQueryResult) {
 	currency := p.client.Currency
 
-	var pp decimal.Decimal
 	if result.CostComponent.CustomPrice() != nil {
 		logging.Logger.Debug().Msgf("Using user-defined custom price %v for %s %s.", *result.CostComponent.CustomPrice(), result.Resource.Name, result.CostComponent.Name)
 		result.CostComponent.SetPrice(*result.CostComponent.CustomPrice())
@@ -284,17 +287,56 @@ func (p *PriceFetcher) setCostComponentPrice(result apiclient.PriceQueryResult) 
 
 	// Some resources may have identical records in CPAPI for the same product
 	// filters, several products are always returned and they can only be
-	// distinguished by their prices. However if we pick the first product it may not
+	// distinguished by their prices. However, if we pick the first product it may not
 	// have the price due to price filter and the lookup fails. Filtering the
-	// products with prices helps to solve that.
-	var productsWithPrices []gjson.Result
+	// products with prices helps to solve that. To make sure we get a consistent price
+	// between runs, we sort any multiple prices so we always pick the smallest non-zero
+	// price first.
+	var productPrices [][]productPrice
 	for _, product := range products {
-		if len(product.Get("prices").Array()) > 0 {
-			productsWithPrices = append(productsWithPrices, product)
+		pricesResults := product.Get("prices").Array()
+		if len(pricesResults) > 0 {
+			// map pricesResults to decimals
+			var prices []productPrice
+			for _, price := range pricesResults {
+				p, err := decimal.NewFromString(price.Get(currency).String())
+				if err != nil {
+					logging.Logger.Warn().Msgf("Error converting price to '%v' (using 0.00)  '%v': %s", currency, price.Get(currency).String(), err.Error())
+					prices = append(prices, productPrice{Hash: price.Get("priceHash").String(), Price: decimal.Zero})
+					continue
+				}
+				prices = append(prices, productPrice{Hash: price.Get("priceHash").String(), Price: p})
+			}
+
+			// sort prices with the smallest non-zero price first
+			sort.Slice(prices, func(i, j int) bool {
+				if prices[i].Price.IsZero() {
+					return false // Treat zero as larger, so it goes to the end
+				}
+				if prices[j].Price.IsZero() {
+					return true // Non-zero should come before zero
+				}
+				// Both prices are non-zero, sort in ascending order
+				return prices[i].Price.LessThan(prices[j].Price)
+			})
+
+			productPrices = append(productPrices, prices)
 		}
 	}
 
-	if len(productsWithPrices) == 0 {
+	// sort productPrices with the smallest non-zero price first
+	sort.Slice(productPrices, func(i, j int) bool {
+		if productPrices[i][0].Price.IsZero() {
+			return false // Treat zero as larger, so it goes to the end
+		}
+		if productPrices[j][0].Price.IsZero() {
+			return true // Non-zero should come before zero
+		}
+		// Both prices are non-zero, sort in ascending order
+		return productPrices[i][0].Price.LessThan(productPrices[j][0].Price)
+	})
+
+	if len(productPrices) == 0 {
 		if result.CostComponent.IgnoreIfMissingPrice {
 			logging.Logger.Debug().Msgf("No prices found for %s %s, ignoring since IgnoreIfMissingPrice is set.", result.Resource.Name, result.CostComponent.Name)
 			result.Resource.RemoveCostComponent(result.CostComponent)
@@ -305,23 +347,14 @@ func (p *PriceFetcher) setCostComponentPrice(result apiclient.PriceQueryResult) 
 		return
 	}
 
-	if len(productsWithPrices) > 1 {
-		logging.Logger.Debug().Msgf("Multiple products with prices found for %s %s, using the first product", result.Resource.Name, result.CostComponent.Name)
+	if len(productPrices) > 1 {
+		logging.Logger.Debug().Msgf("Multiple products with prices found for %s %s, using the smallest non-zero price", result.Resource.Name, result.CostComponent.Name)
 	}
 
-	prices := productsWithPrices[0].Get("prices").Array()
-	if len(prices) > 1 {
-		logging.Logger.Debug().Msgf("Multiple prices found for %s %s, using the first price", result.Resource.Name, result.CostComponent.Name)
+	if len(productPrices[0]) > 1 {
+		logging.Logger.Debug().Msgf("Multiple prices found for %s %s, using the smallest non-zero price", result.Resource.Name, result.CostComponent.Name)
 	}
 
-	var err error
-	pp, err = decimal.NewFromString(prices[0].Get(currency).String())
-	if err != nil {
-		logging.Logger.Warn().Msgf("Error converting price to '%v' (using 0.00)  '%v': %s", currency, prices[0].Get(currency).String(), err.Error())
-		result.CostComponent.SetPrice(decimal.Zero)
-		return
-	}
-
-	result.CostComponent.SetPrice(pp)
-	result.CostComponent.SetPriceHash(prices[0].Get("priceHash").String())
+	result.CostComponent.SetPrice(productPrices[0][0].Price)
+	result.CostComponent.SetPriceHash(productPrices[0][0].Hash)
 }

--- a/internal/providers/terraform/aws/rds_cluster_instance_test.go
+++ b/internal/providers/terraform/aws/rds_cluster_instance_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func TestRDSClusterInstanceGoldenFile(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "rds_cluster_instance_test")
+	tftest.GoldenFileResourceTestsWithOpts(t, "rds_cluster_instance_test", &tftest.GoldenFileOptions{
+		CaptureLogs: true,
+	})
 }

--- a/internal/providers/terraform/aws/rds_cluster_test.go
+++ b/internal/providers/terraform/aws/rds_cluster_test.go
@@ -7,21 +7,22 @@ import (
 )
 
 func TestRDSClusterGoldenFile(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "rds_cluster_test")
+	tftest.GoldenFileResourceTestsWithOpts(t, "rds_cluster_test", &tftest.GoldenFileOptions{
+		CaptureLogs: true,
+	})
 }
 
 func TestRDSClusterChinaGoldenFile(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
 
 	tftest.GoldenFileResourceTestsWithOpts(t, "rds_cluster_china_test", &tftest.GoldenFileOptions{
-		Currency: "CNY",
+		CaptureLogs: true,
+		Currency:    "CNY",
 	})
 }

--- a/internal/providers/terraform/aws/sfn_state_machine_test.go
+++ b/internal/providers/terraform/aws/sfn_state_machine_test.go
@@ -12,5 +12,13 @@ func TestSFnStateMachineGoldenFile(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	tftest.GoldenFileResourceTests(t, "sfn_state_machine_test")
+	// Don't run the terraform cli since it is complaining about the test examples:
+	// Error: validating Step Functions State Machine definition:
+	//        operation error SFN: ValidateStateMachineDefinition,
+	//        https response error StatusCode: 400, RequestID: 4059cfcd-96ae-4921-afb0-25a552d4f601,
+	//        api error UnrecognizedClientException: The security token included in the request is invalid.
+	opts := tftest.DefaultGoldenFileOptions()
+	opts.IgnoreCLI = true
+
+	tftest.GoldenFileHCLResourceTestsWithOpts(t, "sfn_state_machine_test", opts)
 }

--- a/internal/providers/terraform/aws/sns_topic_test.go
+++ b/internal/providers/terraform/aws/sns_topic_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestSNSTopicGoldenFile(t *testing.T) {
-	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
-
-	tftest.GoldenFileResourceTests(t, "sns_topic_test")
+	opts := tftest.DefaultGoldenFileOptions()
+	opts.CaptureLogs = true
+	tftest.GoldenFileResourceTestsWithOpts(t, "sns_topic_test", opts)
 }

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
@@ -41,6 +41,26 @@
  ├─ Storage (general purpose SSD, gp2)                                       30  GB                             $6.90    
  └─ Additional backup storage                                             1,000  GB                            $95.00  * 
                                                                                                                          
+ aws_db_instance.extended_support["aurora-5.7"]                                                                          
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
+ └─ Extended support (year 1)                                             1,460  vCPU-hours                   $146.00    
+                                                                                                                         
+ aws_db_instance.extended_support["aurora-5.7.44"]                                                                       
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
+ └─ Extended support (year 1)                                             1,460  vCPU-hours                   $146.00    
+                                                                                                                         
+ aws_db_instance.extended_support["aurora-mysql-5.7"]                                                                    
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
+ └─ Extended support (year 1)                                             1,460  vCPU-hours                   $146.00    
+                                                                                                                         
+ aws_db_instance.extended_support["aurora-mysql-5.7.44"]                                                                 
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
+ └─ Extended support (year 1)                                             1,460  vCPU-hours                   $146.00    
+                                                                                                                         
  aws_db_instance.extended_support["aurora-postgresql-11"]                                                                
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
  ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
@@ -126,27 +146,11 @@
  ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
  └─ Additional backup storage                                 Monthly cost depends on usage: $0.021 per GB               
                                                                                                                          
- aws_db_instance.extended_support["aurora-5.7"]                                                                          
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
- └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
-                                                                                                                         
- aws_db_instance.extended_support["aurora-5.7.44"]                                                                       
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
- └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
-                                                                                                                         
  aws_db_instance.extended_support["aurora-8.0"]                                                                          
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
  └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
                                                                                                                          
  aws_db_instance.extended_support["aurora-8.0.36"]                                                                       
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
- └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
-                                                                                                                         
- aws_db_instance.extended_support["aurora-mysql-5.7"]                                                                    
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
- └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
-                                                                                                                         
- aws_db_instance.extended_support["aurora-mysql-5.7.44"]                                                                 
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
  └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
                                                                                                                          
@@ -306,7 +310,7 @@
  ├─ Database instance (reserved, Single-AZ, db.t3.large)                    730  hours                          $0.00    
  └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
                                                                                                                          
- OVERALL TOTAL                                                                                             $11,880.39 
+ OVERALL TOTAL                                                                                             $12,464.39 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -317,5 +321,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $10,719 ┃      $1,161 ┃    $11,880 ┃
+┃ main                                               ┃       $11,303 ┃      $1,161 ┃    $12,464 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/eks_cluster_test/eks_cluster_test.golden
@@ -17,7 +17,7 @@
  └─ EKS cluster (extended support)                 730  hours       $438.00   
                                                                               
  aws_eks_cluster.extended_support["1.28"]                                     
- └─ EKS cluster                                    730  hours        $73.00   
+ └─ EKS cluster (extended support)                 730  hours       $438.00   
                                                                               
  aws_eks_cluster.extended_support["1.29"]                                     
  └─ EKS cluster                                    730  hours        $73.00   
@@ -25,7 +25,7 @@
  aws_eks_cluster.my_aws_eks_cluster                                           
  └─ EKS cluster                                    730  hours        $73.00   
                                                                               
- OVERALL TOTAL                                                   $2,409.00 
+ OVERALL TOTAL                                                   $2,774.00 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -36,5 +36,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $2,409 ┃           - ┃     $2,409 ┃
+┃ main                                               ┃        $2,774 ┃           - ┃     $2,774 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/lightsail_instance_test/lightsail_instance_test.golden
@@ -2,12 +2,12 @@
  Name                            Monthly Qty  Unit   Monthly Cost   
                                                                     
  aws_lightsail_instance.linux1                                      
- └─ Virtual server (Linux/UNIX)          730  hours        $78.49   
+ └─ Virtual server (Linux/UNIX)          730  hours        $82.42   
                                                                     
  aws_lightsail_instance.win1                                        
- └─ Virtual server (Windows)             730  hours        $19.62   
+ └─ Virtual server (Windows)             730  hours        $21.58   
                                                                     
- OVERALL TOTAL                                            $98.11 
+ OVERALL TOTAL                                           $104.00 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -18,5 +18,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $98 ┃           - ┃        $98 ┃
+┃ main                                               ┃          $104 ┃           - ┃       $104 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/rds_cluster_china_test/rds_cluster_china_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_china_test/rds_cluster_china_test.golden
@@ -20,3 +20,7 @@
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
 ┃ main                                               ┃       0.00 元 ┃           - ┃    0.00 元 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+Logs:
+
+WARN No products found for aws_rds_cluster.mysql_china Backup storage. Product filter: {"vendorName":"aws","service":"AmazonRDS","productFamily":"Storage Snapshot","region":"cn-north-1","attributeFilters":[{"key":"databaseEngine","value_regex":"/Aurora MySQL/i"},{"key":"usagetype","value_regex":"/Aurora:BackupUsage$/i"}]} Price filter:null
+WARN No products found for aws_rds_cluster.mysql_china Snapshot export. Product filter: {"vendorName":"aws","service":"AmazonRDS","productFamily":"System Operation","region":"cn-north-1","attributeFilters":[{"key":"databaseEngine","value_regex":"/Aurora MySQL/i"},{"key":"usagetype","value_regex":"/Aurora:SnapshotExportToS3$/i"}]} Price filter:null

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
@@ -14,6 +14,14 @@
  aws_rds_cluster_instance.aurora_serverless_v2_with_usage                                                                                    
  └─ Aurora serverless v2                                                                  3,650  ACU-hours                        $438.00  * 
                                                                                                                                              
+ aws_rds_cluster_instance.extended_support["aurora-mysql-5.7"]                                                                               
+ ├─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72    
+ └─ Extended support (year 1)                                                             1,460  vCPU-hours                       $146.00    
+                                                                                                                                             
+ aws_rds_cluster_instance.extended_support["aurora-mysql-5.7.44"]                                                                            
+ ├─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72    
+ └─ Extended support (year 1)                                                             1,460  vCPU-hours                       $146.00    
+                                                                                                                                             
  aws_rds_cluster_instance.extended_support["aurora-postgresql-11"]                                                                           
  ├─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72    
  └─ Extended support (year 1)                                                             1,460  vCPU-hours                       $146.00    
@@ -33,12 +41,6 @@
  ├─ CPU credits                                                                              60  vCPU-hours                         $5.40  * 
  ├─ Performance Insights Long Term Retention (db.t3.large)                                    2  vCPU-month                         $5.90    
  └─ Performance Insights API                                                             12.345  1000 requests                      $0.12  * 
-                                                                                                                                             
- aws_rds_cluster_instance.extended_support["aurora-mysql-5.7"]                                                                               
- └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72    
-                                                                                                                                             
- aws_rds_cluster_instance.extended_support["aurora-mysql-5.7.44"]                                                                            
- └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72    
                                                                                                                                              
  aws_rds_cluster_instance.extended_support["aurora-mysql-8.0"]                                                                               
  └─ Database instance (on-demand, db.t3.large)                                              730  hours                            $119.72    
@@ -105,7 +107,7 @@
  ├─ Aurora serverless v2                                                    Monthly cost depends on usage: $0.12 per ACU-hours               
  └─ Performance Insights API                                                Monthly cost depends on usage: $0.01 per 1000 requests           
                                                                                                                                              
- OVERALL TOTAL                                                                                                                  $6,695.11 
+ OVERALL TOTAL                                                                                                                  $6,987.11 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -116,7 +118,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,809 ┃        $886 ┃     $6,695 ┃
+┃ main                                               ┃        $6,101 ┃        $886 ┃     $6,987 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
@@ -120,6 +120,3 @@
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
 ┃ main                                               ┃        $6,101 ┃        $886 ┃     $6,987 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-Logs:
-
-WARN Multiple products with prices found for aws_rds_cluster.aurora_io_optimized Storage (I/O-optimized), using the smallest non-zero price. Product filter: {"vendorName":"aws","service":"AmazonRDS","productFamily":"Database Storage","region":"us-east-1","attributeFilters":[{"key":"databaseEngine","value_regex":"/(Any|Aurora MySQL)/i"},{"key":"usagetype","value_regex":"/Aurora:IO-OptimizedStorageUsage$/i"}]} Price filter:null

--- a/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_instance_test/rds_cluster_instance_test.golden
@@ -118,3 +118,6 @@
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
 ┃ main                                               ┃        $5,809 ┃        $886 ┃     $6,695 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+Logs:
+
+WARN Multiple products with prices found for aws_rds_cluster.aurora_io_optimized Storage (I/O-optimized), using the smallest non-zero price. Product filter: {"vendorName":"aws","service":"AmazonRDS","productFamily":"Database Storage","region":"us-east-1","attributeFilters":[{"key":"databaseEngine","value_regex":"/(Any|Aurora MySQL)/i"},{"key":"usagetype","value_regex":"/Aurora:IO-OptimizedStorageUsage$/i"}]} Price filter:null

--- a/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
@@ -78,6 +78,3 @@
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
 ┃ main                                               ┃         $0.00 ┃    $176,131 ┃   $176,131 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-Logs:
-
-WARN Multiple products with prices found for aws_rds_cluster.my_sql_serverless_io_optimized Storage (I/O-optimized), using the smallest non-zero price. Product filter: {"vendorName":"aws","service":"AmazonRDS","productFamily":"Database Storage","region":"us-east-1","attributeFilters":[{"key":"databaseEngine","value_regex":"/(Any|Aurora MySQL)/i"},{"key":"usagetype","value_regex":"/Aurora:IO-OptimizedStorageUsage$/i"}]} Price filter:null

--- a/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
@@ -78,3 +78,6 @@
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
 ┃ main                                               ┃         $0.00 ┃    $176,131 ┃   $176,131 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+Logs:
+
+WARN Multiple products with prices found for aws_rds_cluster.my_sql_serverless_io_optimized Storage (I/O-optimized), using the smallest non-zero price. Product filter: {"vendorName":"aws","service":"AmazonRDS","productFamily":"Database Storage","region":"us-east-1","attributeFilters":[{"key":"databaseEngine","value_regex":"/(Any|Aurora MySQL)/i"},{"key":"usagetype","value_regex":"/Aurora:IO-OptimizedStorageUsage$/i"}]} Price filter:null

--- a/internal/providers/terraform/aws/testdata/s3_bucket_china_test/s3_bucket_china_test.golden
+++ b/internal/providers/terraform/aws/testdata/s3_bucket_china_test/s3_bucket_china_test.golden
@@ -11,8 +11,8 @@
  ├─ Intelligent tiering                                                                                   
  │  ├─ Storage (frequent access)                        20,000  GB                         3,900.00 元  * 
  │  ├─ Storage (infrequent access)                      20,000  GB                         2,675.40 元  * 
- │  ├─ Storage (archive access)                         20,000  GB                           not found  * 
- │  ├─ Storage (deep archive access)                    20,000  GB                           not found  * 
+ │  ├─ Storage (archive access)                         20,000  GB                           601.20 元  * 
+ │  ├─ Storage (deep archive access)                    20,000  GB                           267.20 元  * 
  │  ├─ Monitoring and automation                            20  1k objects                     0.33 元  * 
  │  ├─ PUT, COPY, POST, LIST requests                       20  1k requests                    0.09 元  * 
  │  ├─ GET, SELECT, and all other requests                  20  1k requests                    0.03 元  * 
@@ -71,7 +71,7 @@
     ├─ Select data scanned                  Monthly cost depends on usage: 0.01593 元 per GB              
     └─ Select data returned                 Monthly cost depends on usage: 0.0057 元 per GB               
                                                                                                           
- OVERALL TOTAL (CNY)                                                                       87,161.77 元 
+ OVERALL TOTAL (CNY)                                                                       88,030.17 元 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -82,5 +82,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       0.00 元 ┃   87,162 元 ┃  87,162 元 ┃
+┃ main                                               ┃       0.00 元 ┃   88,030 元 ┃  88,030 元 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/sns_topic_test/sns_topic_test.golden
+++ b/internal/providers/terraform/aws/testdata/sns_topic_test/sns_topic_test.golden
@@ -77,3 +77,10 @@
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
 ┃ main                                               ┃         $0.00 ┃         $27 ┃        $27 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+Logs:
+
+WARN No prices found for aws_sns_topic.sns_topic SMS notifications (over 100). Product filter: {"vendorName":"aws","service":"AmazonSNS","productFamily":"Message Delivery","region":"us-east-1","attributeFilters":[{"key":"usagetype","value_regex":"/DeliveryAttempts-SMS$/i"}]} Price filter:{"startUsageAmount":"100"}
+WARN No prices found for aws_sns_topic.sns_topic_another_region SMS notifications (over 100). Product filter: {"vendorName":"aws","service":"AmazonSNS","productFamily":"Message Delivery","region":"us-east-1","attributeFilters":[{"key":"usagetype","value_regex":"/DeliveryAttempts-SMS$/i"}]} Price filter:{"startUsageAmount":"100"}
+WARN No prices found for aws_sns_topic.sns_topic_withChargedSubscribers SMS notifications (over 100). Product filter: {"vendorName":"aws","service":"AmazonSNS","productFamily":"Message Delivery","region":"us-east-1","attributeFilters":[{"key":"usagetype","value_regex":"/DeliveryAttempts-SMS$/i"}]} Price filter:{"startUsageAmount":"100"}
+WARN No prices found for aws_sns_topic.sns_topic_withFreeNotifications SMS notifications (over 100). Product filter: {"vendorName":"aws","service":"AmazonSNS","productFamily":"Message Delivery","region":"us-east-1","attributeFilters":[{"key":"usagetype","value_regex":"/DeliveryAttempts-SMS$/i"}]} Price filter:{"startUsageAmount":"100"}
+WARN No prices found for aws_sns_topic.sns_topic_withZeroRequests SMS notifications (over 100). Product filter: {"vendorName":"aws","service":"AmazonSNS","productFamily":"Message Delivery","region":"us-east-1","attributeFilters":[{"key":"usagetype","value_regex":"/DeliveryAttempts-SMS$/i"}]} Price filter:{"startUsageAmount":"100"}

--- a/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
+++ b/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
@@ -33,7 +33,3 @@
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
 ┃ main                                               ┃           $31 ┃          $7 ┃        $38 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
-Logs:
-
-WARN Multiple prices found for aws_waf_web_acl.my_waf Requests, using the smallest non-zero price. Product filter: {"vendorName":"aws","service":"awswaf","productFamily":"Web Application Firewall","region":"us-east-1","attributeFilters":[{"key":"usagetype","value_regex":"/^[A-Z0-9]*-(?!ShieldProtected-)Request$/i"}]} Price filter:{"purchaseOption":"on_demand"}
-WARN Multiple prices found for aws_waf_web_acl.withoutUsage Requests, using the smallest non-zero price. Product filter: {"vendorName":"aws","service":"awswaf","productFamily":"Web Application Firewall","region":"us-east-1","attributeFilters":[{"key":"usagetype","value_regex":"/^[A-Z0-9]*-(?!ShieldProtected-)Request$/i"}]} Price filter:{"purchaseOption":"on_demand"}

--- a/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
+++ b/internal/providers/terraform/aws/testdata/waf_web_acl_test/waf_web_acl_test.golden
@@ -33,3 +33,7 @@
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
 ┃ main                                               ┃           $31 ┃          $7 ┃        $38 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+Logs:
+
+WARN Multiple prices found for aws_waf_web_acl.my_waf Requests, using the smallest non-zero price. Product filter: {"vendorName":"aws","service":"awswaf","productFamily":"Web Application Firewall","region":"us-east-1","attributeFilters":[{"key":"usagetype","value_regex":"/^[A-Z0-9]*-(?!ShieldProtected-)Request$/i"}]} Price filter:{"purchaseOption":"on_demand"}
+WARN Multiple prices found for aws_waf_web_acl.withoutUsage Requests, using the smallest non-zero price. Product filter: {"vendorName":"aws","service":"awswaf","productFamily":"Web Application Firewall","region":"us-east-1","attributeFilters":[{"key":"usagetype","value_regex":"/^[A-Z0-9]*-(?!ShieldProtected-)Request$/i"}]} Price filter:{"purchaseOption":"on_demand"}

--- a/internal/providers/terraform/azure/public_ip.go
+++ b/internal/providers/terraform/azure/public_ip.go
@@ -43,7 +43,7 @@ func NewAzureRMPublicIP(d *schema.ResourceData, u *schema.UsageData) *schema.Res
 			skuTier = skuTierVal
 		}
 		if skuTier == "Global" {
-			sku = "Standard" // When sku_tier is Global, sku is Standard
+			sku = "Global" // When sku_tier is Global, skuname is global
 			meterName = "Global IPv4 " + allocationMethod + " Public IP"
 		} else {
 			meterName = "Standard IPv4 " + allocationMethod + " Public IP"

--- a/internal/providers/terraform/azure/public_ip.go
+++ b/internal/providers/terraform/azure/public_ip.go
@@ -23,10 +23,15 @@ func NewAzureRMPublicIP(d *schema.ResourceData, u *schema.UsageData) *schema.Res
 	var meterName string
 	sku := "Standard" // default sku is Standard
 	skuTier := "Regional"
-	allocationMethod := d.Get("allocation_method").String()
 
 	if d.Get("sku").Type != gjson.Null {
 		sku = d.Get("sku").String()
+	}
+
+	allocationMethod := strings.ToLower(d.Get("allocation_method").String())
+	if allocationMethod == "dynamic" {
+		// dynamic IPs imply a basic sku.
+		sku = "Basic"
 	}
 
 	switch sku {
@@ -70,7 +75,7 @@ func PublicIPCostComponent(name, region, sku, meterName string) *schema.CostComp
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "productName", Value: strPtr("IP Addresses")},
 				{Key: "skuName", Value: strPtr(sku)},
-				{Key: "meterName", Value: strPtr(meterName)},
+				{Key: "meterName", ValueRegex: regexPtr(meterName)},
 			},
 		},
 		PriceFilter: &schema.PriceFilter{

--- a/internal/providers/terraform/azure/testdata/application_gateway_test/application_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/application_gateway_test/application_gateway_test.golden
@@ -42,9 +42,9 @@
  └─ Data processing (0-10TB)                                       Monthly cost depends on usage: $0.00 per GB    
                                                                                                                   
  azurerm_public_ip.example                                                                                        
- └─ IP address (dynamic, regional)                                           730  hours              not found    
+ └─ IP address (dynamic, regional)                                           730  hours                  $2.92    
                                                                                                                   
- OVERALL TOTAL                                                                                       $5,911.62 
+ OVERALL TOTAL                                                                                       $5,914.54 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -56,5 +56,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $3,571 ┃      $2,340 ┃     $5,912 ┃
+┃ main                                               ┃        $3,574 ┃      $2,340 ┃     $5,915 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/cognitive_account_test/cognitive_account_test.golden
@@ -178,9 +178,9 @@
  └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records         
                                                                                                                                    
  azurerm_cognitive_account.with_usage["SpeechServices-S0"]                                                                         
- ├─ Speech to text                                                                    20  hours                        not found   
+ ├─ Speech to text                                                                    20  hours                           $20.00   
  ├─ Speech to text batch                                                              56  hours                           $10.08   
- ├─ Speech to text custom model                                                       17  hours                        not found   
+ ├─ Speech to text custom model                                                       17  hours                           $20.40   
  ├─ Speech to text custom model batch                                                 44  hours                            $9.90   
  ├─ Speech to text custom endpoint hosting                                           372  hours                           $20.00   
  ├─ Speech to text custom training                                                     2  hours                           $20.00   
@@ -218,7 +218,7 @@
                                                                                                                                    
  azurerm_cognitive_account.speech_with_commitment["invalid"]                                                                       
  ├─ Speech to text batch                                              Monthly cost depends on usage: $0.18 per hours               
- ├─ Speech to text custom model                                       not found                                                    
+ ├─ Speech to text custom model                                       Monthly cost depends on usage: $1.20 per hours               
  ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.23 per hours               
  ├─ Speech to text custom endpoint hosting                            Monthly cost depends on usage: $0.05375 per hours            
  ├─ Speech to text custom training                                    Monthly cost depends on usage: $10.00 per hours              
@@ -250,9 +250,9 @@
  └─ Speech requests                                                   Monthly cost depends on usage: $5.50 per 1K transactions     
                                                                                                                                    
  azurerm_cognitive_account.without_usage["SpeechServices-S0"]                                                                      
- ├─ Speech to text                                                    not found                                                    
+ ├─ Speech to text                                                    Monthly cost depends on usage: $1.00 per hours               
  ├─ Speech to text batch                                              Monthly cost depends on usage: $0.18 per hours               
- ├─ Speech to text custom model                                       not found                                                    
+ ├─ Speech to text custom model                                       Monthly cost depends on usage: $1.20 per hours               
  ├─ Speech to text custom model batch                                 Monthly cost depends on usage: $0.23 per hours               
  ├─ Speech to text custom endpoint hosting                            Monthly cost depends on usage: $0.05375 per hours            
  ├─ Speech to text custom training                                    Monthly cost depends on usage: $10.00 per hours              
@@ -281,7 +281,7 @@
  ├─ Customized training                                               Monthly cost depends on usage: $3.00 per hour                
  └─ Text analytics for health (5K-500K)                               Monthly cost depends on usage: $25.00 per 1K records         
                                                                                                                                    
- OVERALL TOTAL                                                                                                      $314,836.35 
+ OVERALL TOTAL                                                                                                      $314,876.75 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -295,7 +295,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃      $314,836 ┃           - ┃   $314,836 ┃
+┃ main                                               ┃      $314,877 ┃           - ┃   $314,877 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_database_test/mssql_database_test.golden
@@ -55,19 +55,19 @@
  ├─ Long-term retention (RA-GRS)                                        1,000  GB                          $50.00  * 
  └─ PITR backup storage (RA-GRS)                                          500  GB                         $100.00  * 
                                                                                                                      
- azurerm_mssql_database.backup_zone                                                                                  
- ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47    
- ├─ SQL license                                                         2,920  vCore-hours                $291.90    
- ├─ Storage                                                                 5  GB                           $0.58    
- ├─ Long-term retention (ZRS)                                           1,000  GB                          $31.30  * 
- └─ PITR backup storage (ZRS)                                             500  GB                          $62.50  * 
-                                                                                                                     
  azurerm_mssql_database.backup_local                                                                                 
  ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47    
  ├─ SQL license                                                         2,920  vCore-hours                $291.90    
  ├─ Storage                                                                 5  GB                           $0.58    
  ├─ Long-term retention (LRS)                                           1,000  GB                          $25.00  * 
  └─ PITR backup storage (LRS)                                             500  GB                          $50.00  * 
+                                                                                                                     
+ azurerm_mssql_database.backup_zone                                                                                  
+ ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47    
+ ├─ SQL license                                                         2,920  vCore-hours                $291.90    
+ ├─ Storage                                                                 5  GB                           $0.58    
+ ├─ Long-term retention (ZRS)                                           1,000  GB                          $25.00  * 
+ └─ PITR backup storage (ZRS)                                             500  GB                          $50.00  * 
                                                                                                                      
  azurerm_mssql_database.general_purpose_gen                                                                          
  ├─ Compute (provisioned, GP_Gen5_4)                                      730  hours                      $444.47    
@@ -116,7 +116,7 @@
  ├─ Long-term retention (RA-GRS)                             Monthly cost depends on usage: $0.05 per GB             
  └─ PITR backup storage (RA-GRS)                             Monthly cost depends on usage: $0.20 per GB             
                                                                                                                      
- OVERALL TOTAL                                                                                         $31,585.37 
+ OVERALL TOTAL                                                                                         $31,566.57 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -128,5 +128,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $30,593 ┃        $992 ┃    $31,585 ┃
+┃ main                                               ┃       $30,593 ┃        $973 ┃    $31,567 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/mssql_managed_instance_test/mssql_managed_instance_test.golden
+++ b/internal/providers/terraform/azure/testdata/mssql_managed_instance_test/mssql_managed_instance_test.golden
@@ -4,8 +4,8 @@
  azurerm_mssql_managed_instance.example3                                                    
  ├─ Compute (BC_GEN5 40 cores)                       730  hours                $9,778.47    
  ├─ Additional Storage                                32  GB                       $4.38    
- ├─ PITR backup storage (ZRS)                        100  GB                      $14.90  * 
- └─ LTR backup storage (ZRS)                         100  GB                       $3.72  * 
+ ├─ PITR backup storage (ZRS)                        100  GB                      $11.90  * 
+ └─ LTR backup storage (ZRS)                         100  GB                       $2.98  * 
                                                                                             
  azurerm_mssql_managed_instance.example2                                                    
  ├─ Compute (GP_GEN5 16 cores)                       730  hours                $1,955.69    
@@ -20,7 +20,7 @@
  ├─ SQL license                                    2,920  vCore-hours            $291.90    
  └─ LTR backup storage (LRS)                           5  GB                       $0.15  * 
                                                                                             
- OVERALL TOTAL                                                                $12,558.78 
+ OVERALL TOTAL                                                                $12,555.04 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -32,5 +32,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $12,528 ┃         $31 ┃    $12,559 ┃
+┃ main                                               ┃       $12,528 ┃         $27 ┃    $12,555 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/public_ip_test/public_ip_test.golden
+++ b/internal/providers/terraform/azure/testdata/public_ip_test/public_ip_test.golden
@@ -1,16 +1,16 @@
 
  Name                               Monthly Qty  Unit   Monthly Cost   
                                                                        
+ azurerm_public_ip.global                                              
+ └─ IP address (static, global)             730  hours         $7.30   
+                                                                       
  azurerm_public_ip.example                                             
  └─ IP address (static, regional)           730  hours         $3.65   
                                                                        
  azurerm_public_ip.example1                                            
  └─ IP address (dynamic, regional)          730  hours         $2.92   
                                                                        
- azurerm_public_ip.global                                              
- └─ IP address (static, global)             730  hours     not found   
-                                                                       
- OVERALL TOTAL                                                $6.57 
+ OVERALL TOTAL                                               $13.87 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -22,5 +22,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃            $7 ┃           - ┃         $7 ┃
+┃ main                                               ┃           $14 ┃           - ┃        $14 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/sql_managed_instance_test/sql_managed_instance_test.golden
+++ b/internal/providers/terraform/azure/testdata/sql_managed_instance_test/sql_managed_instance_test.golden
@@ -4,8 +4,8 @@
  azurerm_sql_managed_instance.example3                                                    
  ├─ Compute (BC_GEN5 40 Cores)                     730  hours                $9,778.47    
  ├─ Storage                                         32  GB                       $4.38    
- ├─ PITR backup storage (ZRS)                      100  GB                      $14.90  * 
- └─ LTR backup storage (ZRS)                       100  GB                       $3.72  * 
+ ├─ PITR backup storage (ZRS)                      100  GB                      $11.90  * 
+ └─ LTR backup storage (ZRS)                       100  GB                       $2.98  * 
                                                                                           
  azurerm_sql_managed_instance.example2                                                    
  ├─ Compute (GP_GEN5 16 Cores)                     730  hours                $1,955.69    
@@ -20,7 +20,7 @@
  ├─ SQL license                                  2,920  vCore-hours            $291.90    
  └─ LTR backup storage (LRS)                         5  GB                       $0.15  * 
                                                                                           
- OVERALL TOTAL                                                              $12,558.78 
+ OVERALL TOTAL                                                              $12,555.04 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -32,5 +32,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $12,528 ┃         $31 ┃    $12,559 ┃
+┃ main                                               ┃       $12,528 ┃         $27 ┃    $12,555 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/virtual_network_gateway_connection_test/virtual_network_gateway_connection_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_network_gateway_connection_test/virtual_network_gateway_connection_test.golden
@@ -55,9 +55,9 @@
  └─ VPN gateway (VpnGw5)                                          730  hours                     $10.95   
                                                                                                           
  azurerm_public_ip.example                                                                                
- └─ IP address (dynamic, regional)                                730  hours                  not found   
+ └─ IP address (dynamic, regional)                                730  hours                      $2.92   
                                                                                                           
- OVERALL TOTAL                                                                               $5,961.91 
+ OVERALL TOTAL                                                                               $5,964.83 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -69,5 +69,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,962 ┃           - ┃     $5,962 ┃
+┃ main                                               ┃        $5,965 ┃           - ┃     $5,965 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/virtual_network_gateway_test/virtual_network_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_network_gateway_test/virtual_network_gateway_test.golden
@@ -37,9 +37,9 @@
  └─ VPN gateway data tranfer               Monthly cost depends on usage: $0.035 per GB        
                                                                                                
  azurerm_public_ip.example                                                                     
- └─ IP address (dynamic, regional)                     730  hours                  not found   
+ └─ IP address (dynamic, regional)                     730  hours                      $2.92   
                                                                                                
- OVERALL TOTAL                                                                   $49,244.35 
+ OVERALL TOTAL                                                                   $49,247.27 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -51,5 +51,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $49,244 ┃           - ┃    $49,244 ┃
+┃ main                                               ┃       $49,247 ┃           - ┃    $49,247 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/virtual_network_gateway_test.go
+++ b/internal/providers/terraform/azure/virtual_network_gateway_test.go
@@ -7,11 +7,9 @@ import (
 )
 
 func TestAzureRMVirtualNetworkGateway(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("skipping test in short mode")
 	}
-
-	opts := tftest.DefaultGoldenFileOptions()
-	opts.CaptureLogs = true
-	tftest.GoldenFileResourceTestsWithOpts(t, "virtual_network_gateway_test", opts)
+	tftest.GoldenFileResourceTests(t, "virtual_network_gateway_test")
 }

--- a/internal/providers/terraform/google/testdata/cloudfunctions_function_test/cloudfunctions_function_test.golden
+++ b/internal/providers/terraform/google/testdata/cloudfunctions_function_test/cloudfunctions_function_test.golden
@@ -1,19 +1,19 @@
 
- Name                                        Monthly Qty  Unit         Monthly Cost    
-                                                                                       
- google_cloudfunctions_function.my_function                                            
- ├─ CPU                                        1,200,000  GHz-seconds     not found  * 
- ├─ Memory                                       750,000  GB-seconds      not found  * 
- ├─ Invocations                               10,000,000  invocations     not found  * 
- └─ Outbound data transfer                           100  GB              not found  * 
-                                                                                       
- google_cloudfunctions_function.function                                               
- ├─ CPU                                      not found                                 
- ├─ Memory                                   not found                                 
- ├─ Invocations                              not found                                 
- └─ Outbound data transfer                   not found                                 
-                                                                                       
- OVERALL TOTAL                                                                $0.00 
+ Name                                               Monthly Qty  Unit                      Monthly Cost    
+                                                                                                           
+ google_cloudfunctions_function.my_function                                                                
+ ├─ CPU                                               1,200,000  GHz-seconds                     $12.00  * 
+ ├─ Memory                                              750,000  GB-seconds                       $1.88  * 
+ ├─ Invocations                                      10,000,000  invocations                      $4.00  * 
+ └─ Outbound data transfer                                  100  GB                              $12.00  * 
+                                                                                                           
+ google_cloudfunctions_function.function                                                                   
+ ├─ CPU                                      Monthly cost depends on usage: $0.00001 per GHz-seconds       
+ ├─ Memory                                   Monthly cost depends on usage: $0.0000025 per GB-seconds      
+ ├─ Invocations                              Monthly cost depends on usage: $0.0000004 per invocations     
+ └─ Outbound data transfer                   Monthly cost depends on usage: $0.12 per GB                   
+                                                                                                           
+ OVERALL TOTAL                                                                                   $29.88 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -24,5 +24,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃         $0.00 ┃           - ┃      $0.00 ┃
+┃ main                                               ┃         $0.00 ┃         $30 ┃        $30 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_address_test/compute_address_test.golden
@@ -25,13 +25,13 @@
  └─ IP address (standard VM)                                        730  hours         $3.65   
                                                                                                
  google_compute_instance.preemptible_instance_with_ip                                          
- ├─ Instance usage (Linux/UNIX, preemptible, f1-micro)              730  hours         $2.56   
+ ├─ Instance usage (Linux/UNIX, preemptible, f1-micro)              730  hours         $2.22   
  └─ Standard provisioned storage (pd-standard)                       10  GB            $0.40   
                                                                                                
  google_compute_address.preemptible_static                                                     
  └─ IP address (preemptible VM)                                     730  hours         $1.83   
                                                                                                
- OVERALL TOTAL                                                                       $47.66 
+ OVERALL TOTAL                                                                       $47.32 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -43,5 +43,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃           $48 ┃           - ┃        $48 ┃
+┃ main                                               ┃           $47 ┃           - ┃        $47 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
@@ -16,7 +16,7 @@
  └─ NVIDIA L4 (on-demand)                                                  730  hours       $286.18   
                                                                                                       
  google_compute_instance.preemptible_gpu                                                              
- ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               730  hours       $152.19   
+ ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               730  hours       $144.60   
  ├─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
  └─ NVIDIA Tesla K80 (preemptible)                                       2,920  hours       $501.95   
                                                                                                       
@@ -56,8 +56,8 @@
  └─ Local SSD provisioned storage                                          750  GB           $60.00   
                                                                                                       
  google_compute_instance.custom_preemptible                                                           
- ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)              730  hours        $40.47   
- ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)                730  hours        $17.29   
+ ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)              730  hours        $38.46   
+ ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)                730  hours        $16.43   
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
                                                                                                       
  google_compute_instance.custom_n2d                                                                   
@@ -66,7 +66,7 @@
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
                                                                                                       
  google_compute_instance.preemptible_local_ssd                                                        
- ├─ Instance usage (Linux/UNIX, preemptible, f1-micro)                     730  hours         $2.56   
+ ├─ Instance usage (Linux/UNIX, preemptible, f1-micro)                     730  hours         $2.22   
  ├─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
  └─ Local SSD provisioned storage                                          375  GB           $21.00   
                                                                                                       
@@ -79,14 +79,14 @@
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
                                                                                                       
  google_compute_instance.preemptible                                                                  
- ├─ Instance usage (Linux/UNIX, preemptible, f1-micro)                     730  hours         $2.56   
+ ├─ Instance usage (Linux/UNIX, preemptible, f1-micro)                     730  hours         $2.22   
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
                                                                                                       
  google_compute_instance.with_hours                                                                   
  ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)                       100  hours         $0.76   
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
                                                                                                       
- OVERALL TOTAL                                                                          $10,356.12 
+ OVERALL TOTAL                                                                          $10,344.98 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -99,7 +99,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $10,356 ┃           - ┃    $10,356 ┃
+┃ main                                               ┃       $10,345 ┃           - ┃    $10,345 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.tf
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.tf
@@ -59,7 +59,7 @@ resource "google_compute_instance" "preemptible" {
 }
 
 resource "google_compute_instance" "local_ssd" {
-  name         = "local_ssd"
+  name         = "local-ssd"
   machine_type = "f1-micro"
   zone         = "us-central1-a"
 
@@ -83,7 +83,7 @@ resource "google_compute_instance" "local_ssd" {
 }
 
 resource "google_compute_instance" "preemptible_local_ssd" {
-  name         = "preemptible_local_ssd"
+  name         = "preemptible-local-ssd"
   machine_type = "f1-micro"
   zone         = "us-central1-a"
 
@@ -128,7 +128,7 @@ resource "google_compute_instance" "gpu" {
 }
 
 resource "google_compute_instance" "gpu_l4" {
-  name         = "gpu_l4"
+  name         = "gpu-l4"
   machine_type = "g2-standard-4"
   zone         = "us-central1-a"
 
@@ -149,7 +149,7 @@ resource "google_compute_instance" "gpu_l4" {
 }
 
 resource "google_compute_instance" "preemptible_gpu" {
-  name         = "preemptible_gpu"
+  name         = "preemptible-gpu"
   machine_type = "n1-standard-16"
   zone         = "us-central1-a"
 
@@ -227,7 +227,7 @@ resource "google_compute_instance" "custom" {
 }
 
 resource "google_compute_instance" "custom_preemptible" {
-  name         = "custom_preemptible"
+  name         = "custom-preemptible"
   machine_type = "custom-6-20480"
   zone         = "us-central1-a"
 
@@ -247,7 +247,7 @@ resource "google_compute_instance" "custom_preemptible" {
 }
 
 resource "google_compute_instance" "custom_n1" {
-  name         = "custom_n1"
+  name         = "custom-n1"
   machine_type = "n1-custom-6-20480"
   zone         = "us-central1-a"
 
@@ -263,7 +263,7 @@ resource "google_compute_instance" "custom_n1" {
 }
 
 resource "google_compute_instance" "custom_n2" {
-  name         = "custom_n2"
+  name         = "custom-n2"
   machine_type = "n2-custom-6-20480"
   zone         = "us-central1-a"
 
@@ -280,7 +280,7 @@ resource "google_compute_instance" "custom_n2" {
 
 
 resource "google_compute_instance" "custom_n2d" {
-  name         = "custom_n2d"
+  name         = "custom-n2d"
   machine_type = "n2d-custom-4-20480"
   zone         = "us-central1-a"
 
@@ -300,7 +300,7 @@ resource "google_compute_instance" "custom_n2d" {
 }
 
 resource "google_compute_instance" "custom_ext" {
-  name         = "custom_ext"
+  name         = "custom-ext"
   machine_type = "custom-2-15360-ext"
   zone         = "us-central1-a"
 
@@ -317,7 +317,7 @@ resource "google_compute_instance" "custom_ext" {
 
 // Not supported yet
 resource "google_compute_instance" "e2_custom" {
-  name         = "e2_custom"
+  name         = "e2-custom"
   machine_type = "e2-custom-2-15360"
   zone         = "us-central1-a"
 
@@ -333,7 +333,7 @@ resource "google_compute_instance" "e2_custom" {
 }
 
 resource "google_compute_instance" "sud_20_perc_with_hours" {
-  name         = "n2_standard_8"
+  name         = "n2-standard-8"
   machine_type = "n2-standard-8"
   zone         = "us-central1-a"
 
@@ -349,7 +349,7 @@ resource "google_compute_instance" "sud_20_perc_with_hours" {
 }
 
 resource "google_compute_instance" "sud_30_perc_with_hours" {
-  name         = "m1_ultramem_80"
+  name         = "m1-ultramem-80"
   machine_type = "m1-ultramem-80"
   zone         = "us-central1-a"
 

--- a/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
+++ b/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
@@ -10,7 +10,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 8,760  hours                  $4,660.30    
  │  └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $1,826.28    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $1,735.18    
     └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00    
                                                                                                                          
  google_container_cluster.with_node_pools_regional                                                                       
@@ -22,7 +22,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 4,380  hours                  $2,330.15    
  │  └─ Standard provisioned storage (pd-standard)                               600  GB                        $24.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $1,826.28    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $1,735.18    
     └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00    
                                                                                                                          
  google_container_cluster.with_node_config                                                                               
@@ -42,7 +42,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 5,840  hours                  $3,106.86    
  │  └─ Standard provisioned storage (pd-standard)                               800  GB                        $32.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $608.76    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $578.39    
     └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
                                                                                                                          
  google_container_cluster.with_node_pools_zonal_withUsage                                                                
@@ -54,7 +54,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 2,920  hours                  $1,553.43    
  │  └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $608.76    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $578.39    
     └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
                                                                                                                          
  google_container_cluster.with_unsupported_node_pool                                                                     
@@ -63,7 +63,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                      6,570  hours                    $220.13    
  │  └─ Standard provisioned storage (pd-standard)                               900  GB                        $36.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $1,826.28    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $1,735.18    
     └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00    
                                                                                                                          
  google_container_cluster.with_node_pools_node_locations                                                                 
@@ -75,7 +75,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 2,920  hours                  $1,553.43    
  │  └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               1,460  hours                    $304.38    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               1,460  hours                    $289.20    
     └─ Standard provisioned storage (pd-standard)                               200  GB                         $8.00    
                                                                                                                          
  google_container_cluster.with_node_pools_zonal                                                                          
@@ -87,7 +87,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 1,460  hours                    $776.72    
  │  └─ Standard provisioned storage (pd-standard)                               200  GB                         $8.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $608.76    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $578.39    
     └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
                                                                                                                          
  google_container_cluster.autopilot_with_usage                                                                           
@@ -138,7 +138,7 @@
  ├─ Autopilot memory                                                Monthly cost depends on usage: $3.59 per GB          
  └─ Autopilot ephemeral storage                                     Monthly cost depends on usage: $0.040004 per GB      
                                                                                                                          
- OVERALL TOTAL                                                                                             $30,162.55 
+ OVERALL TOTAL                                                                                             $29,782.95 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -149,7 +149,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $29,654 ┃        $509 ┃    $30,163 ┃
+┃ main                                               ┃       $29,274 ┃        $509 ┃    $29,783 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
@@ -65,13 +65,13 @@
  └─ Standard provisioned storage (pd-standard)                         800  GB           $32.00   
                                                                                                   
  google_container_node_pool.with_preemptible_instance                                             
- ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours       $121.41   
- ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $51.86   
+ ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours       $115.37   
+ ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $49.28   
  └─ Standard provisioned storage (pd-standard)                         300  GB           $12.00   
                                                                                                   
  google_container_node_pool.with_spot_instance                                                    
- ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours       $121.41   
- ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $51.86   
+ ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours       $115.37   
+ ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $49.28   
  └─ Standard provisioned storage (pd-standard)                         300  GB           $12.00   
                                                                                                   
  google_container_node_pool.autoscaling_zonal                                                     
@@ -122,7 +122,7 @@
  ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                1,460  hours        $48.92   
  └─ Standard provisioned storage (pd-standard)                         200  GB            $8.00   
                                                                                                   
- OVERALL TOTAL                                                                      $28,076.01 
+ OVERALL TOTAL                                                                      $28,058.75 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -133,5 +133,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $28,076 ┃           - ┃    $28,076 ┃
+┃ main                                               ┃       $28,059 ┃           - ┃    $28,059 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -250,7 +250,12 @@ func goldenFileResourceTestWithOpts(t *testing.T, pName string, testName string,
 		level = *options.LogLevel
 	}
 
-	logBuf := testutil.ConfigureTestToCaptureLogs(t, runCtx, level)
+	var logBuf *bytes.Buffer
+	if options != nil && options.CaptureLogs {
+		logBuf = testutil.ConfigureTestToCaptureLogs(t, runCtx, level)
+	} else {
+		testutil.ConfigureTestToFailOnLogs(t, runCtx)
+	}
 
 	if options != nil && options.Currency != "" {
 		runCtx.Config.Currency = options.Currency

--- a/internal/providers/terraform/tftest/tftest.go
+++ b/internal/providers/terraform/tftest/tftest.go
@@ -349,7 +349,7 @@ func loadResources(t *testing.T, pName string, tfProject TerraformProject, runCt
 }
 
 func RunCostCalculations(runCtx *config.RunContext, projects []*schema.Project) ([]*schema.Project, error) {
-	pf := prices.NewPriceFetcher(runCtx)
+	pf := prices.NewPriceFetcher(runCtx, true)
 	for _, project := range projects {
 		err := pf.PopulatePrices(project)
 		if err != nil {

--- a/internal/resources/aws/backup_vault.go
+++ b/internal/resources/aws/backup_vault.go
@@ -54,13 +54,13 @@ func (r *BackupVault) PopulateUsage(u *schema.UsageData) {
 func (r *BackupVault) BuildResource() *schema.Resource {
 	costComponents := []*schema.CostComponent{}
 
-	bd := backupData{ref: "monthly_efs_warm_backup_gb", name: "EFS backup (warm)", unit: "GB", usageType: "WarmStorage-ByteHrs-EFS", service: "AWSBackup", family: "AWS Backup Storage"}
+	bd := backupData{ref: "monthly_efs_warm_backup_gb", name: "EFS backup (warm)", unit: "GB", usageType: "WarmStorage-ByteHrs-EFS$", service: "AWSBackup", family: "AWS Backup Storage"}
 	if r.MonthlyEFSWarmBackupGB != nil {
 		bd.qty = decimalPtr(decimal.NewFromFloat(*r.MonthlyEFSWarmBackupGB))
 	}
 	costComponents = append(costComponents, r.backupVaultCostComponent(bd))
 
-	bd = backupData{ref: "monthly_efs_cold_backup_gb", name: "EFS backup (cold)", unit: "GB", usageType: "EarlyDelete-ColdByteHrs-EFS", service: "AWSBackup", family: "AWS Backup Early Delete Size"}
+	bd = backupData{ref: "monthly_efs_cold_backup_gb", name: "EFS backup (cold)", unit: "GB", usageType: "ColdStorage-ByteHrs-EFS$", service: "AWSBackup", family: "AWS Backup Storage"}
 	if r.MonthlyEFSColdBackupGB != nil {
 		bd.qty = decimalPtr(decimal.NewFromFloat(*r.MonthlyEFSColdBackupGB))
 	}

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -471,8 +471,9 @@ func performanceInsightsAPIRequestCostComponent(region string, additionalRequest
 // engine version Year1 is the date when the extended support starts, Year 3 is
 // the date when the extended increases price.
 type ExtendedSupportDates struct {
-	Year1 time.Time
-	Year3 time.Time
+	UsagetypeVersion string
+	Year1            time.Time
+	Year3            time.Time
 }
 
 // ExtendedSupport contains the extended support dates for a specific RDS engine.
@@ -506,6 +507,11 @@ func (s ExtendedSupport) CostComponent(version string, region string, d time.Tim
 		}
 	}
 
+	usagetypeVersion := supportDates.UsagetypeVersion
+	if usagetypeVersion == "" {
+		usagetypeVersion = matchingVersion
+	}
+
 	if !supportDates.Year3.IsZero() && d.After(supportDates.Year3) {
 		return &schema.CostComponent{
 			Name:           "Extended support (year 3)",
@@ -517,7 +523,7 @@ func (s ExtendedSupport) CostComponent(version string, region string, d time.Tim
 				Region:     strPtr(region),
 				Service:    strPtr("AmazonRDS"),
 				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "usagetype", ValueRegex: regexPtr("ExtendedSupport:Yr3:" + s.Engine + matchingVersion)},
+					{Key: "usagetype", ValueRegex: regexPtr("ExtendedSupport:Yr3:" + s.Engine + usagetypeVersion)},
 				},
 			},
 		}
@@ -534,7 +540,7 @@ func (s ExtendedSupport) CostComponent(version string, region string, d time.Tim
 				Region:     strPtr(region),
 				Service:    strPtr("AmazonRDS"),
 				AttributeFilters: []*schema.AttributeFilter{
-					{Key: "usagetype", ValueRegex: regexPtr("ExtendedSupport:Yr1-Yr2:" + s.Engine + matchingVersion)},
+					{Key: "usagetype", ValueRegex: regexPtr("ExtendedSupport:Yr1-Yr2:" + s.Engine + usagetypeVersion)},
 				},
 			},
 		}
@@ -557,8 +563,8 @@ var (
 	mysqlAuroraExtendedSupport = ExtendedSupport{
 		Engine: "AuroraMySQL",
 		Versions: map[string]ExtendedSupportDates{
-			"5.7": {Year1: time.Date(2024, time.December, 1, 0, 0, 0, 0, time.UTC)}, // Year3 is zero because it's N/A
-			"8":   {Year1: time.Date(2027, time.May, 1, 0, 0, 0, 0, time.UTC)},      // Year3 is zero because it's N/A
+			"5.7": {UsagetypeVersion: "2", Year1: time.Date(2024, time.December, 1, 0, 0, 0, 0, time.UTC)}, // Year3 is zero because it's N/A
+			"8":   {UsagetypeVersion: "3", Year1: time.Date(2027, time.May, 1, 0, 0, 0, 0, time.UTC)},      // Year3 is zero because it's N/A
 		},
 	}
 

--- a/internal/resources/aws/lb.go
+++ b/internal/resources/aws/lb.go
@@ -145,7 +145,7 @@ func (r *LB) capacityUnitsCostComponent(productFamily string, maxLCU *decimal.De
 			ProductFamily: strPtr(productFamily),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "locationType", Value: strPtr("AWS Region")},
-				{Key: "usagetype", ValueRegex: strPtr("/^LCUUsage/")},
+				{Key: "usagetype", ValueRegex: strPtr("/^([A-Z]{3}\\d-|Global-|EU-)?LCUUsage/")},
 			},
 		},
 		UsageBased: true,

--- a/internal/resources/aws/lb.go
+++ b/internal/resources/aws/lb.go
@@ -145,7 +145,7 @@ func (r *LB) capacityUnitsCostComponent(productFamily string, maxLCU *decimal.De
 			ProductFamily: strPtr(productFamily),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "locationType", Value: strPtr("AWS Region")},
-				{Key: "usagetype", ValueRegex: strPtr("/LCUUsage/")},
+				{Key: "usagetype", ValueRegex: strPtr("/^LCUUsage/")},
 			},
 		},
 		UsageBased: true,

--- a/internal/resources/aws/s3_intelligent_tiering_storage_class.go
+++ b/internal/resources/aws/s3_intelligent_tiering_storage_class.go
@@ -60,8 +60,8 @@ func (a *S3IntelligentTieringStorageClass) BuildResource() *schema.Resource {
 		CostComponents: []*schema.CostComponent{
 			s3StorageCostComponent("Storage (frequent access)", "AmazonS3", a.Region, "TimedStorage-INT-FA-ByteHrs", a.FrequentAccessStorageGB),
 			s3StorageCostComponent("Storage (infrequent access)", "AmazonS3", a.Region, "TimedStorage-INT-IA-ByteHrs", a.InfrequentAccessStorageGB),
-			s3StorageVolumeTypeCostComponent("Storage (archive access)", "AmazonS3", a.Region, "TimedStorage-INT-AA-ByteHrs", "IntelligentTieringArchiveAccess", a.FrequentAccessStorageGB),
-			s3StorageVolumeTypeCostComponent("Storage (deep archive access)", "AmazonS3", a.Region, "TimedStorage-INT-DAA-ByteHrs", "IntelligentTieringDeepArchiveAccess", a.InfrequentAccessStorageGB),
+			s3StorageVolumeTypeCostComponent("Storage (archive access)", "AmazonS3", a.Region, "TimedStorage-INT-AA-ByteHrs", "IntelligentTieringArchive", a.FrequentAccessStorageGB),
+			s3StorageVolumeTypeCostComponent("Storage (deep archive access)", "AmazonS3", a.Region, "TimedStorage-INT-DAA-ByteHrs", "IntelligentTieringDeepArchive", a.InfrequentAccessStorageGB),
 			s3MonitoringCostComponent(a.Region, a.MonitoredObjects),
 			s3ApiCostComponent("PUT, COPY, POST, LIST requests", "AmazonS3", a.Region, "Requests-INT-Tier1", a.MonthlyTier1Requests),
 			s3ApiCostComponent("GET, SELECT, and all other requests", "AmazonS3", a.Region, "Requests-INT-Tier2", a.MonthlyTier2Requests),

--- a/internal/resources/azure/cognitive_account_speech.go
+++ b/internal/resources/azure/cognitive_account_speech.go
@@ -188,7 +188,7 @@ func (r *CognitiveAccountSpeech) costComponents() []*schema.CostComponent {
 		costComponents = append(costComponents, r.commitmentTierHourlyCostComponents("Speech to text", connectedContainerCommitmentTier, "Commitment Tier Speech to Text Connected", *r.MonthlyConnectedContainerCommitmentSpeechToTextHrs, floatPtrToDecimalPtr(r.MonthlyConnectedContainerCommitmentSpeechToTextOverageHrs))...)
 	}
 	if (r.MonthlyCommitmentSpeechToTextHrs == nil && r.MonthlyConnectedContainerCommitmentSpeechToTextHrs == nil) || r.MonthlySpeechToTextStandardHrs != nil {
-		costComponents = append(costComponents, r.s0HourlyCostComponent("Speech to text", "Speech To Text", r.MonthlySpeechToTextStandardHrs))
+		costComponents = append(costComponents, r.s0HourlyCostComponent("Speech to text", "S1 Speech To Text", r.MonthlySpeechToTextStandardHrs))
 	}
 
 	costComponents = append(costComponents,
@@ -202,7 +202,7 @@ func (r *CognitiveAccountSpeech) costComponents() []*schema.CostComponent {
 		costComponents = append(costComponents, r.commitmentTierHourlyCostComponents("Speech to text custom model", connectedContainerCommitmentTier, "Commitment Tier Custom Speech to Text Connected", *r.MonthlyConnectedContainerCommitmentSpeechToTextCustomModelHrs, floatPtrToDecimalPtr(r.MonthlyConnectedContainerCommitmentSpeechToTextCustomModelOverageHrs))...)
 	}
 	if (r.MonthlyCommitmentSpeechToTextCustomModelHrs == nil && r.MonthlyConnectedContainerCommitmentSpeechToTextCustomModelHrs == nil) || r.MonthlySpeechToTextCustomModelHrs != nil {
-		costComponents = append(costComponents, r.s0HourlyCostComponent("Speech to text custom model", "Custom Speech To Text", r.MonthlySpeechToTextCustomModelHrs))
+		costComponents = append(costComponents, r.s0HourlyCostComponent("Speech to text custom model", "S1 Custom Speech To Text", r.MonthlySpeechToTextCustomModelHrs))
 	}
 
 	costComponents = append(costComponents, []*schema.CostComponent{

--- a/internal/resources/google/cloudfunctions_function.go
+++ b/internal/resources/google/cloudfunctions_function.go
@@ -78,10 +78,10 @@ func (r *CloudFunctionsFunction) BuildResource() *schema.Resource {
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("gcp"),
 					Region:        strPtr(r.Region),
-					Service:       strPtr("Cloud Functions"),
+					Service:       strPtr("Cloud Run Functions"),
 					ProductFamily: strPtr("ApplicationServices"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "description", Value: strPtr("CPU Time")},
+						{Key: "description", ValueRegex: regexPtr("\\(1st Gen\\) CPU Time")},
 					},
 				},
 				UsageBased: true,
@@ -94,10 +94,10 @@ func (r *CloudFunctionsFunction) BuildResource() *schema.Resource {
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("gcp"),
 					Region:        strPtr(r.Region),
-					Service:       strPtr("Cloud Functions"),
+					Service:       strPtr("Cloud Run Functions"),
 					ProductFamily: strPtr("ApplicationServices"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "description", Value: strPtr("Memory Time")},
+						{Key: "description", ValueRegex: regexPtr("\\(1st Gen\\) Memory Time")},
 					},
 				},
 				UsageBased: true,
@@ -110,10 +110,10 @@ func (r *CloudFunctionsFunction) BuildResource() *schema.Resource {
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("gcp"),
 					Region:        strPtr("global"),
-					Service:       strPtr("Cloud Functions"),
+					Service:       strPtr("Cloud Run Functions"),
 					ProductFamily: strPtr("ApplicationServices"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "description", Value: strPtr("Invocations")},
+						{Key: "description", ValueRegex: regexPtr("\\(1st Gen\\) Invocations")},
 					},
 				},
 				PriceFilter: &schema.PriceFilter{
@@ -129,10 +129,10 @@ func (r *CloudFunctionsFunction) BuildResource() *schema.Resource {
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr("gcp"),
 					Region:        strPtr(r.Region),
-					Service:       strPtr("Cloud Functions"),
+					Service:       strPtr("Cloud Run Functions"),
 					ProductFamily: strPtr("ApplicationServices"),
 					AttributeFilters: []*schema.AttributeFilter{
-						{Key: "description", ValueRegex: regexPtr("^Network Data Transfer Out")},
+						{Key: "description", ValueRegex: regexPtr("\\(1st Gen\\) Network Data Transfer Out")},
 					},
 				},
 				PriceFilter: &schema.PriceFilter{

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -219,6 +219,15 @@ func ConfigureTestToCaptureLogs(t *testing.T, runCtx *config.RunContext, level s
 	return logBuf
 }
 
+func ConfigureTestToFailOnLogs(t *testing.T, runCtx *config.RunContext) {
+	runCtx.Config.LogLevel = "warn"
+	runCtx.Config.SetLogDisableTimestamps(true)
+	runCtx.Config.SetLogWriter(io.MultiWriter(os.Stderr, ErrorOnAnyWriter{t}))
+
+	err := logging.ConfigureBaseLogger(runCtx.Config)
+	require.Nil(t, err)
+}
+
 // From https://gist.github.com/stoewer/fbe273b711e6a06315d19552dd4d33e6
 func toSnakeCase(s string) string {
 	var res = make([]rune, 0, len(s))


### PR DESCRIPTION
First, this updates price lookups to choose the smallest non-zero price when multiple prices or products are matched. Doing this deterministically will prevent the random price 'flip flops' that have been causing intermittent test failures and estimate inconsistencies.

Second, this restores the functionality to fail tests on _unexpected_ multiple price/product warnings so that we can detect (and fix) price filters that have atrophied due to changes in the pricing database.

Finally, a dozen or so atrophied price filters have been updated and fixed.