### PR TITLE
feat: add prefer_folder_name_for_env autodetect config

### DIFF
--- a/cmd/infracost/testdata/generate/prefer_folder_name/expected.golden
+++ b/cmd/infracost/testdata/generate/prefer_folder_name/expected.golden
@@ -1,0 +1,20 @@
+version: 0.1
+
+projects:
+  - path: infra
+    name: infra-qa
+    terraform_var_files:
+      - envs/qa/prod.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - infra/**
+      - infra/envs/qa/prod.tfvars
+  - path: infra
+    name: infra-stg
+    terraform_var_files:
+      - envs/stg/dev.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - infra/**
+      - infra/envs/stg/dev.tfvars
+

--- a/cmd/infracost/testdata/generate/prefer_folder_name/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/prefer_folder_name/infracost.yml.tmpl
@@ -1,0 +1,8 @@
+version: 0.1
+autodetect:
+  env_names:
+    - qa
+    - dev
+    - prod
+    - stg
+  prefer_folder_name_for_env: true

--- a/cmd/infracost/testdata/generate/prefer_folder_name/tree.txt
+++ b/cmd/infracost/testdata/generate/prefer_folder_name/tree.txt
@@ -1,0 +1,8 @@
+.
+└── infra
+    ├── envs
+    │   ├── stg
+    │   │   └── dev.tfvars
+    │   └── qa
+    │       └── prod.tfvars
+    └── main.tf

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,19 @@ type AutodetectConfig struct {
 	// var files. This is useful when there are non-standard terraform var file
 	// names which use different extensions.
 	TerraformVarFileExtensions []string `yaml:"terraform_var_file_extensions,omitempty" ignored:"true"`
+	// PreferFolderNameForEnv tells the autodetect to prefer the folder name over the
+	// over a env specified in a tfvars file. For example, given the following
+	// folder structure:
+	//
+	// .
+	// ├── qa
+	// │   └── dev.tfvars
+	// └── staging
+	//     └── prod.tfvars
+	//
+	// If PreferFolderNameForEnv is true, then the autodetect will group the projects
+	// by the folder name so the projects will be named "qa" and "staging".
+	PreferFolderNameForEnv bool `yaml:"prefer_folder_name_for_env,omitempty" ignored:"true"`
 }
 
 type PathOverride struct {

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -76,6 +76,7 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 		MaxSearchDepth:             ctx.Config.Autodetect.MaxSearchDepth,
 		ForceProjectType:           ctx.Config.Autodetect.ForceProjectType,
 		TerraformVarFileExtensions: ctx.Config.Autodetect.TerraformVarFileExtensions,
+		PreferFolderNameForEnv:     ctx.Config.Autodetect.PreferFolderNameForEnv,
 	}
 
 	// if the config file path is set, we should set the project locator to use the


### PR DESCRIPTION
Adds new configuration field which allows users to specify how envs are inferred. Setting `prefer_folder_name_for_env: true` means that the envs are inferred from folder names rather than the terraform vars contained in that folder. This is to solve the case where customers have envs defined by folder names but also with coliding tfvar names e.g:

```
.
└── infra
    ├── envs
    │   ├── stg
    │   │   └── prod.tfvars
    │   └── qa
    │       └── prod.tfvars
    └── main.tf
```

This normally occurs if they have strange environment setup or they have mis spelled or copied a tfvar file.