### PR TITLE
fix: treat underlying Terraform errors as Terragrunt project errors

### DIFF
--- a/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/diff_with_compare_to_with_past_project_error_terragrunt.golden
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/diff_with_compare_to_with_past_project_error_terragrunt.golden
@@ -1,0 +1,25 @@
+──────────────────────────────────
+Project: us
+Module path: REPLACED_PROJECT_PATH/testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/dev
+Errors:
+  Diff baseline error:
+    Failed to download module "doesntexist" - error fetching module doesntexist from remote:
+      stat BAD_MODULE_PATH:
+        no such file or directory
+
+──────────────────────────────────
+Project: us
+Module path: REPLACED_PROJECT_PATH/testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/prod
+Errors:
+  Diff baseline error:
+    Failed to download module "doesntexist" - error fetching module doesntexist from remote:
+      stat BAD_MODULE_PATH:
+        no such file or directory
+
+──────────────────────────────────
+
+4 cloud resources were detected:
+∙ 4 were estimated
+
+Err:
+

--- a/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/infracost.yml
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/infracost.yml
@@ -1,0 +1,5 @@
+version: 0.1
+
+projects:
+  - name: us
+    path: "./testdata/diff_with_compare_to_with_past_project_error_terragrunt/us"

--- a/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/prior.json
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/prior.json
@@ -1,0 +1,135 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "stub-branch",
+    "vcsCommitSha": "stub-sha",
+    "vcsCommitAuthorName": "stub-author",
+    "vcsCommitAuthorEmail": "stub@stub.com",
+    "vcsCommitTimestamp": "2025-01-28T12:16:43.297656+01:00",
+    "vcsCommitMessage": "stub-message",
+    "vcsRepositoryUrl": "https://github.com/infracost/infracost",
+    "configFilePath": "testdata/diff_with_compare_to_with_past_project_error_terragrunt/infracost.yml"
+  },
+  "currency": "USD",
+  "projects": [
+    {
+      "name": "us",
+      "displayName": "us",
+      "metadata": {
+        "path": "testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/dev",
+        "type": "terragrunt_dir",
+        "terraformModulePath": "testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/dev",
+        "vcsSubPath": "testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/dev",
+        "errors": [
+          {
+            "code": 201,
+            "message": "Failed to download module \"doesntexist\" - error fetching module doesntexist from remote: stat BAD_MODULE_PATH: no such file or directory",
+            "data": {
+              "moduleSource": "doesntexist",
+              "source": "https"
+            },
+            "isError": true
+          }
+        ]
+      },
+      "pastBreakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "breakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 0,
+        "totalSupportedResources": 0,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 0,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
+      }
+    },
+    {
+      "name": "us",
+      "displayName": "us",
+      "metadata": {
+        "path": "testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/prod",
+        "type": "terragrunt_dir",
+        "terraformModulePath": "testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/prod",
+        "vcsSubPath": "testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/prod",
+        "errors": [
+          {
+            "code": 201,
+            "message": "Failed to download module \"doesntexist\" - error fetching module doesntexist from remote: stat BAD_MODULE_PATH: no such file or directory",
+            "data": {
+              "moduleSource": "doesntexist",
+              "source": "https"
+            },
+            "isError": true
+          }
+        ]
+      },
+      "pastBreakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "breakdown": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 0,
+        "totalSupportedResources": 0,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 0,
+        "totalNoPriceResources": 0,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {}
+      }
+    }
+  ],
+  "totalHourlyCost": "0",
+  "totalMonthlyCost": "0",
+  "totalMonthlyUsageCost": "0",
+  "pastTotalHourlyCost": "0",
+  "pastTotalMonthlyCost": "0",
+  "pastTotalMonthlyUsageCost": "0",
+  "diffTotalHourlyCost": "0",
+  "diffTotalMonthlyCost": "0",
+  "diffTotalMonthlyUsageCost": "0",
+  "timeGenerated": "2025-01-28T12:16:43.297656+01:00",
+  "summary": {
+    "totalDetectedResources": 0,
+    "totalSupportedResources": 0,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 0,
+    "totalNoPriceResources": 0,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {}
+  }
+}
+
+
+

--- a/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/terragrunt.hcl
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/terragrunt.hcl
@@ -1,0 +1,18 @@
+locals {
+  aws_region = "us-east-1" # <<<<< Try changing this to eu-west-1 to compare the costs
+}
+
+# Generate an AWS provider block
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "aws" {
+  region                      = "${local.aws_region}"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+EOF
+}

