### PR TITLE
feat(azure): Add support for `azurerm_iothub_device_update_account` and `azurerm_iothub_device_update_instance`

### DIFF
--- a/internal/providers/terraform/azure/iothub_device_update_account.go
+++ b/internal/providers/terraform/azure/iothub_device_update_account.go
@@ -1,0 +1,20 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getIotHubDeviceUpdateAccountRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "azurerm_iothub_device_update_account",
+		CoreRFunc: NewIotHubDeviceUpdateAccount,
+	}
+}
+
+func NewIotHubDeviceUpdateAccount(d *schema.ResourceData) schema.CoreResource {
+	return &azure.IotHubDeviceUpdateAccount{
+		Address: d.Address,
+		Region:  d.Region,
+	}
+}

--- a/internal/providers/terraform/azure/iothub_device_update_account_test.go
+++ b/internal/providers/terraform/azure/iothub_device_update_account_test.go
@@ -1,0 +1,17 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureRMIotHubDeviceUpdateAccount(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	opts := tftest.DefaultGoldenFileOptions()
+	tftest.GoldenFileResourceTestsWithOpts(t, "iothub_device_update_account_test", opts)
+}

--- a/internal/providers/terraform/azure/iothub_device_update_instance.go
+++ b/internal/providers/terraform/azure/iothub_device_update_instance.go
@@ -1,0 +1,21 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getIotHubDeviceUpdateInstanceRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "azurerm_iothub_device_update_instance",
+		CoreRFunc: NewIotHubDeviceUpdateInstance,
+	}
+}
+
+func NewIotHubDeviceUpdateInstance(d *schema.ResourceData) schema.CoreResource {
+	return &azure.IotHubDeviceUpdateInstance{
+		Address: d.Address,
+		Region:  d.Region,
+		Sku:     d.Get("sku").String(), 
+	}
+}

--- a/internal/providers/terraform/azure/iothub_device_update_instance_test.go
+++ b/internal/providers/terraform/azure/iothub_device_update_instance_test.go
@@ -1,0 +1,17 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureRMIotHubDeviceUpdateInstance(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	opts := tftest.DefaultGoldenFileOptions()
+	tftest.GoldenFileResourceTestsWithOpts(t, "iothub_device_update_instance_test", opts)
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -169,6 +169,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getFederatedIdentityCredentialRegistryItem(),
 	getCognitiveAccountRegistryItem(),
 	getCognitiveDeploymentRegistryItem(),
+	getIotHubDeviceUpdateAccountRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -170,6 +170,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getCognitiveAccountRegistryItem(),
 	getCognitiveDeploymentRegistryItem(),
 	getIotHubDeviceUpdateAccountRegistryItem(),
+	getIotHubDeviceUpdateInstanceRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/azure/testdata/iothub_device_update_account_test/iothub_device_update_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/iothub_device_update_account_test/iothub_device_update_account_test.golden
@@ -1,0 +1,18 @@
+ Name                                                     Monthly Qty  Unit     Monthly Cost  
+                                                                                             
+ azurerm_iothub_device_update_account.example_account              730  hours          $0.73  
+   └─ Device update tenants                                        730  hours          $0.73  
+
+ OVERALL TOTAL                                                                       $0.73  
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+1 cloud resource was detected:
+∙ 1 was estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                                      ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ iothub_device_update_account_test                            ┃         $0.73 ┃           - ┃      $0.73 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/iothub_device_update_account_test/iothub_device_update_account_test.tf
+++ b/internal/providers/terraform/azure/testdata/iothub_device_update_account_test/iothub_device_update_account_test.tf
@@ -1,0 +1,18 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_iothub_device_update_account" "example_account" {
+  name                = "example-update-account"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  tags = {
+    purpose = "testing"
+  }
+}

--- a/internal/providers/terraform/azure/testdata/iothub_device_update_account_test/iothub_device_update_account_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/iothub_device_update_account_test/iothub_device_update_account_test.usage.yml
@@ -1,0 +1,4 @@
+version: 0.1
+resource_usage:
+  azurerm_iothub_device_update_account.example_account:
+    has_standard_instance: true

--- a/internal/providers/terraform/azure/testdata/iothub_device_update_instance_test/iothub_device_update_instance_test.golden
+++ b/internal/providers/terraform/azure/testdata/iothub_device_update_instance_test/iothub_device_update_instance_test.golden
@@ -1,0 +1,18 @@
+ Name                                                       Monthly Qty  Unit     Monthly Cost  
+                                                                                               
+ azurerm_iothub_device_update_instance.standard_instance           500  device         $50.00  
+   └─ Device update devices                                        500  device         $50.00  
+
+ OVERALL TOTAL                                                                         $50.00  
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+1 cloud resource was detected:
+∙ 1 was estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                                       ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ iothub_device_update_instance_test                            ┃        $50.00 ┃           - ┃     $50.00 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/iothub_device_update_instance_test/iothub_device_update_instance_test.tf
+++ b/internal/providers/terraform/azure/testdata/iothub_device_update_instance_test/iothub_device_update_instance_test.tf
@@ -1,0 +1,36 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_iothub_device_update_account" "example_account" {
+  name                = "example-update-account"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_iothub" "iothub_single" {
+  name                = "example-iothub"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  sku {
+    name     = "S1"
+    capacity = 1
+  }
+
+  tags = {
+    purpose = "testing"
+  }
+}
+
+resource "azurerm_iothub_device_update_instance" "standard_instance" {
+  name                     = "example-update-instance"
+  device_update_account_id = azurerm_iothub_device_update_account.example_account.id
+  iothub_id                = azurerm_iothub.iothub_single.id
+}

