### PR TITLE
feat: add detected env name to input vars/workspace

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -356,6 +356,11 @@ func TestBreakdownTerraformDirectoryWithRecursiveModules(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", dir}, &GoldenFileOptions{RunTerraformCLI: true})
 }
 
+func TestBreakdownTerraformProvidedDefaultEnvs(t *testing.T) {
+	dir := path.Join("./testdata", testutil.CalcGoldenFileTestdataDirName())
+	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--config-file", path.Join(dir, "infracost.yml")}, nil)
+}
+
 func TestBreakdownTerraformFieldsAll(t *testing.T) {
 	GoldenFileCommandTest(t, testutil.CalcGoldenFileTestdataDirName(), []string{"breakdown", "--path", "./testdata/example_plan.json", "--usage-file", "./testdata/example_usage.yml", "--fields", "all"}, nil)
 }

--- a/cmd/infracost/testdata/breakdown_terraform_provided_default_envs/breakdown_terraform_provided_default_envs.golden
+++ b/cmd/infracost/testdata/breakdown_terraform_provided_default_envs/breakdown_terraform_provided_default_envs.golden
@@ -1,0 +1,49 @@
+Project: dev
+Module path: REPLACED_PROJECT_PATH/testdata/breakdown_terraform_provided_default_envs/mod
+
+ Name                                                 Monthly Qty  Unit   Monthly Cost   
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, t2.micro)          730  hours         $8.47   
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                      50  GB            $5.00   
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                  1,000  GB          $125.00   
+    └─ Provisioned IOPS                                       800  IOPS         $52.00   
+                                                                                         
+ Project total                                                                 $190.47   
+
+──────────────────────────────────
+Project: prod
+Module path: REPLACED_PROJECT_PATH/testdata/breakdown_terraform_provided_default_envs/mod
+Workspace: stg
+
+ Name                                                 Monthly Qty  Unit   Monthly Cost   
+                                                                                         
+ aws_instance.web_app                                                                    
+ ├─ Instance usage (Linux/UNIX, on-demand, t3.large)          730  hours        $60.74   
+ ├─ root_block_device                                                                    
+ │  └─ Storage (general purpose SSD, gp2)                      50  GB            $5.00   
+ └─ ebs_block_device[0]                                                                  
+    ├─ Storage (provisioned IOPS SSD, io1)                  1,000  GB          $125.00   
+    └─ Provisioned IOPS                                       800  IOPS         $52.00   
+                                                                                         
+ Project total                                                                 $242.74   
+
+ OVERALL TOTAL                                                                $433.20 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ dev                                                ┃          $190 ┃           - ┃       $190 ┃
+┃ prod                                               ┃          $243 ┃           - ┃       $243 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
+
+Err:
+

--- a/cmd/infracost/testdata/breakdown_terraform_provided_default_envs/infracost.yml
+++ b/cmd/infracost/testdata/breakdown_terraform_provided_default_envs/infracost.yml
@@ -1,0 +1,8 @@
+version: 0.1
+
+projects:
+  - path: "./testdata/breakdown_terraform_provided_default_envs/mod"
+    name: "dev"
+  - path: "./testdata/breakdown_terraform_provided_default_envs/mod"
+    name: "prod"
+    terraform_workspace: "stg"

--- a/cmd/infracost/testdata/breakdown_terraform_provided_default_envs/mod/main.tf
+++ b/cmd/infracost/testdata/breakdown_terraform_provided_default_envs/mod/main.tf
@@ -1,0 +1,33 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+variable "env" {}
+
+locals {
+  instance_types = {
+    dev  = "t2.micro"
+    prod = "t3.medium"
+    stg  = "t3.large"
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = local.instance_types[var.env]
+
+  root_block_device {
+    volume_size = 50
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = 1000
+    iops        = 800
+  }
+}


### PR DESCRIPTION
adds the inferred env name as a starting variable input to the terraform project if no user workspace has been defined. This is preferable over using just the base "default" workspace.