### PR TITLE
perf: Performance optimisations + metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - staticcheck
     - typecheck
     - unused
+    - prealloc
 
 linters-settings:
   gocritic:

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -296,7 +296,7 @@ func (r *parallelRunner) run() ([]projectResult, error) {
 		projectCounts[provider.DisplayType()] = 1
 	}
 
-	var order []string
+	order := make([]string, 0, len(projectCounts))
 	for displayType := range projectCounts {
 		order = append(order, displayType)
 	}

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -114,9 +114,7 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 
 	for _, projectResult := range projectResults {
 		projectContexts = append(projectContexts, projectResult.ctx)
-		for _, project := range projectResult.projectOut.projects {
-			projects = append(projects, project)
-		}
+		projects = append(projects, projectResult.projectOut.projects...)
 	}
 
 	r, err := output.ToOutputFormat(runCtx.Config, projects)

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Rhymond/go-money"
+	"github.com/infracost/infracost/internal/metrics"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
@@ -113,7 +114,7 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 
 	for _, projectResult := range projectResults {
 		for _, project := range projectResult.projectOut.projects {
-			projectContexts = append(projectContexts, projectResult.ctx)
+			projectContexts = append(projectContexts, projectResult.ctx) // TODO: should this be in the outer loop?
 			projects = append(projects, project)
 		}
 	}
@@ -237,6 +238,8 @@ func newParallelRunner(cmd *cobra.Command, runCtx *config.RunContext) (*parallel
 	}
 	runCtx.ContextValues.SetValue("parallelism", parallelism)
 
