### PR TITLE
fix: fix the wrong error return value

### DIFF
--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -444,7 +444,7 @@ func (p *DirProvider) runRemotePlan(opts *CmdOptions, args []string) ([]byte, er
 			Links map[string]string
 		}
 	}
-	if json.Unmarshal(body, &parsedResp) != nil {
+	if err = json.Unmarshal(body, &parsedResp); err != nil {
 		return []byte{}, err
 	}
 


### PR DESCRIPTION
Since we have already checked err before and returned when err != nil, err must be nil here. 

So we should  reassign err.