### PR TITLE
enhance: improve Terragrunt inputs parsing

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -1565,6 +1565,21 @@ func TestBreakdownTerragruntAutodetectionConfigFileOutput(t *testing.T) {
 	)
 }
 
+func TestBreakdownTerragruntPartialInputs(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+	GoldenFileCommandTest(
+		t,
+		testutil.CalcGoldenFileTestdataDirName(),
+		[]string{
+			"breakdown",
+			"--path", dir,
+			"--log-level", "info",
+		},
+		&GoldenFileOptions{LogLevel: strPtr("info"), IgnoreNonGraph: true},
+	)
+}
+
 func strPtr(s string) *string {
 	return &s
 }

--- a/cmd/infracost/testdata/breakdown_terraform_file_funcs/breakdown_terraform_file_funcs.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_file_funcs/breakdown_terraform_file_funcs.golden
@@ -128,7 +128,7 @@ Project: main
     └─ Storage (general purpose SSD, gp2)                                                        8  GB            $0.80   
                                                                                                                           
  module.mod_files.aws_instance.file["pd"]                                                                                 
- ├─ Instance usage (Linux/UNIX, on-demand, )                                                   730  hours     not found   
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-infracost-mock-44956be29f34)          730  hours     not found   
  └─ root_block_device                                                                                                     
     └─ Storage (general purpose SSD, gp2)                                                        8  GB            $0.80   
                                                                                                                           

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/breakdown_terragrunt_file_funcs.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/breakdown_terragrunt_file_funcs.golden
@@ -123,12 +123,12 @@ Project: main
     └─ Storage (general purpose SSD, gp2)                                                        8  GB            $0.80   
                                                                                                                           
  aws_instance.template_file["pdabs"]                                                                                      
- ├─ Instance usage (Linux/UNIX, on-demand, instance_type-infracost-mock-44956be29f34)          730  hours     not found   
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-infracost-mock-44956be29f34)          730  hours     not found
  └─ root_block_device                                                                                                     
     └─ Storage (general purpose SSD, gp2)                                                        8  GB            $0.80   
                                                                                                                           
  module.mod_files.aws_instance.file["pd"]                                                                                 
- ├─ Instance usage (Linux/UNIX, on-demand, )                                                   730  hours     not found   
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-infracost-mock-44956be29f34)          730  hours     not found
  └─ root_block_device                                                                                                     
     └─ Storage (general purpose SSD, gp2)                                                        8  GB            $0.80   
                                                                                                                           

--- a/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/breakdown_terragrunt_file_funcs.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_file_funcs/breakdown_terragrunt_file_funcs.golden
@@ -123,12 +123,12 @@ Project: main
     └─ Storage (general purpose SSD, gp2)                                                        8  GB            $0.80   
                                                                                                                           
  aws_instance.template_file["pdabs"]                                                                                      
- ├─ Instance usage (Linux/UNIX, on-demand, instance_type-infracost-mock-44956be29f34)          730  hours     not found
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-infracost-mock-44956be29f34)          730  hours     not found   
  └─ root_block_device                                                                                                     
     └─ Storage (general purpose SSD, gp2)                                                        8  GB            $0.80   
                                                                                                                           
  module.mod_files.aws_instance.file["pd"]                                                                                 
- ├─ Instance usage (Linux/UNIX, on-demand, instance_type-infracost-mock-44956be29f34)          730  hours     not found
+ ├─ Instance usage (Linux/UNIX, on-demand, instance_type-infracost-mock-44956be29f34)          730  hours     not found   
  └─ root_block_device                                                                                                     
     └─ Storage (general purpose SSD, gp2)                                                        8  GB            $0.80   
                                                                                                                           

