### PR TITLE
fix: add trailing registry URL slash

### DIFF
--- a/internal/hcl/modules/registry.go
+++ b/internal/hcl/modules/registry.go
@@ -111,6 +111,9 @@ func (d *Disco) ModuleLocation(source string) (RegistryURL, bool, error) {
 	if err != nil {
 		return RegistryURL{}, false, fmt.Errorf("unable to discover registry service using host %s %w", host, err)
 	}
+	if !strings.HasSuffix(serviceURL.Path, "/") {
+		serviceURL.Path += "/"
+	}
 
 	r := RegistryURL{
 		Host:      host,
@@ -136,6 +139,9 @@ func (d *Disco) DownloadLocation(moduleURL RegistryURL, version string) (string,
 	serviceURL, err := d.disco.DiscoverServiceURL(hostname, moduleServiceID)
 	if err != nil {
 		return "", fmt.Errorf("unable to discover registry service using host %s %w", moduleURL.Host, err)
+	}
+	if !strings.HasSuffix(serviceURL.Path, "/") {
+		serviceURL.Path += "/"
 	}
 
 	var u *url.URL


### PR DESCRIPTION
Typically, the https://registry.terraform.io/.well-known/terraform.json returns `{"modules.v1":"/v1/modules/","providers.v1":"/v1/providers/"}`

If instead, a custom registry returns no trailing slash, like `{"modules.v1":"/v1/modules","providers.v1":"/v1/providers"}
Then we'd fetch URLs mashing together the path with the module name.   This fixes that, akin to https://github.com/hashicorp/terraform/commit/34b4000be964095232df9a04e53596f61bb921c5