### PR TITLE
chore: don't follow redirects when checking public

### DIFF
--- a/internal/hcl/modules/public_checker.go
+++ b/internal/hcl/modules/public_checker.go
@@ -14,7 +14,11 @@ type HttpPublicModuleChecker struct {
 func NewHttpPublicModuleChecker() *HttpPublicModuleChecker {
 	return &HttpPublicModuleChecker{
 		client: &http.Client{
-			Timeout: 5 * time.Second,
+			Timeout: 2 * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				// Stop following redirects
+				return http.ErrUseLastResponse
+			},
 		},
 	}
 }


### PR DESCRIPTION
When checking if a module is public, don't follow any redirects to avoid
hitting enterprise github sites. We err on the side of caution and only
treat as public if the first call is a 200 - this is the case for public
github repos
