### PR TITLE
fix: duplicate projects with force with invalid project

### DIFF
--- a/cmd/infracost/testdata/generate/force_project_type_no_valid_project/expected-tree.golden
+++ b/cmd/infracost/testdata/generate/force_project_type_no_valid_project/expected-tree.golden
@@ -1,0 +1,3 @@
+└── dup (terraform)
+    ├── dev.tfvars
+    └── prod.tfvars

--- a/cmd/infracost/testdata/generate/force_project_type_no_valid_project/expected.golden
+++ b/cmd/infracost/testdata/generate/force_project_type_no_valid_project/expected.golden
@@ -1,0 +1,20 @@
+version: 0.1
+
+projects:
+  - path: dup
+    name: dup-dev
+    terraform_var_files:
+      - dev.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - dup/**
+      - dup/dev.tfvars
+  - path: dup
+    name: dup-prod
+    terraform_var_files:
+      - prod.tfvars
+    skip_autodetect: true
+    dependency_paths:
+      - dup/**
+      - dup/prod.tfvars
+

--- a/cmd/infracost/testdata/generate/force_project_type_no_valid_project/infracost.yml.tmpl
+++ b/cmd/infracost/testdata/generate/force_project_type_no_valid_project/infracost.yml.tmpl
@@ -1,0 +1,3 @@
+version: 0.1
+autodetect:
+  force_project_type: terraform

--- a/cmd/infracost/testdata/generate/force_project_type_no_valid_project/tree.txt
+++ b/cmd/infracost/testdata/generate/force_project_type_no_valid_project/tree.txt
@@ -1,0 +1,6 @@
+.
+└── dup
+    ├── terragrunt.hcl
+    ├── blank.tf
+    ├── prod.tfvars
+    └── dev.tfvars

--- a/internal/hcl/project_locator.go
+++ b/internal/hcl/project_locator.go
@@ -1467,16 +1467,16 @@ func (p *ProjectLocator) shouldUseProject(dir discoveredProject, force bool) boo
 		return false
 	}
 
-	if force {
-		return true
-	}
-
 	if p.shouldIncludeDir(dir.path) {
 		return true
 	}
 
 	if p.shouldRemoveDuplicateProject(dir) {
 		return false
+	}
+
+	if force {
+		return true
 	}
 
 	// we only include Terraform projects that have been found alongside Terragrunt


### PR DESCRIPTION
Resolves issue where invalid terraform project (no backend/provider blocks) are found in the same directory as a terragrunt project. If we try and force the project type in this scenario, the project locator resolve 0 valid projects and then fell back to just adding in all projects. I've fixed this by only "forcing" the fallback projects if they are of the forced project type.