### PR TITLE
fix: vars causing unknown keys

### DIFF
--- a/cmd/infracost/breakdown_test.go
+++ b/cmd/infracost/breakdown_test.go
@@ -214,6 +214,29 @@ func TestBreakdownFormatJsonPropagateDefaultsToVolumeTags(t *testing.T) {
 	)
 }
 
+func TestBreakdownFormatJsonMissingDefaultTags(t *testing.T) {
+	testName := testutil.CalcGoldenFileTestdataDirName()
+	dir := path.Join("./testdata", testName)
+
+	GoldenFileCommandTest(
+		t,
+		testName,
+		[]string{
+			"breakdown",
+			"--format", "json",
+			"--config-file", path.Join(dir, "config.yml"),
+		},
+		&GoldenFileOptions{
+			CaptureLogs: true,
+			IsJSON:      true,
+			JSONInclude: regexp.MustCompile("^(name|missingVarsCausingUnknownDefaultTagKeys)$"),
+			JSONExclude: regexp.MustCompile("^(costComponents|metadata|pastBreakdown|subresources)$"),
+		}, func(ctx *config.RunContext) {
+			ctx.Config.TagPoliciesEnabled = true
+		},
+	)
+}
+
 func TestBreakdownFormatJSONShowSkipped(t *testing.T) {
 	opts := DefaultOptions()
 	opts.IsJSON = true

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/breakdown_format_json_missing_default_tags.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/breakdown_format_json_missing_default_tags.golden
@@ -4,6 +4,19 @@
       "breakdown": {
         "resources": [
           {
+            "missingVarsCausingUnknownDefaultTagKeys": [
+              "var.tags"
+            ],
+            "name": "aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var_tag_key"
+    },
+    {
+      "breakdown": {
+        "resources": [
+          {
             "name": "module.mymod.aws_instance.web_app"
           }
         ]
@@ -79,6 +92,9 @@
         ]
       },
       "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var"
+    },
+    {
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var_tag_key"
     }
   ]
 }
@@ -86,4 +102,6 @@ Err:
 
 
 Logs:
