### PR TITLE
feat(aws): add aws_cloudfront_function support

### DIFF
--- a/internal/providers/terraform/aws/cloudfront_function.go
+++ b/internal/providers/terraform/aws/cloudfront_function.go
@@ -1,0 +1,21 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/resources/aws"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getCloudfrontFunctionRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "aws_cloudfront_function",
+		CoreRFunc: newCloudfrontFunction,
+	}
+}
+
+func newCloudfrontFunction(d *schema.ResourceData) schema.CoreResource {
+	region := d.Region
+	return &aws.CloudfrontFunction{
+		Address: d.Address,
+		Region:  region,
+	}
+}

--- a/internal/providers/terraform/aws/cloudfront_function_test.go
+++ b/internal/providers/terraform/aws/cloudfront_function_test.go
@@ -1,0 +1,16 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestCloudfrontFunction(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "cloudfront_function_test")
+}

--- a/internal/providers/terraform/aws/registry.go
+++ b/internal/providers/terraform/aws/registry.go
@@ -123,6 +123,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getSchedulerScheduleRegistryItem(),
 	getPipesPipeRegistryItem(),
 	getCloudwatchEventTargetRegistryItem(),
+	getCloudfrontFunctionRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/aws/testdata/cloudfront_function_test/cloudfront_function_test.golden
+++ b/internal/providers/terraform/aws/testdata/cloudfront_function_test/cloudfront_function_test.golden
@@ -1,0 +1,19 @@
+
+ Name                                                Monthly Qty  Unit            Monthly Cost    
+                                                                                                  
+ aws_cloudfront_function.bibit_deeplink_cf_function                                               
+ └─ Total number of invocations                              0.2  1M invocations         $0.02  * 
+                                                                                                  
+ OVERALL TOTAL                                                                           $0.02 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+1 cloud resource was detected:
+∙ 1 was estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ main                                               ┃         $0.00 ┃       $0.02 ┃      $0.02 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/aws/testdata/cloudfront_function_test/cloudfront_function_test.tf
+++ b/internal/providers/terraform/aws/testdata/cloudfront_function_test/cloudfront_function_test.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  skip_region_validation      = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+# Add example resources for CloudfrontFunction below
+
+# resource "aws_cloudfront_function" "cloudfront_function" {
+# }
+resource "aws_cloudfront_function" "bibit_deeplink_cf_function" {
+  name    = "test_func"
+  runtime = "cloudfront-js-2.0"
+  comment = "Bibit Deeplink CF Function Script"
+  publish = true
+  code    = <<-EOT
+  async function handler(event) {
+      var request = event.request;
+      var uri = request.uri;
+      
+      // Check whether the URI is missing a file name.
+      if (uri.endsWith('/')) {
+          request.uri += 'index.html';
+      } 
+      // Check whether the URI is missing a file extension.
+      else if (!uri.includes('.')) {
+          request.uri += '/index.html';
+      }
+
+      return request;
+  }
+  EOT
+}

--- a/internal/providers/terraform/aws/testdata/cloudfront_function_test/cloudfront_function_test.usage.yml
+++ b/internal/providers/terraform/aws/testdata/cloudfront_function_test/cloudfront_function_test.usage.yml
@@ -1,0 +1,4 @@
+version: 0.1
+resource_usage:
+  aws_cloudfront_function:
+    monthly_requests: 200000

--- a/internal/resources/aws/cloudfront_function.go
+++ b/internal/resources/aws/cloudfront_function.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+// CloudfrontFunction struct represents an AWS CloudFront Function. With
+// CloudFront Functions, you can write lightweight functions in JavaScript
+// for high-scale, latency-sensitive CDN customizations.
+//
+// Resource information: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html
+// Pricing information: https://aws.amazon.com/cloudfront/pricing/
+type CloudfrontFunction struct {
+	Address string
+	Region  string
+
+	MonthlyRequests *int64 `infracost_usage:"monthly_requests"`
+}
+
+// CoreType returns the name of this resource type
+func (r *CloudfrontFunction) CoreType() string {
+	return "CloudfrontFunction"
+}
+
+// UsageSchema defines a list which represents the usage schema of CloudfrontFunction.
+func (r *CloudfrontFunction) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "MonthlyRequests", DefaultValue: 0, ValueType: schema.Int64},
+	}
+}
+
+// PopulateUsage parses the u schema.UsageData into the CloudfrontFunction.
+// It uses the `infracost_usage` struct tags to populate data into the CloudfrontFunction.
+func (r *CloudfrontFunction) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+// BuildResource builds a schema.Resource from a valid CloudfrontFunction struct.
+// This method is called after the resource is initialised by an IaC provider.
+// See providers folder for more information.
+func (r *CloudfrontFunction) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{}
+
+	costComponents = append(costComponents, r.monthlyRequestsCostComponent())
+
+	return &schema.Resource{
+		Name:           r.Address,
+		UsageSchema:    r.UsageSchema(),
+		CostComponents: costComponents,
+	}
+}
+
+func (r *CloudfrontFunction) monthlyRequestsCostComponent() *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "Total number of invocations",
+		Unit:            "1M invocations",
+		UnitMultiplier:  decimal.NewFromInt(1000000),
+		MonthlyQuantity: intPtrToDecimalPtr(r.MonthlyRequests),
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Service:       strPtr("AmazonCloudFront"),
+			ProductFamily: strPtr("Request"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "usagetype", Value: strPtr("Executions-CloudFrontFunctions")},
+				{Key: "groupDescription", ValueRegex: regexPtr("CloudFront Function")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("on_demand"),
+			StartUsageAmount: strPtr("2000000"),
+		},
+		UsageBased: true,
+	}
+}


### PR DESCRIPTION
## Objective:

Add support for AWS CloudFront Function. Fixes #3268.

## Pricing details:

I am using https://aws.amazon.com/cloudfront/pricing/ as the source of my calculation. To calculate the price, users have to sum their cloudfront distribution requests, and multiply it with existing AWS prices which is $0.1 per 1M invocations / request. The difficult thing is that this resource is not on AWS Pricing calculator yet.

## Status:

- [x] Generated the resource files
- [x] Updated the internal/resources file
- [x] Updated the internal/provider/terraform/.../resources file
- [x] Added usage parameters to infracost-usage-example.yml
- [ ] Added test cases without usage-file
- [x] Added test cases with usage-file
- [x] Compared test case output to cloud cost calculator
- [x] Created a PR to update "Supported Resources" in the [docs](https://github.com/infracost/docs/pull/683)

## Issues:

Fix #3268 