### PR TITLE
fix: Add local modules to manifest if they are source mapped

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/infracost/infracost
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -901,7 +901,7 @@ func joinModuleSubDir(moduleAddr string, submodulePath string) string {
 	return moduleAddr
 }
 
-// mapSource maps the module source to a new source if it is in the source map
+// MapSource maps the module source to a new source if it is in the source map
 // otherwise it returns the original source. It works similarly to the
 // TERRAGRUNT_SOURCE_MAP environment variable except it matches by prefixes
 // and supports query params. It works by matching the longest prefix first,

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -244,6 +244,12 @@ func (m *ModuleLoader) loadModules(path string, prefix string) ([]*ManifestModul
 					manifestMu.Unlock()
 				}
 
+				if IsLocalModule(metadata.Source) && metadata.IsSourceMapped {
+					manifestMu.Lock()
+					manifestModules = append(manifestModules, metadata)
+					manifestMu.Unlock()
+				}
+
 				moduleDir := filepath.Join(m.cachePath, metadata.Dir)
 				nestedManifestModules, err := m.loadModules(moduleDir, metadata.Key+".")
 				if err != nil {
@@ -277,8 +283,9 @@ func (m *ModuleLoader) loadModule(moduleCall *tfconfig.ModuleCall, parentPath st
 	key := prefix + moduleCall.Name
 	source := moduleCall.Source
 	version := moduleCall.Version
+	isSourceMapped := false
 
-	mappedResult, err := mapSource(m.sourceMap, source)
+	mappedResult, err := MapSource(m.sourceMap, source)
 	if err != nil {
 		return nil, err
 	}
@@ -286,11 +293,13 @@ func (m *ModuleLoader) loadModule(moduleCall *tfconfig.ModuleCall, parentPath st
 	if mappedResult.Source != source {
 		m.logger.Debug().Msgf("remapping module source %s to %s", source, mappedResult.Source)
 		source = mappedResult.Source
+		isSourceMapped = true
 	}
 
 	if mappedResult.Version != "" {
 		m.logger.Debug().Msgf("remapping module version %s to %s", version, mappedResult.Version)
 		version = mappedResult.Version
+		isSourceMapped = true
 	}
 
 	manifestModule, err := m.cache.lookupModule(key, moduleCall)
@@ -340,9 +349,10 @@ func (m *ModuleLoader) loadModule(moduleCall *tfconfig.ModuleCall, parentPath st
 		}
 
 		return &ManifestModule{
-			Key:    key,
-			Source: source,
-			Dir:    path.Clean(dir),
+			Key:            key,
+			Source:         source,
+			Dir:            path.Clean(dir),
+			IsSourceMapped: isSourceMapped,
 		}, nil
 	}
 
@@ -900,7 +910,7 @@ func joinModuleSubDir(moduleAddr string, submodulePath string) string {
 // It does not support mapping registry versions to git tags since we can't
 // guarantee that the tag is correct - depending on the git repo the version
 // might be prefixed with a 'v' or not.
-func mapSource(sourceMap config.TerraformSourceMap, source string) (SourceMapResult, error) {
+func MapSource(sourceMap config.TerraformSourceMap, source string) (SourceMapResult, error) {
 	result := SourceMapResult{
 		Source:   source,
 		Version:  "",

--- a/internal/hcl/modules/loader_test.go
+++ b/internal/hcl/modules/loader_test.go
@@ -55,10 +55,11 @@ func testLoaderE2E(t *testing.T, path string, expectedModules []*ManifestModule,
 	expected := []*ManifestModule{}
 	for _, m := range expectedModules {
 		e := &ManifestModule{
-			Key:         m.Key,
-			Source:      m.Source,
-			Version:     m.Version,
-			DownloadURL: m.DownloadURL,
+			Key:            m.Key,
+			Source:         m.Source,
+			Version:        m.Version,
+			DownloadURL:    m.DownloadURL,
+			IsSourceMapped: m.IsSourceMapped,
 		}
 
 		if !opts.IgnoreDir {
@@ -807,6 +808,51 @@ func TestSourceMapGitSubmodule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testLoaderE2E(t, "./testdata/sourcemap_git_submodule", tt.want, TestLoaderE2EOpts{SourceMap: tt.sourceMap, Cleanup: true, IgnoreDir: true})
+		})
+	}
+}
+
+func TestSourceMapLocalModule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
+	tests := []struct {
+		name      string
+		sourceMap config.TerraformSourceMap
+		want      []*ManifestModule
+	}{
+		{
+			name:      "empty source map",
+			sourceMap: config.TerraformSourceMap{},
+			want:      []*ManifestModule{},
+		},
+		{
+			name: "with mapping",
+			sourceMap: config.TerraformSourceMap{
+				"../sourcemap_local_module/": "",
+			},
+			want: []*ManifestModule{
+				{
+					Key:            "local-module",
+					Source:         "./modules/local-module",
+					Version:        "",
+					IsSourceMapped: true,
+				},
+			},
+		},
+		{
+			name: "when path is not starting with the map",
+			sourceMap: config.TerraformSourceMap{
+				"./modules": "",
+			},
+			want: []*ManifestModule{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testLoaderE2E(t, "./testdata/sourcemap_local_module", tt.want, TestLoaderE2EOpts{SourceMap: tt.sourceMap, Cleanup: true, IgnoreDir: true})
 		})
 	}
 }

--- a/internal/hcl/modules/manifest.go
+++ b/internal/hcl/modules/manifest.go
@@ -39,11 +39,12 @@ func (m Manifest) Get(key string) ManifestModule {
 
 // ManifestModule represents a single module in the manifest.json file
 type ManifestModule struct {
-	Key         string `json:"Key"`
-	Source      string `json:"Source"`
-	Version     string `json:"Version,omitempty"`
-	Dir         string `json:"Dir"`
-	DownloadURL string
+	Key            string `json:"Key"`
+	Source         string `json:"Source"`
+	Version        string `json:"Version,omitempty"`
+	Dir            string `json:"Dir"`
+	DownloadURL    string
+	IsSourceMapped bool `json:"-"`
 }
 
 func (m ManifestModule) URL() string {

--- a/internal/hcl/modules/testdata/sourcemap_local_module/main.tf
+++ b/internal/hcl/modules/testdata/sourcemap_local_module/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+module "local-module" {
+  source        = "../sourcemap_local_module/./modules/local-module"
+  instance_type = "m5.4xlarge"
+}

--- a/internal/hcl/modules/testdata/sourcemap_local_module/modules/local-module/main.tf
+++ b/internal/hcl/modules/testdata/sourcemap_local_module/modules/local-module/main.tf
@@ -1,0 +1,7 @@
+variable "instance_type" {
+}
+
+resource "aws_instance" "web_app" {
+  ami           = "ami-674cbc1e"
+  instance_type = var.instance_type
+}


### PR DESCRIPTION
When a module's source has a relative path like `../../modules/` but needs to be mapped to another path, the module is still loaded using the original source value.
Important: this mapping only works when the path starts with the mapping value.