### PR TITLE
enhance: update URL normalizing to work with both SSH and HTTPS URLs

### DIFF
--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 
+	giturls "github.com/chainguard-dev/git-urls"
 	"github.com/infracost/infracost/internal/metrics"
 	"github.com/infracost/infracost/internal/schema"
 
@@ -603,7 +604,7 @@ func (p *HCLProvider) getResourceOutput(block *hcl.Block, moduleSourceURL string
 }
 
 func buildModuleFilename(filename string, moduleSourceURL string) string {
-	httpsURL, err := transformSSHToHTTPS(moduleSourceURL)
+	httpsURL, err := normalizeModuleURL(moduleSourceURL)
 	if err != nil {
 		logging.Logger.Debug().Err(err).Msgf("failed to build module filename, could not transform url %s to https", moduleSourceURL)
 		return ""
@@ -628,42 +629,35 @@ func buildModuleFilename(filename string, moduleSourceURL string) string {
 	return moduleFilename
 }
 
-func transformSSHToHTTPS(sshURL string) (string, error) {
-	if !strings.HasPrefix(sshURL, "git@") {
-		// nothing to do, the URL is not an SSH URL
-		return sshURL, nil
+func normalizeModuleURL(sshURL string) (string, error) {
+	// git::ssh and git:https aren't recognized as a valid URL scheme, so we need to strip it so they just use ssh or https schemes
+	u := sshURL
+	if strings.HasPrefix(sshURL, "git::") {
+		u = strings.Replace(sshURL, "git::", "", 1)
 	}
 
-	colonCount := strings.Count(sshURL, ":")
-	var domainAndPort, path string
-
-	switch colonCount {
-	case 1:
-		components := strings.SplitN(sshURL, ":", 2)
-		userAndDomain := strings.Split(components[0], "@")
-		if len(userAndDomain) != 2 {
-			return "", fmt.Errorf("invalid SSH URL format")
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		// Try parsing it as a git URL
+		parsedURL, err = giturls.Parse(u)
+		if err != nil {
+			return "", err
 		}
-		domainAndPort = userAndDomain[1]
-		path = components[1]
-	case 2:
-		// case with a port in the url
-		components := strings.SplitN(sshURL, ":", 3)
-		userAndDomain := strings.Split(components[0], "@")
-		if len(userAndDomain) != 2 {
-			return "", fmt.Errorf("invalid SSH URL format")
-		}
-		domainAndPort = userAndDomain[1]
-		path = components[2]
-	default:
-		return "", fmt.Errorf("invalid SSH URL format")
 	}
 
-	// remove port if it exists
-	domainComponents := strings.SplitN(domainAndPort, ":", 2)
-	domain := domainComponents[0]
+	// Save the query string, since this is lost when we normalize the URL
+	// and it may contain the ref
+	query := parsedURL.Query()
 
-	return strings.TrimSuffix(fmt.Sprintf("https://%s/%s", domain, path), "/"), nil
+	res, err := modules.NormalizeGitURLToHTTPS(parsedURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Add the query string back in
+	res.RawQuery = query.Encode()
+
+	return res.String(), nil
 }
 
 func (p *HCLProvider) marshalProviderBlock(block *hcl.Block) string {

--- a/internal/providers/terraform/hcl_provider_test.go
+++ b/internal/providers/terraform/hcl_provider_test.go
@@ -292,29 +292,34 @@ func TestHCLProvider_LoadPlanJSON(t *testing.T) {
 	}
 }
 
-func TestTransformSSHToHTTPS(t *testing.T) {
+func TestNormalizeModuleURL(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected string
 	}{
-		{"git@github.com:user/repo.git", "https://github.com/user/repo.git"},
-		{"git@gitlab.com:group/project.git", "https://gitlab.com/group/project.git"},
-		{"git@bitbucket.org:team/repo.git", "https://bitbucket.org/team/repo.git"},
-		{"git@myserver.com:2222:user/repo.git", "https://myserver.com/user/repo.git"},                                    // with port
-		{"git@ssh.dev.azure.com:v3/organization/project/repo", "https://ssh.dev.azure.com/v3/organization/project/repo"}, // Azure Repos
-		{"invalid-url", "invalid-url"},                                     // invalid SSH URL
-		{"user@github.com:user/repo.git", "user@github.com:user/repo.git"}, // unexpected username
+		{"git@github.com:user/repo.git", "https://github.com/user/repo"},
+		{"git@gitlab.com:group/project.git", "https://gitlab.com/group/project"},
+		{"git@bitbucket.org:team/repo.git", "https://bitbucket.org/team/repo"},
+		{"git@ssh.dev.azure.com:v3/organization/project/repo", "https://dev.azure.com/organization/project/_git/repo"}, // Azure Repos
+		{"user@github.com:user/repo.git", "https://github.com/user/repo"},                                              // ssh with custom username
+		{"ssh://git@myserver.com:2222/user/repo.git", "https://myserver.com/user/repo"},                                // with port
+		{"git+ssh://git@myserver.com/user/repo.git", "https://myserver.com/user/repo"},                                 // with git+ssh
+		{"git::ssh://git@myserver.com/user/repo.git", "https://myserver.com/user/repo"},                                // with git::ssh
+		{"https://github.com/user/repo.git", "https://github.com/user/repo"},                                           // https
+		{"https://user@myserver.com/user/repo.git", "https://myserver.com/user/repo"},                                  // https with username
+		{"git::https://github.com/user/repo.git", "https://github.com/user/repo"},                                      // git::https
+		{"git::ssh://git@myserver.com/user/repo.git?ref=a094835", "https://myserver.com/user/repo?ref=a094835"},        // git::ssh with ref
 	}
 
 	for _, test := range tests {
-		output, err := transformSSHToHTTPS(test.input)
+		output, err := normalizeModuleURL(test.input)
 		if err != nil {
 			if test.expected != "" {
-				t.Errorf("transformSSHToHTTPS(%q) returned an error: %v", test.input, err)
+				t.Errorf("normalizeModuleURL(%q) returned an error: %v", test.input, err)
 			}
 		} else {
 			if !reflect.DeepEqual(output, test.expected) {
-				t.Errorf("transformSSHToHTTPS(%q) = %q, want %q", test.input, output, test.expected)
+				t.Errorf("normalizeModuleURL(%q) = %q, want %q", test.input, output, test.expected)
 			}
 		}
 	}

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -803,7 +803,7 @@ func forceHttpsDownload(sourceURL string, opts *tgoptions.TerragruntOptions, ter
 		return false
 	}
 
-	newUrl, err := modules.TransformSSHToHttps(u)
+	newUrl, err := modules.NormalizeGitURLToHTTPS(u)
 	if err != nil {
 		return false
 	}

--- a/internal/providers/terraform/testdata/hcl_provider_test/adds_source_url_from_remote_module/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/adds_source_url_from_remote_module/expected.json
@@ -66,15 +66,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_acl.this",
-                      "startLine": 66,
-                      "endLine": 103
+                      "startLine": 65,
+                      "endLine": 102
                     }
                   ],
                   "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                  "endLine": 103,
+                  "endLine": 102,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 66
+                  "startLine": 65
                 }
               },
               {
@@ -103,15 +103,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 924,
-                      "endLine": 939
+                      "startLine": 922,
+                      "endLine": 937
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 939,
+                  "endLine": 937,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 924
+                  "startLine": 922
                 }
               },
               {
@@ -139,15 +139,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 913,
-                      "endLine": 922
+                      "startLine": 911,
+                      "endLine": 920
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 922,
+                  "endLine": 920,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 913
+                  "startLine": 911
                 }
               },
               {
@@ -179,15 +179,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_versioning.this",
-                      "startLine": 160,
-                      "endLine": 174
+                      "startLine": 159,
+                      "endLine": 173
                     }
                   ],
                   "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                  "endLine": 174,
