### PR TITLE
feat: support caching public modules

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,9 +172,10 @@ type Config struct {
 	// TerraformSourceMap replaces any source URL with the provided value.
 	TerraformSourceMap TerraformSourceMap `envconfig:"TERRAFORM_SOURCE_MAP"`
 
-	S3ModuleCacheRegion string `envconfig:"S3_MODULE_CACHE_REGION"`
-	S3ModuleCacheBucket string `envconfig:"S3_MODULE_CACHE_BUCKET"`
-	S3ModuleCachePrefix string `envconfig:"S3_MODULE_CACHE_PREFIX"`
+	S3ModuleCacheRegion  string `envconfig:"S3_MODULE_CACHE_REGION"`
+	S3ModuleCacheBucket  string `envconfig:"S3_MODULE_CACHE_BUCKET"`
+	S3ModuleCachePrefix  string `envconfig:"S3_MODULE_CACHE_PREFIX"`
+	S3ModuleCachePrivate bool   `envconfig:"S3_MODULE_CACHE_PRIVATE, default=false"`
 
 	// metrics dump path
 	MetricsPath string `envconfig:"METRICS_PATH"`

--- a/internal/hcl/modules/fetch.go
+++ b/internal/hcl/modules/fetch.go
@@ -29,9 +29,10 @@ const defaultModuleRetrieveTimeout = 3 * time.Minute
 // PackageFetcher downloads modules from a remote source to the given destination
 // This supports all the non-local and non-Terraform registry sources listed here: https://www.terraform.io/language/modules/sources
 type PackageFetcher struct {
-	remoteCache RemoteCache
-	logger      zerolog.Logger
-	getters     map[string]getter.Getter
+	remoteCache         RemoteCache
+	logger              zerolog.Logger
+	getters             map[string]getter.Getter
+	publicModuleChecker PublicModuleChecker
 }
 
 // use a global cache to avoid downloading the same module multiple times for each project
@@ -78,6 +79,13 @@ func WithGetters(getters map[string]getter.Getter) PackageFetcherOpts {
 	}
 }
 
