### PR TITLE
feat: add new openai models and cost components

### DIFF
--- a/internal/providers/terraform/azure/cognitive_deployment.go
+++ b/internal/providers/terraform/azure/cognitive_deployment.go
@@ -31,10 +31,12 @@ func newCognitiveDeployment(d *schema.ResourceData) schema.CoreResource {
 	region := d.Region
 
 	return &azure.CognitiveDeployment{
-		Address: d.Address,
-		Region:  region,
-		Model:   strings.ToLower(d.Get("model.0.name").String()),
-		Version: strings.ToLower(d.Get("model.0.version").String()),
-		Tier:    strings.ToLower(d.Get("scale.0.tier").String()),
+		Address:  d.Address,
+		Region:   region,
+		Model:    strings.ToLower(d.Get("model.0.name").String()),
+		Version:  strings.ToLower(d.Get("model.0.version").String()),
+		Tier:     strings.ToLower(d.Get("scale.0.tier").String()),
+		SKU:      strings.ToLower(d.Get("sku.0.name").String()),
+		Capacity: d.Get("sku.0.capacity").Int(),
 	}
 }

--- a/internal/providers/terraform/azure/cognitive_deployment_test.go
+++ b/internal/providers/terraform/azure/cognitive_deployment_test.go
@@ -13,5 +13,6 @@ func TestCognitiveDeployment(t *testing.T) {
 
 	opts := tftest.DefaultGoldenFileOptions()
 	opts.CaptureLogs = true
+	opts.IgnoreCLI = true
 	tftest.GoldenFileResourceTestsWithOpts(t, "cognitive_deployment_test", opts)
 }

--- a/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.golden
+++ b/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.golden
@@ -1,388 +1,1772 @@
 