+                  "endLine": 173,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 160
+                  "startLine": 159
                 }
               }
             ],
@@ -254,15 +254,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_acl.this",
-                      "startLine": 66,
-                      "endLine": 103
+                      "startLine": 65,
+                      "endLine": 102
                     }
                   ],
                   "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                  "endLine": 103,
+                  "endLine": 102,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 66
+                  "startLine": 65
                 }
               },
               {
@@ -291,15 +291,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 924,
-                      "endLine": 939
+                      "startLine": 922,
+                      "endLine": 937
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 939,
+                  "endLine": 937,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 924
+                  "startLine": 922
                 }
               },
               {
@@ -327,15 +327,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 913,
-                      "endLine": 922
+                      "startLine": 911,
+                      "endLine": 920
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 922,
+                  "endLine": 920,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 913
+                  "startLine": 911
                 }
               },
               {
@@ -367,15 +367,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_versioning.this",
-                      "startLine": 160,
-                      "endLine": 174
+                      "startLine": 159,
+                      "endLine": 173
                     }
                   ],
                   "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                  "endLine": 174,
+                  "endLine": 173,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 160
+                  "startLine": 159
                 }
               }
             ],
@@ -507,15 +507,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_acl.this",
-                      "startLine": 66,
-                      "endLine": 103
+                      "startLine": 65,
+                      "endLine": 102
                     }
                   ],
                   "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                  "endLine": 103,