--- a/cmd/infracost/testdata/breakdown_terragrunt_partial_inputs/breakdown_terragrunt_partial_inputs.golden
+++ b/cmd/infracost/testdata/breakdown_terragrunt_partial_inputs/breakdown_terragrunt_partial_inputs.golden
@@ -1,0 +1,38 @@
+Project: prod
+Module path: prod
+
+ Name                                                           Monthly Qty  Unit                        Monthly Cost   
+                                                                                                                        
+ aws_instance.web_app                                                                                                   
+ ├─ Instance usage (Linux/UNIX, on-demand, m5.4xlarge)                  730  hours                            $560.64   
+ ├─ root_block_device                                                                                                   
+ │  └─ Storage (general purpose SSD, gp2)                               100  GB                                $10.00   
+ └─ ebs_block_device[0]                                                                                                 
+    ├─ Storage (provisioned IOPS SSD, io1)                            1,000  GB                               $125.00   
+    └─ Provisioned IOPS                                                 800  IOPS                              $52.00   
+                                                                                                                        
+ aws_lambda_function.hello_world                                                                                        
+ ├─ Requests                                            Monthly cost depends on usage: $0.20 per 1M requests            
+ ├─ Ephemeral storage                                   Monthly cost depends on usage: $0.0000000309 per GB-seconds     
+ └─ Duration (first 6B)                                 Monthly cost depends on usage: $0.0000166667 per GB-seconds     
+                                                                                                                        
+ OVERALL TOTAL                                                                                               $747.64 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ prod                                               ┃          $748 ┃           - ┃       $748 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+
+
+Logs:
+INFO Autodetected 1 Terragrunt project across 1 root module
+INFO Found Terragrunt project prod at directory prod

--- a/cmd/infracost/testdata/breakdown_terragrunt_partial_inputs/modules/example/main.tf
+++ b/cmd/infracost/testdata/breakdown_terragrunt_partial_inputs/modules/example/main.tf
@@ -1,0 +1,48 @@
+variable "instance_type" {
+  description = "The EC2 instance type for the web app"
+  type        = string
+}
+
+variable "root_block_device_volume_size" {
+  description = "The size of the root block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_volume_size" {
+  description = "The size of the block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_iops" {
+  description = "The number of IOPS for the block device for the web app EC2 instance"
+  type        = number
+}
+
+variable "hello_world_function_memory_size" {
+  description = "The memory to allocate to the hello world Lambda function"
+  type        = number
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = var.root_block_device_volume_size
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = var.block_device_volume_size
+    iops        = var.block_device_iops
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:aws:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  memory_size   = var.hello_world_function_memory_size
+}

--- a/cmd/infracost/testdata/breakdown_terragrunt_partial_inputs/prod/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_partial_inputs/prod/terragrunt.hcl
@@ -1,0 +1,27 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+locals {
+  test = yamldecode(sops_decrypt_file("test.yml"))
+  test2 = jsondecode(sops_decrypt_file("test.json"))
+  test3 = run_cmd("echo", "hello")
+}
+
+inputs = merge(
+  yamldecode(file("doesnotexist")).foo,
+  yamldecode(file("badfile")).bar,
+  {
+    some_bad_input: local.test3.output
+    instance_type = "m5.4xlarge"
+    root_block_device_volume_size = 100
+    block_device_volume_size = 1000
+    block_device_iops = 800
+
+    hello_world_function_memory_size = 1024
+  }
+)

--- a/cmd/infracost/testdata/breakdown_terragrunt_partial_inputs/terragrunt.hcl
+++ b/cmd/infracost/testdata/breakdown_terragrunt_partial_inputs/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+  aws_region = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+}
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region                      = "${local.aws_region}"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+EOF
+}