+	metrics.GetCounter("parallel_runner.parallelism", false).Add(parallelism)
+
 	return &parallelRunner{
 		parallelism:    parallelism,
 		runCtx:         runCtx,
@@ -251,6 +254,9 @@ func (r *parallelRunner) run() ([]projectResult, error) {
 	var queue []projectJob
 	var totalRootModules int
 	var i int
+
+	parallelRunnerTimer := metrics.GetTimer("parallel_runner.run.total_duration", false).Start()
+	defer parallelRunnerTimer.Stop()
 
 	isAuto := r.runCtx.IsAutoDetect()
 	for _, p := range r.runCtx.Config.Projects {
@@ -271,6 +277,10 @@ func (r *parallelRunner) run() ([]projectResult, error) {
 
 		totalRootModules += detectionOutput.RootModules
 	}
+
+	metrics.GetCounter("parallel_runner.project_count", false).Add(i)
+	metrics.GetCounter("parallel_runner.root_module_count", false).Add(totalRootModules)
+
 	projectCounts := make(map[string]int)
 	for _, job := range queue {
 		if job.err != nil {
@@ -363,6 +373,7 @@ func (r *parallelRunner) run() ([]projectResult, error) {
 	errGroup, _ := errgroup.WithContext(context.Background())
 	for i := 0; i < r.parallelism; i++ {
 		errGroup.Go(func() (err error) {
+
 			// defer a function to recover from any panics spawned by child goroutines.
 			// This is done as recover works only in the same goroutine that it is called.
 			// We need to catch any child goroutine panics and hand them up to the main caller
@@ -375,29 +386,43 @@ func (r *parallelRunner) run() ([]projectResult, error) {
 			}()
 
 			for job := range jobs {
-				var configProjects *projectOutput
-				ctx := job.ctx
-				if job.err != nil {
-					configProjects = newErroredProject(job.provider, job.ctx, job.err)
-				} else {
-					configProjects, err = r.runProvider(job)
-					ctx = job.provider.Context()
-					if err != nil {
-						configProjects = newErroredProject(job.provider, ctx, err)
+				func() {
+					var metricContext []string
+					if job.provider != nil {
+						metricContext = append(metricContext, job.provider.Type())
+						if job.provider.Context() != nil {
+							metricContext = append(metricContext, job.provider.Context().ProjectConfig.Path)
+						}
+					}
+					jobTimer := metrics.GetTimer("parallel_runner.job.duration", false, metricContext...).Start()
+					defer jobTimer.Stop()
+
+					var configProjects *projectOutput
+					ctx := job.ctx
+					if job.err != nil {
+						configProjects = newErroredProject(job.provider, job.ctx, job.err)
+					} else {
+						configProjects, err = r.runProvider(job)
+						ctx = job.provider.Context()
+						if err != nil {
+							configProjects = newErroredProject(job.provider, ctx, err)
+						}
+
 					}
 
-				}
-
-				projectResultChan <- projectResult{
-					index:      job.index,
-					ctx:        ctx,
-					projectOut: configProjects,
-				}
+					projectResultChan <- projectResult{
+						index:      job.index,
+						ctx:        ctx,
+						projectOut: configProjects,
+					}
+				}()
 			}
 
 			return nil
 		})
 	}
+
+	allJobsTimer := metrics.GetTimer("parallel_runner.all_jobs.duration", false).Start()
 
 	for _, job := range queue {
 		jobs <- job
@@ -406,6 +431,7 @@ func (r *parallelRunner) run() ([]projectResult, error) {
 	close(jobs)
 
 	err := errGroup.Wait()
+	allJobsTimer.Stop()
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +479,9 @@ func (r *parallelRunner) runProvider(job projectJob) (out *projectOutput, err er
 
 	// Generate usage file
 	if r.runCtx.Config.SyncUsageFile {
+		usageGenTimer := metrics.GetTimer("parallel_runner.usage_gen.duration", false, path).Start()
 		err = r.generateUsageFile(job.provider)
+		usageGenTimer.Stop()
 		if err != nil {
 			return nil, fmt.Errorf("Error generating usage file %w", err)
 		}
@@ -512,7 +540,9 @@ func (r *parallelRunner) runProvider(job projectJob) (out *projectOutput, err er
 	out = &projectOutput{}
 
 	t1 := time.Now()
+	loadResourcesTimer := metrics.GetTimer("parallel_runner.load_resources.duration", false, path).Start()
 	projects, err := job.provider.LoadResources(usageData)
+	loadResourcesTimer.Stop()
 	if err != nil {
 		r.cmd.PrintErrln()
 		return nil, err
@@ -520,8 +550,12 @@ func (r *parallelRunner) runProvider(job projectJob) (out *projectOutput, err er
 
 	_ = r.uploadCloudResourceIDs(projects)
 
+	buildResourcesTimer := metrics.GetTimer("parallel_runner.build_resources.duration", false, path).Start()
 	r.buildResources(projects)
+	buildResourcesTimer.Stop()
 
+	costingTimer := metrics.GetTimer("parallel_runner.costing.duration", false, path).Start()
+	defer costingTimer.Stop()
 	logging.Logger.Debug().Msg("Retrieving cloud prices to calculate costs")
 
 	for _, project := range projects {

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -113,8 +113,8 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 	projectContexts := make([]*config.ProjectContext, 0)
 
 	for _, projectResult := range projectResults {
+		projectContexts = append(projectContexts, projectResult.ctx)
 		for _, project := range projectResult.projectOut.projects {
-			projectContexts = append(projectContexts, projectResult.ctx) // TODO: should this be in the outer loop?
 			projects = append(projects, project)
 		}
 	}

--- a/cmd/infracost/testdata/breakdown_with_policy_data_upload_plan_json/breakdown_with_policy_data_upload_plan_json-upload.golden
+++ b/cmd/infracost/testdata/breakdown_with_policy_data_upload_plan_json/breakdown_with_policy_data_upload_plan_json-upload.golden
@@ -67,7 +67,7 @@ storePolicyResources:
           },
           "references": [],
           "infracostMetadata": {
-            "calls": null,
+            "calls": [],
             "checksum": "a1c17a5372d0b56215b34af598a205bb8cdc208b82780e3ba2cac92460b26dd7",
             "endLine": 0,
             "filename": "",

--- a/internal/apiclient/policy.go
+++ b/internal/apiclient/policy.go
@@ -250,8 +250,9 @@ func filterResource(rd *schema.ResourceData, al allowList) policy2Resource {
 		return references[i].Key < references[j].Key
 	})
 
-	var mdCalls []policy2InfracostMetadataCall
-	for _, c := range rd.Metadata["calls"].Array() {
+	calls := rd.Metadata["calls"].Array()
+	mdCalls := make([]policy2InfracostMetadataCall, 0, len(calls))
+	for _, c := range calls {
 		mdCalls = append(mdCalls, policy2InfracostMetadataCall{
 			BlockName: c.Get("blockName").String(),
 			EndLine:   c.Get("endLine").Int(),

--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -361,7 +361,7 @@ func (c *PricingAPIClient) PerformRequest(req BatchRequest) ([]PriceQueryResult,
 	}
 
 	// now we deduplicate the queries, ensuring that a request for a price only happens once.
-	var deduplicatedServerQueries []pricingQuery
+	deduplicatedServerQueries := make([]pricingQuery, 0, len(serverQueries))
 	seenQueries := map[uint64]bool{}
 	for _, query := range serverQueries {
 		if seenQueries[query.hash] {

--- a/internal/apiclient/usage.go
+++ b/internal/apiclient/usage.go
@@ -177,7 +177,7 @@ func (c *UsageAPIClient) buildActualCostsQuery(vars ActualCostsQueryVariables) G
 // ListUsageQuantities queries the Infracost Cloud Usage API to retrieve usage estimates
 // derived from cloud provider reported usage and costs.
 func (c *UsageAPIClient) ListUsageQuantities(vars []*UsageQuantitiesQueryVariables) ([]*schema.UsageData, error) {
-	var queries []GraphQLQuery
+	queries := make([]GraphQLQuery, 0, len(vars))
 	for _, v := range vars {
 		logging.Logger.Debug().Msgf("Getting usage quantities from %s for %s %s %v", c.endpoint, v.ResourceType, v.Address, v.UsageKeys)
 		queries = append(queries, c.buildUsageQuantitiesQuery(*v))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -163,6 +163,9 @@ type Config struct {
 	S3ModuleCacheBucket string `envconfig:"S3_MODULE_CACHE_BUCKET"`
 	S3ModuleCachePrefix string `envconfig:"S3_MODULE_CACHE_PREFIX"`
 
+	// metrics dump path
+	MetricsPath string `envconfig:"METRICS_PATH"`
+
 	// Org settings
 	EnableCloudForOrganization bool
 

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -1122,9 +1122,10 @@ func (attr *Attribute) AllReferences() []*Reference {
 // VerticesReferenced traverses all the Expressions used by the attribute to build a
 // list of all the Blocks referenced by the Attribute.
 func (attr *Attribute) VerticesReferenced(b *Block) []VertexReference {
-	var refs []VertexReference
+	allRefs := attr.AllReferences()
+	refs := make([]VertexReference, 0, len(allRefs))
 
-	for _, ref := range attr.AllReferences() {
+	for _, ref := range allRefs {
 		key := ref.String()
 
 		if shouldSkipRef(b, attr, key) {

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -829,7 +829,7 @@ func (b *Block) Children() Blocks {
 		return nil
 	}
 
-	var children Blocks
+	children := make(Blocks, 0, len(b.childBlocks))
 	for _, child := range b.childBlocks {
 		// Skip lifecycle meta argument blocks since it never needs to be evaluated
 		if supportsLifecycle(child) && child.Type() == "lifecycle" {

--- a/internal/hcl/context.go
+++ b/internal/hcl/context.go
@@ -122,12 +122,7 @@ func mergeVars(src cty.Value, parts []string, value cty.Value) cty.Value {
 // takes precedence over object `a`, unless both values are valid cty objects, in
 // which case they are recursively merged.
 func mergeObjects(a cty.Value, b cty.Value) cty.Value {
-	output := make(map[string]cty.Value)
-
-	for key, val := range a.AsValueMap() {
-		output[key] = val
-	}
-
+	output := a.AsValueMap()
 	for key, val := range b.AsValueMap() {
 		old, exists := output[key]
 

--- a/internal/hcl/context.go
+++ b/internal/hcl/context.go
@@ -101,7 +101,7 @@ func mergeVars(src cty.Value, parts []string, value cty.Value) cty.Value {
 		return value
 	}
 
-	data := make(map[string]cty.Value)
+	var data map[string]cty.Value
 	if src.Type().IsObjectType() && !src.IsNull() && src.LengthInt() > 0 {
 		data = src.AsValueMap()
 		tmp, ok := data[parts[0]] // nolint:gosec // ignore "G602: slice index out of range" since we already check len(parts) == 0
@@ -110,6 +110,8 @@ func mergeVars(src cty.Value, parts []string, value cty.Value) cty.Value {
 		} else {
 			src = tmp
 		}
+	} else {
+		data = make(map[string]cty.Value)
 	}
 
 	data[parts[0]] = mergeVars(src, parts[1:], value) // nolint:gosec // ignore "G602: slice index out of range" since we already check len(parts) == 0

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/tryfunc"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
+	"github.com/infracost/infracost/internal/metrics"
 	componentsFuncs "github.com/turbot/terraform-components/lang/funcs"
 
 	"github.com/hashicorp/go-cty-funcs/crypto"
@@ -239,6 +240,10 @@ func (e *Evaluator) MissingVars() []string {
 // this Module.
 func (e *Evaluator) Run() (*Module, error) {
 	var lastContext hcl.EvalContext
+
+	timer := metrics.GetTimer("evaluator.run", false, e.module.RootPath).Start()
+	defer timer.Stop()
+
 	// first we need to evaluate the top level Context - so this can be passed to any child modules that are found.
 	e.logger.Debug().Msg("evaluating top level context")
 	e.evaluate(lastContext)

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/ext/tryfunc"
 	"github.com/hashicorp/hcl/v2/ext/typeexpr"
-	"github.com/infracost/infracost/internal/metrics"
 	componentsFuncs "github.com/turbot/terraform-components/lang/funcs"
 
 	"github.com/hashicorp/go-cty-funcs/crypto"
@@ -240,9 +239,6 @@ func (e *Evaluator) MissingVars() []string {
 // this Module.
 func (e *Evaluator) Run() (*Module, error) {
 	var lastContext hcl.EvalContext
-
-	timer := metrics.GetTimer("evaluator.run", false, e.module.RootPath).Start()
-	defer timer.Stop()
 
 	// first we need to evaluate the top level Context - so this can be passed to any child modules that are found.
 	e.logger.Debug().Msg("evaluating top level context")

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -324,7 +324,7 @@ func (g *Graph) Populate(evaluator *Evaluator) error {
 
 				// Check if the source vertex exists
 				_, err := g.dag.GetVertex(srcID)
-				if err == nil {
+				if err == nil || true {
 					g.logger.Debug().Msgf("adding edge: %s, %s", srcID, dstID)
 					edges = append(edges, dag.EdgeInput{
 						SrcID: srcID,
@@ -342,7 +342,7 @@ func (g *Graph) Populate(evaluator *Evaluator) error {
 
 					// Check if the source vertex exists
 					_, err := g.dag.GetVertex(srcID)
-					if err == nil {
+					if err == nil || true {
 						g.logger.Debug().Msgf("adding edge: %s, %s", srcID, dstID)
 						edges = append(edges, dag.EdgeInput{
 							SrcID: srcID,

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -383,17 +383,15 @@ func (g *Graph) AsJSON() ([]byte, error) {
 func (g *Graph) Walk() {
 	v := NewGraphVisitor(g.logger, g.vertexMutex)
 
-	// flowCallback := func(d *dag.DAG, id string, parentResults []dag.FlowResult) (interface{}, error) {
-	// 	vertex, _ := d.GetVertex(id)
-	//
-	// 	v.Visit(id, vertex)
-	//
-	// 	return vertex, nil
-	// }
+	flowCallback := func(d *dag.DAG, id string, parentResults []dag.FlowResult) (interface{}, error) {
+		vertex, _ := d.GetVertex(id)
 
-	g.dag.BFSWalk(v)
+		v.Visit(id, vertex)
 
-	// _, _ = g.dag.DescendantsFlow(g.rootVertex.ID(), nil, flowCallback)
+		return vertex, nil
+	}
+
+	_, _ = g.dag.DescendantsFlow(g.rootVertex.ID(), nil, flowCallback)
 }
 
 func (g *Graph) Run(evaluator *Evaluator) (*Module, error) {
@@ -423,13 +421,12 @@ func NewGraphVisitor(logger zerolog.Logger, vertexMutex *sync.Mutex) *GraphVisit
 	}
 }
 
-func (v *GraphVisitor) Visit(vertex dag.Vertexer) {
-	id, rawVertex := vertex.Vertex()
-	vert := rawVertex.(Vertex)
-	v.logger.Debug().Msgf("visiting vertex %q", id)
+func (v *GraphVisitor) Visit(id string, vertex interface{}) {
+	vert := vertex.(Vertex)
+	v.logger.Debug().Msgf("visiting vertex %q", vert.ID())
 	err := vert.Visit(v.vertexMutex)
 	if err != nil {
-		v.logger.Debug().Err(err).Msgf("ignoring vertex %q because an error was encountered", id)
+		v.logger.Debug().Err(err).Msgf("ignoring vertex %q because an error was encountered", vert.ID())
 	}
 }
 

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -99,37 +99,14 @@ func (g *Graph) ReduceTransitively() {
 }
 
 func (g *Graph) Populate(evaluator *Evaluator) error {
+	var vertexes []Vertex
 
 	blocks, err := g.loadAllBlocks(evaluator)
 	if err != nil {
 		return err
 	}
 
-	// Build a set of all the provider keys so we can look up
-	// provider references later
-	providerKeys := make(map[string]string)
-	edges := make([]dag.EdgeInput, 0)
-
-	// load variables first because we depend on this for module loading next
-	for _, block := range Blocks(blocks).OfType("variable") {
-		vertex := &VertexVariable{
-			logger:        g.logger,
-			moduleConfigs: g.moduleConfigs,
-			block:         block,
-		}
-		id := vertex.ID()
-		g.logger.Debug().Msgf("adding vertex: %s", id)
-		err := g.dag.AddVertexByID(id, vertex)
-		if err != nil {
-			// We don't actually mind if blocks are added multiple times
-			// since this helps us support cases like _override.tf files
-			// and in-progress changes.
-			g.logger.Debug().Err(err).Msgf("error adding vertex %q", id)
-		}
-	}
-
 	for _, block := range blocks {
-		var vertexes []Vertex
 		switch block.Type() {
 		case "locals":
 			for _, attr := range block.GetAttributes() {
@@ -141,21 +118,68 @@ func (g *Graph) Populate(evaluator *Evaluator) error {
 				})
 			}
 		case "module":
+			vertexes = append(vertexes, &VertexModuleCall{
+				logger:        g.logger,
+				moduleConfigs: g.moduleConfigs,
+				block:         block,
+			})
+			vertexes = append(vertexes, &VertexModuleExit{
+				logger:        g.logger,
+				moduleConfigs: g.moduleConfigs,
+				block:         block,
+			})
+		case "variable":
+			vertexes = append(vertexes, &VertexVariable{
+				logger:        g.logger,
+				moduleConfigs: g.moduleConfigs,
+				block:         block,
+			})
+		case "output":
+			vertexes = append(vertexes, &VertexOutput{
+				logger:        g.logger,
+				moduleConfigs: g.moduleConfigs,
+				block:         block,
+			})
+		case "provider":
+			vertexes = append(vertexes, &VertexProvider{
+				logger:        g.logger,
+				moduleConfigs: g.moduleConfigs,
+				block:         block,
+			})
+		case "resource":
+			vertexes = append(vertexes, &VertexResource{
+				logger:        g.logger,
+				moduleConfigs: g.moduleConfigs,
+				block:         block,
+			})
+		case "data":
+			vertexes = append(vertexes, &VertexData{
+				logger:        g.logger,
+				moduleConfigs: g.moduleConfigs,
+				block:         block,
+			})
+		}
+	}
 
+	// Build a set of all the provider keys so we can look up
+	// provider references later
+	providerKeys := make(map[string]string)
+	for _, vertex := range vertexes {
+		if _, ok := vertex.(*VertexProvider); ok {
+			providerKeys[vertex.ID()] = vertex.ID()
+		}
+	}
+
+	// Also add a mapping for all the provider attributes in module calls
+	// so we can look up the providers based on their alias later.
+	for _, vertex := range vertexes {
+		if v, ok := vertex.(*VertexModuleCall); ok {
 			// Decode the provider attribute to get the aliases
-			attr := block.GetAttribute("providers")
+			attr := v.block.GetAttribute("providers")
 			if attr == nil {
 				continue
 			}
 
-			vertex := &VertexModuleCall{
-				logger:        g.logger,
-				moduleConfigs: g.moduleConfigs,
-				block:         block,
-			}
-
-			// Also add a mapping for all the provider attributes in module calls
-			// so we can look up the providers based on their alias later.
 			providers := attr.DecodeProviders()
 			for alias, provider := range providers {
 				// Generate the full key and value for the provider map relative to the module
@@ -178,187 +202,147 @@ func (g *Graph) Populate(evaluator *Evaluator) error {
 
 				providerKeys[key] = val
 			}
+		}
+	}
 
-			vertexes = append(vertexes, vertex)
-			vertexes = append(vertexes, &VertexModuleExit{
-				logger:        g.logger,
-				moduleConfigs: g.moduleConfigs,
-				block:         block,
-			})
-		case "output":
-			vertexes = append(vertexes, &VertexOutput{
-				logger:        g.logger,
-				moduleConfigs: g.moduleConfigs,
-				block:         block,
-			})
-		case "provider":
-			vertex := &VertexProvider{
-				logger:        g.logger,
-				moduleConfigs: g.moduleConfigs,
-				block:         block,
+	for _, vertex := range vertexes {
+		id := vertex.ID()
+
+		g.logger.Debug().Msgf("adding vertex: %s", id)
+		err := g.dag.AddVertexByID(id, vertex)
+		if err != nil {
+			// We don't actually mind if blocks are added multiple times
+			// since this helps us support cases like _override.tf files
+			// and in-progress changes.
+			g.logger.Debug().Err(err).Msgf("error adding vertex %q", id)
+		}
+	}
+
+	for _, vertex := range vertexes {
+		id := vertex.ID()
+		modAddr := vertex.ModuleAddress()
+
+		if modAddr == "" {
+			g.logger.Debug().Msgf("adding edge: %s, %s", g.rootVertex.ID(), id)
+			if err := g.dag.AddEdge(g.rootVertex.ID(), id); err != nil {
+				return fmt.Errorf("error adding edge %s, %s %w", g.rootVertex.ID(), id, err)
 			}
-			vertexes = append(vertexes, vertex)
-			providerKeys[vertex.ID()] = vertex.ID()
-		case "resource":
-			vertexes = append(vertexes, &VertexResource{
-				logger:        g.logger,
-				moduleConfigs: g.moduleConfigs,
-				block:         block,
-			})
-		case "data":
-			vertexes = append(vertexes, &VertexData{
-				logger:        g.logger,
-				moduleConfigs: g.moduleConfigs,
-				block:         block,
-			})
+		} else {
+			// Add the module call edge
+			g.logger.Debug().Msgf("adding edge: %s, %s", moduleCallID(modAddr), id)
+			if err := g.dag.AddEdge(moduleCallID(modAddr), id); err != nil {
+				return fmt.Errorf("error adding edge %s, %s %w", moduleCallID(modAddr), id, err)
+			}
+
+			// Add the module exit edge
+			g.logger.Debug().Msgf("adding edge: %s, %s", id, modAddr)
+			if err := g.dag.AddEdge(id, modAddr); err != nil {
+				return fmt.Errorf("error adding edge %s, %s %w", id, modAddr, err)
+			}
 		}
 
-		for _, vertex := range vertexes {
-			id := vertex.ID()
-			g.logger.Debug().Msgf("adding vertex: %s", id)
-			err := g.dag.AddVertexByID(id, vertex)
-			if err != nil {
-				// We don't actually mind if blocks are added multiple times
-				// since this helps us support cases like _override.tf files
-				// and in-progress changes.
-				g.logger.Debug().Err(err).Msgf("error adding vertex %q", id)
+		for _, ref := range vertex.References() {
+			var srcID string
+
+			parts := strings.Split(ref.Key, ".")
+			idx := len(parts)
+
+			// data references should always have a length of 3
+			// provider references might have a length of 3 (if using an alias) or 2 (if not).
+			if (strings.HasPrefix(ref.Key, "data.") || strings.HasPrefix(ref.Key, "provider.")) && len(parts) >= 3 {
+				// Source ID is the first 3 parts or less if the length of parts is less than 3
+				idx = 3
+			} else if len(parts) >= 2 {
+				// variable, local, resources and output references should all have length 2
+				idx = 2
+			}
+			srcID = strings.Join(parts[:idx], ".")
+
+			// Don't add the module prefix for providers since they are
+			// evaluated in the root module
+			if !strings.HasPrefix(srcID, "provider.") && ref.ModuleAddress != "" {
+				modAddress := stripCount(ref.ModuleAddress)
+
+				srcID = fmt.Sprintf("%s.%s", modAddress, srcID)
 			}
 
-			modAddr := vertex.ModuleAddress()
+			// Find the correct provider vertex by looking in for a matching provider
+			// block in the module hierarchy. If we can't find one, then we should
+			// assume the reference is to a provider in the root module.
+			if strings.HasPrefix(srcID, "provider.") {
+				modAddress := vertex.ModuleAddress()
 
-			if modAddr == "" {
-				g.logger.Debug().Msgf("adding edge: %s, %s", g.rootVertex.ID(), id)
-				edges = append(edges, dag.EdgeInput{
-					SrcID: g.rootVertex.ID(),
-					DstID: id,
-				})
-			} else {
-				// Add the module call edge
-				g.logger.Debug().Msgf("adding edge: %s, %s", moduleCallID(modAddr), id)
-				edges = append(edges, dag.EdgeInput{
-					SrcID: moduleCallID(modAddr),
-					DstID: id,
-				})
+				for modAddress != "" {
+					k := fmt.Sprintf("%s.%s", modAddress, srcID)
+					if v, ok := providerKeys[k]; ok {
+						srcID = v
+						break
+					}
 
-				// Add the module exit edge
-				g.logger.Debug().Msgf("adding edge: %s, %s", id, modAddr)
-				edges = append(edges, dag.EdgeInput{
-					SrcID: id,
-					DstID: modAddr,
-				})
+					modAddress, _ = splitModuleAddr(modAddress)
+				}
 			}
 
-			for _, ref := range vertex.References() {
-				var srcID string
+			dstID := id
 
-				parts := strings.Split(ref.Key, ".")
-				idx := len(parts)
+			// If the vertex is a module call and the attribute for the reference isn't a module call
+			// arg (source, count, for_each), etc, then the reference is a module input and points to
+			// a variable block within the module. In that case we should add the edge directly to that
+			// variable block instead of the module call. We need to do this to avoid a circular dependency
+			// where a module input can depend on a module output, e.g:
+			//
+			// module "my_module" {
+			//   source = "./foo"
+			//   foo = module.my_module.bar
+			// }
+			if _, ok := vertex.(*VertexModuleCall); ok {
+				if ref.AttributeName != "" && attrIsVarInput(ref.AttributeName) {
+					dstID = fmt.Sprintf("%s.variable.%s", stripModuleCallPrefix(id), ref.AttributeName)
 
-				// data references should always have a length of 3
-				// provider references might have a length of 3 (if using an alias) or 2 (if not).
-				if (strings.HasPrefix(ref.Key, "data.") || strings.HasPrefix(ref.Key, "provider.")) && len(parts) >= 3 {
-					// Source ID is the first 3 parts or less if the length of parts is less than 3
-					idx = 3
-				} else if len(parts) >= 2 {
-					// variable, local, resources and output references should all have length 2
-					idx = 2
-				}
-				srcID = strings.Join(parts[:idx], ".")
-
-				// Don't add the module prefix for providers since they are
-				// evaluated in the root module
-				if !strings.HasPrefix(srcID, "provider.") && ref.ModuleAddress != "" {
-					modAddress := stripCount(ref.ModuleAddress)
-
-					srcID = fmt.Sprintf("%s.%s", modAddress, srcID)
-				}
-
-				// Find the correct provider vertex by looking in for a matching provider
-				// block in the module hierarchy. If we can't find one, then we should
-				// assume the reference is to a provider in the root module.
-				if strings.HasPrefix(srcID, "provider.") {
-					modAddress := vertex.ModuleAddress()
-
-					for modAddress != "" {
-						k := fmt.Sprintf("%s.%s", modAddress, srcID)
-						if v, ok := providerKeys[k]; ok {
-							srcID = v
-							break
-						}
-
-						modAddress, _ = splitModuleAddr(modAddress)
-					}
-				}
-
-				dstID := id
-
-				// If the vertex is a module call and the attribute for the reference isn't a module call
-				// arg (source, count, for_each), etc, then the reference is a module input and points to
-				// a variable block within the module. In that case we should add the edge directly to that
-				// variable block instead of the module call. We need to do this to avoid a circular dependency
-				// where a module input can depend on a module output, e.g:
-				//
-				// module "my_module" {
-				//   source = "./foo"
-				//   foo = module.my_module.bar
-				// }
-				if _, ok := vertex.(*VertexModuleCall); ok {
-					if ref.AttributeName != "" && attrIsVarInput(ref.AttributeName) {
-						dstID = fmt.Sprintf("%s.variable.%s", stripModuleCallPrefix(id), ref.AttributeName)
-
-						// Check this vertex exists
-						_, err := g.dag.GetVertex(dstID)
-						if err != nil {
-							g.logger.Debug().Err(err).Msgf("ignoring edge %s, %s because the destination vertex doesn't exist", srcID, dstID)
-							continue
-						}
-					}
-				}
-
-				// Strip the count/index suffix from the source ID
-				srcID = stripCount(srcID)
-
-				if srcID == dstID {
-					continue
-				}
-
-				// Check if the source vertex exists
-				_, err := g.dag.GetVertex(srcID)
-				if err == nil || true {
-					g.logger.Debug().Msgf("adding edge: %s, %s", srcID, dstID)
-					edges = append(edges, dag.EdgeInput{
-						SrcID: srcID,
-						DstID: dstID,
-					})
-
-					continue
-				}
-
-				// If the source vertex doesn't exist, it might be a module output attribute,
-				// so we need to check if the module output exists and add an edge from that
-				// to the current vertex instead.
-				if ref.ModuleAddress != "" && stripCount(ref.ModuleAddress) != modAddr {
-					srcID = fmt.Sprintf("%s.%s", stripCount(ref.ModuleAddress), parts[0])
-
-					// Check if the source vertex exists
-					_, err := g.dag.GetVertex(srcID)
-					if err == nil || true {
-						g.logger.Debug().Msgf("adding edge: %s, %s", srcID, dstID)
-						edges = append(edges, dag.EdgeInput{
-							SrcID: srcID,
-							DstID: dstID,
-						})
-
+					// Check this vertex exists
+					_, err := g.dag.GetVertex(dstID)
+					if err != nil {
+						g.logger.Debug().Err(err).Msgf("ignoring edge %s, %s because the destination vertex doesn't exist", srcID, dstID)
 						continue
 					}
 				}
 			}
-		}
-	}
 
-	err = g.dag.AddEdges(edges)
-	if err != nil {
-		return fmt.Errorf("error adding edges %w", err)
+			// Strip the count/index suffix from the source ID
+			srcID = stripCount(srcID)
+
+			if srcID == dstID {
+				continue
+			}
+
+			// Check if the source vertex exists
+			_, err := g.dag.GetVertex(srcID)
+			if err == nil {
+				g.logger.Debug().Msgf("adding edge: %s, %s", srcID, dstID)
+				if err := g.dag.AddEdge(srcID, dstID); err != nil {
+					return fmt.Errorf("error adding edge %s, %s %w", srcID, dstID, err)
+				}
+				continue
+			}
+
+			// If the source vertex doesn't exist, it might be a module output attribute,
+			// so we need to check if the module output exists and add an edge from that
+			// to the current vertex instead.
+			if ref.ModuleAddress != "" && stripCount(ref.ModuleAddress) != modAddr {
+				srcID = fmt.Sprintf("%s.%s", stripCount(ref.ModuleAddress), parts[0])
+
+				// Check if the source vertex exists
+				_, err := g.dag.GetVertex(srcID)
+				if err == nil {
+					g.logger.Debug().Msgf("adding edge: %s, %s", srcID, dstID)
+					if err := g.dag.AddEdge(srcID, dstID); err != nil {
+						return fmt.Errorf("error adding edge %s, %s %w", srcID, dstID, err)
+					}
+
+					continue
+				}
+			}
+		}
 	}
 
 	// Setup initial context
@@ -442,10 +426,10 @@ func (g *Graph) loadAllBlocks(evaluator *Evaluator) ([]*Block, error) {
 }
 
 func (g *Graph) loadBlocksForModule(evaluator *Evaluator) ([]*Block, error) {
-	blocks := make([]*Block, 0, len(evaluator.module.Blocks))
-	copy(blocks, evaluator.module.Blocks)
+	var blocks []*Block
 
 	for _, block := range evaluator.module.Blocks {
+		blocks = append(blocks, block)
 
 		if block.Type() == "module" {
 			modCall, err := evaluator.loadModule(block)

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -95,7 +95,7 @@ func NewGraphWithRoot(logger zerolog.Logger, vertexMutex *sync.Mutex) (*Graph, e
 }
 
 func (g *Graph) ReduceTransitively() {
-	// g.dag.ReduceTransitively()
+	g.dag.ReduceTransitively()
 }
 
 func (g *Graph) Populate(evaluator *Evaluator) error {
@@ -383,15 +383,17 @@ func (g *Graph) AsJSON() ([]byte, error) {
 func (g *Graph) Walk() {
 	v := NewGraphVisitor(g.logger, g.vertexMutex)
 
-	flowCallback := func(d *dag.DAG, id string, parentResults []dag.FlowResult) (interface{}, error) {
-		vertex, _ := d.GetVertex(id)
+	// flowCallback := func(d *dag.DAG, id string, parentResults []dag.FlowResult) (interface{}, error) {
+	// 	vertex, _ := d.GetVertex(id)
+	//
+	// 	v.Visit(id, vertex)
+	//
+	// 	return vertex, nil
+	// }
 
-		v.Visit(id, vertex)
+	g.dag.BFSWalk(v)
 
-		return vertex, nil
-	}
-
-	_, _ = g.dag.DescendantsFlow(g.rootVertex.ID(), nil, flowCallback)
+	// _, _ = g.dag.DescendantsFlow(g.rootVertex.ID(), nil, flowCallback)
 }
 
 func (g *Graph) Run(evaluator *Evaluator) (*Module, error) {
@@ -421,13 +423,12 @@ func NewGraphVisitor(logger zerolog.Logger, vertexMutex *sync.Mutex) *GraphVisit
 	}
 }
 
-func (v *GraphVisitor) Visit(id string, vertex interface{}) {
-	v.logger.Debug().Msgf("visiting vertex %q", id)
-
+func (v *GraphVisitor) Visit(vertex dag.Vertexer) {
 	vert := vertex.(Vertex)
+	v.logger.Debug().Msgf("visiting vertex %q", vert.ID())
 	err := vert.Visit(v.vertexMutex)
 	if err != nil {
-		v.logger.Debug().Err(err).Msgf("ignoring vertex %q because an error was encountered", id)
+		v.logger.Debug().Err(err).Msgf("ignoring vertex %q because an error was encountered", vert.ID())
 	}
 }
 

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -99,7 +99,6 @@ func (g *Graph) ReduceTransitively() {
 }
 
 func (g *Graph) Populate(evaluator *Evaluator) error {
-	var vertexes []Vertex
 
 	blocks, err := g.loadAllBlocks(evaluator)
 	if err != nil {

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -224,20 +224,26 @@ func (g *Graph) Populate(evaluator *Evaluator) error {
 
 		if modAddr == "" {
 			g.logger.Debug().Msgf("adding edge: %s, %s", g.rootVertex.ID(), id)
-			if err := g.dag.AddEdge(g.rootVertex.ID(), id); err != nil {
-				return fmt.Errorf("error adding edge %s, %s %w", g.rootVertex.ID(), id, err)
+			if ok, _ := g.dag.IsEdge(g.rootVertex.ID(), id); !ok {
+				if err := g.dag.AddEdge(g.rootVertex.ID(), id); err != nil {
+					return fmt.Errorf("error adding edge %s, %s %w", g.rootVertex.ID(), id, err)
+				}
 			}
 		} else {
 			// Add the module call edge
 			g.logger.Debug().Msgf("adding edge: %s, %s", moduleCallID(modAddr), id)
-			if err := g.dag.AddEdge(moduleCallID(modAddr), id); err != nil {
-				return fmt.Errorf("error adding edge %s, %s %w", moduleCallID(modAddr), id, err)
+			if ok, _ := g.dag.IsEdge(moduleCallID(modAddr), id); !ok {
+				if err := g.dag.AddEdge(moduleCallID(modAddr), id); err != nil {
+					return fmt.Errorf("error adding edge %s, %s %w", moduleCallID(modAddr), id, err)
+				}
 			}
 
 			// Add the module exit edge
 			g.logger.Debug().Msgf("adding edge: %s, %s", id, modAddr)
-			if err := g.dag.AddEdge(id, modAddr); err != nil {
-				return fmt.Errorf("error adding edge %s, %s %w", id, modAddr, err)
+			if ok, _ := g.dag.IsEdge(id, modAddr); !ok {
+				if err := g.dag.AddEdge(id, modAddr); err != nil {
+					return fmt.Errorf("error adding edge %s, %s %w", id, modAddr, err)
+				}
 			}
 		}
 
@@ -319,8 +325,10 @@ func (g *Graph) Populate(evaluator *Evaluator) error {
 			_, err := g.dag.GetVertex(srcID)
 			if err == nil {
 				g.logger.Debug().Msgf("adding edge: %s, %s", srcID, dstID)
-				if err := g.dag.AddEdge(srcID, dstID); err != nil {
-					return fmt.Errorf("error adding edge %s, %s %w", srcID, dstID, err)
+				if ok, _ := g.dag.IsEdge(srcID, dstID); !ok {
+					if err := g.dag.AddEdge(srcID, dstID); err != nil {
+						return fmt.Errorf("error adding edge %s, %s %w", srcID, dstID, err)
+					}
 				}
 				continue
 			}
@@ -335,8 +343,10 @@ func (g *Graph) Populate(evaluator *Evaluator) error {
 				_, err := g.dag.GetVertex(srcID)
 				if err == nil {
 					g.logger.Debug().Msgf("adding edge: %s, %s", srcID, dstID)
-					if err := g.dag.AddEdge(srcID, dstID); err != nil {
-						return fmt.Errorf("error adding edge %s, %s %w", srcID, dstID, err)
+					if ok, _ := g.dag.IsEdge(srcID, dstID); !ok {
+						if err := g.dag.AddEdge(srcID, dstID); err != nil {
+							return fmt.Errorf("error adding edge %s, %s %w", srcID, dstID, err)
+						}
 					}
 
 					continue

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -402,7 +402,7 @@ func TopologicalWalk(graph *dag.DAG, visitor func(id string, vertex Vertex)) {
 			queue = append(queue, queueItem{
 				id:     id,
 				vertex: vertex.(Vertex),
-			}) // Add root vertices to the queue
+			})
 		}
 	}
 
@@ -410,7 +410,7 @@ func TopologicalWalk(graph *dag.DAG, visitor func(id string, vertex Vertex)) {
 	for len(queue) > 0 {
 		current := queue[0]
 		queue = queue[1:]
-		visitor(current.id, current.vertex) // Call visitor function
+		visitor(current.id, current.vertex)
 
 		children, _ := graph.GetChildren(current.id)
 		for id, successor := range children {
@@ -465,11 +465,10 @@ func (g *Graph) loadAllBlocks(evaluator *Evaluator) ([]*Block, error) {
 }
 
 func (g *Graph) loadBlocksForModule(evaluator *Evaluator) ([]*Block, error) {
-	blocks := make([]*Block, 0, len(evaluator.module.Blocks))
+	blocks := make([]*Block, len(evaluator.module.Blocks))
 	copy(blocks, evaluator.module.Blocks)
-	moduleBlocks := evaluator.module.Blocks.OfType("module")
 
-	for _, block := range moduleBlocks {
+	for _, block := range evaluator.module.Blocks.OfType("module") {
 		modCall, err := evaluator.loadModule(block)
 		if err != nil {
 			return nil, fmt.Errorf("could not load module %q", block.FullName())

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -424,11 +424,12 @@ func NewGraphVisitor(logger zerolog.Logger, vertexMutex *sync.Mutex) *GraphVisit
 }
 
 func (v *GraphVisitor) Visit(vertex dag.Vertexer) {
-	vert := vertex.(Vertex)
-	v.logger.Debug().Msgf("visiting vertex %q", vert.ID())
+	id, rawVertex := vertex.Vertex()
+	vert := rawVertex.(Vertex)
+	v.logger.Debug().Msgf("visiting vertex %q", id)
 	err := vert.Visit(v.vertexMutex)
 	if err != nil {
-		v.logger.Debug().Err(err).Msgf("ignoring vertex %q because an error was encountered", vert.ID())
+		v.logger.Debug().Err(err).Msgf("ignoring vertex %q because an error was encountered", id)
 	}
 }
 

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -95,7 +95,7 @@ func NewGraphWithRoot(logger zerolog.Logger, vertexMutex *sync.Mutex) (*Graph, e
 }
 
 func (g *Graph) ReduceTransitively() {
-	g.dag.ReduceTransitively()
+	// g.dag.ReduceTransitively()
 }
 
 func (g *Graph) Populate(evaluator *Evaluator) error {

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -402,9 +402,6 @@ func TopologicalWalk(graph *dag.DAG, visitor func(id string, vertex Vertex)) {
 		current := queue[0]
 		queue = queue[1:]
 		visitor(current.id, current.vertex)
-
-		// TODO: parallelize this
-
 		children, _ := graph.GetChildren(current.id)
 		for id, successor := range children {
 			inDegrees[id]--

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -383,15 +383,21 @@ func (g *Graph) AsJSON() ([]byte, error) {
 func (g *Graph) Walk() {
 	v := NewGraphVisitor(g.logger, g.vertexMutex)
 
-	flowCallback := func(d *dag.DAG, id string, parentResults []dag.FlowResult) (interface{}, error) {
-		vertex, _ := d.GetVertex(id)
+	// flowCallback := func(d *dag.DAG, id string, parentResults []dag.FlowResult) (interface{}, error) {
+	// 	vertex, _ := d.GetVertex(id)
+	//
+	// 	v.Visit(id, vertex)
+	//
+	// 	return vertex, nil
+	// }
 
+	idChan, _, _ := g.dag.DescendantsWalker(g.rootVertex.ID())
+	for id := range idChan {
+		vertex, _ := g.dag.GetVertex(id)
 		v.Visit(id, vertex)
-
-		return vertex, nil
 	}
 
-	_, _ = g.dag.DescendantsFlow(g.rootVertex.ID(), nil, flowCallback)
+	// _, _ = g.dag.DescendantsFlow(g.rootVertex.ID(), nil, flowCallback)
 }
 
 func (g *Graph) Run(evaluator *Evaluator) (*Module, error) {
@@ -423,10 +429,10 @@ func NewGraphVisitor(logger zerolog.Logger, vertexMutex *sync.Mutex) *GraphVisit
 
 func (v *GraphVisitor) Visit(id string, vertex interface{}) {
 	vert := vertex.(Vertex)
-	v.logger.Debug().Msgf("visiting vertex %q", vert.ID())
+	v.logger.Debug().Msgf("visiting vertex %q", id)
 	err := vert.Visit(v.vertexMutex)
 	if err != nil {
-		v.logger.Debug().Err(err).Msgf("ignoring vertex %q because an error was encountered", vert.ID())
+		v.logger.Debug().Err(err).Msgf("ignoring vertex %q because an error was encountered", id)
 	}
 }
 

--- a/internal/hcl/graph.go
+++ b/internal/hcl/graph.go
@@ -382,22 +382,12 @@ func (g *Graph) AsJSON() ([]byte, error) {
 
 func (g *Graph) Walk() {
 	v := NewGraphVisitor(g.logger, g.vertexMutex)
-
-	// flowCallback := func(d *dag.DAG, id string, parentResults []dag.FlowResult) (interface{}, error) {
-	// 	vertex, _ := d.GetVertex(id)
-	//
-	// 	v.Visit(id, vertex)
-	//
-	// 	return vertex, nil
-	// }
-
-	idChan, _, _ := g.dag.DescendantsWalker(g.rootVertex.ID())
-	for id := range idChan {
-		vertex, _ := g.dag.GetVertex(id)
+	flowCallback := func(d *dag.DAG, id string, _ []dag.FlowResult) (interface{}, error) {
+		vertex, _ := d.GetVertex(id)
 		v.Visit(id, vertex)
+		return nil, nil
 	}
-
-	// _, _ = g.dag.DescendantsFlow(g.rootVertex.ID(), nil, flowCallback)
+	_, _ = g.dag.DescendantsFlow(g.rootVertex.ID(), nil, flowCallback)
 }
 
 func (g *Graph) Run(evaluator *Evaluator) (*Module, error) {

--- a/internal/hcl/graph_vertex_module_call.go
+++ b/internal/hcl/graph_vertex_module_call.go
@@ -78,8 +78,6 @@ func (v *VertexModuleCall) Visit(mutex *sync.Mutex) error {
 }
 
 func (v *VertexModuleCall) evaluate(e *Evaluator, b *Block, mutex *sync.Mutex) error {
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	if b.Label() == "" {
 		return fmt.Errorf("module block %s has no label", b.FullName())
@@ -92,8 +90,6 @@ func (v *VertexModuleCall) evaluate(e *Evaluator, b *Block, mutex *sync.Mutex) e
 }
 
 func (v *VertexModuleCall) expand(e *Evaluator, b *Block, mutex *sync.Mutex) ([]*Block, error) {
-	mutex.Lock()
-	defer mutex.Unlock()
 	expanded := []*Block{b}
 	expanded = e.expandBlockForEaches(expanded)
 	expanded = e.expandBlockCounts(expanded)

--- a/internal/hcl/graph_vertex_module_exit.go
+++ b/internal/hcl/graph_vertex_module_exit.go
@@ -25,8 +25,6 @@ func (v *VertexModuleExit) References() []VertexReference {
 }
 
 func (v *VertexModuleExit) Visit(mutex *sync.Mutex) error {
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	moduleInstances := v.moduleConfigs.Get(v.block.FullName())
 

--- a/internal/hcl/graph_vertex_output.go
+++ b/internal/hcl/graph_vertex_output.go
@@ -29,8 +29,6 @@ func (v *VertexOutput) References() []VertexReference {
 }
 
 func (v *VertexOutput) Visit(mutex *sync.Mutex) error {
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	moduleInstances := v.moduleConfigs.Get(v.block.ModuleAddress())
 	if len(moduleInstances) == 0 {

--- a/internal/hcl/graph_vertex_provider.go
+++ b/internal/hcl/graph_vertex_provider.go
@@ -33,8 +33,6 @@ func (v *VertexProvider) References() []VertexReference {
 }
 
 func (v *VertexProvider) Visit(mutex *sync.Mutex) error {
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	provider := v.block.Label()
 	if provider == "" {

--- a/internal/hcl/graph_vertex_resource.go
+++ b/internal/hcl/graph_vertex_resource.go
@@ -27,8 +27,6 @@ func (v *VertexResource) References() []VertexReference {
 }
 
 func (v *VertexResource) Visit(mutex *sync.Mutex) error {
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	moduleInstances := v.moduleConfigs.Get(v.block.ModuleAddress())
 	if len(moduleInstances) == 0 {

--- a/internal/hcl/graph_vertex_variable.go
+++ b/internal/hcl/graph_vertex_variable.go
@@ -27,8 +27,6 @@ func (v *VertexVariable) References() []VertexReference {
 }
 
 func (v *VertexVariable) Visit(mutex *sync.Mutex) error {
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	moduleInstances := v.moduleConfigs.Get(v.block.ModuleAddress())
 	if len(moduleInstances) == 0 {

--- a/internal/hcl/graph_vertex_variable.go
+++ b/internal/hcl/graph_vertex_variable.go
@@ -49,8 +49,8 @@ func (v *VertexVariable) Visit(mutex *sync.Mutex) error {
 
 		if moduleInstance.moduleCall != nil {
 			attrName := v.block.TypeLabel()
-			attr, ok := moduleInstance.moduleCall.Definition.AttributesAsMap()[attrName]
-			if ok {
+			attr := moduleInstance.moduleCall.Definition.GetAttribute(attrName)
+			if attr != nil {
 				inputVars = map[string]cty.Value{
 					attrName: attr.Value(),
 				}

--- a/internal/hcl/modules/fetch.go
+++ b/internal/hcl/modules/fetch.go
@@ -40,6 +40,11 @@ type PackageFetcher struct {
 var localCache sync.Map
 var errorCache sync.Map
 
+func ResetGlobalModuleCache() {
+	localCache = sync.Map{}
+	errorCache = sync.Map{}
+}
+
 type PackageFetcherOpts func(*PackageFetcher)
 
 // NewPackageFetcher constructs a new package fetcher

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -221,8 +221,6 @@ func (m *ModuleLoader) loadModules(path string, prefix string) ([]*ManifestModul
 	manifestMu := sync.Mutex{}
 
 	remoteModuleCounter := metrics.GetCounter("remote_module.count", true)
-	submoduleLoadTimer := metrics.GetTimer("submodule.load.total_duration", false, path).Start()
-	defer submoduleLoadTimer.Stop()
 
 	for i := 0; i < getProcessCount(); i++ {
 		errGroup.Go(func() error {

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -203,7 +203,6 @@ func (m *ModuleLoader) Load(path string) (man *Manifest, err error) {
 
 // loadModules recursively loads the modules from the given path.
 func (m *ModuleLoader) loadModules(path string, prefix string) ([]*ManifestModule, error) {
-	manifestModules := make([]*ManifestModule, 0)
 
 	module, err := m.loadModuleFromPath(path)
 	if err != nil {
@@ -212,6 +211,7 @@ func (m *ModuleLoader) loadModules(path string, prefix string) ([]*ManifestModul
 
 	numJobs := len(module.ModuleCalls)
 	jobs := make(chan *tfconfig.ModuleCall, numJobs)
+	manifestModules := make([]*ManifestModule, len(jobs))
 	for _, moduleCall := range module.ModuleCalls {
 		jobs <- moduleCall
 	}
@@ -801,8 +801,7 @@ func (m *ModuleLoader) loadRemoteModule(key string, source string) (*ManifestMod
 	manifestModule.Dir = path.Clean(filepath.Join(moduleDownloadDir, submodulePath))
 
 	// lock the download destination so that we don't interact with an incomplete download.
-	// we can't use module address as the key here because the module address might be different for the same module,
-	// e.g. ssh vs https
+	// we can't use module address here as the version may be different
 	unlock := m.sync.Lock(dest)
 	defer unlock()
 

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -415,7 +415,7 @@ func (m *ModuleLoader) checkoutPathIfRequired(repoRoot string, dir string) error
 // RecursivelyAddDirsToSparseCheckout adds the given directories to the sparse-checkout file list.
 // It then checks any symlinks within the directories and adds them to the sparse-checkout file list as well.
 func RecursivelyAddDirsToSparseCheckout(repoRoot string, sourceURL string, packageFetcher *PackageFetcher, existingDirs []string, dirs []string, mu *sync.Mutex, logger zerolog.Logger, depth int) error {
-	var newDirs []string
+	newDirs := make([]string, 0, len(dirs))
 
 	// Sort the existing directories and dirs to be added by length
 	// This ensures that parent directories are added before child directories

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -800,8 +800,10 @@ func (m *ModuleLoader) loadRemoteModule(key string, source string) (*ManifestMod
 	}
 	manifestModule.Dir = path.Clean(filepath.Join(moduleDownloadDir, submodulePath))
 
-	// lock the module address so that we don't interact with an incomplete download.
-	unlock := m.sync.Lock(moduleAddr)
+	// lock the download destination so that we don't interact with an incomplete download.
+	// we can't use module address as the key here because the module address might be different for the same module,
+	// e.g. ssh vs https
+	unlock := m.sync.Lock(dest)
 	defer unlock()
 
 	_, err = os.Stat(dest)

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -274,9 +274,6 @@ func (m *ModuleLoader) loadModule(moduleCall *tfconfig.ModuleCall, parentPath st
 	source := moduleCall.Source
 	version := moduleCall.Version
 
-	moduleLoadTimer := metrics.GetTimer("submodule.load.duration", false, source, version).Start()
-	defer moduleLoadTimer.Stop()
-
 	mappedResult, err := mapSource(m.sourceMap, source)
 	if err != nil {
 		return nil, err
@@ -344,6 +341,9 @@ func (m *ModuleLoader) loadModule(moduleCall *tfconfig.ModuleCall, parentPath st
 			Dir:    path.Clean(dir),
 		}, nil
 	}
+
+	moduleLoadTimer := metrics.GetTimer("submodule.remote_load.duration", false, source, version).Start()
+	defer moduleLoadTimer.Stop()
 
 	manifestModule, err = m.loadRegistryModule(key, source, version)
 	if err != nil {

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -731,8 +731,10 @@ func (m *ModuleLoader) loadRegistryModule(key string, source string, version str
 	}
 	manifestModule.Dir = path.Clean(filepath.Join(moduleDownloadDir, submodulePath))
 
-	// lock the module address so that we don't interact with an incomplete download.
-	unlock := m.sync.Lock(moduleAddr)
+	// lock the download destination so that we don't interact with an incomplete download.
+	// we can't use module address as the key here because the module address might be different for the same module,
+	// e.g. ssh vs https
+	unlock := m.sync.Lock(dest)
 	defer unlock()
 
 	lookupResult, err := m.registryLoader.lookupModule(moduleAddr, version)

--- a/internal/hcl/modules/loader_test.go
+++ b/internal/hcl/modules/loader_test.go
@@ -24,6 +24,9 @@ type TestLoaderE2EOpts = struct {
 }
 
 func testLoaderE2E(t *testing.T, path string, expectedModules []*ManifestModule, opts TestLoaderE2EOpts) {
+
+	ResetGlobalModuleCache()
+
 	if opts.Cleanup {
 		err := os.RemoveAll(filepath.Join(path, config.InfracostDir))
 		assert.NoError(t, err)

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -93,8 +93,8 @@ func (p *Parser) sortVarFilesByPrecedence(paths []string, autoDetected bool) {
 }
 
 func makePathsRelativeToInitial(paths []string, initialPath string) []string {
-	var filenames []string
 
+	filenames := make([]string, 0, len(paths))
 	for _, name := range paths {
 		if path.IsAbs(name) {
 			filenames = append(filenames, name)
@@ -404,7 +404,7 @@ func (p *Parser) DependencyPaths() []string {
 		return nil
 	}
 
-	var sortedCalls []string
+	sortedCalls := make([]string, 0, len(p.moduleCalls)+len(p.tfvarsPaths)+1)
 	for _, call := range p.moduleCalls {
 		relCall := call
 		dep, err := filepath.Rel(p.startingPath, call)

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -100,7 +100,7 @@ func CreateEnvFileMatcher(names []string, extensions []string) *EnvFileMatcher {
 		return len(extensions[i]) > len(extensions[j])
 	})
 
-	var envNames []string
+	envNames := make([]string, 0, len(names))
 	var wildcards []string
 	for _, name := range names {
 		// envNames can contain wildcards, we need to handle them separately. e.g: dev-*
@@ -130,7 +130,7 @@ func CreateEnvFileMatcher(names []string, extensions []string) *EnvFileMatcher {
 }
 
 func createWildcardGlobPaths(dirs []string) []string {
-	var paths []string
+	paths := make([]string, 0, len(dirs)*2)
 	for _, dir := range dirs {
 		paths = append(paths, path.Join(dir, "**"))
 	}
@@ -494,7 +494,7 @@ func CreateTreeNode(basePath string, paths []RootPath, varFiles map[string][]Roo
 		root.AddPath(path)
 	}
 
-	var varFilesSorted []string
+	varFilesSorted := make([]string, 0, len(varFiles))
 	for dir := range varFiles {
 		varFilesSorted = append(varFilesSorted, dir)
 	}
@@ -1116,13 +1116,13 @@ func (r *RootPath) EnvGroupings() []VarFileGrouping {
 		}
 	}
 
-	var envNames []string
+	envNames := make([]string, 0, len(varFileGrouping))
 	for env := range varFileGrouping {
 		envNames = append(envNames, env)
 	}
 	sort.Strings(envNames)
 
-	var varEnvs []VarFileGrouping
+	varEnvs := make([]VarFileGrouping, 0, len(envNames))
 	for _, env := range envNames {
 		varEnvs = append(varEnvs, VarFileGrouping{
 			Name:              env,
@@ -1752,7 +1752,7 @@ func (p *ProjectLocator) findTerragruntDirs(fullPath string) {
 // removeParentTerragruntFiles removes any parent Terragrunt config files from
 // the list of discovered Terragrunt configuration files.
 func (p *ProjectLocator) removeParentTerragruntFiles(startingPath string, files []string) []string {
-	var paths []RootPath
+	paths := make([]RootPath, 0, len(files))
 	nameMap := make(map[string]string)
 	for _, file := range files {
 		dir := filepath.Dir(file)

--- a/internal/metrics/counter.go
+++ b/internal/metrics/counter.go
@@ -1,0 +1,43 @@
+package metrics
+
+import "sync"
+
+type Counter struct {
+	value int
+	mu    sync.Mutex
+}
+
+func (c *Counter) Result() Result {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return Result{
+		Unit:  "count",
+		Value: c.value,
+	}
+}
+
+func GetCounter(name string, reuse bool, context ...string) *Counter {
+	if reuse {
+		existing := coreRegistry.Find(name, TypeCounter)
+		if existing != nil {
+			return existing.(*Counter)
+		}
+	}
+	c := &Counter{}
+	coreRegistry.Add(name, TypeCounter, c, context...)
+	return c
+}
+
+func (c *Counter) Inc() *Counter {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.value++
+	return c
+}
+
+func (c *Counter) Add(value int) *Counter {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.value += value
+	return c
+}

--- a/internal/metrics/counter.go
+++ b/internal/metrics/counter.go
@@ -11,7 +11,6 @@ func (c *Counter) Result() Result {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return Result{
-		Unit:  "count",
 		Value: c.value,
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,94 @@
+package metrics
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+type Type string
+
+const (
+	TypeCounter Type = "counter"
+	TypeTimer   Type = "timer"
+	TypeSetting Type = "setting"
+)
+
+type Metric interface {
+	Result() Result
+}
+
+type Result struct {
+	Unit  string      `json:"unit"`
+	Value interface{} `json:"value"`
+}
+
+type registeredMetric struct {
+	Name    string   `json:"name"`
+	Key     int      `json:"key"`
+	Type    Type     `json:"type"`
+	Context []string `json:"context,omitempty"`
+	Metric  Metric   `json:"-"`
+}
+
+type FullResult struct {
+	registeredMetric
+	Result
+}
+
+type registry struct {
+	mu      sync.RWMutex
+	metrics []registeredMetric
+}
+
+var coreRegistry = &registry{}
+
+func (r *registry) Add(name string, t Type, m Metric, context ...string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	highestKey := -1
+	for _, m := range r.metrics {
+		if m.Name == name && m.Type == t && m.Key > highestKey {
+			highestKey = m.Key
+		}
+	}
+	r.metrics = append(r.metrics, registeredMetric{
+		Name:    name,
+		Type:    t,
+		Metric:  m,
+		Key:     highestKey + 1,
+		Context: context,
+	})
+}
+
+func (r *registry) Find(name string, t Type) Metric {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, m := range r.metrics {
+		if m.Name == name && m.Type == t {
+			return m.Metric
+		}
+	}
+	return nil
+}
+
+func GetData() []FullResult {
+	coreRegistry.mu.RLock()
+	defer coreRegistry.mu.RUnlock()
+	data := make([]FullResult, 0, len(coreRegistry.metrics))
+	for _, m := range coreRegistry.metrics {
+		data = append(data, FullResult{
+			registeredMetric: m,
+			Result:           m.Metric.Result(),
+		})
+	}
+	return data
+}
+
+func WriteMetrics(path string) error {
+	data, err := json.Marshal(GetData())
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -109,5 +109,5 @@ func WriteMetrics(path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, 0600)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -19,16 +19,16 @@ type Metric interface {
 }
 
 type Result struct {
-	Unit  string      `json:"unit"`
-	Value interface{} `json:"value"`
+	Unit  string
+	Value interface{}
 }
 
 type registeredMetric struct {
-	Name    string   `json:"name"`
-	Key     int      `json:"key"`
-	Type    Type     `json:"type"`
-	Context []string `json:"context,omitempty"`
-	Metric  Metric   `json:"-"`
+	Name    string
+	Key     int
+	Type    Type
+	Context []string
+	Metric  Metric
 }
 
 type registry struct {
@@ -71,13 +71,12 @@ type Output []OutputMetric
 
 type OutputMetric struct {
 	Name   string        `json:"name"`
-	Type   Type          `json:"type"`
-	Unit   string        `json:"unit"`
-	Values []OutputValue `json:"values"`
+	Unit   string        `json:"unit,omitempty"`
+	Values []OutputValue `json:"values,omitempty"`
 }
 
 type OutputValue struct {
-	Context []string    `json:"context"`
+	Context []string    `json:"context,omitempty"`
 	Value   interface{} `json:"value"`
 }
 
@@ -95,7 +94,6 @@ func WriteMetrics(path string) error {
 		if metric == nil {
 			metric = &OutputMetric{
 				Name: m.Name,
-				Type: m.Type,
 				Unit: result.Unit,
 			}
 			outputMap[m.Name] = metric

--- a/internal/metrics/setting.go
+++ b/internal/metrics/setting.go
@@ -11,7 +11,6 @@ func (s *Setting) Result() Result {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return Result{
-		Unit:  "setting",
 		Value: s.value,
 	}
 }

--- a/internal/metrics/setting.go
+++ b/internal/metrics/setting.go
@@ -1,0 +1,30 @@
+package metrics
+
+import "sync"
+
+type Setting struct {
+	value interface{}
+	mu    sync.Mutex
+}
+
+func (s *Setting) Result() Result {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Result{
+		Unit:  "setting",
+		Value: s.value,
+	}
+}
+
+func GetSetting(name string, context ...string) *Setting {
+	c := &Setting{}
+	coreRegistry.Add(name, TypeSetting, c, context...)
+	return c
+}
+
+func (s *Setting) Set(value any) *Setting {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.value = value
+	return s
+}

--- a/internal/metrics/timer.go
+++ b/internal/metrics/timer.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+)
+
+type Timer struct {
+	group       string
+	name        string
+	startTime   time.Time
+	elapsedTime time.Duration
+	running     bool
+	mu          sync.Mutex
+}
+
+func (t *Timer) Result() Result {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	elapsed := t.elapsedTime.Milliseconds()
+	if t.running {
+		elapsed += time.Since(t.startTime).Milliseconds()
+	}
+	return Result{
+		Unit:  "ms",
+		Value: elapsed,
+	}
+}
+
+func GetTimer(name string, reuse bool, context ...string) *Timer {
+	if reuse {
+		existing := coreRegistry.Find(name, TypeTimer)
+		if existing != nil {
+			return existing.(*Timer)
+		}
+	}
+	t := &Timer{}
+	coreRegistry.Add(name, TypeTimer, t, context...)
+	return t
+}
+
+func (t *Timer) Start() *Timer {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.running {
+		return t
+	}
+
+	t.startTime = time.Now()
+	t.running = true
+	return t
+}
+
+func (t *Timer) Stop() *Timer {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.running {
+		return t
+	}
+
+	t.elapsedTime += time.Since(t.startTime)
+	t.running = false
+	return t
+}

--- a/internal/metrics/timer.go
+++ b/internal/metrics/timer.go
@@ -6,8 +6,6 @@ import (
 )
 
 type Timer struct {
-	group       string
-	name        string
 	startTime   time.Time
 	elapsedTime time.Duration
 	running     bool

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Rhymond/go-money"
+	"github.com/infracost/infracost/internal/metrics"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
@@ -36,6 +37,8 @@ type ReportInput struct {
 // Load reads the file at the location p and the file body into a Root struct. Load naively
 // validates that the Infracost JSON body is valid by checking the that the version attribute is within a supported range.
 func Load(p string) (Root, error) {
+	timer := metrics.GetTimer("output.load.duration", false).Start()
+	defer timer.Stop()
 	var out Root
 	_, err := os.Stat(p)
 	if errors.Is(err, os.ErrNotExist) {
@@ -118,6 +121,8 @@ func LoadPaths(paths []string) ([]ReportInput, error) {
 // in the prior Root. If we can't find a matching project then we assume that the project
 // has been newly created and will show a 100% increase in the output Root.
 func CompareTo(c *config.Config, current, prior Root) (Root, error) {
+	compareTimer := metrics.GetTimer("output.compare.duration", false).Start()
+	defer compareTimer.Stop()
 	currentProjectLabels := make(map[string]bool, len(current.Projects))
 	for _, p := range current.Projects {
 		currentProjectLabels[p.LabelWithMetadata()] = true

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -370,7 +370,7 @@ func buildActualCostRows(t table.Writer, currency string, actualCosts []ActualCo
 }
 
 func filterZeroValComponents(costComponents []CostComponent, resourceName string) []CostComponent {
-	var filteredComponents []CostComponent
+	filteredComponents := make([]CostComponent, 0, len(costComponents))
 	for _, c := range costComponents {
 		if c.MonthlyQuantity != nil && c.MonthlyQuantity.IsZero() {
 			logging.Logger.Debug().Msgf("Hiding cost with no usage: %s '%s'", resourceName, c.Name)
@@ -383,7 +383,7 @@ func filterZeroValComponents(costComponents []CostComponent, resourceName string
 }
 
 func filterZeroValResources(resources []Resource, resourceName string) []Resource {
-	var filteredResources []Resource
+	filteredResources := make([]Resource, 0, len(resources))
 	for _, r := range resources {
 		filteredComponents := filterZeroValComponents(r.CostComponents, fmt.Sprintf("%s.%s", resourceName, r.Name))
 		filteredSubResources := filterZeroValResources(r.SubResources, fmt.Sprintf("%s.%s", resourceName, r.Name))

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -144,7 +144,7 @@ func (p *PriceFetcher) LogWarnings() {
 		return
 	}
 
-	var data []*notFoundData
+	data := make([]*notFoundData, 0, len(p.resources))
 	for _, v := range p.resources {
 		data = append(data, v)
 	}

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -213,7 +213,7 @@ func (p *PriceFetcher) getPricesConcurrent(resources []*schema.Resource) error {
 		numWorkers = 16
 	}
 
-	reqs := p.client.BatchRequests(resources, batchSize)
+	reqs := p.client.BatchRequests(resources, 100) // batchSize)
 
 	numJobs := len(reqs)
 	jobs := make(chan apiclient.BatchRequest, numJobs)

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -201,7 +201,7 @@ func (p *PriceFetcher) PopulatePrices(project *schema.Project) error {
 
 // getPricesConcurrent gets the prices of all resources concurrently.
 // Concurrency level is calculated using the following formula:
-// max(min(4, numCPU * 4), 16)
+// min(max(4, numCPU * 4), 16)
 func (p *PriceFetcher) getPricesConcurrent(resources []*schema.Resource) error {
 	// Set the number of workers
 	numWorkers := 4
@@ -234,6 +234,8 @@ func (p *PriceFetcher) getPricesConcurrent(resources []*schema.Resource) error {
 		jobs <- r
 	}
 
+	close(jobs)
+
 	// Get the result of the jobs
 	for i := 0; i < numJobs; i++ {
 		err := <-resultErrors
@@ -241,6 +243,9 @@ func (p *PriceFetcher) getPricesConcurrent(resources []*schema.Resource) error {
 			return err
 		}
 	}
+
+	close(resultErrors)
+
 	return nil
 }
 

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	batchSize = 5
+	batchSize = 1000
 )
 
 // notFoundData represents a single price not found entry
@@ -213,7 +213,7 @@ func (p *PriceFetcher) getPricesConcurrent(resources []*schema.Resource) error {
 		numWorkers = 16
 	}
 
-	reqs := p.client.BatchRequests(resources, 100) // batchSize)
+	reqs := p.client.BatchRequests(resources, batchSize)
 
 	numJobs := len(reqs)
 	jobs := make(chan apiclient.BatchRequest, numJobs)

--- a/internal/prices/prices.go
+++ b/internal/prices/prices.go
@@ -48,7 +48,7 @@ func NewPriceFetcher(ctx *config.RunContext, warnOnPriceErrors bool) *PriceFetch
 		components:        make(map[string]int),
 		mux:               &sync.RWMutex{},
 		runCtx:            ctx,
-		client:            apiclient.NewPricingAPIClient(ctx),
+		client:            apiclient.GetPricingAPIClient(ctx),
 		warnOnPriceErrors: warnOnPriceErrors,
 	}
 }

--- a/internal/providers/cloudformation/parser.go
+++ b/internal/providers/cloudformation/parser.go
@@ -91,7 +91,7 @@ func (p *Parser) createResource(d *schema.ResourceData, u *schema.UsageData) par
 }
 
 func (p *Parser) parseTemplate(t *cloudformation.Template, usage schema.UsageMap) []parsedResource {
-	var resources []parsedResource
+	resources := make([]parsedResource, 0, len(t.Resources))
 
 	for name, d := range t.Resources {
 		resourceData := schema.NewCFResourceData(d.AWSCloudFormationType(), "aws", name, nil, d)

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -39,8 +39,6 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 		projectContext.ContextValues.SetValue("project_type", projectType)
 	}
 
-	metrics.GetSetting("project_type", project.Path).Set(projectType)
-
 	switch projectType {
 	case ProjectTypeTerraformPlanJSON:
 		return &DetectionOutput{Providers: []schema.Provider{terraform.NewPlanJSONProvider(projectContext, includePastResources)}, RootModules: 1}, nil

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 
 	"github.com/awslabs/goformation/v7"
-	"github.com/infracost/infracost/internal/metrics"
-
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/hcl"
 	"github.com/infracost/infracost/internal/logging"
@@ -53,9 +51,6 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 	case ProjectTypeCloudFormation:
 		return &DetectionOutput{Providers: []schema.Provider{cloudformation.NewTemplateProvider(projectContext, includePastResources)}, RootModules: 1}, nil
 	}
-
-	autodetectTimer := metrics.GetTimer("autodetect.duration", false, project.Path).Start()
-	defer autodetectTimer.Stop()
 
 	pathOverrides := make([]hcl.PathOverrideConfig, len(ctx.Config.Autodetect.PathOverrides))
 	for i, override := range ctx.Config.Autodetect.PathOverrides {

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -470,9 +470,6 @@ func (p *HCLProvider) modulesToPlanJSON(rootModule *hcl.Module) ([]byte, error) 
 
 func (p *HCLProvider) marshalModule(module *hcl.Module) ModuleOut {
 
-	moduleTimer := metrics.GetTimer("hcl.MarshalModule", false, module.ModulePath).Start()
-	defer moduleTimer.Stop()
-
 	metrics.GetCounter("module.count", true).Inc()
 
 	moduleConfig := ModuleConfig{

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -470,7 +470,7 @@ func (p *HCLProvider) modulesToPlanJSON(rootModule *hcl.Module) ([]byte, error) 
 
 func (p *HCLProvider) marshalModule(module *hcl.Module) ModuleOut {
 
-	moduleTimer := metrics.GetTimer("hcl.MarshalModule", false, p.ctx.ProjectConfig.Path).Start()
+	moduleTimer := metrics.GetTimer("hcl.MarshalModule", false, module.ModulePath).Start()
 	defer moduleTimer.Stop()
 
 	metrics.GetCounter("module.count", true).Inc()

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -32,6 +32,7 @@ import (
 	hcl2 "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/infracost/infracost/internal/metrics"
 	"github.com/rs/zerolog"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -266,6 +267,10 @@ func (i *terragruntWorkingDirInfo) addWarning(pd *schema.ProjectDiag) {
 // LoadResources finds any Terragrunt projects, prepares them by downloading any required source files, then
 // process each with an HCLProvider.
 func (p *TerragruntHCLProvider) LoadResources(usage schema.UsageMap) ([]*schema.Project, error) {
+
+	loadResourcesTimer := metrics.GetTimer("terragrunt.LoadResources", false, p.ctx.ProjectConfig.Path).Start()
+	defer loadResourcesTimer.Stop()
+
 	dirs, err := p.prepWorkingDirs()
 	if err != nil {
 		return nil, err

--- a/internal/resources/google/artifact_registry_repository.go
+++ b/internal/resources/google/artifact_registry_repository.go
@@ -192,7 +192,7 @@ func (r *ArtifactRegistryRepository) toEgressFilters() []artifactRegistryEgressF
 
 	values := r.MonthlyEgressDataTransferGB.Values()
 
-	var data []artifactRegistryEgressFilters
+	data := make([]artifactRegistryEgressFilters, 0, len(values))
 	transferMap := make(map[string]int)
 
 	for _, region := range values {

--- a/internal/schema/project.go
+++ b/internal/schema/project.go
@@ -413,7 +413,7 @@ func (p *Project) AllResources() []*Resource {
 		}
 	}
 
-	var resources []*Resource
+	resources := make([]*Resource, 0, len(m))
 	for r := range m {
 		resources = append(resources, r)
 	}
@@ -434,7 +434,7 @@ func (p *Project) AllPartialResources() []*PartialResource {
 		}
 	}
 
-	var resources []*PartialResource
+	resources := make([]*PartialResource, 0, len(m))
 	for r := range m {
 		resources = append(resources, r)
 	}

--- a/internal/usage/usage_file.go
+++ b/internal/usage/usage_file.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/infracost/infracost/internal/metrics"
 	"github.com/pkg/errors"
 	"golang.org/x/mod/semver"
 	yamlv3 "gopkg.in/yaml.v3"
@@ -48,6 +49,8 @@ func CreateUsageFile(path string) error {
 }
 
 func LoadUsageFile(path string) (*UsageFile, error) {
+	loadUsageTimer := metrics.GetTimer("parallel_runner.load_usage.duration", false, path).Start()
+	defer loadUsageTimer.Stop()
 	blankUsage := NewBlankUsageFile()
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		logging.Logger.Debug().Msg("Specified usage file does not exist. Using a blank file")

--- a/internal/vcs/metadata.go
+++ b/internal/vcs/metadata.go
@@ -600,7 +600,7 @@ func (f *metadataFetcher) getFileChanges(path string, r *git.Repository, current
 		changedMap[change.To.Name] = struct{}{}
 	}
 
-	var changedFiles []string
+	changedFiles := make([]string, 0, len(changedMap))
 	for name := range changedMap {
 		if name == "" {
 			continue


### PR DESCRIPTION
- preallocates backing arrays for slices (where we know the max size)
- switches to adding graph edges individually, saving on memory and some redundant checks
- removes some unnecessary allocations
- swaps out a map+mutex combination to use sync.Map instead
- replaces a .AttributesAsMap()[attrName] with .GetAttribute(attrName)
- defines and uses a lightweight TopologicalWalk function which walks the graph in a more efficent way
- adds performance metrics (must be set in config to do this) which are written to a file for - analysis in the runner/api
- fixes a small bug with content of events we're recording
- fixed a bug with conflicting module downloads causing git process to hang/fail
- fixed module cache usage