### PR TITLE
chore(hcl): simplify auto-generated project names by stripping repo path

### DIFF
--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -595,7 +595,7 @@ func (p *Parser) ProjectName() string {
 		return p.projectName
 	}
 
-	name := config.CleanProjectName(p.RelativePath())
+	name := filepath.Base(config.CleanProjectName(p.RelativePath()))
 
 	if p.moduleSuffix != "" {
 		name = fmt.Sprintf("%s-%s", name, p.moduleSuffix)


### PR DESCRIPTION
Previously, auto-generated project names included the full repository path
(e.g., my-org/my-repo/dev), which made them unnecessarily long in CLI output,
pull request comments, and Infracost Cloud.

This change updates the ProjectName method to only use the final directory
(e.g., dev or prod), resulting in cleaner and more readable project names.

This simplifies visual output and improves UX for mono-repos with nested project
structures.

Closes: #2015 