+// Option to provide a checker to determine if a module is public
+func WithPublicModuleChecker(publicModuleChecker PublicModuleChecker) PackageFetcherOpts {
+	return func(p *PackageFetcher) {
+		p.publicModuleChecker = publicModuleChecker
+	}
+}
+
 // fetch downloads the remote module using the go-getter library
 // See: https://github.com/hashicorp/go-getter
 func (p *PackageFetcher) Fetch(moduleAddr string, dest string) error {
@@ -102,7 +110,10 @@ func (p *PackageFetcher) Fetch(moduleAddr string, dest string) error {
 		p.logger.Debug().Msgf("error fetching module %s from local cache: %s", util.RedactUrl(moduleAddr), err)
 	}
 
-	fetched, err = p.fetchFromRemoteCache(moduleAddr, dest)
+	// check if the module is public by HEADing the module address
+	isPublicModule := p.isPublicModule(moduleAddr)
+
+	fetched, err = p.fetchFromRemoteCache(moduleAddr, dest, isPublicModule)
 	if fetched {
 		p.logger.Trace().Msgf("cache hit (remote): %s", moduleAddr)
 		localCache.Store(moduleAddr, dest)
@@ -126,13 +137,24 @@ func (p *PackageFetcher) Fetch(moduleAddr string, dest string) error {
 	if p.remoteCache != nil {
 		ttl := determineTTL(moduleAddr)
 		p.logger.Debug().Msgf("putting module %s into remote cache with ttl %s", util.RedactUrl(moduleAddr), ttl)
-		err = p.remoteCache.Put(moduleAddr, dest, ttl)
+		err = p.remoteCache.Put(moduleAddr, dest, ttl, isPublicModule)
 		if err != nil {
 			p.logger.Warn().Msgf("error putting module %s into remote cache: %s", util.RedactUrl(moduleAddr), err)
 		}
 	}
 
 	return nil
+}
+
+func (p *PackageFetcher) isPublicModule(moduleAddr string) bool {
+	if p.publicModuleChecker == nil {
+		return false
+	}
+	result, err := p.publicModuleChecker.IsPublicModule(moduleAddr)
+	if err != nil {
+		p.logger.Error().Msgf("Failed to check if %s is a public module: %v", util.RedactUrl(moduleAddr), err)
+	}
+	return result
 }
 
 func (p *PackageFetcher) fetchFromLocalCache(moduleAddr, dest string) (bool, error) {
@@ -172,12 +194,12 @@ func (p *PackageFetcher) fetchFromLocalCache(moduleAddr, dest string) (bool, err
 	return true, nil
 }
 
-func (p *PackageFetcher) fetchFromRemoteCache(moduleAddr, dest string) (bool, error) {
+func (p *PackageFetcher) fetchFromRemoteCache(moduleAddr, dest string, public bool) (bool, error) {
 	if p.remoteCache == nil {
 		return false, nil
 	}
 
-	ok, err := p.remoteCache.Exists(moduleAddr)
+	ok, err := p.remoteCache.Exists(moduleAddr, public)
 	if err != nil {
 		return false, err
 	}
@@ -186,7 +208,7 @@ func (p *PackageFetcher) fetchFromRemoteCache(moduleAddr, dest string) (bool, er
 		return false, nil
 	}
 
-	err = p.remoteCache.Get(moduleAddr, dest)
+	err = p.remoteCache.Get(moduleAddr, dest, public)
 	if err != nil {
 		return false, err
 	}

--- a/internal/hcl/modules/public_checker.go
+++ b/internal/hcl/modules/public_checker.go
@@ -1,0 +1,48 @@
+package modules
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type HttpPublicModuleChecker struct {
+	client *http.Client
+}
+
+func NewHttpPublicModuleChecker() *HttpPublicModuleChecker {
+	return &HttpPublicModuleChecker{
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+// IsPublic checks if a module is public by making a HEAD request to the module address
+// and checking if the response status code is 200.
+func (h *HttpPublicModuleChecker) IsPublicModule(moduleAddr string) (bool, error) {
+	u := strings.TrimPrefix(moduleAddr, "git::")
+
+	parsedUrl, err := url.Parse(u)
+	if err != nil {
+		return false, err
+	}
+
+	if parsedUrl.Scheme == "" {
+		parsedUrl.Scheme = "https"
+	}
+
+	req, err := http.NewRequest("HEAD", parsedUrl.String(), nil)
+	if err != nil {
+		return false, err
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK, nil
+}

--- a/internal/hcl/modules/public_checker_test.go
+++ b/internal/hcl/modules/public_checker_test.go
@@ -1,0 +1,55 @@
+package modules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPublic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
+	tests := []struct {
+		name       string
+		moduleAddr string
+		expected   bool
+	}{
+		{
+			name:       "public module",
+			moduleAddr: "https://github.com/terraform-aws-modules/terraform-aws-alb?ref=46852b88a2bf09bd097e6ad3d1acc9a763cf9005",
+			expected:   true,
+		},
+		{
+			name:       "private module",
+			moduleAddr: "https://github.com/infracost/infracost-modules?ref=0.0.1",
+			expected:   false,
+		},
+		{
+			name:       "public module from git",
+			moduleAddr: "git::https://github.com/terraform-aws-modules/terraform-aws-alb?ref=46852b88a2bf09bd097e6ad3d1acc9a763cf9005",
+			expected:   true,
+		},
+		{
+			name:       "private module from git",
+			moduleAddr: "git::https://github.com/infracost/infracost-modules?ref=0.0.1",
+			expected:   false,
+		},
+		{
+			name:       "public with no scheme",
+			moduleAddr: "github.com/infracost/infracost-modules?ref=0.0.1",
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := NewHttpPublicModuleChecker()
+			got, err := checker.IsPublicModule(tt.moduleAddr)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+
+}

--- a/internal/hcl/modules/s3_cache.go
+++ b/internal/hcl/modules/s3_cache.go
@@ -18,13 +18,15 @@ import (
 )
 
 type S3Cache struct {
-	s3Client   *s3.S3
-	bucketName string
-	prefix     string
+	s3Client     *s3.S3
+	bucketName   string
+	prefix       string
+	publicPrefix string
+	cachePrivate bool
 }
 
 // NewS3Cache creates a new S3Cache instance
-func NewS3Cache(region, bucketName, prefix string) (*S3Cache, error) {
+func NewS3Cache(region, bucketName, prefix string, cachePrivate bool) (*S3Cache, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 		Config: aws.Config{
@@ -36,16 +38,23 @@ func NewS3Cache(region, bucketName, prefix string) (*S3Cache, error) {
 	}
 
 	return &S3Cache{
-		s3Client:   s3.New(sess),
-		bucketName: bucketName,
-		prefix:     prefix,
+		s3Client:     s3.New(sess),
+		bucketName:   bucketName,
+		prefix:       prefix,
+		publicPrefix: "publicModules",
+		cachePrivate: cachePrivate,
 	}, nil
 }
 
-func (cache *S3Cache) applyPrefix(key string) string {
+func (cache *S3Cache) applyPrefix(key string, public bool) string {
 	// URL encode the key first since the module address contains /'s
 	// and these create folders in S3
 	encodedKey := url.QueryEscape(key)
+
+	// if its public, put it in the public prefix
+	if public {
+		return fmt.Sprintf("%s/%s", cache.publicPrefix, encodedKey)
+	}
 
 	if cache.prefix != "" {
 		return fmt.Sprintf("%s/%s", cache.prefix, encodedKey)
@@ -54,8 +63,8 @@ func (cache *S3Cache) applyPrefix(key string) string {
 }
 
 // Exists checks if the key exists in the S3 bucket
-func (cache *S3Cache) Exists(key string) (bool, error) {
-	prefixedKey := cache.applyPrefix(key)
+func (cache *S3Cache) Exists(key string, public bool) (bool, error) {
+	prefixedKey := cache.applyPrefix(key, public)
 	headObj, err := cache.s3Client.HeadObject(&s3.HeadObjectInput{
 		Bucket: aws.String(cache.bucketName),
 		Key:    aws.String(prefixedKey),
@@ -86,8 +95,8 @@ func (cache *S3Cache) Exists(key string) (bool, error) {
 }
 
 // Get downloads the key from the S3 bucket to the destPath
-func (cache *S3Cache) Get(key, destPath string) error {
-	prefixedKey := cache.applyPrefix(key)
+func (cache *S3Cache) Get(key, destPath string, public bool) error {
+	prefixedKey := cache.applyPrefix(key, public)
 
 	// Download from S3
 	result, err := cache.s3Client.GetObject(&s3.GetObjectInput{
@@ -123,8 +132,8 @@ func (cache *S3Cache) Get(key, destPath string) error {
 }
 
 // Put uploads the srcPath to the S3 bucket with the key
-func (cache *S3Cache) Put(key, srcPath string, ttl time.Duration) error {
-	prefixedKey := cache.applyPrefix(key)
+func (cache *S3Cache) Put(key, srcPath string, ttl time.Duration, public bool) error {
+	prefixedKey := cache.applyPrefix(key, public)
 
 	// Generate a temporary file path without creating the file
 	tmpPath := filepath.Join(os.TempDir(), fmt.Sprintf("s3cache-%s.tar.gz", uuid.New().String()))

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
@@ -8,7 +8,7 @@
  └─ Instance usage (Linux, pay as you go, Standard_DS2_v2)                     1,460  hours        $213.16   
                                                                                                              
  azurerm_kubernetes_cluster_node_pool.windows_sku                                                            
- ├─ Instance usage (Windows, pay as you go, Standard_DS2_v2)                     730  hours        $183.96   
+ ├─ Instance usage (Windows, pay as you go, Standard_DS2_v2)                     730  hours        $173.74   
  └─ os_disk                                                                                                  
     └─ Storage (P10, LRS)                                                          1  months        $19.71   
                                                                                                              
@@ -48,7 +48,7 @@
  └─ os_disk                                                                                                  
     └─ Storage (S10, LRS)                                                          1  months         $5.89   
                                                                                                              
- OVERALL TOTAL                                                                                  $1,320.42 
+ OVERALL TOTAL                                                                                  $1,310.20 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -60,5 +60,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $1,320 ┃           - ┃     $1,320 ┃
+┃ main                                               ┃        $1,310 ┃           - ┃     $1,310 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_machine_test/virtual_machine_test.golden
@@ -932,13 +932,6 @@
     ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
     └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
                                                                                                                                       
- azurerm_virtual_machine.windows_vms["Standard_DS5_v2"]                                                                               
- ├─ Instance usage (Windows, pay as you go, Standard_DS5_v2)                           730  hours                        $1,471.68    
- ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
- └─ storage_os_disk                                                                                                                   
-    ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
-    └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
-                                                                                                                                      
  azurerm_virtual_machine.linux_vms["Standard_A9"]                                                                                     
  ├─ Instance usage (Linux, pay as you go, Standard_A9)                                 730  hours                        $1,423.50    
  ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
@@ -948,6 +941,13 @@
                                                                                                                                       
  azurerm_virtual_machine.windows_vms["Standard_D5_v2"]                                                                                
  ├─ Instance usage (Windows, pay as you go, Standard_D5_v2)                            730  hours                        $1,389.92    
+ ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
+ └─ storage_os_disk                                                                                                                   
+    ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
+    └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
+                                                                                                                                      
+ azurerm_virtual_machine.windows_vms["Standard_DS5_v2"]                                                                               
+ ├─ Instance usage (Windows, pay as you go, Standard_DS5_v2)                           730  hours                        $1,389.92    
  ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
  └─ storage_os_disk                                                                                                                   
     ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
@@ -1493,7 +1493,7 @@
     └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
                                                                                                                                       
  azurerm_virtual_machine.windows                                                                                                      
- ├─ Instance usage (Windows, pay as you go, Standard_DS1_v2)                           730  hours                           $91.98    
+ ├─ Instance usage (Windows, pay as you go, Standard_DS1_v2)                           730  hours                           $86.87    
  ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
  ├─ storage_os_disk                                                                                                                   
  │  ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
@@ -1680,7 +1680,7 @@
     └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
                                                                                                                                       
  azurerm_virtual_machine.windows_withMonthlyHours                                                                                     
- ├─ Instance usage (Windows, pay as you go, Standard_DS1_v2)                           100  hours                           $12.60    
+ ├─ Instance usage (Windows, pay as you go, Standard_DS1_v2)                           100  hours                           $11.90    
  ├─ Ultra disk reservation (if unattached)                              Monthly cost depends on usage: $4.38 per vCPU                 
  └─ storage_os_disk                                                                                                                   
     ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
@@ -1693,7 +1693,7 @@
     ├─ Storage (S4, LRS)                                                                 1  months                           $1.54    
     └─ Disk operations                                                  Monthly cost depends on usage: $0.0005 per 10k operations     
                                                                                                                                       
- OVERALL TOTAL                                                                                                       $1,053,518.52 
+ OVERALL TOTAL                                                                                                       $1,053,430.95 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -1705,5 +1705,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃    $1,053,518 ┃       $0.55 ┃ $1,053,519 ┃
+┃ main                                               ┃    $1,053,430 ┃       $0.55 ┃ $1,053,431 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/virtual_network_gateway_connection_test/virtual_network_gateway_connection_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_network_gateway_connection_test/virtual_network_gateway_connection_test.golden
@@ -22,7 +22,7 @@
  └─ VPN gateway data tranfer                          Monthly cost depends on usage: $0.035 per GB        
                                                                                                           
  azurerm_virtual_network_gateway.VpnGw1AZ                                                                 
- ├─ VPN gateway (VpnGw1AZ)                                        730  hours                    $263.53   
+ ├─ VPN gateway (VpnGw1AZ)                                        730  hours                    $153.30   
  ├─ VPN gateway P2S tunnels (over 128)                Monthly cost depends on usage: $7.30 per tunnel     
  └─ VPN gateway data tranfer                          Monthly cost depends on usage: $0.035 per GB        
                                                                                                           
@@ -57,7 +57,7 @@
  azurerm_public_ip.example                                                                                
  └─ IP address (dynamic, regional)                                730  hours                      $2.92   
                                                                                                           
- OVERALL TOTAL                                                                               $5,964.83 
+ OVERALL TOTAL                                                                               $5,854.60 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -69,5 +69,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $5,965 ┃           - ┃     $5,965 ┃
+┃ main                                               ┃        $5,855 ┃           - ┃     $5,855 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/virtual_network_gateway_test/virtual_network_gateway_test.golden
+++ b/internal/providers/terraform/azure/testdata/virtual_network_gateway_test/virtual_network_gateway_test.golden
@@ -22,7 +22,7 @@
  └─ VPN gateway data tranfer                            20  GB                         $0.70   
                                                                                                
  azurerm_virtual_network_gateway.VpnGw1AZ                                                      
- ├─ VPN gateway (VpnGw1AZ)                             730  hours                    $263.53   
+ ├─ VPN gateway (VpnGw1AZ)                             730  hours                    $153.30   
  ├─ VPN gateway P2S tunnels (over 128)                  22  tunnel                   $160.60   
  └─ VPN gateway data tranfer               Monthly cost depends on usage: $0.035 per GB        
                                                                                                
@@ -39,7 +39,7 @@
  azurerm_public_ip.example                                                                     
  └─ IP address (dynamic, regional)                     730  hours                      $2.92   
                                                                                                
- OVERALL TOTAL                                                                   $49,247.27 
+ OVERALL TOTAL                                                                   $49,137.04 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -51,5 +51,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $49,247 ┃           - ┃    $49,247 ┃
+┃ main                                               ┃       $49,137 ┃           - ┃    $49,137 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -164,7 +164,7 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 
 	var remoteCache modules.RemoteCache
 	if runCtx.Config.S3ModuleCacheRegion != "" && runCtx.Config.S3ModuleCacheBucket != "" {
-		s3ModuleCache, err := modules.NewS3Cache(runCtx.Config.S3ModuleCacheRegion, runCtx.Config.S3ModuleCacheBucket, runCtx.Config.S3ModuleCachePrefix)
+		s3ModuleCache, err := modules.NewS3Cache(runCtx.Config.S3ModuleCacheRegion, runCtx.Config.S3ModuleCacheBucket, runCtx.Config.S3ModuleCachePrefix, runCtx.Config.S3ModuleCachePrivate)
 		if err != nil {
 			logger.Warn().Msgf("failed to initialize S3 module cache: %s", err)
 		} else {
@@ -173,13 +173,14 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 	}
 
 	loader := modules.NewModuleLoader(modules.ModuleLoaderOptions{
-		CachePath:         runCtx.Config.CachePath(),
-		HCLParser:         modules.NewSharedHCLParser(),
-		CredentialsSource: credsSource,
-		SourceMap:         runCtx.Config.TerraformSourceMap,
-		Logger:            logger,
-		ModuleSync:        runCtx.ModuleMutex,
-		RemoteCache:       remoteCache,
+		CachePath:           runCtx.Config.CachePath(),
+		HCLParser:           modules.NewSharedHCLParser(),
+		CredentialsSource:   credsSource,
+		SourceMap:           runCtx.Config.TerraformSourceMap,
+		Logger:              logger,
+		ModuleSync:          runCtx.ModuleMutex,
+		RemoteCache:         remoteCache,
+		PublicModuleChecker: modules.NewHttpPublicModuleChecker(),
 	})
 	cachePath := ctx.RunContext.Config.CachePath()
 	initialPath := rootPath.DetectedPath

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -124,7 +124,7 @@ func NewTerragruntHCLProvider(rootPath hcl.RootPath, ctx *config.ProjectContext)
 	var remoteCache modules.RemoteCache
 	runCtx := ctx.RunContext
 	if runCtx.Config.S3ModuleCacheRegion != "" && runCtx.Config.S3ModuleCacheBucket != "" {
-		s3ModuleCache, err := modules.NewS3Cache(runCtx.Config.S3ModuleCacheRegion, runCtx.Config.S3ModuleCacheBucket, runCtx.Config.S3ModuleCachePrefix)
+		s3ModuleCache, err := modules.NewS3Cache(runCtx.Config.S3ModuleCacheRegion, runCtx.Config.S3ModuleCacheBucket, runCtx.Config.S3ModuleCachePrefix, runCtx.Config.S3ModuleCachePrivate)
 		if err != nil {
 			logger.Warn().Msgf("failed to initialize S3 module cache: %s", err)
 		} else {
@@ -135,7 +135,7 @@ func NewTerragruntHCLProvider(rootPath hcl.RootPath, ctx *config.ProjectContext)
 	fetcher := modules.NewPackageFetcher(remoteCache, logger, modules.WithGetters(map[string]getter.Getter{
 		"tfr":  &tgterraform.RegistryGetter{},
 		"file": &tgcliterraform.FileCopyGetter{},
-	}))
+	}), modules.WithPublicModuleChecker(modules.NewHttpPublicModuleChecker()))
 
 	return &TerragruntHCLProvider{
 		ctx:            ctx,


### PR DESCRIPTION
add support for public module caching. The API will be updated to always
pass through the module cache bucket but adding a new env var for
private caching so only runners that are for repos with
`useS3ModuleCache` enabled will store private modules