+                  "endLine": 102,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 66
+                  "startLine": 65
                 }
               },
               {
@@ -544,15 +544,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 924,
-                      "endLine": 939
+                      "startLine": 922,
+                      "endLine": 937
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 939,
+                  "endLine": 937,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 924
+                  "startLine": 922
                 }
               },
               {
@@ -580,15 +580,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 913,
-                      "endLine": 922
+                      "startLine": 911,
+                      "endLine": 920
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 922,
+                  "endLine": 920,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 913
+                  "startLine": 911
                 }
               },
               {
@@ -620,15 +620,15 @@
                     {
                       "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_versioning.this",
-                      "startLine": 160,
-                      "endLine": 174
+                      "startLine": 159,
+                      "endLine": 173
                     }
                   ],
                   "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                  "endLine": 174,
+                  "endLine": 173,
                   "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 160
+                  "startLine": 159
                 }
               }
             ],
@@ -890,15 +890,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_acl.this",
-                    "startLine": 66,
-                    "endLine": 103
+                    "startLine": 65,
+                    "endLine": 102
                   }
                 ],
                 "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                "endLine": 103,
+                "endLine": 102,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 66
+                "startLine": 65
               }
             },
             {
@@ -927,15 +927,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 924,
-                    "endLine": 939
+                    "startLine": 922,
+                    "endLine": 937
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 939,
+                "endLine": 937,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 924
+                "startLine": 922
               }
             },
             {
@@ -963,15 +963,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 913,
-                    "endLine": 922
+                    "startLine": 911,
+                    "endLine": 920
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 922,
+                "endLine": 920,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 913
+                "startLine": 911
               }
             },
             {
@@ -1003,15 +1003,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_versioning.this",
-                    "startLine": 160,
-                    "endLine": 174
+                    "startLine": 159,
+                    "endLine": 173
                   }
                 ],
                 "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                "endLine": 174,
+                "endLine": 173,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 160
+                "startLine": 159
               }
             }
           ],
@@ -1078,15 +1078,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_acl.this",
-                    "startLine": 66,
-                    "endLine": 103
+                    "startLine": 65,
+                    "endLine": 102
                   }
                 ],
                 "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                "endLine": 103,
+                "endLine": 102,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 66
+                "startLine": 65
               }
             },
             {
@@ -1115,15 +1115,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 924,
-                    "endLine": 939
+                    "startLine": 922,
+                    "endLine": 937
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 939,
+                "endLine": 937,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 924
+                "startLine": 922
               }
             },
             {
@@ -1151,15 +1151,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 913,
-                    "endLine": 922
+                    "startLine": 911,
+                    "endLine": 920
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 922,
+                "endLine": 920,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 913
+                "startLine": 911
               }
             },
             {
@@ -1191,15 +1191,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_versioning.this",
-                    "startLine": 160,
-                    "endLine": 174
+                    "startLine": 159,
+                    "endLine": 173
                   }
                 ],
                 "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                "endLine": 174,
+                "endLine": 173,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 160
+                "startLine": 159
               }
             }
           ],
@@ -1331,15 +1331,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_acl.this",
-                    "startLine": 66,
-                    "endLine": 103
+                    "startLine": 65,
+                    "endLine": 102
                   }
                 ],
                 "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                "endLine": 103,
+                "endLine": 102,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 66
+                "startLine": 65
               }
             },
             {
@@ -1368,15 +1368,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 924,
-                    "endLine": 939
+                    "startLine": 922,
+                    "endLine": 937
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 939,
+                "endLine": 937,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 924
+                "startLine": 922
               }
             },
             {
@@ -1404,15 +1404,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 913,
-                    "endLine": 922
+                    "startLine": 911,
+                    "endLine": 920
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 922,
+                "endLine": 920,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 913
+                "startLine": 911
               }
             },
             {
@@ -1444,15 +1444,15 @@
                   {
                     "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_versioning.this",
-                    "startLine": 160,
-                    "endLine": 174
+                    "startLine": 159,
+                    "endLine": 173
                   }
                 ],
                 "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                "endLine": 174,
+                "endLine": 173,
                 "filename": "testdata/hcl_provider_test/adds_source_url_from_remote_module/.infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 160
+                "startLine": 159
               }
             }
           ],

--- a/internal/providers/terraform/testdata/hcl_provider_test/adds_source_url_from_remote_module_chdir/expected.json
+++ b/internal/providers/terraform/testdata/hcl_provider_test/adds_source_url_from_remote_module_chdir/expected.json
@@ -66,15 +66,15 @@
                     {
                       "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_acl.this",
-                      "startLine": 66,
-                      "endLine": 103
+                      "startLine": 65,
+                      "endLine": 102
                     }
                   ],
                   "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                  "endLine": 103,
