### PR TITLE
fix(output): ensure PastBreakdown is non nil

### DIFF
--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -64,6 +64,11 @@ func Load(p string) (Root, error) {
 			p.Metadata = &schema.ProjectMetadata{}
 			out.Projects[i] = p
 		}
+
+		if p.PastBreakdown == nil {
+			p.PastBreakdown = &Breakdown{}
+			out.Projects[i] = p
+		}
 	}
 
 	return out, nil

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -1,0 +1,38 @@
+package output
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ToMarkdown(t *testing.T) {
+
+	cases := []struct {
+		Name     string
+		Fixture  string
+		Expected string
+	}{
+		{"NoPreviousBreakdown", "testdata/ToMarkdown_NoPreviousBreakdown.json", "testdata/ToMarkdown_NoPreviousBreakdown.md"},
+	}
+
+	for i, test := range cases {
+		test := test
+
+		t.Run(fmt.Sprintf("%02d.%s", i+1, test.Name), func(t *testing.T) {
+			r, err := Load(test.Fixture)
+			require.NoError(t, err)
+
+			expected, err := os.ReadFile(test.Expected)
+			require.NoError(t, err)
+
+			actual, err := ToMarkdown(r, Options{ShowAllProjects: true}, MarkdownOptions{})
+			require.NoError(t, err)
+
+			assert.Equal(t, string(expected), string(actual.Msg))
+		})
+	}
+}

--- a/internal/output/testdata/ToMarkdown_NoPreviousBreakdown.json
+++ b/internal/output/testdata/ToMarkdown_NoPreviousBreakdown.json
@@ -1,0 +1,115 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "infracostCommand": "breakdown",
+    "vcsBranch": "",
+    "vcsCommitSha": "",
+    "vcsCommitAuthorName": "",
+    "vcsCommitAuthorEmail": "",
+    "vcsCommitTimestamp": "0001-01-01T00:00:00Z",
+    "vcsCommitMessage": ""
+  },
+  "currency": "USD",
+  "projects": [
+    {
+      "name": ".",
+      "displayName": "main",
+      "metadata": {
+        "path": ".",
+        "type": "terraform_dir",
+        "remoteModuleCalls": [
+          "registry.terraform.io/terraform-aws-modules/ecr/aws"
+        ]
+      },
+      "breakdown": {
+        "resources": [
+          {
+            "name": "module.ecr.aws_ecr_repository.this[0]",
+            "resourceType": "aws_ecr_repository",
+            "tags": {
+              "Example1": "foo",
+              "Example2": "bar"
+            },
+            "providerSupportsDefaultTags": true,
+            "metadata": {
+              "calls": [
+                {
+                  "blockName": "module.ecr",
+                  "endLine": 12,
+                  "filename": "main.tf",
+                  "startLine": 2
+                },
+                {
+                  "blockName": "aws_ecr_repository.this",
+                  "endLine": 195,
+                  "filename": ".terraform/modules/ecr/main.tf",
+                  "startLine": 177
+                }
+              ],
+              "checksum": "293d23cb524c1f65b33332bc2217e68f5c38309ef60e9686ac4379aa82750654",
+              "endLine": 195,
+              "filename": ".terraform/modules/ecr/main.tf",
+              "startLine": 177
+            },
+            "costComponents": [
+              {
+                "name": "Storage",
+                "unit": "GB",
+                "hourlyQuantity": null,
+                "monthlyQuantity": null,
+                "price": "0.082",
+                "hourlyCost": null,
+                "monthlyCost": null,
+                "usageBased": true,
+                "priceNotFound": false
+              }
+            ]
+          }
+        ],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "diff": {
+        "resources": [],
+        "totalHourlyCost": "0",
+        "totalMonthlyCost": "0",
+        "totalMonthlyUsageCost": "0"
+      },
+      "summary": {
+        "totalDetectedResources": 3,
+        "totalSupportedResources": 1,
+        "totalUnsupportedResources": 0,
+        "totalUsageBasedResources": 1,
+        "totalNoPriceResources": 2,
+        "unsupportedResourceCounts": {},
+        "noPriceResourceCounts": {
+          "aws_ecr_lifecycle_policy": 1,
+          "aws_ecr_repository_policy": 1
+        }
+      }
+    }
+  ],
+  "totalHourlyCost": "0",
+  "totalMonthlyCost": "0",
+  "totalMonthlyUsageCost": "0",
+  "pastTotalHourlyCost": "0",
+  "pastTotalMonthlyCost": "0",
+  "pastTotalMonthlyUsageCost": "0",
+  "diffTotalHourlyCost": "0",
+  "diffTotalMonthlyCost": "0",
+  "diffTotalMonthlyUsageCost": "0",
+  "timeGenerated": "2025-07-08T12:32:33.052444307Z",
+  "summary": {
+    "totalDetectedResources": 3,
+    "totalSupportedResources": 1,
+    "totalUnsupportedResources": 0,
+    "totalUsageBasedResources": 1,
+    "totalNoPriceResources": 2,
+    "unsupportedResourceCounts": {},
+    "noPriceResourceCounts": {
+      "aws_ecr_lifecycle_policy": 1,
+      "aws_ecr_repository_policy": 1
+    }
+  }
+}