--- a/internal/providers/terraform/azure/testdata/iothub_device_update_instance_test/iothub_device_update_instance_test.usage.yml
+++ b/internal/providers/terraform/azure/testdata/iothub_device_update_instance_test/iothub_device_update_instance_test.usage.yml
@@ -1,0 +1,4 @@
+version: 0.1
+resource_usage:
+  azurerm_iothub_device_update_instance.standard_instance:
+    device_count: 500

--- a/internal/resources/azure/iothub_device_update_account.go
+++ b/internal/resources/azure/iothub_device_update_account.go
@@ -1,0 +1,58 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+type IotHubDeviceUpdateAccount struct {
+	Address              string
+	Region               string
+	HasStandardInstance  *bool `infracost_usage:"has_standard_instance"`
+}
+
+func (r *IotHubDeviceUpdateAccount) CoreType() string {
+	return "IotHubDeviceUpdateAccount"
+}
+
+func (r *IotHubDeviceUpdateAccount) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "has_standard_instance", ValueType: schema.Bool, DefaultValue: false},
+	}
+}
+
+func (r *IotHubDeviceUpdateAccount) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+func (r *IotHubDeviceUpdateAccount) BuildResource() *schema.Resource {
+	costComponents := []*schema.CostComponent{}
+
+	if r.HasStandardInstance != nil && *r.HasStandardInstance {
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:           "Device update tenants",
+			Unit:           "tenant",
+			UnitMultiplier: decimal.NewFromInt(1),
+			HourlyQuantity: decimalPtr(decimal.NewFromInt(1)),
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("azure"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Device Update"),
+				ProductFamily: strPtr("Internet of Things"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "meterName", ValueRegex: strPtr("/^Device update tenants$/i")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		})
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		CostComponents: costComponents,
+		UsageSchema:    r.UsageSchema(),
+	}
+}

--- a/internal/resources/azure/iothub_device_update_instance.go
+++ b/internal/resources/azure/iothub_device_update_instance.go
@@ -1,0 +1,72 @@
+package azure
+
+import (
+	"strings"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/shopspring/decimal"
+)
+
+type IotHubDeviceUpdateInstance struct {
+	Address     string
+	Region      string
+	Sku         string
+	DeviceCount *int64 `infracost_usage:"device_count"`
+}
+
+func (r *IotHubDeviceUpdateInstance) CoreType() string {
+	return "IotHubDeviceUpdateInstance"
+}
+
+func (r *IotHubDeviceUpdateInstance) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "device_count", ValueType: schema.Int64, DefaultValue: 0},
+	}
+}
+
+func (r *IotHubDeviceUpdateInstance) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+func (r *IotHubDeviceUpdateInstance) BuildResource() *schema.Resource {
+	if strings.ToLower(r.Sku) != "standard" {
+		return &schema.Resource{
+			Name:      r.Address,
+			NoPrice:   true,
+			IsSkipped: true,
+		}
+	}
+
+	var monthlyQuantity *decimal.Decimal
+	if r.DeviceCount != nil {
+		monthlyQuantity = decimalPtr(decimal.NewFromInt(*r.DeviceCount))
+	}
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name:            "Device update devices",
+			Unit:            "device",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: monthlyQuantity,
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("azure"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Device Update"),
+				ProductFamily: strPtr("Internet of Things"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "meterName", ValueRegex: strPtr("/^Device update devices$/i")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		CostComponents: costComponents,
+		UsageSchema:    r.UsageSchema(),
+	}
+}

--- a/internal/schema/usage_item.go
+++ b/internal/schema/usage_item.go
@@ -9,6 +9,7 @@ const (
 	StringArray
 	SubResourceUsage
 	KeyValueMap
+	Bool
 )
 
 type UsageItem struct {


### PR DESCRIPTION
### Overview

This PR adds full support for the following Azure IoT Hub Device Update resources:

- `azurerm_iothub_device_update_account`
- `azurerm_iothub_device_update_instance`

### Details

#### `azurerm_iothub_device_update_account`

- Cost component: **Device update tenants**
- Pricing is applied **only** if the account has at least one associated instance with Standard SKU.
- This is controlled via a usage flag:  
  `has_standard_instance: true`

#### `azurerm_iothub_device_update_instance`

- Cost component: **Device update devices**
- Billed per device.
- Controlled via usage key:  
  `device_count: <number_of_devices>`

### Example usage.yml

```yaml
azurerm_iothub_device_update_account.example:
  has_standard_instance: true

azurerm_iothub_device_update_instance.example:
  device_count: 500