--- a/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/dev/terragrunt.hcl
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/dev/terragrunt.hcl
@@ -1,0 +1,16 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type = "t2.micro"
+  root_block_device_volume_size = 50
+  block_device_volume_size = 100
+  block_device_iops = 400
+  
+  hello_world_function_memory_size = 512
+}

--- a/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/modules/example/main.tf
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/modules/example/main.tf
@@ -1,0 +1,49 @@
+variable "instance_type" {
+  description = "The EC2 instance type for the web app"
+  type        = string
+}
+
+variable "root_block_device_volume_size" {
+  description = "The size of the root block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_volume_size" {
+  description = "The size of the block device volume for the web app EC2 instance"
+  type        = number
+}
+
+variable "block_device_iops" {
+  description = "The number of IOPS for the block device for the web app EC2 instance"
+  type        = number
+}
+
+variable "hello_world_function_memory_size" {
+  description = "The memory to allocate to the hello world Lambda function"
+  type        = number
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+
+  root_block_device {
+    volume_size = var.root_block_device_volume_size
+  }
+
+  ebs_block_device {
+    device_name = "my_data"
+    volume_type = "io1"
+    volume_size = var.block_device_volume_size
+    iops        = var.block_device_iops
+  }
+}
+
+resource "aws_lambda_function" "hello_world" {
+  function_name = "hello_world"
+  role          = "arn:aws:lambda:us-east-1:aws:resource-id"
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
+  filename      = "function.zip"
+  memory_size   = var.hello_world_function_memory_size
+}

--- a/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/prod/terragrunt.hcl
+++ b/cmd/infracost/testdata/diff_with_compare_to_with_past_project_error_terragrunt/us/prod/terragrunt.hcl
@@ -1,0 +1,16 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "..//modules/example"
+}
+
+inputs = {
+  instance_type = "m5.4xlarge"
+  root_block_device_volume_size = 100
+  block_device_volume_size = 1000
+  block_device_iops = 800
+  
+  hello_world_function_memory_size = 1024
+}

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -32,7 +32,6 @@ import (
 	hcl2 "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
-	"github.com/infracost/infracost/internal/metrics"
 	"github.com/rs/zerolog"
 	"github.com/sirupsen/logrus"
 	"github.com/zclconf/go-cty/cty"
@@ -40,12 +39,12 @@ import (
 	"github.com/zclconf/go-cty/cty/gocty"
 	ctyJson "github.com/zclconf/go-cty/cty/json"
 
-	"github.com/infracost/infracost/internal/hcl/mock"
-
 	"github.com/infracost/infracost/internal/clierror"
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/hcl"
+	"github.com/infracost/infracost/internal/hcl/mock"
 	"github.com/infracost/infracost/internal/hcl/modules"
+	"github.com/infracost/infracost/internal/metrics"
 	"github.com/infracost/infracost/internal/schema"
 	infSync "github.com/infracost/infracost/internal/sync"
 	"github.com/infracost/infracost/internal/ui"
@@ -258,10 +257,6 @@ type terragruntWorkingDirInfo struct {
 	error            error
 	warnings         []*schema.ProjectDiag
 	evaluatedOutputs cty.Value
-}
-
-func (i *terragruntWorkingDirInfo) addWarning(pd *schema.ProjectDiag) {
-	i.warnings = append(i.warnings, pd)
 }
 
 // LoadResources finds any Terragrunt projects, prepares them by downloading any required source files, then
@@ -678,15 +673,7 @@ func (p *TerragruntHCLProvider) runTerragrunt(opts *tgoptions.TerragruntOptions)
 	}
 
 	mod := h.Module()
-	if mod.Error != nil {
-		path := ""
-		if mod.Module != nil {
-			path = mod.Module.RootPath
-		}
-		info.addWarning(schema.NewDiagTerragruntModuleEvaluationFailure(mod.Error))
-		p.logger.Warn().Msgf("Terragrunt config path %s returned module %s with error: %s", opts.TerragruntConfigPath, path, mod.Error)
-	}
-
+	info.error = mod.Error
 	info.provider = h
 	info.evaluatedOutputs = mod.Module.Blocks.Outputs(true)
 	return info


### PR DESCRIPTION
Prior to this change, when evaluating a Terragrunt project, we treated the underlying Terraform module errors as just a warning diagnostic. This created issues with the diff logic as baseline Terragrunt projects would have warning metadatas but a zero cost as the project could not be evaluated. If this was an intermittent error, which is often the case with Terragrunt and the caching logic then users would see a 100% cost increase for the project as it was seen as going from 0 to the current project price.

I've changed the logic now to treat Terraform errors as first class Terragrunt evaluation errors in the evaluator. This means that when diffing we'll show that we couldn't compute the price instead of a new project addition.