+WARN Input values were not provided for following Terraform variables: "variable.tags". Use --terraform-var-file or --terraform-var to specify them.
+WARN Input values were not provided for following Terraform variables: "variable.tags". Use --terraform-var-file or --terraform-var to specify them.
 WARN Input values were not provided for following Terraform variables: "variable.tags". Use --terraform-var-file or --terraform-var to specify them.

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/breakdown_format_json_missing_default_tags.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/breakdown_format_json_missing_default_tags.golden
@@ -94,7 +94,14 @@
       "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var"
     },
     {
-      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var_tag_key"
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var_tag_key"
     }
   ]
 }

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/breakdown_format_json_missing_default_tags.golden
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/breakdown_format_json_missing_default_tags.golden
@@ -1,0 +1,89 @@
+{
+  "projects": [
+    {
+      "breakdown": {
+        "resources": [
+          {
+            "name": "module.mymod.aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_module_var"
+    },
+    {
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var"
+    },
+    {
+      "breakdown": {
+        "resources": [
+          {
+            "name": "module.mymod.aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_required_module_var"
+    },
+    {
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_var"
+    },
+    {
+      "breakdown": {
+        "resources": [
+          {
+            "name": "module.mymod.aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_module_var"
+    },
+    {
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var"
+    },
+    {
+      "breakdown": {
+        "resources": [
+          {
+            "name": "module.mymod.aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_module_var"
+    },
+    {
+      "breakdown": {
+        "resources": [
+          {
+            "name": "aws_instance.web_app"
+          }
+        ]
+      },
+      "name": "REPLACED_PROJECT_PATH/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var"
+    }
+  ]
+}
+Err:
+
+
+Logs:
+WARN Input values were not provided for following Terraform variables: "variable.tags". Use --terraform-var-file or --terraform-var to specify them.

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/config.yml
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/config.yml
@@ -1,17 +1,19 @@
 version: 0.1
 
 projects:
-  # these projects should have the missingVarsCausingUnknownDefaultTagKeys list on their resources
+  # this project should have the missingVarsCausingUnknownDefaultTagKeys list on its resources
+  - path: ./testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var_tag_key
+  
+  # these projects should not have the missingVarsCausingUnknownDefaultTagKeys list on their resources
   - path: ./testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_module_var
   - path: ./testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var
   - path: ./testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_required_module_var
   - path: ./testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_var
-
-  # these projects should not have the missingVarsCausingUnknownDefaultTagKeys list on their resources
   - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_module_var
   - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var
   - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_module_var
   - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var
+  - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var_tag_key
     terraform_vars:
       tags:
         t1: k1

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/config.yml
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/config.yml
@@ -1,0 +1,17 @@
+version: 0.1
+
+projects:
+  # these projects should have the missingVarsCausingUnknownDefaultTagKeys list on their resources
+  - path: ./testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_module_var
+  - path: ./testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var
+  - path: ./testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_required_module_var
+  - path: ./testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_var
+
+  # these projects should not have the missingVarsCausingUnknownDefaultTagKeys list on their resources
+  - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_module_var
+  - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var
+  - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_module_var
+  - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var
+    terraform_vars:
+      tags:
+        t1: k1

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/config.yml
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/config.yml
@@ -13,7 +13,7 @@ projects:
   - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var
   - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_module_var
   - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var
-  - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var_tag_key
+  - path: ./testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var_tag_key
     terraform_vars:
       tags:
         t1: k1

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_module_var/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_module_var/main.tf
@@ -1,0 +1,4 @@
+module "mymod" {
+  source     = "./module"
+  aws_region = "us-east-1"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_module_var/module/module.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_module_var/module/module.tf
@@ -1,0 +1,19 @@
+variable "tags" {
+  type = map(string)
+}
+
+variable "aws_region" {
+  type = string
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = var.tags
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var/main.tf
@@ -1,0 +1,15 @@
+variable "tags" {
+  type = map(string)
+}
+
+provider "aws" {
+  region = "us-east-1"
+  default_tags {
+    tags = var.tags
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var_tag_key/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var_tag_key/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = merge({
-        Name = "web_app"
+      Name = "web_app"
     }, var.tags)
   }
 }

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var_tag_key/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/missing_required_var_tag_key/main.tf
@@ -1,0 +1,17 @@
+variable "tags" {
+  type = map(string)
+}
+
+provider "aws" {
+  region = "us-east-1"
+  default_tags {
+    tags = merge({
+        Name = "web_app"
+    }, var.tags)
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_required_module_var/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_required_module_var/main.tf
@@ -1,0 +1,5 @@
+module "mymod" {
+  source     = "./module"
+  aws_region = "us-east-1"
+  tags       = local.unknown_var
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_required_module_var/module/module.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_required_module_var/module/module.tf
@@ -1,0 +1,19 @@
+variable "tags" {
+  type = map(string)
+}
+
+variable "aws_region" {
+  type = string
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = var.tags
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_var/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/with_missing_default_tags_flag/unknown_var/main.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = "us-east-1"
+  default_tags {
+    tags = var.unknown_var
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_module_var/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_module_var/main.tf
@@ -1,0 +1,4 @@
+module "mymod" {
+  source     = "./module"
+  aws_region = "us-east-1"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_module_var/module/module.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_module_var/module/module.tf
@@ -1,0 +1,20 @@
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "aws_region" {
+  type = string
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = var.tags
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var/main.tf
@@ -1,0 +1,16 @@
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+provider "aws" {
+  region = "us-east-1"
+  default_tags {
+    tags = var.tags
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var_tag_key/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var_tag_key/main.tf
@@ -1,0 +1,18 @@
+variable "tags" {
+  type = map(string)
+  default = {}
+}
+
+provider "aws" {
+  region = "us-east-1"
+  default_tags {
+    tags = merge({
+        Name = "web_app"
+    }, var.tags)
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var_tag_key/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/default_var_tag_key/main.tf
@@ -1,5 +1,5 @@
 variable "tags" {
-  type = map(string)
+  type    = map(string)
   default = {}
 }
 
@@ -7,7 +7,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = merge({
-        Name = "web_app"
+      Name = "web_app"
     }, var.tags)
   }
 }

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_module_var/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_module_var/main.tf
@@ -1,0 +1,7 @@
+module "mymod" {
+  source     = "./module"
+  aws_region = "us-east-1"
+  tags = {
+    T1 = "V1"
+  }
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_module_var/module/module.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_module_var/module/module.tf
@@ -1,0 +1,20 @@
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "aws_region" {
+  type = string
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = var.tags
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var/main.tf
+++ b/cmd/infracost/testdata/breakdown_format_json_missing_default_tags/without_missing_default_tags_flag/present_var/main.tf
@@ -1,0 +1,15 @@
+variable "tags" {
+  type = map(string)
+}
+
+provider "aws" {
+  region = "us-east-1"
+  default_tags {
+    tags = var.tags
+  }
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = "m5.4xlarge"
+}

--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -287,6 +287,14 @@ func (attr *Attribute) value(retry int) (ctyVal cty.Value) {
 		}
 	}()
 
+	if len(attr.varsCausingUnknownKeys) > 0 {
+		// Reset this here because in some cases (e.g. when initially evaluating a provider block
+		// we can flag variables as missing even though they will later be evaluated correctly.
+		// This should be ok because any vars that should remain in this list will be added again.
+		attr.Logger.Trace().Msgf("Resetting 'varsCausingUnkownKeys for attr: %s. vars: %v", attr.Name(), attr.varsCausingUnknownKeys)
+		attr.varsCausingUnknownKeys = nil
+	}
+
 	var diag hcl.Diagnostics
 	ctyVal, diag = attr.HCLAttr.Expr.Value(attr.Ctx.Inner())
 	if diag.HasErrors() {


### PR DESCRIPTION
This adds test cases and an idea I had for fixing for tag policy errors not triggering when they should (false negative). Unfortunately the fix doesn't work and the test cases don't do what I expect.

@liamg Could you take a look at the tess and give some help on sorting out in what cases we should see the `missingVarsCausingUnknownDefaultTagKeys` flag set on resources?
 