--- a/go.mod
+++ b/go.mod
@@ -117,6 +117,7 @@ require (
 	github.com/soongo/path-to-regexp v1.6.4
 	github.com/spacelift-io/spacectl v1.2.0
 	github.com/turbot/terraform-components v0.0.0-20231213122222-1f3526cab7a7
+	github.com/whilp/git-urls v1.0.0
 	github.com/withfig/autocomplete-tools/packages/cobra v1.2.0
 	github.com/xanzy/go-gitlab v0.86.0
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
@@ -216,7 +217,6 @@ require (
 	github.com/urfave/cli/v2 v2.27.2 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/whilp/git-urls v1.0.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
@@ -274,7 +274,9 @@ replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
-replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20241113223044-d35392684463
+//replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20241113223044-d35392684463
+
+replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20241204130829-f38db1703ecc
 
 replace github.com/heimdalr/dag => github.com/aliscott/dag v1.3.2-0.20231115114512-4ce18c825f94
 

--- a/go.mod
+++ b/go.mod
@@ -274,9 +274,7 @@ replace github.com/jedib0t/go-pretty/v6 => github.com/aliscott/go-pretty/v6 v6.1
 
 replace github.com/spf13/cobra => github.com/spf13/cobra v1.4.0
 
-//replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20241113223044-d35392684463
-
-replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20241204130829-f38db1703ecc
+replace github.com/gruntwork-io/terragrunt => github.com/infracost/terragrunt v0.47.1-0.20241204180911-19aacb9f0819
 
 replace github.com/heimdalr/dag => github.com/aliscott/dag v1.3.2-0.20231115114512-4ce18c825f94
 

--- a/go.sum
+++ b/go.sum
@@ -820,8 +820,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/infracost/go-getter v0.0.0-20240909111353-c0d2eebadfd5 h1:FiK2b8h6CezRGI6CGs7YDVG9nbF2TQGMcRK9iSM37so=
 github.com/infracost/go-getter v0.0.0-20240909111353-c0d2eebadfd5/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
-github.com/infracost/terragrunt v0.47.1-0.20241204130829-f38db1703ecc h1:kbUVHC8SQyfcEaBlLVwBYtNY+CwgA+NTC1tSptykUYA=
-github.com/infracost/terragrunt v0.47.1-0.20241204130829-f38db1703ecc/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
+github.com/infracost/terragrunt v0.47.1-0.20241204180911-19aacb9f0819 h1:vh0SyaOOktlG7BPv0aG3VBVOexEyY+H/yONfCX5Tum8=
+github.com/infracost/terragrunt v0.47.1-0.20241204180911-19aacb9f0819/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=

--- a/go.sum
+++ b/go.sum
@@ -820,8 +820,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/infracost/go-getter v0.0.0-20240909111353-c0d2eebadfd5 h1:FiK2b8h6CezRGI6CGs7YDVG9nbF2TQGMcRK9iSM37so=
 github.com/infracost/go-getter v0.0.0-20240909111353-c0d2eebadfd5/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
-github.com/infracost/terragrunt v0.47.1-0.20241113223044-d35392684463 h1:vE7CFFOLqsCgYjeUJElbt5MoWEkWIZxxXGK2Wu1klu4=
-github.com/infracost/terragrunt v0.47.1-0.20241113223044-d35392684463/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
+github.com/infracost/terragrunt v0.47.1-0.20241204130829-f38db1703ecc h1:kbUVHC8SQyfcEaBlLVwBYtNY+CwgA+NTC1tSptykUYA=
+github.com/infracost/terragrunt v0.47.1-0.20241204130829-f38db1703ecc/go.mod h1:504J5iD5AjGgP5IwHkUWAcfoqvZIhrR1aEvyxDxX1VA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/infracost/infracost/internal/hcl/mock"
 	"github.com/rs/zerolog"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/gocty"
+
+	"github.com/infracost/infracost/internal/hcl/mock"
 )
 
 var (
@@ -48,8 +49,8 @@ type Attribute struct {
 	// Verbose defines if the attribute should log verbose diagnostics messages to debug.
 	Verbose bool
 	Logger  zerolog.Logger
-	// isGraph is a flag that indicates if the attribute should be evaluated with the graph evaluation
-	isGraph bool
+	// IsGraph is a flag that indicates if the attribute should be evaluated with the graph evaluation
+	IsGraph bool
 	// newMock generates a mock value for the attribute if it's value is missing.
 	newMock                func(attr *Attribute) cty.Value
 	previousValue          cty.Value
@@ -135,7 +136,7 @@ func (attr *Attribute) Value() cty.Value {
 
 	attr.Logger.Trace().Msg("fetching attribute value")
 	var val cty.Value
-	if attr.isGraph {
+	if attr.IsGraph {
 		val = attr.graphValue()
 	} else {
 		val = attr.value(0)
@@ -258,7 +259,7 @@ func (attr *Attribute) HasChanged() (change bool) {
 
 	previous := attr.previousValue
 	var current cty.Value
-	if attr.isGraph {
+	if attr.IsGraph {
 		current = attr.graphValue()
 	} else {
 		current = attr.value(0)
@@ -668,6 +669,14 @@ func mockExpressionCalls(expr hcl.Expression, diagnostics hcl.Diagnostics, mocke
 			SrcRange: t.SrcRange,
 		}
 	case *hclsyntax.TemplateExpr:
+		for _, d := range diagnostics {
+			if t == d.Expression {
+				return &hclsyntax.LiteralValueExpr{
+					Val: mockedVal,
+				}
+			}
+		}
+
 		newParts := make([]hclsyntax.Expression, len(t.Parts))
 		for i, part := range t.Parts {
 			newParts[i] = mockExpressionCalls(part, diagnostics, mockedVal)

--- a/internal/hcl/attribute_test.go
+++ b/internal/hcl/attribute_test.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
-	"github.com/infracost/infracost/internal/hcl/mock"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/infracost/infracost/internal/hcl/mock"
 )
 
 func TestAttribute_AsInt(t *testing.T) {
@@ -150,7 +151,7 @@ locals {
 			Variables: map[string]cty.Value{},
 		}},
 		Logger:  discard,
-		isGraph: true,
+		IsGraph: true,
 	}
 
 	attr := Attribute{
@@ -171,7 +172,7 @@ locals {
 		},
 		Verbose: false,
 		Logger:  logger,
-		isGraph: true,
+		IsGraph: true,
 	}
 
 	v := attr.Value()

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -887,7 +887,7 @@ func (b *Block) GetAttributes() []*Attribute {
 				Logger: b.logger.With().Str(
 					"attribute_name", k,
 				).Logger(),
-				isGraph: b.isGraph,
+				IsGraph: b.isGraph,
 			})
 			continue
 		}
@@ -900,7 +900,7 @@ func (b *Block) GetAttributes() []*Attribute {
 			Logger: b.logger.With().Str(
 				"attribute_name", hclAttributes[k].Name,
 			).Logger(),
-			isGraph: b.isGraph,
+			IsGraph: b.isGraph,
 		})
 	}
 
@@ -958,7 +958,7 @@ func (b *Block) syntheticAttribute(name string, val cty.Value) *Attribute {
 		Logger: b.logger.With().Str(
 			"attribute_name", name,
 		).Logger(),
-		isGraph: b.isGraph,
+		IsGraph: b.isGraph,
 	}
 }
 

--- a/internal/hcl/funcs/filesystem_test.go
+++ b/internal/hcl/funcs/filesystem_test.go
@@ -25,14 +25,14 @@ func TestFile(t *testing.T) {
 		{
 			cty.StringVal("testdata/icon.png"),
 			func(t *testing.T) {},
-			cty.NilVal,
-			true, // Not valid UTF-8
+			cty.StringVal(""),
+			false,
 		},
 		{
 			cty.StringVal("testdata/missing"),
 			func(t *testing.T) {},
-			cty.NilVal,
-			true, // no file exists
+			cty.StringVal(""),
+			false,
 		},
 		{
 			cty.StringVal("testdata/hello.txt"),
@@ -472,8 +472,8 @@ func TestFileBase64(t *testing.T) {
 		},
 		{
 			cty.StringVal("testdata/missing"),
-			cty.NilVal,
-			true, // no file exists
+			cty.StringVal(""),
+			false,
 		},
 	}
 


### PR DESCRIPTION
Improves the Terragrunt parser's ability to provide a partial value for the inputs. Prior to this change any nasty hcl errors within the inputs attribute for a Terragrunt hcl file would mean that we passed empty values to the underlying Terraform module call variables. This change hooks into a new DiagnosticFunc hook (see https://github.com/infracost/terragrunt/pull/19) that allows us to fallback to our parsing/mocking logic for the inputs value.

Note: I will merge the terragrunt pull first then update the go mod with the master sha/ref