- Name                                                                                      Monthly Qty  Unit                    Monthly Cost   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["gpt-4-32k"]                                                                                  
- ├─ Language input (gpt-4-32k)                                                                  40,000  1K tokens                  $2,400.00   
- └─ Language output (gpt-4-32k)                                                             13,333.333  1K tokens                  $1,600.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["gpt-4-32k"]                                                                                   
- ├─ Language input (gpt-4-32k)                                                                  40,000  1K tokens                  $2,400.00   
- └─ Language output (gpt-4-32k)                                                             13,333.333  1K tokens                  $1,600.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4-32k"]                                                                            
- ├─ Language input (gpt-4-32k)                                                                  40,000  1K tokens                  $2,400.00   
- └─ Language output (gpt-4-32k)                                                             13,333.333  1K tokens                  $1,600.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["gpt-4"]                                                                                      
- ├─ Language input (gpt-4)                                                                      40,000  1K tokens                  $1,200.00   
- ├─ Language output (gpt-4)                                                                 13,333.333  1K tokens                    $800.00   
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["gpt-4"]                                                                                       
- ├─ Language input (gpt-4)                                                                      40,000  1K tokens                  $1,200.00   
- ├─ Language output (gpt-4)                                                                 13,333.333  1K tokens                    $800.00   
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4"]                                                                                
- ├─ Language input (gpt-4)                                                                      40,000  1K tokens                  $1,200.00   
- ├─ Language output (gpt-4)                                                                 13,333.333  1K tokens                    $800.00   
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["davinci-002"]                                                                                 
- ├─ Base model tokens (davinci-002)                                                              2.847  1K tokens                    $242.00   
- ├─ Fine tuning training (davinci-002)                                                             0.4  hours                         $16.00   
- ├─ Fine tuning hosting (davinci-002)                                                              6.6  hours                         $13.20   
- ├─ Fine tuning input (davinci-002)                                                         13,333.333  1K tokens                     $26.67   
- └─ Fine tuning output (davinci-002)                                                            10,000  1K tokens                     $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["gpt-35-turbo"]                                                                                
- ├─ Language input (gpt-35-turbo)                                                               40,000  1K tokens                     $20.00   
- ├─ Language output (gpt-35-turbo)                                                          13,333.333  1K tokens                     $20.00   
- ├─ Code interpreter sessions (gpt-35-turbo)                                                       667  sessions                      $20.01   
- ├─ Fine tuning training (gpt-35-turbo)                                                            0.4  hours                         $18.00   
- ├─ Fine tuning hosting (gpt-35-turbo)                                                             6.6  hours                         $19.80   
- ├─ Fine tuning input (gpt-35-turbo)                                                        13,333.333  1K tokens                     $20.00   
- └─ Fine tuning output (gpt-35-turbo)                                                           10,000  1K tokens                     $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["text-embedding-3-large"]                                                                     
- └─ Text embeddings (text-embedding-3-large)                                                 1,000,000  1K tokens                    $130.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["text-embedding-3-large"]                                                                      
- └─ Text embeddings (text-embedding-3-large)                                                 1,000,000  1K tokens                    $130.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["text-embedding-3-large"]                                                               
- └─ Text embeddings (text-embedding-3-large)                                                 1,000,000  1K tokens                    $130.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["gpt-35-turbo"]                                                                               
- ├─ Language input (gpt-35-turbo)                                                               40,000  1K tokens                     $20.00   
- ├─ Language output (gpt-35-turbo)                                                          13,333.333  1K tokens                     $20.00   
- ├─ Code interpreter sessions (gpt-35-turbo)                                                       667  sessions                      $20.01   
- ├─ Fine tuning training (gpt-35-turbo)                                                            0.4  hours                         $18.00   
- ├─ Fine tuning hosting (gpt-35-turbo)                                                             6.6  hours                         $19.80   
- ├─ Fine tuning input (gpt-35-turbo)                                                        13,333.333  1K tokens                      $6.67   
- └─ Fine tuning output (gpt-35-turbo)                                                           10,000  1K tokens                     $15.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["gpt-35-turbo"]                                                                         
- ├─ Language input (gpt-35-turbo)                                                               40,000  1K tokens                     $20.00   
- ├─ Language output (gpt-35-turbo)                                                          13,333.333  1K tokens                     $20.00   
- ├─ Code interpreter sessions (gpt-35-turbo)                                                       667  sessions                      $20.01   
- ├─ Fine tuning training (gpt-35-turbo)                                                            0.4  hours                         $18.00   
- ├─ Fine tuning hosting (gpt-35-turbo)                                                             6.6  hours                         $19.80   
- ├─ Fine tuning input (gpt-35-turbo)                                                        13,333.333  1K tokens                      $6.67   
- └─ Fine tuning output (gpt-35-turbo)                                                           10,000  1K tokens                     $15.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["text-embedding-ada-002"]                                                                     
- └─ Text embeddings (text-embedding-ada-002)                                                 1,000,000  1K tokens                    $100.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["text-embedding-ada-002"]                                                                      
- └─ Text embeddings (text-embedding-ada-002)                                                 1,000,000  1K tokens                    $100.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["text-embedding-ada-002"]                                                               
- └─ Text embeddings (text-embedding-ada-002)                                                 1,000,000  1K tokens                    $100.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["gpt-35-turbo-instruct"]                                                                      
- ├─ Language input (gpt-35-turbo-instruct)                                                      40,000  1K tokens                     $60.00   
- └─ Language output (gpt-35-turbo-instruct)                                                 13,333.333  1K tokens                     $26.67   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["gpt-35-turbo-instruct"]                                                                       
- ├─ Language input (gpt-35-turbo-instruct)                                                      40,000  1K tokens                     $60.00   
- └─ Language output (gpt-35-turbo-instruct)                                                 13,333.333  1K tokens                     $26.67   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["gpt-35-turbo-instruct"]                                                                
- ├─ Language input (gpt-35-turbo-instruct)                                                      40,000  1K tokens                     $60.00   
- └─ Language output (gpt-35-turbo-instruct)                                                 13,333.333  1K tokens                     $26.67   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["dall-e-3"]                                                                                    
- ├─ Standard 1024x1024 images (dall-e-3)                                                             5  100 images                    $20.00   
- ├─ Standard 1024x1792 images (dall-e-3)                                                           2.5  100 images                    $20.00   
- ├─ HD 1024x1024 images (dall-e-3)                                                                 2.5  100 images                    $20.00   
- └─ HD 1024x1792 images (dall-e-3)                                                                1.67  100 images                    $20.04   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["dall-e-3"]                                                                             
- ├─ Standard 1024x1024 images (dall-e-3)                                                             5  100 images                    $20.00   
- ├─ Standard 1024x1792 images (dall-e-3)                                                           2.5  100 images                    $20.00   
- ├─ HD 1024x1024 images (dall-e-3)                                                                 2.5  100 images                    $20.00   
- └─ HD 1024x1792 images (dall-e-3)                                                                1.67  100 images                    $20.04   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["davinci-002"]                                                                                
- ├─ Fine tuning training (davinci-002)                                                             0.4  hours                         $16.00   
- ├─ Fine tuning hosting (davinci-002)                                                              6.6  hours                         $13.20   
- ├─ Fine tuning input (davinci-002)                                                         13,333.333  1K tokens                     $26.67   
- └─ Fine tuning output (davinci-002)                                                            10,000  1K tokens                     $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["babbage-002"]                                                                                 
- ├─ Base model tokens (babbage-002)                                                              2.847  1K tokens                     $19.93   
- ├─ Fine tuning training (babbage-002)                                                             0.4  hours                         $13.60   
- ├─ Fine tuning hosting (babbage-002)                                                              6.6  hours                         $11.22   
- ├─ Fine tuning input (babbage-002)                                                         13,333.333  1K tokens                      $5.33   
- └─ Fine tuning output (babbage-002)                                                            10,000  1K tokens                      $4.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["gpt-35-turbo-16k"]                                                                           
- ├─ Language input (gpt-35-turbo-16k)                                                           40,000  1K tokens                     $20.00   
- └─ Language output (gpt-35-turbo-16k)                                                      13,333.333  1K tokens                     $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["gpt-35-turbo-16k"]                                                                            
- ├─ Language input (gpt-35-turbo-16k)                                                           40,000  1K tokens                     $20.00   
- └─ Language output (gpt-35-turbo-16k)                                                      13,333.333  1K tokens                     $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["gpt-35-turbo-16k"]                                                                     
- ├─ Language input (gpt-35-turbo-16k)                                                           40,000  1K tokens                     $20.00   
- └─ Language output (gpt-35-turbo-16k)                                                      13,333.333  1K tokens                     $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["tts-hd"]                                                                               
- └─ Text to speech (tts-hd)                                                                     1.3333  1M characters                 $40.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["babbage-002"]                                                                                
- ├─ Fine tuning training (babbage-002)                                                             0.4  hours                         $13.60   
- ├─ Fine tuning hosting (babbage-002)                                                              6.6  hours                         $11.22   
- ├─ Fine tuning input (babbage-002)                                                         13,333.333  1K tokens                      $5.33   
- └─ Fine tuning output (babbage-002)                                                            10,000  1K tokens                      $4.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["whisper"]                                                                                     
- └─ Text to speech (whisper)                                                                      55.6  hours                         $20.02   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["gpt-4-0125-preview"]                                                                         
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["gpt-4-1106-preview"]                                                                         
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["gpt-4-vision-preview"]                                                                       
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["gpt-4-0125-preview"]                                                                          
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["gpt-4-1106-preview"]                                                                          
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["gpt-4-vision-preview"]                                                                        
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4-0125-preview"]                                                                   
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4-1106-preview"]                                                                   
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4-vision-preview"]                                                                 
- └─ Code interpreter sessions (gpt-4)                                                              667  sessions                      $20.01   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["dall-e-3"]                                                                                   
- └─ Standard 1024x1792 images (dall-e-3)                                                           2.5  100 images                    $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_with_usage["text-embedding-3-small"]                                                                     
- └─ Text embeddings (text-embedding-3-small)                                                 1,000,000  1K tokens                     $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["text-embedding-3-small"]                                                                      
- └─ Text embeddings (text-embedding-3-small)                                                 1,000,000  1K tokens                     $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["text-embedding-3-small"]                                                               
- └─ Text embeddings (text-embedding-3-small)                                                 1,000,000  1K tokens                     $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_with_usage["tts"]                                                                                  
- └─ Text to speech (tts)                                                                        1.3333  1M characters                 $20.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_with_usage["dall-e-2"]                                                                                    
- └─ Standard 1024x1024 images (dall-e-2)                                                             5  100 images                    $10.00   
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["babbage-002"]                                                                             
- ├─ Fine tuning training (babbage-002)                                               Monthly cost depends on usage: $34.00 per hours           
- ├─ Fine tuning hosting (babbage-002)                                                Monthly cost depends on usage: $1.70 per hours            
- ├─ Fine tuning input (babbage-002)                                                  Monthly cost depends on usage: $0.0004 per 1K tokens      
- └─ Fine tuning output (babbage-002)                                                 Monthly cost depends on usage: $0.0004 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["dall-e-3"]                                                                                
- └─ Standard 1024x1792 images (dall-e-3)                                             Monthly cost depends on usage: $8.00 per 100 images       
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["davinci-002"]                                                                             
- ├─ Fine tuning training (davinci-002)                                               Monthly cost depends on usage: $40.00 per hours           
- ├─ Fine tuning hosting (davinci-002)                                                Monthly cost depends on usage: $2.00 per hours            
- ├─ Fine tuning input (davinci-002)                                                  Monthly cost depends on usage: $0.002 per 1K tokens       
- └─ Fine tuning output (davinci-002)                                                 Monthly cost depends on usage: $0.002 per 1K tokens       
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["gpt-35-turbo"]                                                                            
- ├─ Language input (gpt-35-turbo)                                                    Monthly cost depends on usage: $0.0005 per 1K tokens      
- ├─ Language output (gpt-35-turbo)                                                   Monthly cost depends on usage: $0.0015 per 1K tokens      
- ├─ Code interpreter sessions (gpt-35-turbo)                                         Monthly cost depends on usage: $0.03 per sessions         
- ├─ Fine tuning training (gpt-35-turbo)                                              Monthly cost depends on usage: $45.00 per hours           
- ├─ Fine tuning hosting (gpt-35-turbo)                                               Monthly cost depends on usage: $3.00 per hours            
- ├─ Fine tuning input (gpt-35-turbo)                                                 Monthly cost depends on usage: $0.0005 per 1K tokens      
- └─ Fine tuning output (gpt-35-turbo)                                                Monthly cost depends on usage: $0.0015 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["gpt-35-turbo-16k"]                                                                        
- ├─ Language input (gpt-35-turbo-16k)                                                Monthly cost depends on usage: $0.0005 per 1K tokens      
- └─ Language output (gpt-35-turbo-16k)                                               Monthly cost depends on usage: $0.0015 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["gpt-35-turbo-instruct"]                                                                   
- ├─ Language input (gpt-35-turbo-instruct)                                           Monthly cost depends on usage: $0.0015 per 1K tokens      
- └─ Language output (gpt-35-turbo-instruct)                                          Monthly cost depends on usage: $0.002 per 1K tokens       
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["gpt-4"]                                                                                   
- ├─ Language input (gpt-4)                                                           Monthly cost depends on usage: $0.03 per 1K tokens        
- ├─ Language output (gpt-4)                                                          Monthly cost depends on usage: $0.06 per 1K tokens        
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["gpt-4-0125-preview"]                                                                      
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["gpt-4-1106-preview"]                                                                      
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["gpt-4-32k"]                                                                               
- ├─ Language input (gpt-4-32k)                                                       Monthly cost depends on usage: $0.06 per 1K tokens        
- └─ Language output (gpt-4-32k)                                                      Monthly cost depends on usage: $0.12 per 1K tokens        
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["gpt-4-vision-preview"]                                                                    
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["text-embedding-3-large"]                                                                  
- └─ Text embeddings (text-embedding-3-large)                                         Monthly cost depends on usage: $0.00013 per 1K tokens     
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["text-embedding-3-small"]                                                                  
- └─ Text embeddings (text-embedding-3-small)                                         Monthly cost depends on usage: $0.00002 per 1K tokens     
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus2_without_usage["text-embedding-ada-002"]                                                                  
- └─ Text embeddings (text-embedding-ada-002)                                         Monthly cost depends on usage: $0.0001 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["babbage-002"]                                                                              
- ├─ Base model tokens (babbage-002)                                                  Monthly cost depends on usage: $7.00 per 1K tokens        
- ├─ Fine tuning training (babbage-002)                                               Monthly cost depends on usage: $34.00 per hours           
- ├─ Fine tuning hosting (babbage-002)                                                Monthly cost depends on usage: $1.70 per hours            
- ├─ Fine tuning input (babbage-002)                                                  Monthly cost depends on usage: $0.0004 per 1K tokens      
- └─ Fine tuning output (babbage-002)                                                 Monthly cost depends on usage: $0.0004 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["dall-e-2"]                                                                                 
- └─ Standard 1024x1024 images (dall-e-2)                                             Monthly cost depends on usage: $2.00 per 100 images       
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["dall-e-3"]                                                                                 
- ├─ Standard 1024x1024 images (dall-e-3)                                             Monthly cost depends on usage: $4.00 per 100 images       
- ├─ Standard 1024x1792 images (dall-e-3)                                             Monthly cost depends on usage: $8.00 per 100 images       
- ├─ HD 1024x1024 images (dall-e-3)                                                   Monthly cost depends on usage: $8.00 per 100 images       
- └─ HD 1024x1792 images (dall-e-3)                                                   Monthly cost depends on usage: $12.00 per 100 images      
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["davinci-002"]                                                                              
- ├─ Base model tokens (davinci-002)                                                  Monthly cost depends on usage: $85.00 per 1K tokens       
- ├─ Fine tuning training (davinci-002)                                               Monthly cost depends on usage: $40.00 per hours           
- ├─ Fine tuning hosting (davinci-002)                                                Monthly cost depends on usage: $2.00 per hours            
- ├─ Fine tuning input (davinci-002)                                                  Monthly cost depends on usage: $0.002 per 1K tokens       
- └─ Fine tuning output (davinci-002)                                                 Monthly cost depends on usage: $0.002 per 1K tokens       
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["gpt-35-turbo"]                                                                             
- ├─ Language input (gpt-35-turbo)                                                    Monthly cost depends on usage: $0.0005 per 1K tokens      
- ├─ Language output (gpt-35-turbo)                                                   Monthly cost depends on usage: $0.0015 per 1K tokens      
- ├─ Code interpreter sessions (gpt-35-turbo)                                         Monthly cost depends on usage: $0.03 per sessions         
- ├─ Fine tuning training (gpt-35-turbo)                                              Monthly cost depends on usage: $45.00 per hours           
- ├─ Fine tuning hosting (gpt-35-turbo)                                               Monthly cost depends on usage: $3.00 per hours            
- ├─ Fine tuning input (gpt-35-turbo)                                                 Monthly cost depends on usage: $0.0015 per 1K tokens      
- └─ Fine tuning output (gpt-35-turbo)                                                Monthly cost depends on usage: $0.002 per 1K tokens       
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["gpt-35-turbo-16k"]                                                                         
- ├─ Language input (gpt-35-turbo-16k)                                                Monthly cost depends on usage: $0.0005 per 1K tokens      
- └─ Language output (gpt-35-turbo-16k)                                               Monthly cost depends on usage: $0.0015 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["gpt-35-turbo-instruct"]                                                                    
- ├─ Language input (gpt-35-turbo-instruct)                                           Monthly cost depends on usage: $0.0015 per 1K tokens      
- └─ Language output (gpt-35-turbo-instruct)                                          Monthly cost depends on usage: $0.002 per 1K tokens       
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["gpt-4"]                                                                                    
- ├─ Language input (gpt-4)                                                           Monthly cost depends on usage: $0.03 per 1K tokens        
- ├─ Language output (gpt-4)                                                          Monthly cost depends on usage: $0.06 per 1K tokens        
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["gpt-4-0125-preview"]                                                                       
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["gpt-4-1106-preview"]                                                                       
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["gpt-4-32k"]                                                                                
- ├─ Language input (gpt-4-32k)                                                       Monthly cost depends on usage: $0.06 per 1K tokens        
- └─ Language output (gpt-4-32k)                                                      Monthly cost depends on usage: $0.12 per 1K tokens        
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["gpt-4-vision-preview"]                                                                     
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["text-embedding-3-large"]                                                                   
- └─ Text embeddings (text-embedding-3-large)                                         Monthly cost depends on usage: $0.00013 per 1K tokens     
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["text-embedding-3-small"]                                                                   
- └─ Text embeddings (text-embedding-3-small)                                         Monthly cost depends on usage: $0.00002 per 1K tokens     
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["text-embedding-ada-002"]                                                                   
- └─ Text embeddings (text-embedding-ada-002)                                         Monthly cost depends on usage: $0.0001 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.eastus_without_usage["whisper"]                                                                                  
- └─ Text to speech (whisper)                                                         Monthly cost depends on usage: $0.36 per hours            
-                                                                                                                                               
- azurerm_cognitive_deployment.free_tier                                                                                                        
- ├─ Language input (gpt-4)                                                           Monthly cost depends on usage: $0.03 per 1K tokens        
- ├─ Language output (gpt-4)                                                          Monthly cost depends on usage: $0.06 per 1K tokens        
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["dall-e-3"]                                                                          
- ├─ Standard 1024x1024 images (dall-e-3)                                             Monthly cost depends on usage: $4.00 per 100 images       
- ├─ Standard 1024x1792 images (dall-e-3)                                             Monthly cost depends on usage: $8.00 per 100 images       
- ├─ HD 1024x1024 images (dall-e-3)                                                   Monthly cost depends on usage: $8.00 per 100 images       
- └─ HD 1024x1792 images (dall-e-3)                                                   Monthly cost depends on usage: $12.00 per 100 images      
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["gpt-35-turbo"]                                                                      
- ├─ Language input (gpt-35-turbo)                                                    Monthly cost depends on usage: $0.0005 per 1K tokens      
- ├─ Language output (gpt-35-turbo)                                                   Monthly cost depends on usage: $0.0015 per 1K tokens      
- ├─ Code interpreter sessions (gpt-35-turbo)                                         Monthly cost depends on usage: $0.03 per sessions         
- ├─ Fine tuning training (gpt-35-turbo)                                              Monthly cost depends on usage: $45.00 per hours           
- ├─ Fine tuning hosting (gpt-35-turbo)                                               Monthly cost depends on usage: $3.00 per hours            
- ├─ Fine tuning input (gpt-35-turbo)                                                 Monthly cost depends on usage: $0.0005 per 1K tokens      
- └─ Fine tuning output (gpt-35-turbo)                                                Monthly cost depends on usage: $0.0015 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["gpt-35-turbo-16k"]                                                                  
- ├─ Language input (gpt-35-turbo-16k)                                                Monthly cost depends on usage: $0.0005 per 1K tokens      
- └─ Language output (gpt-35-turbo-16k)                                               Monthly cost depends on usage: $0.0015 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["gpt-35-turbo-instruct"]                                                             
- ├─ Language input (gpt-35-turbo-instruct)                                           Monthly cost depends on usage: $0.0015 per 1K tokens      
- └─ Language output (gpt-35-turbo-instruct)                                          Monthly cost depends on usage: $0.002 per 1K tokens       
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4"]                                                                             
- ├─ Language input (gpt-4)                                                           Monthly cost depends on usage: $0.03 per 1K tokens        
- ├─ Language output (gpt-4)                                                          Monthly cost depends on usage: $0.06 per 1K tokens        
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4-0125-preview"]                                                                
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4-1106-preview"]                                                                
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4-32k"]                                                                         
- ├─ Language input (gpt-4-32k)                                                       Monthly cost depends on usage: $0.06 per 1K tokens        
- └─ Language output (gpt-4-32k)                                                      Monthly cost depends on usage: $0.12 per 1K tokens        
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4-vision-preview"]                                                              
- └─ Code interpreter sessions (gpt-4)                                                Monthly cost depends on usage: $0.03 per sessions         
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["text-embedding-3-large"]                                                            
- └─ Text embeddings (text-embedding-3-large)                                         Monthly cost depends on usage: $0.00013 per 1K tokens     
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["text-embedding-3-small"]                                                            
- └─ Text embeddings (text-embedding-3-small)                                         Monthly cost depends on usage: $0.00002 per 1K tokens     
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["text-embedding-ada-002"]                                                            
- └─ Text embeddings (text-embedding-ada-002)                                         Monthly cost depends on usage: $0.0001 per 1K tokens      
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["tts"]                                                                               
- └─ Text to speech (tts)                                                             Monthly cost depends on usage: $15.00 per 1M characters   
-                                                                                                                                               
- azurerm_cognitive_deployment.swedencentral_without_usage["tts-hd"]                                                                            
- └─ Text to speech (tts-hd)                                                          Monthly cost depends on usage: $30.00 per 1M characters   
-                                                                                                                                               
- OVERALL TOTAL                                                                                                                   $20,498.94 
+ Name                                                                                                       Monthly Qty  Unit                    Monthly Cost   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_regional["gpt4o_high_capacity"]                                                                                       
+ ├─ Provisioned throughput units (gpt-4o)                                                                         3,650  hours                      $7,300.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4.5-preview"]                                                                                       
+ ├─ Text input (gpt-4.5-preview)                                                                                 40,000  1K tokens                  $3,630.00   
+ ├─ Text output (gpt-4.5-preview)                                                                            13,333.333  1K tokens                  $2,420.00   
+ ├─ Cached text input (gpt-4.5-preview)                                                                          20,000  1K tokens                    $907.50   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4.5-preview-2025-02-27"]                                                                            
+ ├─ Text input (gpt-4.5-preview)                                                                                 40,000  1K tokens                  $3,630.00   
+ ├─ Text output (gpt-4.5-preview)                                                                            13,333.333  1K tokens                  $2,420.00   
+ ├─ Cached text input (gpt-4.5-preview)                                                                          20,000  1K tokens                    $907.50   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4.5-preview"]                                                                                             
+ ├─ Text input (gpt-4.5-preview)                                                                                 40,000  1K tokens                  $3,300.00   
+ ├─ Text output (gpt-4.5-preview)                                                                            13,333.333  1K tokens                  $2,200.00   
+ ├─ Cached text input (gpt-4.5-preview)                                                                          20,000  1K tokens                    $825.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4.5-preview-2025-02-27"]                                                                                  
+ ├─ Text input (gpt-4.5-preview)                                                                                 40,000  1K tokens                  $3,300.00   
+ ├─ Text output (gpt-4.5-preview)                                                                            13,333.333  1K tokens                  $2,200.00   
+ ├─ Cached text input (gpt-4.5-preview)                                                                          20,000  1K tokens                    $825.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4.5-preview"]                                                                                              
+ ├─ Text input (gpt-4.5-preview)                                                                                 40,000  1K tokens                  $3,300.00   
+ ├─ Text output (gpt-4.5-preview)                                                                            13,333.333  1K tokens                  $2,200.00   
+ ├─ Cached text input (gpt-4.5-preview)                                                                          20,000  1K tokens                    $825.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4.5-preview-2025-02-27"]                                                                                   
+ ├─ Text input (gpt-4.5-preview)                                                                                 40,000  1K tokens                  $3,300.00   
+ ├─ Text output (gpt-4.5-preview)                                                                            13,333.333  1K tokens                  $2,200.00   
+ ├─ Cached text input (gpt-4.5-preview)                                                                          20,000  1K tokens                    $825.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4-32k"]                                                                                                   
+ ├─ Text input (gpt-4-32k)                                                                                       40,000  1K tokens                  $2,400.00   
+ ├─ Text output (gpt-4-32k)                                                                                  13,333.333  1K tokens                  $1,600.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4-32k"]                                                                                                    
+ ├─ Text input (gpt-4-32k)                                                                                       40,000  1K tokens                  $2,400.00   
+ ├─ Text output (gpt-4-32k)                                                                                  13,333.333  1K tokens                  $1,600.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4-32k"]                                                                                             
+ ├─ Text input (gpt-4-32k)                                                                                       40,000  1K tokens                  $2,400.00   
+ ├─ Text output (gpt-4-32k)                                                                                  13,333.333  1K tokens                  $1,600.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_data_zone["o1_mini_data_zone"]                                                                                        
+ ├─ Provisioned throughput units (o1-mini)                                                                        2,920  hours                      $3,212.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_provisioned["gpt4o_regional"]                                                                                             
+ ├─ Provisioned throughput units (gpt-4o)                                                                         1,460  hours                      $2,920.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_comparison["regional"]                                                                                                
+ ├─ Provisioned throughput units (gpt-4o)                                                                         1,460  hours                      $2,920.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_regional["gpt35_turbo"]                                                                                               
+ ├─ Provisioned throughput units (gpt-35-turbo)                                                                   1,460  hours                      $2,920.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Fine tuning training (gpt-35-turbo)                                                               Monthly cost depends on usage: $45.00 per hours           
+ ├─ Fine tuning hosting (gpt-35-turbo)                                                                Monthly cost depends on usage: $3.00 per hours            
+ ├─ Fine tuning input (gpt-35-turbo)                                                                  Monthly cost depends on usage: $0.0015 per 1K tokens      
+ └─ Fine tuning output (gpt-35-turbo)                                                                 Monthly cost depends on usage: $0.002 per 1K tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_provisioned["o3_mini_regional"]                                                                                     
+ ├─ Provisioned throughput units (o3-mini)                                                                        1,460  hours                      $2,920.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_provisioned["gpt4_global"]                                                                                                
+ ├─ Provisioned throughput units (gpt-4)                                                                          2,190  hours                      $2,190.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_global["gpt4_32k"]                                                                                                    
+ ├─ Provisioned throughput units (gpt-4-32k)                                                                      2,190  hours                      $2,190.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4"]                                                                                                       
+ ├─ Text input (gpt-4)                                                                                           40,000  1K tokens                  $1,200.00   
+ ├─ Text output (gpt-4)                                                                                      13,333.333  1K tokens                    $800.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4"]                                                                                                        
+ ├─ Text input (gpt-4)                                                                                           40,000  1K tokens                  $1,200.00   
+ ├─ Text output (gpt-4)                                                                                      13,333.333  1K tokens                    $800.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4"]                                                                                                 
+ ├─ Text input (gpt-4)                                                                                           40,000  1K tokens                  $1,200.00   
+ ├─ Text output (gpt-4)                                                                                      13,333.333  1K tokens                    $800.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["o1"]                                                                                                    
+ ├─ Text input (o1)                                                                                              40,000  1K tokens                    $726.00   
+ ├─ Text output (o1)                                                                                         13,333.333  1K tokens                    $968.00   
+ ├─ Cached text input (o1)                                                                                       20,000  1K tokens                    $181.50   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["o1-2024-12-17"]                                                                                         
+ ├─ Text input (o1)                                                                                              40,000  1K tokens                    $726.00   
+ ├─ Text output (o1)                                                                                         13,333.333  1K tokens                    $968.00   
+ ├─ Cached text input (o1)                                                                                       20,000  1K tokens                    $181.50   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["o1"]                                                                                                          
+ ├─ Text input (o1)                                                                                              40,000  1K tokens                    $660.00   
+ ├─ Text output (o1)                                                                                         13,333.333  1K tokens                    $880.00   
+ ├─ Cached text input (o1)                                                                                       20,000  1K tokens                    $165.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["o1-2024-12-17"]                                                                                               
+ ├─ Text input (o1)                                                                                              40,000  1K tokens                    $660.00   
+ ├─ Text output (o1)                                                                                         13,333.333  1K tokens                    $880.00   
+ ├─ Cached text input (o1)                                                                                       20,000  1K tokens                    $165.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["o1"]                                                                                                           
+ ├─ Text input (o1)                                                                                              40,000  1K tokens                    $660.00   
+ ├─ Text output (o1)                                                                                         13,333.333  1K tokens                    $880.00   
+ ├─ Cached text input (o1)                                                                                       20,000  1K tokens                    $165.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["o1-2024-12-17"]                                                                                                
+ ├─ Text input (o1)                                                                                              40,000  1K tokens                    $660.00   
+ ├─ Text output (o1)                                                                                         13,333.333  1K tokens                    $880.00   
+ ├─ Cached text input (o1)                                                                                       20,000  1K tokens                    $165.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_comparison["data_zone"]                                                                                               
+ ├─ Provisioned throughput units (gpt-4o)                                                                         1,460  hours                      $1,606.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_data_zone["gpt4o_data_zone"]                                                                                          
+ ├─ Provisioned throughput units (gpt-4o)                                                                         1,460  hours                      $1,606.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_comparison["global"]                                                                                                  
+ ├─ Provisioned throughput units (gpt-4o)                                                                         1,460  hours                      $1,460.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_regional["gpt4o"]                                                                                                     
+ ├─ Provisioned throughput units (gpt-4o)                                                                           730  hours                      $1,460.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.new_foundation_models["gpt45_preview"]                                                                                            
+ ├─ Text input (gpt-4.5-preview)                                                                                  8,000  1K tokens                    $660.00   
+ ├─ Text output (gpt-4.5-preview)                                                                                 3,000  1K tokens                    $495.00   
+ ├─ Cached text input (gpt-4.5-preview)                                                                           4,000  1K tokens                    $165.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.realtime_models["gpt4o_realtime_1001"]                                                                                            
+ ├─ Text input (gpt-4o-realtime-preview)                                                                          4,000  1K tokens                     $22.00   
+ ├─ Text output (gpt-4o-realtime-preview)                                                                         1,500  1K tokens                     $33.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                                  4,000  1k tokens                    $440.00   
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                                 2,500  1k tokens                    $550.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_provisioned["gpt4o_data_zone"]                                                                                      
+ ├─ Provisioned throughput units (gpt-4o)                                                                           730  hours                        $803.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.provisioned_global["gpt4"]                                                                                                        
+ ├─ Provisioned throughput units (gpt-4)                                                                            730  hours                        $730.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.realtime_models["gpt4o_realtime_1217"]                                                                                            
+ ├─ Text input (gpt-4o-realtime-preview)                                                                          6,000  1K tokens                     $33.00   
+ ├─ Text output (gpt-4o-realtime-preview)                                                                         2,000  1K tokens                     $44.00   
+ ├─ Cached text input (gpt-4o-realtime-preview)                                                                   3,000  1K tokens                      $8.25   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                                  6,000  1k tokens                    $264.00   
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                                 4,000  1k tokens                    $352.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-realtime-preview-2024-12-17"]                                                                    
+ ├─ Text input (gpt-4o-realtime-preview)                                                                         40,000  1K tokens                    $242.00   
+ ├─ Text output (gpt-4o-realtime-preview)                                                                    13,333.333  1K tokens                    $322.67   
+ ├─ Cached text input (gpt-4o-realtime-preview)                                                                  20,000  1K tokens                     $60.50   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.0484 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.0968 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-realtime-preview-2024-12-17"]                                                                          
+ ├─ Text input (gpt-4o-realtime-preview)                                                                         40,000  1K tokens                    $220.00   
+ ├─ Text output (gpt-4o-realtime-preview)                                                                    13,333.333  1K tokens                    $293.33   
+ ├─ Cached text input (gpt-4o-realtime-preview)                                                                  20,000  1K tokens                     $55.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-realtime-preview-2024-12-17"]                                                                           
+ ├─ Text input (gpt-4o-realtime-preview)                                                                         40,000  1K tokens                    $220.00   
+ ├─ Text output (gpt-4o-realtime-preview)                                                                    13,333.333  1K tokens                    $293.33   
+ ├─ Cached text input (gpt-4o-realtime-preview)                                                                  20,000  1K tokens                     $55.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-realtime-preview-2024-10-01"]                                                                    
+ ├─ Text input (gpt-4o-realtime-preview)                                                                         40,000  1K tokens                    $242.00   
+ ├─ Text output (gpt-4o-realtime-preview)                                                                    13,333.333  1K tokens                    $322.67   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.12 per 1k tokens        
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.24 per 1k tokens        
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-realtime-preview-2024-10-01"]                                                                          
+ ├─ Text input (gpt-4o-realtime-preview)                                                                         40,000  1K tokens                    $220.00   
+ ├─ Text output (gpt-4o-realtime-preview)                                                                    13,333.333  1K tokens                    $293.33   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.11 per 1k tokens        
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.22 per 1k tokens        
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-realtime-preview-2024-10-01"]                                                                           
+ ├─ Text input (gpt-4o-realtime-preview)                                                                         40,000  1K tokens                    $220.00   
+ ├─ Text output (gpt-4o-realtime-preview)                                                                    13,333.333  1K tokens                    $293.33   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.11 per 1k tokens        
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.22 per 1k tokens        
+                                                                                                                                                                
+ azurerm_cognitive_deployment.audio_models["gpt4o_audio"]                                                                                                       
+ ├─ Text input (gpt-4o-audio-preview)                                                                             5,000  1K tokens                     $13.75   
+ ├─ Text output (gpt-4o-audio-preview)                                                                            2,500  1K tokens                     $27.50   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                                     5,000  1k tokens                    $220.00   
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                                    2,500  1k tokens                    $220.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o"]                                                                                                       
+ ├─ Text input (gpt-4o)                                                                                          40,000  1K tokens                    $200.00   
+ ├─ Text output (gpt-4o)                                                                                     13,333.333  1K tokens                    $200.00   
+ ├─ File search tool calls                                                                                            5  1k calls                      $12.50   
+ ├─ File search vector storage                                                                                      3.5  GB                             $0.35   
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o"]                                                                                                      
+ ├─ Text input (gpt-4o)                                                                                          40,000  1K tokens                    $200.00   
+ ├─ Text output (gpt-4o)                                                                                     13,333.333  1K tokens                    $200.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-2024-05-13"]                                                                                           
+ ├─ Text input (gpt-4o)                                                                                          40,000  1K tokens                    $200.00   
+ ├─ Text output (gpt-4o)                                                                                     13,333.333  1K tokens                    $200.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-2024-05-13"]                                                                                            
+ ├─ Text input (gpt-4o)                                                                                          40,000  1K tokens                    $200.00   
+ ├─ Text output (gpt-4o)                                                                                     13,333.333  1K tokens                    $200.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o"]                                                                                                
+ ├─ Text input (gpt-4o)                                                                                          40,000  1K tokens                    $200.00   
+ ├─ Text output (gpt-4o)                                                                                     13,333.333  1K tokens                    $200.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-2024-05-13"]                                                                                     
+ ├─ Text input (gpt-4o)                                                                                          40,000  1K tokens                    $200.00   
+ ├─ Text output (gpt-4o)                                                                                     13,333.333  1K tokens                    $200.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["computer-use-preview"]                                                                                  
+ ├─ Text input (computer-use-preview)                                                                            40,000  1K tokens                    $145.20   
+ ├─ Text output (computer-use-preview)                                                                       13,333.333  1K tokens                    $193.60   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["computer-use-preview-global"]                                                                           
+ ├─ Text input (computer-use-preview)                                                                            40,000  1K tokens                    $145.20   
+ ├─ Text output (computer-use-preview)                                                                       13,333.333  1K tokens                    $193.60   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["computer-use-preview"]                                                                                        
+ ├─ Text input (computer-use-preview)                                                                            40,000  1K tokens                    $132.00   
+ ├─ Text output (computer-use-preview)                                                                       13,333.333  1K tokens                    $176.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["computer-use-preview-global"]                                                                                 
+ ├─ Text input (computer-use-preview)                                                                            40,000  1K tokens                    $132.00   
+ ├─ Text output (computer-use-preview)                                                                       13,333.333  1K tokens                    $176.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["computer-use-preview"]                                                                                         
+ ├─ Text input (computer-use-preview)                                                                            40,000  1K tokens                    $132.00   
+ ├─ Text output (computer-use-preview)                                                                       13,333.333  1K tokens                    $176.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["computer-use-preview-global"]                                                                                  
+ ├─ Text input (computer-use-preview)                                                                            40,000  1K tokens                    $132.00   
+ ├─ Text output (computer-use-preview)                                                                       13,333.333  1K tokens                    $176.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["davinci-002"]                                                                                                  
+ ├─ Base model tokens (davinci-002)                                                                               2.847  1K tokens                    $242.00   
+ ├─ Fine tuning training (davinci-002)                                                                              0.4  hours                         $16.00   
+ ├─ Fine tuning hosting (davinci-002)                                                                               6.6  hours                         $13.20   
+ ├─ Fine tuning input (davinci-002)                                                                          13,333.333  1K tokens                     $26.67   
+ └─ Fine tuning output (davinci-002)                                                                             10,000  1K tokens                     $20.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.new_foundation_models["o1_model"]                                                                                                 
+ ├─ Text input (o1)                                                                                               7,000  1K tokens                    $115.50   
+ ├─ Text output (o1)                                                                                              2,500  1K tokens                    $165.00   
+ ├─ Cached text input (o1)                                                                                        3,500  1K tokens                     $28.88   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-2024-08-06"]                                                                                     
+ ├─ Text input (gpt-4o)                                                                                          40,000  1K tokens                    $110.00   
+ ├─ Text output (gpt-4o)                                                                                     13,333.333  1K tokens                    $146.67   
+ ├─ Cached text input (gpt-4o)                                                                                   20,000  1K tokens                     $30.26   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-2024-08-06"]                                                                                           
+ ├─ Text input (gpt-4o)                                                                                          40,000  1K tokens                    $110.00   
+ ├─ Text output (gpt-4o)                                                                                     13,333.333  1K tokens                    $146.67   
+ ├─ Cached text input (gpt-4o)                                                                                   20,000  1K tokens                     $27.50   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-2024-08-06"]                                                                                            
+ ├─ Text input (gpt-4o)                                                                                          40,000  1K tokens                    $110.00   
+ ├─ Text output (gpt-4o)                                                                                     13,333.333  1K tokens                    $146.67   
+ ├─ Cached text input (gpt-4o)                                                                                   20,000  1K tokens                     $27.50   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-audio-preview"]                                                                                  
+ ├─ Text input (gpt-4o-audio-preview)                                                                            40,000  1K tokens                    $121.00   
+ ├─ Text output (gpt-4o-audio-preview)                                                                       13,333.333  1K tokens                    $161.33   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.0484 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.0968 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-audio-preview-2024-12-17"]                                                                       
+ ├─ Text input (gpt-4o-audio-preview)                                                                            40,000  1K tokens                    $121.00   
+ ├─ Text output (gpt-4o-audio-preview)                                                                       13,333.333  1K tokens                    $161.33   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.0484 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.0968 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-audio-preview"]                                                                                        
+ ├─ Text input (gpt-4o-audio-preview)                                                                            40,000  1K tokens                    $110.00   
+ ├─ Text output (gpt-4o-audio-preview)                                                                       13,333.333  1K tokens                    $146.67   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-audio-preview-2024-12-17"]                                                                             
+ ├─ Text input (gpt-4o-audio-preview)                                                                            40,000  1K tokens                    $110.00   
+ ├─ Text output (gpt-4o-audio-preview)                                                                       13,333.333  1K tokens                    $146.67   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-audio-preview"]                                                                                         
+ ├─ Text input (gpt-4o-audio-preview)                                                                            40,000  1K tokens                    $110.00   
+ ├─ Text output (gpt-4o-audio-preview)                                                                       13,333.333  1K tokens                    $146.67   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-audio-preview-2024-12-17"]                                                                              
+ ├─ Text input (gpt-4o-audio-preview)                                                                            40,000  1K tokens                    $110.00   
+ ├─ Text output (gpt-4o-audio-preview)                                                                       13,333.333  1K tokens                    $146.67   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-35-turbo-16k"]                                                                                            
+ ├─ Text input (gpt-35-turbo-16k)                                                                                40,000  1K tokens                    $120.00   
+ ├─ Text output (gpt-35-turbo-16k)                                                                           13,333.333  1K tokens                     $53.33   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-35-turbo-16k"]                                                                                             
+ ├─ Text input (gpt-35-turbo-16k)                                                                                40,000  1K tokens                    $120.00   
+ ├─ Text output (gpt-35-turbo-16k)                                                                           13,333.333  1K tokens                     $53.33   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-35-turbo-16k"]                                                                                      
+ ├─ Text input (gpt-35-turbo-16k)                                                                                40,000  1K tokens                    $120.00   
+ ├─ Text output (gpt-35-turbo-16k)                                                                           13,333.333  1K tokens                     $53.33   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-35-turbo"]                                                                                                 
+ ├─ Text input (gpt-35-turbo)                                                                                    40,000  1K tokens                     $60.00   
+ ├─ Text output (gpt-35-turbo)                                                                               13,333.333  1K tokens                     $26.67   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Fine tuning training (gpt-35-turbo)                                                                             0.4  hours                         $18.00   
+ ├─ Fine tuning hosting (gpt-35-turbo)                                                                              6.6  hours                         $19.80   
+ ├─ Fine tuning input (gpt-35-turbo)                                                                         13,333.333  1K tokens                     $20.00   
+ └─ Fine tuning output (gpt-35-turbo)                                                                            10,000  1K tokens                     $20.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-35-turbo"]                                                                                                
+ ├─ Text input (gpt-35-turbo)                                                                                    40,000  1K tokens                     $60.00   
+ ├─ Text output (gpt-35-turbo)                                                                               13,333.333  1K tokens                     $26.67   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Fine tuning training (gpt-35-turbo)                                                                             0.4  hours                         $18.00   
+ ├─ Fine tuning hosting (gpt-35-turbo)                                                                              6.6  hours                         $19.80   
+ ├─ Fine tuning input (gpt-35-turbo)                                                                         13,333.333  1K tokens                      $6.67   
+ └─ Fine tuning output (gpt-35-turbo)                                                                            10,000  1K tokens                     $15.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-35-turbo"]                                                                                          
+ ├─ Text input (gpt-35-turbo)                                                                                    40,000  1K tokens                     $60.00   
+ ├─ Text output (gpt-35-turbo)                                                                               13,333.333  1K tokens                     $26.67   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Fine tuning training (gpt-35-turbo)                                                                             0.4  hours                         $18.00   
+ ├─ Fine tuning hosting (gpt-35-turbo)                                                                              6.6  hours                         $19.80   
+ ├─ Fine tuning input (gpt-35-turbo)                                                                         13,333.333  1K tokens                      $6.67   
+ └─ Fine tuning output (gpt-35-turbo)                                                                            10,000  1K tokens                     $15.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["o1-mini"]                                                                                               
+ ├─ Text input (o1-mini)                                                                                         40,000  1K tokens                     $53.24   
+ ├─ Text output (o1-mini)                                                                                    13,333.333  1K tokens                     $70.99   
+ ├─ Cached text input (o1-mini)                                                                                  20,000  1K tokens                     $13.32   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["o1-mini-2024-09-12"]                                                                                    
+ ├─ Text input (o1-mini)                                                                                         40,000  1K tokens                     $53.24   
+ ├─ Text output (o1-mini)                                                                                    13,333.333  1K tokens                     $70.99   
+ ├─ Cached text input (o1-mini)                                                                                  20,000  1K tokens                     $13.32   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["o3-mini"]                                                                                               
+ ├─ Text input (o3-mini)                                                                                         40,000  1K tokens                     $53.24   
+ ├─ Text output (o3-mini)                                                                                    13,333.333  1K tokens                     $70.99   
+ ├─ Cached text input (o3-mini)                                                                                  20,000  1K tokens                     $13.32   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["o3-mini-2025-01-31"]                                                                                    
+ ├─ Text input (o3-mini)                                                                                         40,000  1K tokens                     $53.24   
+ ├─ Text output (o3-mini)                                                                                    13,333.333  1K tokens                     $70.99   
+ ├─ Cached text input (o3-mini)                                                                                  20,000  1K tokens                     $13.32   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["o1-mini"]                                                                                                     
+ ├─ Text input (o1-mini)                                                                                         40,000  1K tokens                     $48.40   
+ ├─ Text output (o1-mini)                                                                                    13,333.333  1K tokens                     $64.53   
+ ├─ Cached text input (o1-mini)                                                                                  20,000  1K tokens                     $12.10   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["o1-mini-2024-09-12"]                                                                                          
+ ├─ Text input (o1-mini)                                                                                         40,000  1K tokens                     $48.40   
+ ├─ Text output (o1-mini)                                                                                    13,333.333  1K tokens                     $64.53   
+ ├─ Cached text input (o1-mini)                                                                                  20,000  1K tokens                     $12.10   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["o3-mini"]                                                                                                     
+ ├─ Text input (o3-mini)                                                                                         40,000  1K tokens                     $48.40   
+ ├─ Text output (o3-mini)                                                                                    13,333.333  1K tokens                     $64.53   
+ ├─ Cached text input (o3-mini)                                                                                  20,000  1K tokens                     $12.10   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["o3-mini-2025-01-31"]                                                                                          
+ ├─ Text input (o3-mini)                                                                                         40,000  1K tokens                     $48.40   
+ ├─ Text output (o3-mini)                                                                                    13,333.333  1K tokens                     $64.53   
+ ├─ Cached text input (o3-mini)                                                                                  20,000  1K tokens                     $12.10   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["o3-mini"]                                                                                                      
+ ├─ Text input (o3-mini)                                                                                         40,000  1K tokens                     $48.40   
+ ├─ Text output (o3-mini)                                                                                    13,333.333  1K tokens                     $64.53   
+ ├─ Cached text input (o3-mini)                                                                                  20,000  1K tokens                     $12.10   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["o3-mini-2025-01-31"]                                                                                           
+ ├─ Text input (o3-mini)                                                                                         40,000  1K tokens                     $48.40   
+ ├─ Text output (o3-mini)                                                                                    13,333.333  1K tokens                     $64.53   
+ ├─ Cached text input (o3-mini)                                                                                  20,000  1K tokens                     $12.10   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["text-embedding-3-large"]                                                                                      
+ └─ Text embeddings (text-embedding-3-large)                                                                  1,000,000  1K tokens                    $130.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["text-embedding-3-large"]                                                                                       
+ └─ Text embeddings (text-embedding-3-large)                                                                  1,000,000  1K tokens                    $130.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["text-embedding-3-large"]                                                                                
+ └─ Text embeddings (text-embedding-3-large)                                                                  1,000,000  1K tokens                    $130.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["text-embedding-ada-002"]                                                                                      
+ └─ Text embeddings (text-embedding-ada-002)                                                                  1,000,000  1K tokens                    $100.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["text-embedding-ada-002"]                                                                                       
+ └─ Text embeddings (text-embedding-ada-002)                                                                  1,000,000  1K tokens                    $100.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["text-embedding-ada-002"]                                                                                
+ └─ Text embeddings (text-embedding-ada-002)                                                                  1,000,000  1K tokens                    $100.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-mini-realtime-preview"]                                                                          
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                                    40,000  1K tokens                     $29.04   
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                               13,333.333  1K tokens                     $38.72   
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                             20,000  1K tokens                      $7.26   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.0121 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.0242 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-mini-realtime-preview-2024-12-17"]                                                               
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                                    40,000  1K tokens                     $29.04   
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                               13,333.333  1K tokens                     $38.72   
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                             20,000  1K tokens                      $7.26   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.0121 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.0242 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.realtime_models["gpt4o_mini_realtime"]                                                                                            
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                                     3,500  1K tokens                      $2.31   
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                                    1,200  1K tokens                      $3.17   
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                              1,750  1K tokens                      $0.58   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                             3,500  1k tokens                     $38.50   
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                            2,000  1k tokens                     $44.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-mini-realtime-preview"]                                                                                
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                                    40,000  1K tokens                     $26.40   
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                               13,333.333  1K tokens                     $35.20   
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                             20,000  1K tokens                      $6.60   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-mini-realtime-preview-2024-12-17"]                                                                     
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                                    40,000  1K tokens                     $26.40   
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                               13,333.333  1K tokens                     $35.20   
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                             20,000  1K tokens                      $6.60   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-mini-realtime-preview"]                                                                                 
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                                    40,000  1K tokens                     $26.40   
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                               13,333.333  1K tokens                     $35.20   
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                             20,000  1K tokens                      $6.60   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-mini-realtime-preview-2024-12-17"]                                                                      
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                                    40,000  1K tokens                     $26.40   
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                               13,333.333  1K tokens                     $35.20   
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                             20,000  1K tokens                      $6.60   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["dall-e-3"]                                                                                                     
+ ├─ Standard 1024x1024 images (dall-e-3)                                                                              5  100 images                    $20.00   
+ ├─ Standard 1024x1792 images (dall-e-3)                                                                            2.5  100 images                    $20.00   
+ ├─ HD 1024x1024 images (dall-e-3)                                                                                  2.5  100 images                    $20.00   
+ └─ HD 1024x1792 images (dall-e-3)                                                                                 1.67  100 images                    $20.04   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["dall-e-3"]                                                                                              
+ ├─ Standard 1024x1024 images (dall-e-3)                                                                              5  100 images                    $20.00   
+ ├─ Standard 1024x1792 images (dall-e-3)                                                                            2.5  100 images                    $20.00   
+ ├─ HD 1024x1024 images (dall-e-3)                                                                                  2.5  100 images                    $20.00   
+ └─ HD 1024x1792 images (dall-e-3)                                                                                 1.67  100 images                    $20.04   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["davinci-002"]                                                                                                 
+ ├─ Fine tuning training (davinci-002)                                                                              0.4  hours                         $16.00   
+ ├─ Fine tuning hosting (davinci-002)                                                                               6.6  hours                         $13.20   
+ ├─ Fine tuning input (davinci-002)                                                                          13,333.333  1K tokens                     $26.67   
+ └─ Fine tuning output (davinci-002)                                                                             10,000  1K tokens                     $20.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.audio_models["gpt4o_mini_audio"]                                                                                                  
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                                        3,000  1K tokens                      $0.50   
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                                       1,500  1K tokens                      $0.99   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                                3,000  1k tokens                     $33.00   
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                               1,500  1k tokens                     $33.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["babbage-002"]                                                                                                  
+ ├─ Base model tokens (babbage-002)                                                                               2.847  1K tokens                     $19.93   
+ ├─ Fine tuning training (babbage-002)                                                                              0.4  hours                         $13.60   
+ ├─ Fine tuning hosting (babbage-002)                                                                               6.6  hours                         $11.22   
+ ├─ Fine tuning input (babbage-002)                                                                          13,333.333  1K tokens                      $5.33   
+ └─ Fine tuning output (babbage-002)                                                                             10,000  1K tokens                      $4.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["o1-mini"]                                                                                                      
+ ├─ Cached text input (o1-mini)                                                                                  20,000  1K tokens                     $33.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["o1-mini-2024-09-12"]                                                                                           
+ ├─ Cached text input (o1-mini)                                                                                  20,000  1K tokens                     $33.00   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["tts-hd"]                                                                                                
+ └─ Text to speech (tts-hd)                                                                                      1.3333  1M characters                 $40.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-mini"]                                                                                           
+ ├─ Text input (gpt-4o-mini)                                                                                     40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini)                                                                                13,333.333  1K tokens                      $8.80   
+ ├─ Cached text input (gpt-4o-mini)                                                                              20,000  1K tokens                      $1.82   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-mini-2024-07-18"]                                                                                
+ ├─ Text input (gpt-4o-mini)                                                                                     40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini)                                                                                13,333.333  1K tokens                      $8.80   
+ ├─ Cached text input (gpt-4o-mini)                                                                              20,000  1K tokens                      $1.82   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-mini"]                                                                                                 
+ ├─ Text input (gpt-4o-mini)                                                                                     40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini)                                                                                13,333.333  1K tokens                      $8.80   
+ ├─ Cached text input (gpt-4o-mini)                                                                              20,000  1K tokens                      $1.66   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-mini-2024-07-18"]                                                                                      
+ ├─ Text input (gpt-4o-mini)                                                                                     40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini)                                                                                13,333.333  1K tokens                      $8.80   
+ ├─ Cached text input (gpt-4o-mini)                                                                              20,000  1K tokens                      $1.66   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-mini"]                                                                                                  
+ ├─ Text input (gpt-4o-mini)                                                                                     40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini)                                                                                13,333.333  1K tokens                      $8.80   
+ ├─ Cached text input (gpt-4o-mini)                                                                              20,000  1K tokens                      $1.66   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-mini-2024-07-18"]                                                                                       
+ ├─ Text input (gpt-4o-mini)                                                                                     40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini)                                                                                13,333.333  1K tokens                      $8.80   
+ ├─ Cached text input (gpt-4o-mini)                                                                              20,000  1K tokens                      $1.66   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-mini-audio-preview"]                                                                             
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                                       40,000  1K tokens                      $7.28   
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                                  13,333.333  1K tokens                      $9.68   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.0121 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.0242 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-mini-audio-preview-2024-12-17"]                                                                  
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                                       40,000  1K tokens                      $7.28   
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                                  13,333.333  1K tokens                      $9.68   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.0121 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.0242 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-mini-audio-preview"]                                                                                   
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                                       40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                                  13,333.333  1K tokens                      $8.80   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-mini-audio-preview-2024-12-17"]                                                                        
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                                       40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                                  13,333.333  1K tokens                      $8.80   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-mini-audio-preview"]                                                                                    
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                                       40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                                  13,333.333  1K tokens                      $8.80   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-mini-audio-preview-2024-12-17"]                                                                         
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                                       40,000  1K tokens                      $6.60   
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                                  13,333.333  1K tokens                      $8.80   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["babbage-002"]                                                                                                 
+ ├─ Fine tuning training (babbage-002)                                                                              0.4  hours                         $13.60   
+ ├─ Fine tuning hosting (babbage-002)                                                                               6.6  hours                         $11.22   
+ ├─ Fine tuning input (babbage-002)                                                                          13,333.333  1K tokens                      $5.33   
+ └─ Fine tuning output (babbage-002)                                                                             10,000  1K tokens                      $4.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["whisper"]                                                                                                      
+ └─ Text to speech (whisper)                                                                                       55.6  hours                         $20.02   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4-0125-preview"]                                                                                          
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4-1106-preview"]                                                                                          
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["gpt-4o-realtime-preview"]                                                                                     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4-0125-preview"]                                                                                           
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4-1106-preview"]                                                                                           
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["gpt-4o-realtime-preview"]                                                                                      
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4-0125-preview"]                                                                                    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4-1106-preview"]                                                                                    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["gpt-4o-realtime-preview"]                                                                               
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                                       667  sessions                      $20.01   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["dall-e-3"]                                                                                                    
+ └─ Standard 1024x1792 images (dall-e-3)                                                                            2.5  100 images                    $20.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_with_usage["text-embedding-3-small"]                                                                                      
+ └─ Text embeddings (text-embedding-3-small)                                                                  1,000,000  1K tokens                     $20.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["text-embedding-3-small"]                                                                                       
+ └─ Text embeddings (text-embedding-3-small)                                                                  1,000,000  1K tokens                     $20.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["text-embedding-3-small"]                                                                                
+ └─ Text embeddings (text-embedding-3-small)                                                                  1,000,000  1K tokens                     $20.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_with_usage["tts"]                                                                                                   
+ └─ Text to speech (tts)                                                                                         1.3333  1M characters                 $20.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.computer_use_models                                                                                                               
+ ├─ Text input (computer-use-preview)                                                                             2,000  1K tokens                      $6.60   
+ ├─ Text output (computer-use-preview)                                                                            1,000  1K tokens                     $13.20   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.new_foundation_models["o3_mini_model"]                                                                                            
+ ├─ Text input (o3-mini)                                                                                          6,000  1K tokens                      $7.26   
+ ├─ Text output (o3-mini)                                                                                         2,200  1K tokens                     $10.65   
+ ├─ Cached text input (o3-mini)                                                                                   3,000  1K tokens                      $1.82   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_with_usage["dall-e-2"]                                                                                                     
+ └─ Standard 1024x1024 images (dall-e-2)                                                                              5  100 images                    $10.00   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.new_foundation_models["o1_mini_model"]                                                                                            
+ ├─ Cached text input (o1-mini)                                                                                   2,750  1K tokens                      $4.54   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["babbage-002"]                                                                                              
+ ├─ Fine tuning training (babbage-002)                                                                Monthly cost depends on usage: $34.00 per hours           
+ ├─ Fine tuning hosting (babbage-002)                                                                 Monthly cost depends on usage: $1.70 per hours            
+ ├─ Fine tuning input (babbage-002)                                                                   Monthly cost depends on usage: $0.0004 per 1K tokens      
+ └─ Fine tuning output (babbage-002)                                                                  Monthly cost depends on usage: $0.0004 per 1K tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["computer-use-preview"]                                                                                     
+ ├─ Text input (computer-use-preview)                                                                 Monthly cost depends on usage: $0.0033 per 1K tokens      
+ ├─ Text output (computer-use-preview)                                                                Monthly cost depends on usage: $0.0132 per 1K tokens      
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["computer-use-preview-global"]                                                                              
+ ├─ Text input (computer-use-preview)                                                                 Monthly cost depends on usage: $0.0033 per 1K tokens      
+ ├─ Text output (computer-use-preview)                                                                Monthly cost depends on usage: $0.0132 per 1K tokens      
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["dall-e-3"]                                                                                                 
+ └─ Standard 1024x1792 images (dall-e-3)                                                              Monthly cost depends on usage: $8.00 per 100 images       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["davinci-002"]                                                                                              
+ ├─ Fine tuning training (davinci-002)                                                                Monthly cost depends on usage: $40.00 per hours           
+ ├─ Fine tuning hosting (davinci-002)                                                                 Monthly cost depends on usage: $2.00 per hours            
+ ├─ Fine tuning input (davinci-002)                                                                   Monthly cost depends on usage: $0.002 per 1K tokens       
+ └─ Fine tuning output (davinci-002)                                                                  Monthly cost depends on usage: $0.002 per 1K tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-35-turbo"]                                                                                             
+ ├─ Text input (gpt-35-turbo)                                                                         Monthly cost depends on usage: $0.0015 per 1K tokens      
+ ├─ Text output (gpt-35-turbo)                                                                        Monthly cost depends on usage: $0.002 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Fine tuning training (gpt-35-turbo)                                                               Monthly cost depends on usage: $45.00 per hours           
+ ├─ Fine tuning hosting (gpt-35-turbo)                                                                Monthly cost depends on usage: $3.00 per hours            
+ ├─ Fine tuning input (gpt-35-turbo)                                                                  Monthly cost depends on usage: $0.0005 per 1K tokens      
+ └─ Fine tuning output (gpt-35-turbo)                                                                 Monthly cost depends on usage: $0.0015 per 1K tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-35-turbo-16k"]                                                                                         
+ ├─ Text input (gpt-35-turbo-16k)                                                                     Monthly cost depends on usage: $0.003 per 1K tokens       
+ ├─ Text output (gpt-35-turbo-16k)                                                                    Monthly cost depends on usage: $0.004 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4"]                                                                                                    
+ ├─ Text input (gpt-4)                                                                                Monthly cost depends on usage: $0.03 per 1K tokens        
+ ├─ Text output (gpt-4)                                                                               Monthly cost depends on usage: $0.06 per 1K tokens        
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4-0125-preview"]                                                                                       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4-1106-preview"]                                                                                       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4-32k"]                                                                                                
+ ├─ Text input (gpt-4-32k)                                                                            Monthly cost depends on usage: $0.06 per 1K tokens        
+ ├─ Text output (gpt-4-32k)                                                                           Monthly cost depends on usage: $0.12 per 1K tokens        
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4.5-preview"]                                                                                          
+ ├─ Text input (gpt-4.5-preview)                                                                      Monthly cost depends on usage: $0.0825 per 1K tokens      
+ ├─ Text output (gpt-4.5-preview)                                                                     Monthly cost depends on usage: $0.17 per 1K tokens        
+ ├─ Cached text input (gpt-4.5-preview)                                                               Monthly cost depends on usage: $0.04125 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4.5-preview-2025-02-27"]                                                                               
+ ├─ Text input (gpt-4.5-preview)                                                                      Monthly cost depends on usage: $0.0825 per 1K tokens      
+ ├─ Text output (gpt-4.5-preview)                                                                     Monthly cost depends on usage: $0.17 per 1K tokens        
+ ├─ Cached text input (gpt-4.5-preview)                                                               Monthly cost depends on usage: $0.04125 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o"]                                                                                                   
+ ├─ Text input (gpt-4o)                                                                               Monthly cost depends on usage: $0.005 per 1K tokens       
+ ├─ Text output (gpt-4o)                                                                              Monthly cost depends on usage: $0.015 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-2024-05-13"]                                                                                        
+ ├─ Text input (gpt-4o)                                                                               Monthly cost depends on usage: $0.005 per 1K tokens       
+ ├─ Text output (gpt-4o)                                                                              Monthly cost depends on usage: $0.015 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-2024-08-06"]                                                                                        
+ ├─ Text input (gpt-4o)                                                                               Monthly cost depends on usage: $0.00275 per 1K tokens     
+ ├─ Text output (gpt-4o)                                                                              Monthly cost depends on usage: $0.011 per 1K tokens       
+ ├─ Cached text input (gpt-4o)                                                                        Monthly cost depends on usage: $0.001375 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-audio-preview"]                                                                                     
+ ├─ Text input (gpt-4o-audio-preview)                                                                 Monthly cost depends on usage: $0.00275 per 1K tokens     
+ ├─ Text output (gpt-4o-audio-preview)                                                                Monthly cost depends on usage: $0.011 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-audio-preview-2024-12-17"]                                                                          
+ ├─ Text input (gpt-4o-audio-preview)                                                                 Monthly cost depends on usage: $0.00275 per 1K tokens     
+ ├─ Text output (gpt-4o-audio-preview)                                                                Monthly cost depends on usage: $0.011 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-mini"]                                                                                              
+ ├─ Text input (gpt-4o-mini)                                                                          Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini)                                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini)                                                                   Monthly cost depends on usage: $0.000083 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-mini-2024-07-18"]                                                                                   
+ ├─ Text input (gpt-4o-mini)                                                                          Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini)                                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini)                                                                   Monthly cost depends on usage: $0.000083 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-mini-audio-preview"]                                                                                
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                            Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                           Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-mini-audio-preview-2024-12-17"]                                                                     
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                            Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                           Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-mini-realtime-preview"]                                                                             
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                        Monthly cost depends on usage: $0.00264 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                  Monthly cost depends on usage: $0.00033 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-mini-realtime-preview-2024-12-17"]                                                                  
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                        Monthly cost depends on usage: $0.00264 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                  Monthly cost depends on usage: $0.00033 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-realtime-preview"]                                                                                  
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-realtime-preview-2024-10-01"]                                                                       
+ ├─ Text input (gpt-4o-realtime-preview)                                                              Monthly cost depends on usage: $0.0055 per 1K tokens      
+ ├─ Text output (gpt-4o-realtime-preview)                                                             Monthly cost depends on usage: $0.022 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.11 per 1k tokens        
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.22 per 1k tokens        
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["gpt-4o-realtime-preview-2024-12-17"]                                                                       
+ ├─ Text input (gpt-4o-realtime-preview)                                                              Monthly cost depends on usage: $0.0055 per 1K tokens      
+ ├─ Text output (gpt-4o-realtime-preview)                                                             Monthly cost depends on usage: $0.022 per 1K tokens       
+ ├─ Cached text input (gpt-4o-realtime-preview)                                                       Monthly cost depends on usage: $0.00275 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["o1"]                                                                                                       
+ ├─ Text input (o1)                                                                                   Monthly cost depends on usage: $0.0165 per 1K tokens      
+ ├─ Text output (o1)                                                                                  Monthly cost depends on usage: $0.066 per 1K tokens       
+ ├─ Cached text input (o1)                                                                            Monthly cost depends on usage: $0.00825 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["o1-2024-12-17"]                                                                                            
+ ├─ Text input (o1)                                                                                   Monthly cost depends on usage: $0.0165 per 1K tokens      
+ ├─ Text output (o1)                                                                                  Monthly cost depends on usage: $0.066 per 1K tokens       
+ ├─ Cached text input (o1)                                                                            Monthly cost depends on usage: $0.00825 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["o1-mini"]                                                                                                  
+ ├─ Text input (o1-mini)                                                                              Monthly cost depends on usage: $0.00121 per 1K tokens     
+ ├─ Text output (o1-mini)                                                                             Monthly cost depends on usage: $0.00484 per 1K tokens     
+ ├─ Cached text input (o1-mini)                                                                       Monthly cost depends on usage: $0.000605 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["o1-mini-2024-09-12"]                                                                                       
+ ├─ Text input (o1-mini)                                                                              Monthly cost depends on usage: $0.00121 per 1K tokens     
+ ├─ Text output (o1-mini)                                                                             Monthly cost depends on usage: $0.00484 per 1K tokens     
+ ├─ Cached text input (o1-mini)                                                                       Monthly cost depends on usage: $0.000605 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["o3-mini"]                                                                                                  
+ ├─ Text input (o3-mini)                                                                              Monthly cost depends on usage: $0.00121 per 1K tokens     
+ ├─ Text output (o3-mini)                                                                             Monthly cost depends on usage: $0.00484 per 1K tokens     
+ ├─ Cached text input (o3-mini)                                                                       Monthly cost depends on usage: $0.000605 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["o3-mini-2025-01-31"]                                                                                       
+ ├─ Text input (o3-mini)                                                                              Monthly cost depends on usage: $0.00121 per 1K tokens     
+ ├─ Text output (o3-mini)                                                                             Monthly cost depends on usage: $0.00484 per 1K tokens     
+ ├─ Cached text input (o3-mini)                                                                       Monthly cost depends on usage: $0.000605 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["text-embedding-3-large"]                                                                                   
+ └─ Text embeddings (text-embedding-3-large)                                                          Monthly cost depends on usage: $0.00013 per 1K tokens     
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["text-embedding-3-small"]                                                                                   
+ └─ Text embeddings (text-embedding-3-small)                                                          Monthly cost depends on usage: $0.00002 per 1K tokens     
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus2_without_usage["text-embedding-ada-002"]                                                                                   
+ └─ Text embeddings (text-embedding-ada-002)                                                          Monthly cost depends on usage: $0.0001 per 1K tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["babbage-002"]                                                                                               
+ ├─ Base model tokens (babbage-002)                                                                   Monthly cost depends on usage: $7.00 per 1K tokens        
+ ├─ Fine tuning training (babbage-002)                                                                Monthly cost depends on usage: $34.00 per hours           
+ ├─ Fine tuning hosting (babbage-002)                                                                 Monthly cost depends on usage: $1.70 per hours            
+ ├─ Fine tuning input (babbage-002)                                                                   Monthly cost depends on usage: $0.0004 per 1K tokens      
+ └─ Fine tuning output (babbage-002)                                                                  Monthly cost depends on usage: $0.0004 per 1K tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["computer-use-preview"]                                                                                      
+ ├─ Text input (computer-use-preview)                                                                 Monthly cost depends on usage: $0.0033 per 1K tokens      
+ ├─ Text output (computer-use-preview)                                                                Monthly cost depends on usage: $0.0132 per 1K tokens      
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["computer-use-preview-global"]                                                                               
+ ├─ Text input (computer-use-preview)                                                                 Monthly cost depends on usage: $0.0033 per 1K tokens      
+ ├─ Text output (computer-use-preview)                                                                Monthly cost depends on usage: $0.0132 per 1K tokens      
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["dall-e-2"]                                                                                                  
+ └─ Standard 1024x1024 images (dall-e-2)                                                              Monthly cost depends on usage: $2.00 per 100 images       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["dall-e-3"]                                                                                                  
+ ├─ Standard 1024x1024 images (dall-e-3)                                                              Monthly cost depends on usage: $4.00 per 100 images       
+ ├─ Standard 1024x1792 images (dall-e-3)                                                              Monthly cost depends on usage: $8.00 per 100 images       
+ ├─ HD 1024x1024 images (dall-e-3)                                                                    Monthly cost depends on usage: $8.00 per 100 images       
+ └─ HD 1024x1792 images (dall-e-3)                                                                    Monthly cost depends on usage: $12.00 per 100 images      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["davinci-002"]                                                                                               
+ ├─ Base model tokens (davinci-002)                                                                   Monthly cost depends on usage: $85.00 per 1K tokens       
+ ├─ Fine tuning training (davinci-002)                                                                Monthly cost depends on usage: $40.00 per hours           
+ ├─ Fine tuning hosting (davinci-002)                                                                 Monthly cost depends on usage: $2.00 per hours            
+ ├─ Fine tuning input (davinci-002)                                                                   Monthly cost depends on usage: $0.002 per 1K tokens       
+ └─ Fine tuning output (davinci-002)                                                                  Monthly cost depends on usage: $0.002 per 1K tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-35-turbo"]                                                                                              
+ ├─ Text input (gpt-35-turbo)                                                                         Monthly cost depends on usage: $0.0015 per 1K tokens      
+ ├─ Text output (gpt-35-turbo)                                                                        Monthly cost depends on usage: $0.002 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Fine tuning training (gpt-35-turbo)                                                               Monthly cost depends on usage: $45.00 per hours           
+ ├─ Fine tuning hosting (gpt-35-turbo)                                                                Monthly cost depends on usage: $3.00 per hours            
+ ├─ Fine tuning input (gpt-35-turbo)                                                                  Monthly cost depends on usage: $0.0015 per 1K tokens      
+ └─ Fine tuning output (gpt-35-turbo)                                                                 Monthly cost depends on usage: $0.002 per 1K tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-35-turbo-16k"]                                                                                          
+ ├─ Text input (gpt-35-turbo-16k)                                                                     Monthly cost depends on usage: $0.003 per 1K tokens       
+ ├─ Text output (gpt-35-turbo-16k)                                                                    Monthly cost depends on usage: $0.004 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4"]                                                                                                     
+ ├─ Text input (gpt-4)                                                                                Monthly cost depends on usage: $0.03 per 1K tokens        
+ ├─ Text output (gpt-4)                                                                               Monthly cost depends on usage: $0.06 per 1K tokens        
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4-0125-preview"]                                                                                        
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4-1106-preview"]                                                                                        
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4-32k"]                                                                                                 
+ ├─ Text input (gpt-4-32k)                                                                            Monthly cost depends on usage: $0.06 per 1K tokens        
+ ├─ Text output (gpt-4-32k)                                                                           Monthly cost depends on usage: $0.12 per 1K tokens        
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4.5-preview"]                                                                                           
+ ├─ Text input (gpt-4.5-preview)                                                                      Monthly cost depends on usage: $0.0825 per 1K tokens      
+ ├─ Text output (gpt-4.5-preview)                                                                     Monthly cost depends on usage: $0.17 per 1K tokens        
+ ├─ Cached text input (gpt-4.5-preview)                                                               Monthly cost depends on usage: $0.04125 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4.5-preview-2025-02-27"]                                                                                
+ ├─ Text input (gpt-4.5-preview)                                                                      Monthly cost depends on usage: $0.0825 per 1K tokens      
+ ├─ Text output (gpt-4.5-preview)                                                                     Monthly cost depends on usage: $0.17 per 1K tokens        
+ ├─ Cached text input (gpt-4.5-preview)                                                               Monthly cost depends on usage: $0.04125 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o"]                                                                                                    
+ ├─ Text input (gpt-4o)                                                                               Monthly cost depends on usage: $0.005 per 1K tokens       
+ ├─ Text output (gpt-4o)                                                                              Monthly cost depends on usage: $0.015 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-2024-05-13"]                                                                                         
+ ├─ Text input (gpt-4o)                                                                               Monthly cost depends on usage: $0.005 per 1K tokens       
+ ├─ Text output (gpt-4o)                                                                              Monthly cost depends on usage: $0.015 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-2024-08-06"]                                                                                         
+ ├─ Text input (gpt-4o)                                                                               Monthly cost depends on usage: $0.00275 per 1K tokens     
+ ├─ Text output (gpt-4o)                                                                              Monthly cost depends on usage: $0.011 per 1K tokens       
+ ├─ Cached text input (gpt-4o)                                                                        Monthly cost depends on usage: $0.001375 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-audio-preview"]                                                                                      
+ ├─ Text input (gpt-4o-audio-preview)                                                                 Monthly cost depends on usage: $0.00275 per 1K tokens     
+ ├─ Text output (gpt-4o-audio-preview)                                                                Monthly cost depends on usage: $0.011 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-audio-preview-2024-12-17"]                                                                           
+ ├─ Text input (gpt-4o-audio-preview)                                                                 Monthly cost depends on usage: $0.00275 per 1K tokens     
+ ├─ Text output (gpt-4o-audio-preview)                                                                Monthly cost depends on usage: $0.011 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-mini"]                                                                                               
+ ├─ Text input (gpt-4o-mini)                                                                          Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini)                                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini)                                                                   Monthly cost depends on usage: $0.000083 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-mini-2024-07-18"]                                                                                    
+ ├─ Text input (gpt-4o-mini)                                                                          Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini)                                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini)                                                                   Monthly cost depends on usage: $0.000083 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-mini-audio-preview"]                                                                                 
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                            Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                           Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-mini-audio-preview-2024-12-17"]                                                                      
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                            Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                           Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-mini-realtime-preview"]                                                                              
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                        Monthly cost depends on usage: $0.00264 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                  Monthly cost depends on usage: $0.00033 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-mini-realtime-preview-2024-12-17"]                                                                   
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                        Monthly cost depends on usage: $0.00264 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                  Monthly cost depends on usage: $0.00033 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.011 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.022 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-realtime-preview"]                                                                                   
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-realtime-preview-2024-10-01"]                                                                        
+ ├─ Text input (gpt-4o-realtime-preview)                                                              Monthly cost depends on usage: $0.0055 per 1K tokens      
+ ├─ Text output (gpt-4o-realtime-preview)                                                             Monthly cost depends on usage: $0.022 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.11 per 1k tokens        
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.22 per 1k tokens        
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["gpt-4o-realtime-preview-2024-12-17"]                                                                        
+ ├─ Text input (gpt-4o-realtime-preview)                                                              Monthly cost depends on usage: $0.0055 per 1K tokens      
+ ├─ Text output (gpt-4o-realtime-preview)                                                             Monthly cost depends on usage: $0.022 per 1K tokens       
+ ├─ Cached text input (gpt-4o-realtime-preview)                                                       Monthly cost depends on usage: $0.00275 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.044 per 1k tokens       
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.088 per 1k tokens       
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["o1"]                                                                                                        
+ ├─ Text input (o1)                                                                                   Monthly cost depends on usage: $0.0165 per 1K tokens      
+ ├─ Text output (o1)                                                                                  Monthly cost depends on usage: $0.066 per 1K tokens       
+ ├─ Cached text input (o1)                                                                            Monthly cost depends on usage: $0.00825 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["o1-2024-12-17"]                                                                                             
+ ├─ Text input (o1)                                                                                   Monthly cost depends on usage: $0.0165 per 1K tokens      
+ ├─ Text output (o1)                                                                                  Monthly cost depends on usage: $0.066 per 1K tokens       
+ ├─ Cached text input (o1)                                                                            Monthly cost depends on usage: $0.00825 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["o1-mini"]                                                                                                   
+ ├─ Cached text input (o1-mini)                                                                       Monthly cost depends on usage: $0.00165 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["o1-mini-2024-09-12"]                                                                                        
+ ├─ Cached text input (o1-mini)                                                                       Monthly cost depends on usage: $0.00165 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["o3-mini"]                                                                                                   
+ ├─ Text input (o3-mini)                                                                              Monthly cost depends on usage: $0.00121 per 1K tokens     
+ ├─ Text output (o3-mini)                                                                             Monthly cost depends on usage: $0.00484 per 1K tokens     
+ ├─ Cached text input (o3-mini)                                                                       Monthly cost depends on usage: $0.000605 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["o3-mini-2025-01-31"]                                                                                        
+ ├─ Text input (o3-mini)                                                                              Monthly cost depends on usage: $0.00121 per 1K tokens     
+ ├─ Text output (o3-mini)                                                                             Monthly cost depends on usage: $0.00484 per 1K tokens     
+ ├─ Cached text input (o3-mini)                                                                       Monthly cost depends on usage: $0.000605 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["text-embedding-3-large"]                                                                                    
+ └─ Text embeddings (text-embedding-3-large)                                                          Monthly cost depends on usage: $0.00013 per 1K tokens     
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["text-embedding-3-small"]                                                                                    
+ └─ Text embeddings (text-embedding-3-small)                                                          Monthly cost depends on usage: $0.00002 per 1K tokens     
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["text-embedding-ada-002"]                                                                                    
+ └─ Text embeddings (text-embedding-ada-002)                                                          Monthly cost depends on usage: $0.0001 per 1K tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.eastus_without_usage["whisper"]                                                                                                   
+ └─ Text to speech (whisper)                                                                          Monthly cost depends on usage: $0.36 per hours            
+                                                                                                                                                                
+ azurerm_cognitive_deployment.free_tier                                                                                                                         
+ ├─ Text input (gpt-4)                                                                                Monthly cost depends on usage: $0.03 per 1K tokens        
+ ├─ Text output (gpt-4)                                                                               Monthly cost depends on usage: $0.06 per 1K tokens        
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["computer-use-preview"]                                                                               
+ ├─ Text input (computer-use-preview)                                                                 Monthly cost depends on usage: $0.00363 per 1K tokens     
+ ├─ Text output (computer-use-preview)                                                                Monthly cost depends on usage: $0.01452 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["computer-use-preview-global"]                                                                        
+ ├─ Text input (computer-use-preview)                                                                 Monthly cost depends on usage: $0.00363 per 1K tokens     
+ ├─ Text output (computer-use-preview)                                                                Monthly cost depends on usage: $0.01452 per 1K tokens     
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["dall-e-3"]                                                                                           
+ ├─ Standard 1024x1024 images (dall-e-3)                                                              Monthly cost depends on usage: $4.00 per 100 images       
+ ├─ Standard 1024x1792 images (dall-e-3)                                                              Monthly cost depends on usage: $8.00 per 100 images       
+ ├─ HD 1024x1024 images (dall-e-3)                                                                    Monthly cost depends on usage: $8.00 per 100 images       
+ └─ HD 1024x1792 images (dall-e-3)                                                                    Monthly cost depends on usage: $12.00 per 100 images      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-35-turbo"]                                                                                       
+ ├─ Text input (gpt-35-turbo)                                                                         Monthly cost depends on usage: $0.0015 per 1K tokens      
+ ├─ Text output (gpt-35-turbo)                                                                        Monthly cost depends on usage: $0.002 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Fine tuning training (gpt-35-turbo)                                                               Monthly cost depends on usage: $45.00 per hours           
+ ├─ Fine tuning hosting (gpt-35-turbo)                                                                Monthly cost depends on usage: $3.00 per hours            
+ ├─ Fine tuning input (gpt-35-turbo)                                                                  Monthly cost depends on usage: $0.0005 per 1K tokens      
+ └─ Fine tuning output (gpt-35-turbo)                                                                 Monthly cost depends on usage: $0.0015 per 1K tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-35-turbo-16k"]                                                                                   
+ ├─ Text input (gpt-35-turbo-16k)                                                                     Monthly cost depends on usage: $0.003 per 1K tokens       
+ ├─ Text output (gpt-35-turbo-16k)                                                                    Monthly cost depends on usage: $0.004 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4"]                                                                                              
+ ├─ Text input (gpt-4)                                                                                Monthly cost depends on usage: $0.03 per 1K tokens        
+ ├─ Text output (gpt-4)                                                                               Monthly cost depends on usage: $0.06 per 1K tokens        
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4-0125-preview"]                                                                                 
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4-1106-preview"]                                                                                 
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4-32k"]                                                                                          
+ ├─ Text input (gpt-4-32k)                                                                            Monthly cost depends on usage: $0.06 per 1K tokens        
+ ├─ Text output (gpt-4-32k)                                                                           Monthly cost depends on usage: $0.12 per 1K tokens        
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4.5-preview"]                                                                                    
+ ├─ Text input (gpt-4.5-preview)                                                                      Monthly cost depends on usage: $0.09075 per 1K tokens     
+ ├─ Text output (gpt-4.5-preview)                                                                     Monthly cost depends on usage: $0.18 per 1K tokens        
+ ├─ Cached text input (gpt-4.5-preview)                                                               Monthly cost depends on usage: $0.045375 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4.5-preview-2025-02-27"]                                                                         
+ ├─ Text input (gpt-4.5-preview)                                                                      Monthly cost depends on usage: $0.09075 per 1K tokens     
+ ├─ Text output (gpt-4.5-preview)                                                                     Monthly cost depends on usage: $0.18 per 1K tokens        
+ ├─ Cached text input (gpt-4.5-preview)                                                               Monthly cost depends on usage: $0.045375 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o"]                                                                                             
+ ├─ Text input (gpt-4o)                                                                               Monthly cost depends on usage: $0.005 per 1K tokens       
+ ├─ Text output (gpt-4o)                                                                              Monthly cost depends on usage: $0.015 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-2024-05-13"]                                                                                  
+ ├─ Text input (gpt-4o)                                                                               Monthly cost depends on usage: $0.005 per 1K tokens       
+ ├─ Text output (gpt-4o)                                                                              Monthly cost depends on usage: $0.015 per 1K tokens       
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-2024-08-06"]                                                                                  
+ ├─ Text input (gpt-4o)                                                                               Monthly cost depends on usage: $0.00275 per 1K tokens     
+ ├─ Text output (gpt-4o)                                                                              Monthly cost depends on usage: $0.011 per 1K tokens       
+ ├─ Cached text input (gpt-4o)                                                                        Monthly cost depends on usage: $0.001513 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-audio-preview"]                                                                               
+ ├─ Text input (gpt-4o-audio-preview)                                                                 Monthly cost depends on usage: $0.003025 per 1K tokens    
+ ├─ Text output (gpt-4o-audio-preview)                                                                Monthly cost depends on usage: $0.0121 per 1K tokens      
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.0484 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.0968 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-audio-preview-2024-12-17"]                                                                    
+ ├─ Text input (gpt-4o-audio-preview)                                                                 Monthly cost depends on usage: $0.003025 per 1K tokens    
+ ├─ Text output (gpt-4o-audio-preview)                                                                Monthly cost depends on usage: $0.0121 per 1K tokens      
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-audio-preview)                                                         Monthly cost depends on usage: $0.0484 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-audio-preview)                                                        Monthly cost depends on usage: $0.0968 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-mini"]                                                                                        
+ ├─ Text input (gpt-4o-mini)                                                                          Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini)                                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini)                                                                   Monthly cost depends on usage: $0.000091 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-mini-2024-07-18"]                                                                             
+ ├─ Text input (gpt-4o-mini)                                                                          Monthly cost depends on usage: $0.000165 per 1K tokens    
+ ├─ Text output (gpt-4o-mini)                                                                         Monthly cost depends on usage: $0.00066 per 1K tokens     
+ ├─ Cached text input (gpt-4o-mini)                                                                   Monthly cost depends on usage: $0.000091 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-mini-audio-preview"]                                                                          
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                            Monthly cost depends on usage: $0.000182 per 1K tokens    
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                           Monthly cost depends on usage: $0.000726 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.0121 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.0242 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-mini-audio-preview-2024-12-17"]                                                               
+ ├─ Text input (gpt-4o-mini-audio-preview)                                                            Monthly cost depends on usage: $0.000182 per 1K tokens    
+ ├─ Text output (gpt-4o-mini-audio-preview)                                                           Monthly cost depends on usage: $0.000726 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-audio-preview)                                                    Monthly cost depends on usage: $0.0121 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-mini-audio-preview)                                                   Monthly cost depends on usage: $0.0242 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-mini-realtime-preview"]                                                                       
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                         Monthly cost depends on usage: $0.000726 per 1K tokens    
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                        Monthly cost depends on usage: $0.002904 per 1K tokens    
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                  Monthly cost depends on usage: $0.000363 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.0121 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.0242 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-mini-realtime-preview-2024-12-17"]                                                            
+ ├─ Text input (gpt-4o-mini-realtime-preview)                                                         Monthly cost depends on usage: $0.000726 per 1K tokens    
+ ├─ Text output (gpt-4o-mini-realtime-preview)                                                        Monthly cost depends on usage: $0.002904 per 1K tokens    
+ ├─ Cached text input (gpt-4o-mini-realtime-preview)                                                  Monthly cost depends on usage: $0.000363 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-mini-realtime-preview)                                                 Monthly cost depends on usage: $0.0121 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-mini-realtime-preview)                                                Monthly cost depends on usage: $0.0242 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-realtime-preview"]                                                                            
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-realtime-preview-2024-10-01"]                                                                 
+ ├─ Text input (gpt-4o-realtime-preview)                                                              Monthly cost depends on usage: $0.00605 per 1K tokens     
+ ├─ Text output (gpt-4o-realtime-preview)                                                             Monthly cost depends on usage: $0.0242 per 1K tokens      
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.12 per 1k tokens        
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.24 per 1k tokens        
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["gpt-4o-realtime-preview-2024-12-17"]                                                                 
+ ├─ Text input (gpt-4o-realtime-preview)                                                              Monthly cost depends on usage: $0.00605 per 1K tokens     
+ ├─ Text output (gpt-4o-realtime-preview)                                                             Monthly cost depends on usage: $0.0242 per 1K tokens      
+ ├─ Cached text input (gpt-4o-realtime-preview)                                                       Monthly cost depends on usage: $0.003025 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ ├─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+ ├─ Audio input tokens (gpt-4o-realtime-preview)                                                      Monthly cost depends on usage: $0.0484 per 1k tokens      
+ └─ Audio output tokens (gpt-4o-realtime-preview)                                                     Monthly cost depends on usage: $0.0968 per 1k tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["o1"]                                                                                                 
+ ├─ Text input (o1)                                                                                   Monthly cost depends on usage: $0.01815 per 1K tokens     
+ ├─ Text output (o1)                                                                                  Monthly cost depends on usage: $0.0726 per 1K tokens      
+ ├─ Cached text input (o1)                                                                            Monthly cost depends on usage: $0.009075 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["o1-2024-12-17"]                                                                                      
+ ├─ Text input (o1)                                                                                   Monthly cost depends on usage: $0.01815 per 1K tokens     
+ ├─ Text output (o1)                                                                                  Monthly cost depends on usage: $0.0726 per 1K tokens      
+ ├─ Cached text input (o1)                                                                            Monthly cost depends on usage: $0.009075 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["o1-mini"]                                                                                            
+ ├─ Text input (o1-mini)                                                                              Monthly cost depends on usage: $0.001331 per 1K tokens    
+ ├─ Text output (o1-mini)                                                                             Monthly cost depends on usage: $0.005324 per 1K tokens    
+ ├─ Cached text input (o1-mini)                                                                       Monthly cost depends on usage: $0.000666 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["o1-mini-2024-09-12"]                                                                                 
+ ├─ Text input (o1-mini)                                                                              Monthly cost depends on usage: $0.001331 per 1K tokens    
+ ├─ Text output (o1-mini)                                                                             Monthly cost depends on usage: $0.005324 per 1K tokens    
+ ├─ Cached text input (o1-mini)                                                                       Monthly cost depends on usage: $0.000666 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["o3-mini"]                                                                                            
+ ├─ Text input (o3-mini)                                                                              Monthly cost depends on usage: $0.001331 per 1K tokens    
+ ├─ Text output (o3-mini)                                                                             Monthly cost depends on usage: $0.005324 per 1K tokens    
+ ├─ Cached text input (o3-mini)                                                                       Monthly cost depends on usage: $0.000666 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["o3-mini-2025-01-31"]                                                                                 
+ ├─ Text input (o3-mini)                                                                              Monthly cost depends on usage: $0.001331 per 1K tokens    
+ ├─ Text output (o3-mini)                                                                             Monthly cost depends on usage: $0.005324 per 1K tokens    
+ ├─ Cached text input (o3-mini)                                                                       Monthly cost depends on usage: $0.000666 per 1K tokens    
+ ├─ File search tool calls                                                                            Monthly cost depends on usage: $2.50 per 1k calls         
+ ├─ File search vector storage                                                                        Monthly cost depends on usage: $0.10 per GB               
+ └─ Code interpreter sessions                                                                         Monthly cost depends on usage: $0.03 per sessions         
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["text-embedding-3-large"]                                                                             
+ └─ Text embeddings (text-embedding-3-large)                                                          Monthly cost depends on usage: $0.00013 per 1K tokens     
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["text-embedding-3-small"]                                                                             
+ └─ Text embeddings (text-embedding-3-small)                                                          Monthly cost depends on usage: $0.00002 per 1K tokens     
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["text-embedding-ada-002"]                                                                             
+ └─ Text embeddings (text-embedding-ada-002)                                                          Monthly cost depends on usage: $0.0001 per 1K tokens      
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["tts"]                                                                                                
+ └─ Text to speech (tts)                                                                              Monthly cost depends on usage: $15.00 per 1M characters   
+                                                                                                                                                                
+ azurerm_cognitive_deployment.swedencentral_without_usage["tts-hd"]                                                                                             
+ └─ Text to speech (tts-hd)                                                                           Monthly cost depends on usage: $30.00 per 1M characters   
+                                                                                                                                                                
+ OVERALL TOTAL                                                                                                                                   $122,469.31 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-116 cloud resources were detected:
-∙ 109 were estimated
+272 cloud resources were detected:
+∙ 265 were estimated
 ∙ 6 were free
 ∙ 1 is not supported yet, see https://infracost.io/requested-resources:
   ∙ 1 x azurerm_cognitive_deployment