--- a/internal/output/testdata/ToMarkdown_NoPreviousBreakdown.md
+++ b/internal/output/testdata/ToMarkdown_NoPreviousBreakdown.md
@@ -1,0 +1,36 @@
+
+<h4>💰 Infracost report</h4>
+<h4>Monthly estimate generated</h4>
+<table>
+  <thead>
+    <td>Changed project</td>
+    <td><span title="Baseline costs are consistent charges for provisioned resources, like the hourly cost for a virtual machine, which stays constant no matter how much it is used. Infracost estimates these resources assuming they are used for the whole month (730 hours).">Baseline cost</span></td>
+    <td><span title="Usage costs are charges based on actual usage, like the storage cost for an object storage bucket. Infracost estimates these resources using the monthly usage values in the usage-file.">Usage cost</span>*</td>
+    <td>Total change</td>
+    <td>New monthly cost</td>
+  </thead>
+  <tbody>
+    <tr>
+      <td>.</td>
+      <td align="right">+$0.00</td>
+      <td align="right">-</td>
+      <td align="right">+$0.00</td>
+      <td align="right">$0</td>
+    </tr>
+  </tbody>
+</table>
+
+
+*Usage costs can be estimated by updating [Infracost Cloud settings](https://www.infracost.io/docs/features/usage_based_resources), see [docs](https://www.infracost.io/docs/features/usage_based_resources/#infracost-usageyml) for other options.
+<details>
+
+<summary>Estimate details </summary>
+
+```
+──────────────────────────────────
+
+3 cloud resources were detected:
+∙ 1 was estimated
+∙ 2 were free
+```
+</details>


### PR DESCRIPTION
## Change

This CL is a continuation of infracost/infracost#3409 and infracost/infracost#3419,
and fixes the source of nil `PastBreakdown`s, during `output.Load`s.

We also add a test for the entire `output.ToMarkdown` flow that is called in
`infracost comment`, hopefully giving us some resiliency to this sort of problem
in the future.

## Changelog

```
2025-07-08  Paul Stemmet  <paul.stemmet@infracost.io>

	chore(output): add ToMarkdown test for PastBreakdown NPEs

2025-07-08  Paul Stemmet  <paul.stemmet@infracost.io>

	fix(output): add nil check for Project.PastBreakdown to output.Load
	The code in internal/output implicitly assumes a Project's PastBreakdown
	field is non-nil (though the Breakdown fields *may* be nil / empty).

	This commit adds a check to the json loader to ensure that if the
	PastBreakdown is nil in the unmarshaled struct, we set it to a non-nil
	(but otherwise empty) Breakdown.
```

---

<sub>References ENG-143</sub>
