### PR TITLE
fix: don't panic when truncating to negative lengths

### DIFF
--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -124,6 +124,10 @@ func formatTitleWithCurrency(title, currency string) string {
 }
 
 func truncateMiddle(s string, maxLen int, fill string) string {
+	if maxLen <= 0 {
+		return ""
+	}
+
 	r := []rune(s)
 
 	if len(r) <= maxLen {


### PR DESCRIPTION
Not sure how it's happening, but somehow the truncate calculation in markdown.go is passing in passing in negative maxLen.