+                  "endLine": 102,
                   "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 66
+                  "startLine": 65
                 }
               },
               {
@@ -103,15 +103,15 @@
                     {
                       "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 924,
-                      "endLine": 939
+                      "startLine": 922,
+                      "endLine": 937
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 939,
+                  "endLine": 937,
                   "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 924
+                  "startLine": 922
                 }
               },
               {
@@ -139,15 +139,15 @@
                     {
                       "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 913,
-                      "endLine": 922
+                      "startLine": 911,
+                      "endLine": 920
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 922,
+                  "endLine": 920,
                   "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 913
+                  "startLine": 911
                 }
               },
               {
@@ -179,15 +179,15 @@
                     {
                       "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                       "blockName": "aws_s3_bucket_versioning.this",
-                      "startLine": 160,
-                      "endLine": 174
+                      "startLine": 159,
+                      "endLine": 173
                     }
                   ],
                   "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                  "endLine": 174,
+                  "endLine": 173,
                   "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 160
+                  "startLine": 159
                 }
               }
             ],
@@ -254,15 +254,15 @@
                     {
                       "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_acl.this",
-                      "startLine": 66,
-                      "endLine": 103
+                      "startLine": 65,
+                      "endLine": 102
                     }
                   ],
                   "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                  "endLine": 103,
+                  "endLine": 102,
                   "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 66
+                  "startLine": 65
                 }
               },
               {
@@ -291,15 +291,15 @@
                     {
                       "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 924,
-                      "endLine": 939
+                      "startLine": 922,
+                      "endLine": 937
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 939,
+                  "endLine": 937,
                   "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 924
+                  "startLine": 922
                 }
               },
               {
@@ -327,15 +327,15 @@
                     {
                       "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 913,
-                      "endLine": 922
+                      "startLine": 911,
+                      "endLine": 920
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 922,
+                  "endLine": 920,
                   "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 913
+                  "startLine": 911
                 }
               },
               {
@@ -367,15 +367,15 @@
                     {
                       "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                       "blockName": "aws_s3_bucket_versioning.this",
-                      "startLine": 160,
-                      "endLine": 174
+                      "startLine": 159,
+                      "endLine": 173
                     }
                   ],
                   "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                  "endLine": 174,
+                  "endLine": 173,
                   "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                  "startLine": 160
+                  "startLine": 159
                 }
               }
             ],
@@ -507,15 +507,15 @@
                     {
                       "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_acl.this",
-                      "startLine": 66,
-                      "endLine": 103
+                      "startLine": 65,
+                      "endLine": 102
                     }
                   ],
                   "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                  "endLine": 103,
+                  "endLine": 102,
                   "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 66
+                  "startLine": 65
                 }
               },
               {
@@ -544,15 +544,15 @@
                     {
                       "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_ownership_controls.this",
-                      "startLine": 924,
-                      "endLine": 939
+                      "startLine": 922,
+                      "endLine": 937
                     }
                   ],
                   "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                  "endLine": 939,
+                  "endLine": 937,
                   "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 924
+                  "startLine": 922
                 }
               },
               {
@@ -580,15 +580,15 @@
                     {
                       "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_public_access_block.this",
-                      "startLine": 913,
-                      "endLine": 922
+                      "startLine": 911,
+                      "endLine": 920
                     }
                   ],
                   "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                  "endLine": 922,
+                  "endLine": 920,
                   "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 913
+                  "startLine": 911
                 }
               },
               {
@@ -620,15 +620,15 @@
                     {
                       "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                       "blockName": "aws_s3_bucket_versioning.this",
-                      "startLine": 160,
-                      "endLine": 174
+                      "startLine": 159,
+                      "endLine": 173
                     }
                   ],
                   "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                  "endLine": 174,
+                  "endLine": 173,
                   "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                   "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                  "startLine": 160
+                  "startLine": 159
                 }
               }
             ],
@@ -890,15 +890,15 @@
                   {
                     "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_acl.this",
-                    "startLine": 66,
-                    "endLine": 103
+                    "startLine": 65,
+                    "endLine": 102
                   }
                 ],
                 "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                "endLine": 103,
+                "endLine": 102,
                 "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 66
