### PR TITLE
chore: Handle git@ urls more cleanly

### DIFF
--- a/internal/hcl/modules/fetch.go
+++ b/internal/hcl/modules/fetch.go
@@ -152,7 +152,7 @@ func (p *PackageFetcher) isPublicModule(moduleAddr string) bool {
 	}
 	result, err := p.publicModuleChecker.IsPublicModule(moduleAddr)
 	if err != nil {
-		p.logger.Error().Msgf("Failed to check if %s is a public module: %v", util.RedactUrl(moduleAddr), err)
+		p.logger.Debug().Msgf("Failed to check if %s is a public module: %v", util.RedactUrl(moduleAddr), err)
 	}
 	return result
 }

--- a/internal/hcl/modules/public_checker.go
+++ b/internal/hcl/modules/public_checker.go
@@ -22,6 +22,11 @@ func NewHttpPublicModuleChecker() *HttpPublicModuleChecker {
 // IsPublic checks if a module is public by making a HEAD request to the module address
 // and checking if the response status code is 200.
 func (h *HttpPublicModuleChecker) IsPublicModule(moduleAddr string) (bool, error) {
+	if strings.HasPrefix(moduleAddr, "git@") {
+		// We don't support git@ urls
+		return false, nil
+	}
+
 	u := strings.TrimPrefix(moduleAddr, "git::")
 
 	parsedUrl, err := url.Parse(u)

--- a/internal/hcl/modules/public_checker_test.go
+++ b/internal/hcl/modules/public_checker_test.go
@@ -41,6 +41,11 @@ func TestIsPublic(t *testing.T) {
 			moduleAddr: "github.com/infracost/infracost-modules?ref=0.0.1",
 			expected:   false,
 		},
+		{
+			name:       "public with git",
+			moduleAddr: "git@github.com:terraform-aws-modules/terraform-aws-alb?ref=46852b88a2bf09bd097e6ad3d1acc9a763cf9005",
+			expected:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
we don't support git@github.com urls in the public checker so asume its
not public