@@ -390,7 +1774,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $20,499 ┃           - ┃    $20,499 ┃
+┃ main                                               ┃      $122,469 ┃           - ┃   $122,469 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.tf
+++ b/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.tf
@@ -9,7 +9,6 @@ locals {
     "gpt-4-32k",
     "gpt-35-turbo",
     "gpt-35-turbo-16k",
-    "gpt-35-turbo-instruct",
     "text-embedding-ada-002",
     "text-embedding-3-small",
     "text-embedding-3-large",
@@ -20,10 +19,32 @@ locals {
     "tts",
     "tts-hd",
     "whisper",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4.5-preview",
+    "gpt-4o-realtime-preview",
+    "gpt-4o-mini-realtime-preview",
+    "gpt-4o-audio-preview",
+    "gpt-4o-mini-audio-preview",
+    "computer-use-preview",
+    "o1",
+    "o1-mini",
+    "o3-mini",
   ]
 
   versions = {
-    "gpt-4" : ["1106-preview", "0125-preview", "vision-preview"]
+    "gpt-4" : ["1106-preview", "0125-preview"],
+    "gpt-4o" : ["2024-05-13", "2024-08-06"],
+    "gpt-4o-mini" : ["2024-07-18"],
+    "gpt-4.5-preview" : ["2025-02-27"],
+    "gpt-4o-realtime-preview" : ["2024-12-17", "2024-10-01"],
+    "gpt-4o-mini-realtime-preview" : ["2024-12-17"],
+    "gpt-4o-audio-preview" : ["2024-12-17"],
+    "gpt-4o-mini-audio-preview" : ["2024-12-17"],
+    "computer-use-preview" : ["global"],
+    "o1" : ["2024-12-17"],
+    "o1-mini" : ["2024-09-12"],
+    "o3-mini" : ["2025-01-31"],
   }
 
   permutations = flatten([
@@ -211,5 +232,299 @@ resource "azurerm_cognitive_deployment" "unsupported" {
 
   sku {
     name = "Standard"
+  }
+}
+
+# New specific test resources for audio, realtime, and file search functionality
+resource "azurerm_cognitive_deployment" "audio_models" {
+  for_each = {
+    "gpt4o_audio" = {
+      model   = "gpt-4o-audio-preview"
+      version = "2024-12-17"
+    }
+    "gpt4o_mini_audio" = {
+      model   = "gpt-4o-mini-audio-preview"
+      version = "2024-12-17"
+    }
+  }
+
+  name                 = "audio-model-${each.key}"
+  cognitive_account_id = azurerm_cognitive_account.eastus.id
+
+  model {
+    format  = "OpenAI"
+    name    = each.value.model
+    version = each.value.version
+  }
+
+  sku {
+    name = "Standard"
+  }
+}
+
+resource "azurerm_cognitive_deployment" "realtime_models" {
+  for_each = {
+    "gpt4o_realtime_1217" = {
+      model   = "gpt-4o-realtime-preview"
+      version = "2024-12-17"
+    }
+    "gpt4o_realtime_1001" = {
+      model   = "gpt-4o-realtime-preview"
+      version = "2024-10-01"
+    }
+    "gpt4o_mini_realtime" = {
+      model   = "gpt-4o-mini-realtime-preview"
+      version = "2024-12-17"
+    }
+  }
+
+  name                 = "realtime-model-${each.key}"
+  cognitive_account_id = azurerm_cognitive_account.eastus.id
+
+  model {
+    format  = "OpenAI"
+    name    = each.value.model
+    version = each.value.version
+  }
+
+  sku {
+    name = "Standard"
+  }
+}
+
+resource "azurerm_cognitive_deployment" "computer_use_models" {
+  name                 = "computer-use-preview"
+  cognitive_account_id = azurerm_cognitive_account.eastus.id
+
+  model {
+    format  = "OpenAI"
+    name    = "computer-use-preview"
+    version = "global"
+  }
+
+  sku {
+    name = "Standard"
+  }
+}
+
+resource "azurerm_cognitive_deployment" "new_foundation_models" {
+  for_each = {
+    "gpt45_preview" = {
+      model   = "gpt-4.5-preview"
+      version = "2025-02-27"
+    }
+    "o1_model" = {
+      model   = "o1"
+      version = "2024-12-17"
+    }
+    "o1_mini_model" = {
+      model   = "o1-mini"
+      version = "2024-09-12"
+    }
+    "o3_mini_model" = {
+      model   = "o3-mini"
+      version = "2025-01-31"
+    }
+  }
+
+  name                 = "foundation-model-${each.key}"
+  cognitive_account_id = azurerm_cognitive_account.eastus.id
+
+  model {
+    format  = "OpenAI"
+    name    = each.value.model
+    version = each.value.version
+  }
+
+  sku {
+    name = "Standard"
+  }
+}
+
+# Provisioned throughput unit tests
+resource "azurerm_cognitive_deployment" "provisioned_regional" {
+  for_each = {
+    "gpt4o" = {
+      model    = "gpt-4o"
+      version  = "2024-05-13"
+      capacity = 1
+    }
+    "gpt4o_high_capacity" = {
+      model    = "gpt-4o"
+      version  = "2024-05-13"
+      capacity = 5
+    }
+    "gpt35_turbo" = {
+      model    = "gpt-35-turbo"
+      version  = "0125"
+      capacity = 2
+    }
+  }
+
+  name                 = "provisioned-regional-${each.key}"
+  cognitive_account_id = azurerm_cognitive_account.eastus.id
+
+  model {
+    format  = "OpenAI"
+    name    = each.value.model
+    version = each.value.version
+  }
+
+  sku {
+    name     = "ProvisionedManaged"
+    capacity = each.value.capacity
+  }
+}
+
+resource "azurerm_cognitive_deployment" "provisioned_global" {
+  for_each = {
+    "gpt4" = {
+      model    = "gpt-4"
+      version  = "0613"
+      capacity = 1
+    }
+    "gpt4_32k" = {
+      model    = "gpt-4-32k"
+      version  = "0613"
+      capacity = 3
+    }
+  }
+
+  name                 = "provisioned-global-${each.key}"
+  cognitive_account_id = azurerm_cognitive_account.eastus.id
+
+  model {
+    format  = "OpenAI"
+    name    = each.value.model
+    version = each.value.version
+  }
+
+  sku {
+    name     = "GlobalProvisionedManaged"
+    capacity = each.value.capacity
+  }
+}
+
+resource "azurerm_cognitive_deployment" "provisioned_data_zone" {
+  for_each = {
+    "gpt4o_data_zone" = {
+      model    = "gpt-4o"
+      version  = "2024-05-13"
+      capacity = 2
+    }
+    "o1_mini_data_zone" = {
+      model    = "o1-mini"
+      version  = "2024-09-12"
+      capacity = 4
+    }
+  }
+
+  name                 = "provisioned-data-zone-${each.key}"
+  cognitive_account_id = azurerm_cognitive_account.eastus.id
+
+  model {
+    format  = "OpenAI"
+    name    = each.value.model
+    version = each.value.version
+  }
+
+  sku {
+    name     = "DataZoneProvisionedManaged"
+    capacity = each.value.capacity
+  }
+}
+
+# Regional provisioned unit tests for different regions
+resource "azurerm_cognitive_deployment" "eastus2_provisioned" {
+  for_each = {
+    "gpt4o_regional" = {
+      model    = "gpt-4o"
+      version  = "2024-05-13"
+      capacity = 2
+      sku_name = "ProvisionedManaged"
+    }
+    "gpt4_global" = {
+      model    = "gpt-4"
+      version  = "0613"
+      capacity = 3
+      sku_name = "GlobalProvisionedManaged"
+    }
+  }
+
+  name                 = "eastus2-provisioned-${each.key}"
+  cognitive_account_id = azurerm_cognitive_account.eastus2.id
+
+  model {
+    format  = "OpenAI"
+    name    = each.value.model
+    version = each.value.version
+  }
+
+  sku {
+    name     = each.value.sku_name
+    capacity = each.value.capacity
+  }
+}
+
+resource "azurerm_cognitive_deployment" "swedencentral_provisioned" {
+  for_each = {
+    "gpt4o_data_zone" = {
+      model    = "gpt-4o"
+      version  = "2024-05-13"
+      capacity = 1
+      sku_name = "DataZoneProvisionedManaged"
+    }
+    "o3_mini_regional" = {
+      model    = "o3-mini"
+      version  = "2025-01-31"
+      capacity = 2
+      sku_name = "ProvisionedManaged"
+    }
+  }
+
+  name                 = "swedencentral-provisioned-${each.key}"
+  cognitive_account_id = azurerm_cognitive_account.swedencentral.id
+
+  model {
+    format  = "OpenAI"
+    name    = each.value.model
+    version = each.value.version
+  }
+
+  sku {
+    name     = each.value.sku_name
+    capacity = each.value.capacity
+  }
+}
+
+# Comprehensive comparison of all three provisioned SKU types for GPT-4o
+resource "azurerm_cognitive_deployment" "provisioned_comparison" {
+  for_each = {
+    "regional" = {
+      sku_name = "ProvisionedManaged"
+      capacity = 2
+    }
+    "global" = {
+      sku_name = "GlobalProvisionedManaged"
+      capacity = 2
+    }
+    "data_zone" = {
+      sku_name = "DataZoneProvisionedManaged"
+      capacity = 2
+    }
+  }
+
+  name                 = "gpt4o-${each.key}-comparison"
+  cognitive_account_id = azurerm_cognitive_account.eastus.id
+
+  model {
+    format  = "OpenAI"
+    name    = "gpt-4o"
+    version = "2024-05-13"
+  }
+
+  sku {
+    name     = each.value.sku_name
+    capacity = each.value.capacity
   }
 }

--- a/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/cognitive_deployment_test/cognitive_deployment_test.usage.yml
@@ -2,6 +2,7 @@ version: 0.1
 resource_usage:
   azurerm_cognitive_deployment.eastus_with_usage[*]:
     monthly_language_input_tokens: 40_000_000
+    monthly_language_cached_input_tokens: 20_000_000
     monthly_language_output_tokens: 13_333_333
     monthly_code_interpreter_sessions: 667
     monthly_base_model_tokens: 2847
@@ -18,6 +19,7 @@ resource_usage:
     monthly_text_to_speech_hours: 55.6
   azurerm_cognitive_deployment.eastus2_with_usage[*]:
     monthly_language_input_tokens: 40_000_000
+    monthly_language_cached_input_tokens: 20_000_000
     monthly_language_output_tokens: 13_333_333
     monthly_code_interpreter_sessions: 667
     monthly_base_model_tokens: 2847
@@ -34,6 +36,7 @@ resource_usage:
     monthly_text_to_speech_hours: 55.6
   azurerm_cognitive_deployment.swedencentral_with_usage[*]:
     monthly_language_input_tokens: 40_000_000
+    monthly_language_cached_input_tokens: 20_000_000
     monthly_language_output_tokens: 13_333_333
     monthly_code_interpreter_sessions: 667
     monthly_base_model_tokens: 2847
@@ -48,4 +51,120 @@ resource_usage:
     monthly_text_embedding_tokens: 1_000_000_000
     monthly_text_to_speech_characters: 1_333_333
     monthly_text_to_speech_hours: 55.6
+  azurerm_cognitive_deployment.gpt4o_specific_tests["gpt4o_global"]:
+    monthly_language_input_tokens: 30_000_000
+    monthly_language_cached_input_tokens: 15_000_000
+    monthly_language_output_tokens: 10_000_000
+  azurerm_cognitive_deployment.gpt4o_specific_tests["gpt4o_regional"]:
+    monthly_language_input_tokens: 30_000_000
+    monthly_language_cached_input_tokens: 15_000_000
+    monthly_language_output_tokens: 10_000_000
+    monthly_fine_tuning_input_tokens: 10_000_000
+    monthly_fine_tuning_output_tokens: 5_000_000
+    monthly_fine_tuning_training_hours: 0.8
+    monthly_fine_tuning_hosting_hours: 10.5
+  azurerm_cognitive_deployment.gpt4o_specific_tests["gpt4o_us_eu_zones"]:
+    monthly_language_input_tokens: 30_000_000
+    monthly_language_cached_input_tokens: 15_000_000
+    monthly_language_output_tokens: 10_000_000
+  azurerm_cognitive_deployment.gpt4o_specific_tests["gpt4o_mini_global"]:
+    monthly_language_input_tokens: 25_000_000
+    monthly_language_cached_input_tokens: 12_500_000
+    monthly_language_output_tokens: 8_000_000
+  azurerm_cognitive_deployment.gpt4o_specific_tests["gpt4o_mini_regional"]:
+    monthly_language_input_tokens: 25_000_000
+    monthly_language_cached_input_tokens: 12_500_000
+    monthly_language_output_tokens: 8_000_000
+    monthly_fine_tuning_input_tokens: 8_000_000
+    monthly_fine_tuning_output_tokens: 4_000_000
+    monthly_fine_tuning_training_hours: 0.6
+    monthly_fine_tuning_hosting_hours: 8.2
+  azurerm_cognitive_deployment.gpt4o_specific_tests["gpt4o_mini_us_eu_zones"]:
+    monthly_language_input_tokens: 25_000_000
+    monthly_language_cached_input_tokens: 12_500_000
+    monthly_language_output_tokens: 8_000_000
+  azurerm_cognitive_deployment.fine_tuned_gpt4o_tests["fine_tuned_gpt4o"]:
+    monthly_language_input_tokens: 35_000_000
+    monthly_language_cached_input_tokens: 17_500_000
+    monthly_language_output_tokens: 12_000_000
+    monthly_fine_tuning_input_tokens: 12_000_000
+    monthly_fine_tuning_output_tokens: 7_000_000
+    monthly_fine_tuning_training_hours: 1.2
+    monthly_fine_tuning_hosting_hours: 12.6
+  azurerm_cognitive_deployment.fine_tuned_gpt4o_tests["fine_tuned_gpt4o_mini"]:
+    monthly_language_input_tokens: 28_000_000
+    monthly_language_cached_input_tokens: 14_000_000
+    monthly_language_output_tokens: 9_500_000
+    monthly_fine_tuning_input_tokens: 9_500_000
+    monthly_fine_tuning_output_tokens: 5_500_000
+    monthly_fine_tuning_training_hours: 0.9
+    monthly_fine_tuning_hosting_hours: 9.8
+
+  # Audio models usage
+  azurerm_cognitive_deployment.audio_models["gpt4o_audio"]:
+    monthly_language_input_tokens: 5_000_000
+    monthly_language_output_tokens: 2_500_000
+    monthly_audio_input_tokens: 5_000_000
+    monthly_audio_output_tokens: 2_500_000
+  
+  azurerm_cognitive_deployment.audio_models["gpt4o_mini_audio"]:
+    monthly_language_input_tokens: 3_000_000
+    monthly_language_output_tokens: 1_500_000
+    monthly_audio_input_tokens: 3_000_000
+    monthly_audio_output_tokens: 1_500_000
+  
+  # Realtime models usage
+  azurerm_cognitive_deployment.realtime_models["gpt4o_realtime_1217"]:
+    monthly_language_input_tokens: 6_000_000
+    monthly_language_cached_input_tokens: 3_000_000
+    monthly_language_output_tokens: 2_000_000
+    monthly_audio_input_tokens: 6_000_000
+    monthly_audio_output_tokens: 4_000_000
+  
+  azurerm_cognitive_deployment.realtime_models["gpt4o_realtime_1001"]:
+    monthly_language_input_tokens: 4_000_000
+    monthly_language_cached_input_tokens: 2_000_000
+    monthly_language_output_tokens: 1_500_000
+    monthly_audio_input_tokens: 4_000_000
+    monthly_audio_output_tokens: 2_500_000
+  
+  azurerm_cognitive_deployment.realtime_models["gpt4o_mini_realtime"]:
+    monthly_language_input_tokens: 3_500_000
+    monthly_language_cached_input_tokens: 1_750_000
+    monthly_language_output_tokens: 1_200_000
+    monthly_audio_input_tokens: 3_500_000
+    monthly_audio_output_tokens: 2_000_000
+
+  # Computer use model usage
+  azurerm_cognitive_deployment.computer_use_models:
+    monthly_language_input_tokens: 2_000_000
+    monthly_language_output_tokens: 1_000_000
+  
+  # New foundation models usage
+  azurerm_cognitive_deployment.new_foundation_models["gpt45_preview"]:
+    monthly_language_input_tokens: 8_000_000
+    monthly_language_cached_input_tokens: 4_000_000
+    monthly_language_output_tokens: 3_000_000
+  
+  azurerm_cognitive_deployment.new_foundation_models["o1_model"]:
+    monthly_language_input_tokens: 7_000_000
+    monthly_language_cached_input_tokens: 3_500_000
+    monthly_language_output_tokens: 2_500_000
+  
+  azurerm_cognitive_deployment.new_foundation_models["o1_mini_model"]:
+    monthly_language_input_tokens: 5_500_000
+    monthly_language_cached_input_tokens: 2_750_000
+    monthly_language_output_tokens: 2_000_000
+  
+  azurerm_cognitive_deployment.new_foundation_models["o3_mini_model"]:
+    monthly_language_input_tokens: 6_000_000
+    monthly_language_cached_input_tokens: 3_000_000
+    monthly_language_output_tokens: 2_200_000
+  
+  # File search functionality usage
+  azurerm_cognitive_deployment.eastus_with_usage["gpt-4o"]:
+    monthly_language_input_tokens: 40_000_000
+    monthly_language_output_tokens: 13_333_333
+    monthly_file_search_tool_calls: 5_000
+    monthly_file_search_storage_gb: 3.5
 

--- a/internal/resources/azure/cognitive_deployment.go
+++ b/internal/resources/azure/cognitive_deployment.go
@@ -10,53 +10,677 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-var languageModelSKUs = map[string]string{
-	"gpt-35-turbo":          "Az-GPT35-Turbo-16K-0125",
-	"gpt-35-turbo-16k":      "Az-GPT35-Turbo-16K-0125",
-	"gpt-35-turbo-instruct": "Az-GPT35-Turbo-Instruct",
-	"gpt-4":                 "Az-GPT4-8K",
-	"gpt-4-32k":             "Az-GPT4-32K",
+type languageModel struct {
+	model            string
+	version          string
+	isDefaultVersion bool
+
+	inputSKUGlobal  string
+	outputSKUGlobal string
+
+	inputSKURegional  string
+	outputSKURegional string
+
+	batchInputSKUGlobal  string
+	batchOutputSKUGlobal string
+
+	inputSKUDataZone  string
+	outputSKUDataZone string
+
+	cachedInputSKUGlobal   string
+	cachedInputSKURegional string
+	cachedInputSKUDataZone string
+
+	batchInputSKUDataZone  string
+	batchOutputSKUDataZone string
+
+	audioInputSKUGlobal  string
+	audioOutputSKUGlobal string
+
+	audioInputSKURegional  string
+	audioOutputSKURegional string
+
+	audioInputSKUDataZone  string
+	audioOutputSKUDataZone string
 }
 
-var languageModelGPT4Versions = map[string]string{
-	"1106-preview":   "Az-GPT4-Turbo-128K",
-	"0125-preview":   "Az-GPT4-Turbo-128K",
-	"vision-preview": "Az-GPT4-Turbo-Vision-128K",
+type sku struct {
+	input       string
+	output      string
+	cachedInput string
+
+	audioInput  string
+	audioOutput string
 }
 
-// The same skus and pricing applies to all models that support the assistant API
-var assistantModels = map[string]struct{}{
-	"gpt-35-turbo": {},
-	"gpt-4":        {},
+func (l languageModel) skuName(skuName string) sku {
+	switch strings.ToLower(skuName) {
+	case "standard":
+		return sku{
+			input:       l.inputSKURegional,
+			output:      l.outputSKURegional,
+			cachedInput: l.cachedInputSKURegional,
+
+			audioInput:  l.audioInputSKURegional,
+			audioOutput: l.audioOutputSKURegional,
+		}
+	case "globalstandard":
+		return sku{
+			input:       l.inputSKUGlobal,
+			output:      l.outputSKUGlobal,
+			cachedInput: l.cachedInputSKUGlobal,
+
+			audioInput:  l.audioInputSKUGlobal,
+			audioOutput: l.audioOutputSKUGlobal,
+		}
+	case "data_zone_standard":
+		return sku{
+			input:       l.inputSKUDataZone,
+			output:      l.outputSKUDataZone,
+			cachedInput: l.cachedInputSKUDataZone,
+
+			audioInput:  l.audioInputSKUDataZone,
+			audioOutput: l.audioOutputSKUDataZone,
+		}
+	case "data_zone_batch":
+		return sku{
+			input:       l.batchInputSKUDataZone,
+			output:      l.batchOutputSKUDataZone,
+			cachedInput: l.cachedInputSKUDataZone,
+
+			audioInput:  l.audioInputSKUDataZone,
+			audioOutput: l.audioOutputSKUDataZone,
+		}
+	case "global_batch":
+		return sku{
+			input:       l.batchInputSKUGlobal,
+			output:      l.batchOutputSKUGlobal,
+			cachedInput: l.cachedInputSKUGlobal,
+
+			audioInput:  l.audioInputSKUGlobal,
+			audioOutput: l.audioOutputSKUGlobal,
+		}
+
+	}
+
+	return sku{
+		input:       l.inputSKUGlobal,
+		output:      l.outputSKUGlobal,
+		cachedInput: l.cachedInputSKUGlobal,
+
+		audioInput:  l.audioInputSKUGlobal,
+		audioOutput: l.audioOutputSKUGlobal,
+	}
 }
 
-var baseModelSKUs = map[string]string{
-	"babbage-002": "Babbage",
-	"davinci-002": "Davinci",
-}
+var (
+	languageModelSKUs = map[string]map[string]languageModel{
+		"gpt-4.5-preview": {
+			"2025-02-27": {
+				model:            "gpt-4.5-preview",
+				version:          "2025-02-27",
+				isDefaultVersion: true,
 
-var fineTuningSKUs = map[string]string{
-	"babbage-002":      "Az-Babbage-002",
-	"davinci-002":      "Az-Davinci-002",
-	"gpt-35-turbo":     "Az-GPT35-Turbo-4K",
-	"gpt-35-turbo-16k": "Az-GPT35-Turbo-16K",
-}
+				inputSKUDataZone:  "gpt 4.5 0227 Inp DZone",
+				outputSKUDataZone: "gpt 4.5 0227 Outp DZone",
 
-var imageSKUs = map[string]string{
-	"dall-e-2": "Az-Image-DALL-E",
-	"dall-e-3": "Az-Image-Dall-E-3",
-}
+				batchInputSKUDataZone:  "gpt 4.5 0227 Batch Inp DZone",
+				batchOutputSKUDataZone: "gpt 4.5 0227 Batch Outp DZone",
 
-var embeddingSKUs = map[string]string{
-	"text-embedding-ada-002": "Az-Embeddings-Ada",
-	"text-embedding-3-small": "Az-Text-Embedding-3-Small",
-	"text-embedding-3-large": "Az-Text-Embedding-3-Large",
-}
+				inputSKUGlobal:  "gpt 4.5 0227 Inp glbl",
+				outputSKUGlobal: "gpt 4.5 0227 Outp glbl",
 
-var speechSKUs = map[string]string{
-	"whisper": "Az-Speech-Whisper",
-	"tts":     "Az-Speech-Text to Speech",
-	"tts-hd":  "Az-Speech-Text to Speech HD",
+				batchInputSKUGlobal:  "gpt 4.5 0227 Batch Inp glbl",
+				batchOutputSKUGlobal: "gpt 4.5 0227 Batch Outp glbl",
+
+				inputSKURegional:  "gpt 4.5 0227 Inp regnl",
+				outputSKURegional: "gpt 4.5 0227 Outp regnl",
+
+				cachedInputSKUGlobal:   "gpt 4.5 0227 cached Inp glbl",
+				cachedInputSKURegional: "gpt 4.5 0227 cached Inp regnl",
+				cachedInputSKUDataZone: "gpt 4.5 0227 cached Inp DZone",
+			},
+		},
+		"gpt-35-turbo": {
+			"0301": {
+				model:            "gpt-35-turbo",
+				version:          "0301",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt-35-turbo4K-Inp-glbl",
+				outputSKUGlobal: "gpt-35-turbo4K-Outp-glbl",
+
+				inputSKURegional:  "gpt-35-turbo-4k-Input-regional",
+				outputSKURegional: "gpt-35-turbo-4k-Output-regional",
+			},
+			"0613": {
+				model:            "gpt-35-turbo",
+				version:          "0613",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt-35-turbo4K-Inp-glbl",
+				outputSKUGlobal: "gpt-35-turbo4K-Outp-glbl",
+
+				inputSKURegional:  "gpt-35-turbo-4k-Input-regional",
+				outputSKURegional: "gpt-35-turbo-4k-Output-regional",
+			},
+			"1106": {
+				model:            "gpt-35-turbo",
+				version:          "1106",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt-35-turbo4K-Inp-glbl",
+				outputSKUGlobal: "gpt-35-turbo4K-Outp-glbl",
+
+				inputSKURegional:  "gpt-35-turbo-4k-Input-regional",
+				outputSKURegional: "gpt-35-turbo-4k-Output-regional",
+			},
+			"0125": {
+				model:            "gpt-35-turbo",
+				version:          "0125",
+				isDefaultVersion: true,
+
+				inputSKUGlobal:  "gpt-35-turbo4K-Inp-glbl",
+				outputSKUGlobal: "gpt-35-turbo4K-Outp-glbl",
+
+				inputSKURegional:  "gpt-35-turbo-4k-Input-regional",
+				outputSKURegional: "gpt-35-turbo-4k-Output-regional",
+			},
+		},
+
+		"gpt-35-turbo-16k": {
+			"0613": {
+				model:            "gpt-35-turbo-16k",
+				version:          "0613",
+				isDefaultVersion: true,
+
+				inputSKUGlobal:  "gpt-35-turbo16K-Inp-glbl",
+				outputSKUGlobal: "gpt-35-turbo16K-Outp-glbl",
+
+				inputSKURegional:  "gpt-35-turbo-16k-Input-regional",
+				outputSKURegional: "gpt-35-turbo-16k-Output-regional",
+
+				batchInputSKUGlobal:  "gpt-35-turbo16K-Batch-Inp-glbl",
+				batchOutputSKUGlobal: "gpt-35-turbo16K-Batch-Outp-glbl",
+			},
+		},
+
+		"gpt-4": {
+			"0125-Preview": {
+				model:            "gpt-4",
+				version:          "0125-Preview",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt-4-8K-Inp-glbl",
+				outputSKUGlobal: "gpt-4-8K-Outp-glbl",
+
+				inputSKURegional:  "gpt-4-8K-Input-regional",
+				outputSKURegional: "gpt-4-8K-Output-regional",
+
+				batchInputSKUGlobal:  "gpt-4-8K-Batch-Inp-glbl",
+				batchOutputSKUGlobal: "gpt-4-8K-Batch-Outp-glbl",
+			},
+			"1106-Preview": {
+				model:            "gpt-4",
+				version:          "1106-Preview",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt-4-8K-Inp-glbl",
+				outputSKUGlobal: "gpt-4-8K-Outp-glbl",
+
+				inputSKURegional:  "gpt-4-8K-Input-regional",
+				outputSKURegional: "gpt-4-8K-Output-regional",
+
+				batchInputSKUGlobal:  "gpt-4-8K-Batch-Inp-glbl",
+				batchOutputSKUGlobal: "gpt-4-8K-Batch-Outp-glbl",
+			},
+			"0613": {
+				model:            "gpt-4",
+				version:          "0613",
+				isDefaultVersion: true,
+
+				inputSKUGlobal:  "gpt-4-8K-Inp-glbl",
+				outputSKUGlobal: "gpt-4-8K-Outp-glbl",
+
+				inputSKURegional:  "gpt-4-8K-Input-regional",
+				outputSKURegional: "gpt-4-8K-Output-regional",
+
+				batchInputSKUGlobal:  "gpt-4-8K-Batch-Inp-glbl",
+				batchOutputSKUGlobal: "gpt-4-8K-Batch-Outp-glbl",
+			},
+			"turbo-2024-04-09": {
+				model:            "gpt-4",
+				version:          "turbo-2024-04-09",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt-4-turbo128K Inp-glbl",
+				outputSKUGlobal: "gpt-4-turbo128K Outp-glbl",
+
+				inputSKURegional:  "gpt-4-turbo-128K Input-regional",
+				outputSKURegional: "gpt-4-turbo-128K Output-regional",
+
+				batchInputSKUGlobal:  "gpt-4-Turbo-Batch-128K Inp-glbl",
+				batchOutputSKUGlobal: "gpt-4-Turbo-Batch-128K Outp-glbl",
+			},
+		},
+
+		"gpt-4-32k": {
+			"0613": {
+				model:            "gpt-4-32k",
+				version:          "0613",
+				isDefaultVersion: true,
+
+				inputSKUGlobal:  "gpt-4-32K-Inp-glbl",
+				outputSKUGlobal: "gpt-4-32K-Outp-glbl",
+
+				inputSKURegional:  "gpt-4-32K-Input-regional",
+				outputSKURegional: "gpt-4-32K-Output-regional",
+			},
+		},
+
+		"gpt-4o": {
+			"2024-05-13": {
+				model:            "gpt-4o",
+				version:          "2024-05-13",
+				isDefaultVersion: true,
+
+				inputSKUGlobal:  "gpt 4o 0513 Input global",
+				outputSKUGlobal: "gpt 4o 0513 Output global",
+
+				inputSKURegional:  "gpt 4o 0513 Input regional",
+				outputSKURegional: "gpt 4o 0513 Output regional",
+
+				inputSKUDataZone:  "gpt 4o 0513 Input Data Zone",
+				outputSKUDataZone: "gpt 4o 0513 Output Data Zone",
+
+				batchInputSKUGlobal:  "gpt 4o 0513 Batch Inp glbl",
+				batchOutputSKUGlobal: "gpt 4o 0513 Batch Outp glbl",
+
+				batchInputSKUDataZone:  "gpt 4o 0513 Batch Inp Data Zone",
+				batchOutputSKUDataZone: "gpt 4o 0513 Batch Outp Data Zone",
+			},
+			"2024-08-06": {
+				model:            "gpt-4o",
+				version:          "2024-08-06",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt-4o-0806-Inp-glbl",
+				outputSKUGlobal: "gpt-4o-0806-Outp-glbl",
+
+				cachedInputSKUGlobal: "gpt 4o 0806 cached Inp glbl",
+
+				inputSKURegional:  "gpt-4o-0806-Inp-regnl",
+				outputSKURegional: "gpt-4o-0806-Outp-regnl",
+
+				cachedInputSKURegional: "gpt 4o 0806 cached Inp regnl",
+
+				inputSKUDataZone:  "gpt 4o 0806 Inp Data Zone",
+				outputSKUDataZone: "gpt 4o 0806 Outp Data Zone",
+
+				cachedInputSKUDataZone: "gpt 4o 0806 cached Inp Data Zone",
+
+				batchInputSKUGlobal:  "gpt-4o-0806-Batch-Inp-glbl",
+				batchOutputSKUGlobal: "gpt-4o-0806-Batch-Outp-glbl",
+
+				batchInputSKUDataZone:  "gpt 4o 0806 Batch Inp Data Zone",
+				batchOutputSKUDataZone: "gpt 4o 0806 Batch Outp Data Zone",
+			},
+			"2024-11-20": {
+				model:            "gpt-4o",
+				version:          "2024-11-20",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt 4o 1120 Inp glbl",
+				outputSKUGlobal: "gpt 4o 1120 Outp glbl",
+
+				cachedInputSKUGlobal: "gpt 4o 1120 cached Inp glbl",
+
+				inputSKURegional:  "gpt 4o 1120 Inp regnl",
+				outputSKURegional: "gpt 4o 1120 Outp regnl",
+
+				cachedInputSKURegional: "gpt 4o 1120 cached Inp regnl",
+
+				inputSKUDataZone:  "gpt 4o 1120 Inp Data Zone",
+				outputSKUDataZone: "gpt 4o 1120 Outp Data Zone",
+
+				cachedInputSKUDataZone: "gpt 4o 1120 cached Inp Data Zone",
+
+				batchInputSKUGlobal:  "gpt 4o 1120 Batch Inp glbl",
+				batchOutputSKUGlobal: "gpt 4o 1120 Batch Outp glbl",
+
+				batchInputSKUDataZone:  "gpt 4o 1120 Batch Inp Data Zone",
+				batchOutputSKUDataZone: "gpt 4o 1120 Batch Outp Data Zone",
+			},
+		},
+
+		"gpt-4o-mini": {
+			"2024-07-18": {
+				model:            "gpt-4o-mini",
+				version:          "2024-07-18",
+				isDefaultVersion: true,
+
+				inputSKUGlobal:  "gpt-4o-mini-0718-Inp-glbl",
+				outputSKUGlobal: "gpt-4o-mini-0718-Outp-glbl",
+
+				cachedInputSKUGlobal: "gpt 4o mini 0718 cached Inp glbl",
+
+				inputSKURegional:  "gpt-4o-mini-0718-Inp-regnl",
+				outputSKURegional: "gpt-4o-mini-0718-Outp-regnl",
+
+				cachedInputSKURegional: "gpt 4o mini 0718 cached Inp regnl",
+
+				inputSKUDataZone:  "gpt 4o mini 0718 Inp Data Zone",
+				outputSKUDataZone: "gpt 4o mini 0718 Outp Data Zone",
+
+				cachedInputSKUDataZone: "gpt 4o mini 0718 cached Inp Data Zone",
+
+				batchInputSKUGlobal:  "gpt-4o-mini-0718-Batch-Inp-glbl",
+				batchOutputSKUGlobal: "gpt-4o-mini-0718-Batch-Outp-glbl",
+
+				batchInputSKUDataZone:  "gpt 4o mini 0718 Batch Inp Data Zone",
+				batchOutputSKUDataZone: "gpt 4o mini0718 BatchOutp DataZone",
+			},
+		},
+
+		"gpt-4o-audio-preview": {
+			"2024-12-17": {
+				model:            "gpt-4o-audio-preview",
+				version:          "2024-12-17",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt-4o-aud-1217-txt Inp glbl",
+				outputSKUGlobal: "gpt-4o-aud-1217-txt Outp glbl",
+
+				inputSKURegional:  "gpt-4o-aud-1217-txt Inp regnl",
+				outputSKURegional: "gpt-4o-aud-1217-txt Outp regnl",
+
+				inputSKUDataZone:  "gpt-4o-aud-1217-txt Inp DZone",
+				outputSKUDataZone: "gpt-4o-aud-1217-txt Outp DZone",
+
+				audioInputSKUGlobal:  "gpt-4o-aud-1217 Inp glbl",
+				audioOutputSKUGlobal: "gpt-4o-aud-1217 Outp glbl",
+
+				audioInputSKURegional:  "gpt-4o-aud-1217 Inp regnl",
+				audioOutputSKURegional: "gpt-4o-aud-1217 Outp regnl",
+
+				audioInputSKUDataZone:  "gpt-4o-aud-1217 Inp DZone",
+				audioOutputSKUDataZone: "gpt-4o-aud-1217 Outp DZone",
+			},
+		},
+
+		"gpt-4o-mini-audio-preview": {
+			"2024-12-17": {
+				model:            "gpt-4o-mini-audio-preview",
+				version:          "2024-12-17",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt4omini-aud1217-txt Inp glbl",
+				outputSKUGlobal: "gpt4omini-aud1217-txt Outp glbl",
+
+				inputSKURegional:  "gpt4omini-aud1217-txt Inp regnl",
+				outputSKURegional: "gpt4omini-aud1217-txt Outp regnl",
+
+				inputSKUDataZone:  "gpt4omini-aud1217-txt Inp DZone",
+				outputSKUDataZone: "gpt4omini-aud1217-txt Outp DZone",
+
+				audioInputSKUGlobal:  "gpt4omini-aud1217 Inp glbl",
+				audioOutputSKUGlobal: "gpt4omini-aud1217 Outp glbl",
+
+				audioInputSKURegional:  "gpt4omini-aud1217 Inp regnl",
+				audioOutputSKURegional: "gpt4omini-aud1217 Outp regnl",
+
+				audioInputSKUDataZone:  "gpt4omini-aud1217 Inp DZone",
+				audioOutputSKUDataZone: "gpt4omini-aud1217 Outp DZone",
+			},
+		},
+
+		"gpt-4o-realtime-preview": {
+			"2024-12-17": {
+				model:            "gpt-4o-realtime-preview",
+				version:          "2024-12-17",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt-4o-rt-txt-1217 Inp glbl",
+				outputSKUGlobal: "gpt-4o-rt-txt-1217 Outp glbl",
+
+				cachedInputSKUGlobal: "gpt-4o-rt-txt-1217 cchd Inp glbl",
+
+				inputSKURegional:  "gpt-4o-rt-txt-1217 Inp regnl",
+				outputSKURegional: "gpt-4o-rt-txt-1217 Outp regnl",
+
+				cachedInputSKURegional: "gpt-4o-rt-txt-1217 cchd Inp rgnl",
+
+				inputSKUDataZone:  "gpt-4o-rt-txt-1217 Inp DZone",
+				outputSKUDataZone: "gpt-4o-rt-txt-1217 Outp DZone",
+
+				cachedInputSKUDataZone: "gpt-4o-rt-txt-1217 cchd Inp DZn",
+
+				audioInputSKUGlobal:  "gpt-4o-rt-aud-1217 Inp glbl",
+				audioOutputSKUGlobal: "gpt-4o-rt-aud-1217 Outp glbl",
+
+				audioInputSKURegional:  "gpt-4o-rt-aud-1217 Inp regnl",
+				audioOutputSKURegional: "gpt-4o-rt-aud-1217 Outp regnl",
+
+				audioInputSKUDataZone:  "gpt-4o-rt-aud-1217 Inp DZone",
+				audioOutputSKUDataZone: "gpt-4o-rt-aud-1217 Outp DZone",
+			},
+			"2024-10-01": {
+				model:            "gpt-4o-realtime-preview",
+				version:          "2024-10-01",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt4o realtime prvw text inp glbl",
+				outputSKUGlobal: "gpt4o realtime prvw text outp glbl",
+
+				cachedInputSKUGlobal: "gpt4o realtime cached text inp glbl",
+
+				inputSKURegional:  "gpt4o realtime prvw text inp regn",
+				outputSKURegional: "gpt4o realtime prvw text outp regn",
+
+				inputSKUDataZone:  "gpt4o realtimePrvwTxtInp DataZone",
+				outputSKUDataZone: "gpt4o realtimePrvwTxtOutp DataZone",
+
+				audioInputSKUGlobal:  "gpt4o realtimePrvw audio inp glbl",
+				audioOutputSKUGlobal: "gpt4o realtimePrvw audio outp glbl",
+
+				audioInputSKURegional:  "gpt4o realtimePrvw audio inp regn",
+				audioOutputSKURegional: "gpt4o realtimePrvw audio outp regn",
+
+				audioInputSKUDataZone:  "gpt4o realtimePrvwAudInp DataZone",
+				audioOutputSKUDataZone: "gpt4o realtimePrvwAudOutp DataZone",
+			},
+		},
+
+		"gpt-4o-mini-realtime-preview": {
+			"2024-12-17": {
+				model:            "gpt-4o-mini-realtime-preview",
+				version:          "2024-12-17",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "gpt4omini-rt-txt1217 Inp glbl",
+				outputSKUGlobal: "gpt4omini-rt-txt1217 Outp glbl",
+
+				cachedInputSKUGlobal: "gpt4omini-rt-txt1217 cchd Inp glbl",
+
+				inputSKURegional:  "gpt4omini-rt-txt1217 Inp regnl",
+				outputSKURegional: "gpt4omini-rt-txt1217 Outp regnl",
+
+				cachedInputSKURegional: "gpt4omini-rt-txt1217 cchd Inp rgnl",
+
+				inputSKUDataZone:  "gpt4omini-rt-txt1217 Inp DZone",
+				outputSKUDataZone: "gpt4omini-rt-txt1217 Outp DZone",
+
+				cachedInputSKUDataZone: "gpt4omini-rt-txt1217 cchd Inp DZn",
+
+				audioInputSKUGlobal:  "gpt4omini-rt-aud1217 Inp glbl",
+				audioOutputSKUGlobal: "gpt4omini-rt-aud1217 Outp glbl",
+
+				audioInputSKURegional:  "gpt4omini-rt-aud1217 Inp regnl",
+				audioOutputSKURegional: "gpt4omini-rt-aud1217 Outp regnl",
+
+				audioInputSKUDataZone:  "gpt4omini-rt-aud1217 Inp DZone",
+				audioOutputSKUDataZone: "gpt4omini-rt-aud1217 Outp DZone",
+			},
+		},
+
+		"computer-use-preview": {
+			"global": {
+				model:            "computer-use-preview",
+				version:          "global",
+				isDefaultVersion: true,
+
+				inputSKUGlobal:  "computer-use-inpt-glbl",
+				outputSKUGlobal: "computer-use-outp-glbl",
+
+				inputSKURegional:  "computer-use-inpt-rgnl",
+				outputSKURegional: "computer-use-outp-rgnl",
+
+				inputSKUDataZone:  "computer-use-inpt-datazone",
+				outputSKUDataZone: "computer-use-outp-datazone",
+
+				batchInputSKUGlobal:  "computer-use-batch-inpt-glbl",
+				batchOutputSKUGlobal: "computer-use-batch-outp-glbl",
+
+				batchInputSKUDataZone:  "computer-use-batch-inpt-datazone",
+				batchOutputSKUDataZone: "computer-use-batch-outp-datazone",
+			},
+		},
+
+		"o1-mini": {
+			"2024-09-12": {
+				model:            "o1-mini",
+				version:          "2024-09-12",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "o1 mini input glbl",
+				outputSKUGlobal: "o1 mini output glbl",
+
+				inputSKURegional:  "o1 mini input regnl",
+				outputSKURegional: "o1 mini output regnl",
+
+				cachedInputSKUGlobal:   "o1 mini cached input glbl",
+				cachedInputSKURegional: "o1 mini cached input regnl",
+				cachedInputSKUDataZone: "o1 mini cached input Data Zone",
+
+				inputSKUDataZone:  "o1 mini input Data Zone",
+				outputSKUDataZone: "o1 mini output Data Zone",
+
+				batchInputSKUGlobal:  "o1 mini Batch Inp glbl",
+				batchOutputSKUGlobal: "o1 mini Batch Outp glbl",
+
+				batchInputSKUDataZone:  "o1 mini Batch Inp Data Zone",
+				batchOutputSKUDataZone: "o1 mini Batch Outp Data Zone",
+			},
+		},
+
+		"o1": {
+			"2024-12-17": {
+				model:            "o1",
+				version:          "2024-12-17",
+				isDefaultVersion: false,
+
+				inputSKUGlobal:  "o1 1217 Inp glbl",
+				outputSKUGlobal: "o1 1217 Outp glbl",
+
+				cachedInputSKUGlobal: "o1 1217 cached Inp glbl",
+
+				inputSKURegional:  "o1 1217 Inp regnl",
+				outputSKURegional: "o1 1217 Outp regnl",
+
+				cachedInputSKURegional: "o1 1217 cached Inp regnl",
+
+				inputSKUDataZone:  "o1 1217 Inp Data Zone",
+				outputSKUDataZone: "o1 1217 Outp Data Zone",
+
+				cachedInputSKUDataZone: "o1 1217 cached Inp Data Zone",
+
+				batchInputSKUGlobal:  "o1 1217 Batch Inp glbl",
+				batchOutputSKUGlobal: "o1 1217 Batch Outp glbl",
+
+				batchInputSKUDataZone:  "o1 1217 Batch Inp Data Zone",
+				batchOutputSKUDataZone: "o1 1217 Batch Outp Data Zone",
+			},
+		},
+
+		"o3-mini": {
+			"2025-01-31": {
+				model:            "o3-mini",
+				version:          "2025-01-31",
+				isDefaultVersion: true,
+
+				inputSKUGlobal:  "o3 mini 0131 input glbl",
+				outputSKUGlobal: "o3 mini 0131 output glbl",
+
+				cachedInputSKUGlobal: "o3 mini 0131 cached input glbl",
+
+				inputSKURegional:  "o3 mini 0131 input regnl",
+				outputSKURegional: "o3 mini 0131 output regnl",
+
+				cachedInputSKURegional: "o3 mini 0131 cached input regnl",
+
+				inputSKUDataZone:  "o3 mini 0131 input Data Zone",
+				outputSKUDataZone: "o3 mini 0131 output Data Zone",
+
+				cachedInputSKUDataZone: "o3 mini 0131 cached input Data Zone",
+
+				batchInputSKUGlobal:  "o3 mini 0131 Batch Inp glbl",
+				batchOutputSKUGlobal: "o3 mini 0131 Batch Outp glbl",
+
+				batchInputSKUDataZone:  "o3 mini 0131 Batch Inp Data Zone",
+				batchOutputSKUDataZone: "o3 mini 0131 Batch Outp Data Zone",
+			},
+		},
+	}
+
+	audioModels                  = map[string]struct{}{}
+	languageModelDefaultVersions = map[string]string{}
+
+	baseModelSKUs = map[string]string{
+		"babbage-002": "Babbage",
+		"davinci-002": "Davinci",
+	}
+	fineTuningSKUs = map[string]string{
+		"babbage-002":      "Az-Babbage-002",
+		"davinci-002":      "Az-Davinci-002",
+		"gpt-35-turbo":     "Az-GPT35-Turbo-4K",
+		"gpt-35-turbo-16k": "Az-GPT35-Turbo-16K",
+	}
+
+	imageSKUs = map[string]string{
+		"dall-e-2": "Az-Image-DALL-E",
+		"dall-e-3": "Az-Image-Dall-E-3",
+	}
+
+	embeddingSKUs = map[string]string{
+		"text-embedding-ada-002": "Az-Embeddings-Ada",
+		"text-embedding-3-small": "Az-Text-Embedding-3-Small",
+		"text-embedding-3-large": "Az-Text-Embedding-3-Large",
+	}
+
+	speechSKUs = map[string]string{
+		"whisper": "Az-Speech-Whisper",
+		"tts":     "Az-Speech-Text to Speech",
+		"tts-hd":  "Az-Speech-Text to Speech HD",
+	}
+)
+
+func init() {
+	for _, versions := range languageModelSKUs {
+		for version, sku := range versions {
+			if sku.isDefaultVersion {
+				languageModelDefaultVersions[sku.model] = version
+			}
+
+			if len(versions) == 1 {
+				languageModelDefaultVersions[sku.model] = version
+			}
+
+			if sku.audioInputSKUGlobal != "" {
+				audioModels[sku.model] = struct{}{}
+			}
+		}
+	}
+
 }
 
 // CognitiveDeployment struct represents an Azure OpenAI Deployment.
@@ -81,22 +705,30 @@ type CognitiveDeployment struct {
 	Version string
 	Tier    string
 
+	SKU      string
+	Capacity int64
+
 	// Usage-based attributes
-	MonthlyLanguageInputTokens     *int64   `infracost_usage:"monthly_language_input_tokens"`
-	MonthlyLanguageOutputTokens    *int64   `infracost_usage:"monthly_language_output_tokens"`
-	MonthlyCodeInterpreterSessions *int64   `infracost_usage:"monthly_code_interpreter_sessions"`
-	MonthlyBaseModelTokens         *int64   `infracost_usage:"monthly_base_model_tokens"`
-	MonthlyFineTuningTrainingHours *float64 `infracost_usage:"monthly_fine_tuning_training_hours"`
-	MonthlyFineTuningHostingHours  *float64 `infracost_usage:"monthly_fine_tuning_hosting_hours"`
-	MonthlyFineTuningInputTokens   *int64   `infracost_usage:"monthly_fine_tuning_input_tokens"`
-	MonthlyFineTuningOutputTokens  *int64   `infracost_usage:"monthly_fine_tuning_output_tokens"`
-	MonthlyStandard10241024Images  *int64   `infracost_usage:"monthly_standard_1024_1024_images"`
-	MonthlyStandard10241792Images  *int64   `infracost_usage:"monthly_standard_1024_1792_images"`
-	MonthlyHD10241024Images        *int64   `infracost_usage:"monthly_hd_1024_1024_images"`
-	MonthlyHD10241792Images        *int64   `infracost_usage:"monthly_hd_1024_1792_images"`
-	MonthlyTextEmbeddingTokens     *int64   `infracost_usage:"monthly_text_embedding_tokens"`
-	MonthlyTextToSpeechCharacters  *int64   `infracost_usage:"monthly_text_to_speech_characters"`
-	MonthlyTextToSpeechHours       *float64 `infracost_usage:"monthly_text_to_speech_hours"`
+	MonthlyLanguageInputTokens       *int64   `infracost_usage:"monthly_language_input_tokens"`
+	MonthlyLanguageOutputTokens      *int64   `infracost_usage:"monthly_language_output_tokens"`
+	MonthlyLanguageCachedInputTokens *int64   `infracost_usage:"monthly_language_cached_input_tokens"`
+	MonthlyCodeInterpreterSessions   *int64   `infracost_usage:"monthly_code_interpreter_sessions"`
+	MonthlyBaseModelTokens           *int64   `infracost_usage:"monthly_base_model_tokens"`
+	MonthlyFineTuningTrainingHours   *float64 `infracost_usage:"monthly_fine_tuning_training_hours"`
+	MonthlyFineTuningHostingHours    *float64 `infracost_usage:"monthly_fine_tuning_hosting_hours"`
+	MonthlyFineTuningInputTokens     *int64   `infracost_usage:"monthly_fine_tuning_input_tokens"`
+	MonthlyFineTuningOutputTokens    *int64   `infracost_usage:"monthly_fine_tuning_output_tokens"`
+	MonthlyStandard10241024Images    *int64   `infracost_usage:"monthly_standard_1024_1024_images"`
+	MonthlyStandard10241792Images    *int64   `infracost_usage:"monthly_standard_1024_1792_images"`
+	MonthlyHD10241024Images          *int64   `infracost_usage:"monthly_hd_1024_1024_images"`
+	MonthlyHD10241792Images          *int64   `infracost_usage:"monthly_hd_1024_1792_images"`
+	MonthlyTextEmbeddingTokens       *int64   `infracost_usage:"monthly_text_embedding_tokens"`
+	MonthlyTextToSpeechCharacters    *int64   `infracost_usage:"monthly_text_to_speech_characters"`
+	MonthlyTextToSpeechHours         *float64 `infracost_usage:"monthly_text_to_speech_hours"`
+	MonthlyAudioInputTokens          *int64   `infracost_usage:"monthly_audio_input_tokens"`
+	MonthlyAudioOutputTokens         *int64   `infracost_usage:"monthly_audio_output_tokens"`
+	MonthlyFileSearchToolCalls       *int64   `infracost_usage:"monthly_file_search_tool_calls"`
+	MonthlyFileSearchStorage         *float64 `infracost_usage:"monthly_file_search_storage_gb"`
 }
 
 // CoreType returns the name of this resource type
@@ -122,6 +754,10 @@ func (r *CognitiveDeployment) UsageSchema() []*schema.UsageItem {
 		{Key: "monthly_text_embeddings", ValueType: schema.Int64, DefaultValue: 0},
 		{Key: "monthly_text_to_speech_characters", ValueType: schema.Int64, DefaultValue: 0},
 		{Key: "monthly_text_to_speech_hours", ValueType: schema.Float64, DefaultValue: 0},
+		{Key: "monthly_audio_input_tokens", ValueType: schema.Int64, DefaultValue: 0},
+		{Key: "monthly_audio_output_tokens", ValueType: schema.Int64, DefaultValue: 0},
+		{Key: "monthly_file_search_tool_calls", ValueType: schema.Int64, DefaultValue: 0},
+		{Key: "monthly_file_search_storage_gb", ValueType: schema.Float64, DefaultValue: 0},
 	}
 }
 
@@ -147,10 +783,11 @@ func (r *CognitiveDeployment) BuildResource() *schema.Resource {
 
 	if _, ok := languageModelSKUs[r.Model]; ok {
 		costComponents = append(costComponents, r.languageCostComponents()...)
+		costComponents = append(costComponents, r.toolCallsCostComponents()...)
 	}
 
-	if _, ok := assistantModels[r.Model]; ok {
-		costComponents = append(costComponents, r.assistantCostComponents()...)
+	if _, ok := audioModels[r.Model]; ok {
+		costComponents = append(costComponents, r.audioCostComponents()...)
 	}
 
 	if _, ok := baseModelSKUs[r.Model]; ok {
@@ -185,39 +822,116 @@ func (r *CognitiveDeployment) BuildResource() *schema.Resource {
 	}
 }
 
+func (r *CognitiveDeployment) audioCostComponents() []*schema.CostComponent {
+	version := r.Version
+	if version == "" {
+		version = languageModelDefaultVersions[r.Model]
+	}
+
+	skuDetails := languageModelSKUs[r.Model][version]
+	sku := skuDetails.skuName(r.SKU)
+
+	var inputQty, outputQty *decimal.Decimal
+	if r.MonthlyAudioInputTokens != nil {
+		inputQty = decimalPtr(decimal.NewFromInt(*r.MonthlyAudioInputTokens).Div(decimal.NewFromInt(1_000)))
+	}
+	if r.MonthlyAudioOutputTokens != nil {
+		outputQty = decimalPtr(decimal.NewFromInt(*r.MonthlyAudioOutputTokens).Div(decimal.NewFromInt(1_000)))
+	}
+
+	return []*schema.CostComponent{
+		{
+			Name:                 fmt.Sprintf("Audio input tokens (%s)", r.Model),
+			Unit:                 "1k tokens",
+			UnitMultiplier:       decimal.NewFromInt(1),
+			MonthlyQuantity:      inputQty,
+			IgnoreIfMissingPrice: true,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr(vendorName),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cognitive Services"),
+				ProductFamily: strPtr("AI + Machine Learning"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr("Azure OpenAI")},
+					{Key: "skuName", Value: strPtr(sku.audioInput)},
+				},
+			},
+		},
+		{
+			Name:                 fmt.Sprintf("Audio output tokens (%s)", r.Model),
+			Unit:                 "1k tokens",
+			UnitMultiplier:       decimal.NewFromInt(1),
+			MonthlyQuantity:      outputQty,
+			IgnoreIfMissingPrice: true,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr(vendorName),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cognitive Services"),
+				ProductFamily: strPtr("AI + Machine Learning"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr("Azure OpenAI")},
+					{Key: "skuName", Value: strPtr(sku.audioOutput)},
+				},
+			},
+		},
+	}
+}
+
 func (r *CognitiveDeployment) languageCostComponents() []*schema.CostComponent {
-	skuPrefix := languageModelSKUs[r.Model]
 	modelName := r.Model
-	if r.Model == "gpt-4" {
-		if v, ok := languageModelGPT4Versions[r.Version]; ok {
-			skuPrefix = v
-			modelName = fmt.Sprintf("%s-%s", r.Model, r.Version)
+	version := r.Version
+	if version == "" {
+		version = languageModelDefaultVersions[r.Model]
+	}
+
+	skuDetails := languageModelSKUs[r.Model][version]
+	sku := skuDetails.skuName(r.SKU)
+
+	if strings.Contains(strings.ToLower(r.SKU), "provisioned") {
+		skuName := "Provisioned Managed Global"
+		if strings.EqualFold(r.SKU, "DataZoneProvisionedManaged") {
+			skuName = "Provisioned Managed Data Zone"
+		}
+
+		if strings.EqualFold(r.SKU, "ProvisionedManaged") {
+			skuName = "Provisioned Managed Regional"
+		}
+
+		return []*schema.CostComponent{
+			{
+				Name:                 fmt.Sprintf("Provisioned throughput units (%s)", modelName),
+				Unit:                 "hours",
+				UnitMultiplier:       decimal.NewFromInt(1),
+				HourlyQuantity:       decimalPtr(decimal.NewFromInt(r.Capacity)),
+				IgnoreIfMissingPrice: true,
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr(vendorName),
+					Region:        strPtr(r.Region),
+					Service:       strPtr("Cognitive Services"),
+					ProductFamily: strPtr("AI + Machine Learning"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "productName", Value: strPtr("Azure OpenAI")},
+						{Key: "skuName", Value: strPtr(skuName)},
+					},
+				},
+			},
 		}
 	}
 
-	var inputSku, outputSku string
-	if r.Model == "gpt-35-turbo" || r.Model == "gpt-35-turbo-16k" {
-		inputSku = fmt.Sprintf("%s Input", skuPrefix)
-		outputSku = fmt.Sprintf("%s Output", skuPrefix)
-	} else if r.Model == "gpt-35-turbo-instruct" {
-		inputSku = fmt.Sprintf("%s-Input", skuPrefix)
-		outputSku = fmt.Sprintf("%s-Output", skuPrefix)
-	} else {
-		inputSku = fmt.Sprintf("%s-Prompt", skuPrefix)
-		outputSku = fmt.Sprintf("%s-Completion", skuPrefix)
-	}
-
-	var inputQty, outputQty *decimal.Decimal
+	var inputQty, outputQty, cachedInputQty *decimal.Decimal
 	if r.MonthlyLanguageInputTokens != nil {
 		inputQty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageInputTokens).Div(decimal.NewFromInt(1_000)))
 	}
 	if r.MonthlyLanguageOutputTokens != nil {
 		outputQty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageOutputTokens).Div(decimal.NewFromInt(1_000)))
 	}
+	if r.MonthlyLanguageCachedInputTokens != nil {
+		cachedInputQty = decimalPtr(decimal.NewFromInt(*r.MonthlyLanguageCachedInputTokens).Div(decimal.NewFromInt(1_000)))
+	}
 
 	return []*schema.CostComponent{
 		{
-			Name:                 fmt.Sprintf("Language input (%s)", modelName),
+			Name:                 fmt.Sprintf("Text input (%s)", modelName),
 			Unit:                 "1K tokens",
 			UnitMultiplier:       decimal.NewFromInt(1),
 			MonthlyQuantity:      inputQty,
@@ -229,13 +943,12 @@ func (r *CognitiveDeployment) languageCostComponents() []*schema.CostComponent {
 				ProductFamily: strPtr("AI + Machine Learning"),
 				AttributeFilters: []*schema.AttributeFilter{
 					{Key: "productName", Value: strPtr("Azure OpenAI")},
-					{Key: "skuName", Value: strPtr(inputSku)},
-					{Key: "meterName", Value: strPtr(fmt.Sprintf("%s Tokens", inputSku))},
+					{Key: "skuName", Value: strPtr(sku.input)},
 				},
 			},
 		},
 		{
-			Name:                 fmt.Sprintf("Language output (%s)", modelName),
+			Name:                 fmt.Sprintf("Text output (%s)", modelName),
 			Unit:                 "1K tokens",
 			UnitMultiplier:       decimal.NewFromInt(1),
 			MonthlyQuantity:      outputQty,
@@ -247,26 +960,15 @@ func (r *CognitiveDeployment) languageCostComponents() []*schema.CostComponent {
 				ProductFamily: strPtr("AI + Machine Learning"),
 				AttributeFilters: []*schema.AttributeFilter{
 					{Key: "productName", Value: strPtr("Azure OpenAI")},
-					{Key: "skuName", Value: strPtr(outputSku)},
-					{Key: "meterName", Value: strPtr(fmt.Sprintf("%s Tokens", outputSku))},
+					{Key: "skuName", Value: strPtr(sku.output)},
 				},
 			},
 		},
-	}
-}
-
-func (r *CognitiveDeployment) assistantCostComponents() []*schema.CostComponent {
-	var qty *decimal.Decimal
-	if r.MonthlyCodeInterpreterSessions != nil {
-		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyCodeInterpreterSessions))
-	}
-
-	return []*schema.CostComponent{
 		{
-			Name:                 fmt.Sprintf("Code interpreter sessions (%s)", r.Model),
-			Unit:                 "sessions",
+			Name:                 fmt.Sprintf("Cached text input (%s)", modelName),
+			Unit:                 "1K tokens",
 			UnitMultiplier:       decimal.NewFromInt(1),
-			MonthlyQuantity:      qty,
+			MonthlyQuantity:      cachedInputQty,
 			IgnoreIfMissingPrice: true,
 			ProductFilter: &schema.ProductFilter{
 				VendorName:    strPtr(vendorName),
@@ -275,8 +977,7 @@ func (r *CognitiveDeployment) assistantCostComponents() []*schema.CostComponent 
 				ProductFamily: strPtr("AI + Machine Learning"),
 				AttributeFilters: []*schema.AttributeFilter{
 					{Key: "productName", Value: strPtr("Azure OpenAI")},
-					{Key: "skuName", Value: strPtr("Az-Assistants-Code-Interpreter")},
-					{Key: "meterName", Value: strPtr("Az-Assistants-Code-Interpreter Session")},
+					{Key: "skuName", Value: strPtr(sku.cachedInput)},
 				},
 			},
 		},
@@ -605,6 +1306,78 @@ func (r *CognitiveDeployment) speechCostComponents() []*schema.CostComponent {
 					{Key: "productName", Value: strPtr("Azure OpenAI")},
 					{Key: "skuName", Value: strPtr(sku)},
 					{Key: "meterName", Value: strPtr(fmt.Sprintf("%s Characters", sku))},
+				},
+			},
+		},
+	}
+}
+
+func (r *CognitiveDeployment) toolCallsCostComponents() []*schema.CostComponent {
+	var toolCallsQty *decimal.Decimal
+	if r.MonthlyFileSearchToolCalls != nil {
+		toolCallsQty = decimalPtr(decimal.NewFromInt(*r.MonthlyFileSearchToolCalls).Div(decimal.NewFromInt(1_000)))
+	}
+
+	var storageQty *decimal.Decimal
+	if r.MonthlyFileSearchStorage != nil {
+		storageQty = decimalPtr(decimal.NewFromFloat(*r.MonthlyFileSearchStorage))
+	}
+
+	var qty *decimal.Decimal
+	if r.MonthlyCodeInterpreterSessions != nil {
+		qty = decimalPtr(decimal.NewFromInt(*r.MonthlyCodeInterpreterSessions))
+	}
+
+	return []*schema.CostComponent{
+		{
+			Name:                 "File search tool calls",
+			Unit:                 "1k calls",
+			UnitMultiplier:       decimal.NewFromInt(1),
+			MonthlyQuantity:      toolCallsQty,
+			IgnoreIfMissingPrice: true,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr(vendorName),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cognitive Services"),
+				ProductFamily: strPtr("AI + Machine Learning"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr("Azure OpenAI")},
+					{Key: "skuName", Value: strPtr("file-search-tool-calls-glbl")},
+				},
+			},
+		},
+		{
+			Name:                 "File search vector storage",
+			Unit:                 "GB",
+			UnitMultiplier:       decimal.NewFromInt(1),
+			MonthlyQuantity:      storageQty,
+			IgnoreIfMissingPrice: true,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr(vendorName),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cognitive Services"),
+				ProductFamily: strPtr("AI + Machine Learning"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr("Azure OpenAI")},
+					{Key: "skuName", Value: strPtr("Assistants-File Search-glbl")},
+				},
+			},
+		},
+		{
+			Name:                 "Code interpreter sessions",
+			Unit:                 "sessions",
+			UnitMultiplier:       decimal.NewFromInt(1),
+			MonthlyQuantity:      qty,
+			IgnoreIfMissingPrice: true,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr(vendorName),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cognitive Services"),
+				ProductFamily: strPtr("AI + Machine Learning"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "productName", Value: strPtr("Azure OpenAI")},
+					{Key: "skuName", Value: strPtr("Az-Assistants-Code-Interpreter")},
+					{Key: "meterName", Value: strPtr("Az-Assistants-Code-Interpreter Session")},
 				},
 			},
 		},


### PR DESCRIPTION
adds new models to cognitive deployment with additional cost components. 

Note: we've hard coded the skus here as there is no consistency in the naming. In future we'll modify the pricing api logic to normalize on ingestion, but it was decided that we don't do this now.