+                "startLine": 65
               }
             },
             {
@@ -927,15 +927,15 @@
                   {
                     "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 924,
-                    "endLine": 939
+                    "startLine": 922,
+                    "endLine": 937
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 939,
+                "endLine": 937,
                 "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 924
+                "startLine": 922
               }
             },
             {
@@ -963,15 +963,15 @@
                   {
                     "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 913,
-                    "endLine": 922
+                    "startLine": 911,
+                    "endLine": 920
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 922,
+                "endLine": 920,
                 "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 913
+                "startLine": 911
               }
             },
             {
@@ -1003,15 +1003,15 @@
                   {
                     "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                     "blockName": "aws_s3_bucket_versioning.this",
-                    "startLine": 160,
-                    "endLine": 174
+                    "startLine": 159,
+                    "endLine": 173
                   }
                 ],
                 "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                "endLine": 174,
+                "endLine": 173,
                 "filename": ".infracost/terraform_modules/30b695ab2291e2ded2ac2e47e63b88e6/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 160
+                "startLine": 159
               }
             }
           ],
@@ -1078,15 +1078,15 @@
                   {
                     "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_acl.this",
-                    "startLine": 66,
-                    "endLine": 103
+                    "startLine": 65,
+                    "endLine": 102
                   }
                 ],
                 "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                "endLine": 103,
+                "endLine": 102,
                 "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 66
+                "startLine": 65
               }
             },
             {
@@ -1115,15 +1115,15 @@
                   {
                     "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 924,
-                    "endLine": 939
+                    "startLine": 922,
+                    "endLine": 937
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 939,
+                "endLine": 937,
                 "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 924
+                "startLine": 922
               }
             },
             {
@@ -1151,15 +1151,15 @@
                   {
                     "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 913,
-                    "endLine": 922
+                    "startLine": 911,
+                    "endLine": 920
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 922,
+                "endLine": 920,
                 "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 913
+                "startLine": 911
               }
             },
             {
@@ -1191,15 +1191,15 @@
                   {
                     "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                     "blockName": "aws_s3_bucket_versioning.this",
-                    "startLine": 160,
-                    "endLine": 174
+                    "startLine": 159,
+                    "endLine": 173
                   }
                 ],
                 "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                "endLine": 174,
+                "endLine": 173,
                 "filename": ".infracost/terraform_modules/2d1f98832c35b580d7d2ddad6b43dc8a/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/v4.1.1/main.tf",
-                "startLine": 160
+                "startLine": 159
               }
             }
           ],
@@ -1331,15 +1331,15 @@
                   {
                     "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_acl.this",
-                    "startLine": 66,
-                    "endLine": 103
+                    "startLine": 65,
+                    "endLine": 102
                   }
                 ],
                 "checksum": "2a79b34cee7ece7b7a5231adf7ebbf8efc9b246e0b02c43ff0857bb70742ac53",
-                "endLine": 103,
+                "endLine": 102,
                 "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 66
+                "startLine": 65
               }
             },
             {
@@ -1368,15 +1368,15 @@
                   {
                     "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_ownership_controls.this",
-                    "startLine": 924,
-                    "endLine": 939
+                    "startLine": 922,
+                    "endLine": 937
                   }
                 ],
                 "checksum": "30169ea40fd2d6891c592ed40354fe60e9dd50d530309030802fafc49eb3f9bb",
-                "endLine": 939,
+                "endLine": 937,
                 "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 924
+                "startLine": 922
               }
             },
             {
@@ -1404,15 +1404,15 @@
                   {
                     "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_public_access_block.this",
-                    "startLine": 913,
-                    "endLine": 922
+                    "startLine": 911,
+                    "endLine": 920
                   }
                 ],
                 "checksum": "37c21c291bc3f8b8e8594a769ba27d4c164473569562b3f4fc7661e58d8e6917",
-                "endLine": 922,
+                "endLine": 920,
                 "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 913
+                "startLine": 911
               }
             },
             {
@@ -1444,15 +1444,15 @@
                   {
                     "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                     "blockName": "aws_s3_bucket_versioning.this",
-                    "startLine": 160,
-                    "endLine": 174
+                    "startLine": 159,
+                    "endLine": 173
                   }
                 ],
                 "checksum": "d87dc101b6296498b9a2114efae840b7b1b1173c2e10fa9b312ae39df0142db5",
-                "endLine": 174,
+                "endLine": 173,
                 "filename": ".infracost/terraform_modules/32fe3779b4dcd7ba3d9f5ca25112691d/main.tf",
                 "moduleFilename": "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/HEAD/main.tf",
-                "startLine": 160
+                "startLine": 159
               }
             }
           ],


### PR DESCRIPTION
* It now works with converting between Azure Devops SSH URLs to HTTPS URLS
* It now strips users from HTTPS URLs
* There's shared logic between using it for forcing HTTPS downloads and generating module HTTPS URLs