### PR TITLE
feat: Add support for google_cloud_scheduler

### DIFF
--- a/internal/providers/terraform/google/cloud_scheduler.go
+++ b/internal/providers/terraform/google/cloud_scheduler.go
@@ -1,0 +1,22 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/resources/google"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+func getCloudSchedulerRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "google_cloud_scheduler",
+		CoreRFunc: NewCloudScheduler,
+	}
+}
+
+func NewCloudScheduler(d *schema.ResourceData) schema.CoreResource {
+	r := &google.CloudScheduler{
+		Address: d.Address,
+		Region:  d.Get("region").String(),
+	}
+
+	return r
+}

--- a/internal/providers/terraform/google/cloud_scheduler_test.go
+++ b/internal/providers/terraform/google/cloud_scheduler_test.go
@@ -1,0 +1,16 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestCloudScheduler(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTests(t, "cloud_scheduler_test")
+}

--- a/internal/providers/terraform/google/registry.go
+++ b/internal/providers/terraform/google/registry.go
@@ -59,6 +59,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getCloudRunServiceRegistryItem(),
 	getCloudRunV2JobRegistryItem(),
 	getCloudRunV2ServiceRegistryItem(),
+	getCloudSchedulerRegistryItem(),
 }
 
 // FreeResources grouped alphabetically

--- a/internal/providers/terraform/google/testdata/cloud_scheduler_test/cloud_scheduler.usage.yml
+++ b/internal/providers/terraform/google/testdata/cloud_scheduler_test/cloud_scheduler.usage.yml
@@ -1,0 +1,4 @@
+version: 0.1
+resource_usage:
+  google_cloud_scheduler.usage:
+    monthly_schedules: 10000

--- a/internal/providers/terraform/google/testdata/cloud_scheduler_test/cloud_scheduler_test.golden
+++ b/internal/providers/terraform/google/testdata/cloud_scheduler_test/cloud_scheduler_test.golden
@@ -1,0 +1,16 @@
+
+ Name  Monthly Qty  Unit  Monthly Cost   
+                                         
+ OVERALL TOTAL                  $0.00 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+2 cloud resources were detected:
+∙ 2 were estimated
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ main                                               ┃         $0.00 ┃           - ┃      $0.00 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/google/testdata/cloud_scheduler_test/cloud_scheduler_test.tf
+++ b/internal/providers/terraform/google/testdata/cloud_scheduler_test/cloud_scheduler_test.tf
@@ -1,0 +1,23 @@
+provider "google" {
+  credentials = "{\"type\":\"service_account\"}"
+  project     = "my-project"
+  region      = "us-central1"
+}
+
+resource "google_cloud_scheduler" "non_usage" {
+  name             = "example-non-usage"
+  schedule         = "* * * * *"
+  time_zone        = "Etc/UTC"
+  http_target {
+    uri = "https://example.com/task"
+  }
+}
+
+resource "google_cloud_scheduler" "usage" {
+  name             = "example-usage"
+  schedule         = "* * * * *"
+  time_zone        = "Etc/UTC"
+  http_target {
+    uri = "https://example.com/task"
+  }
+}

--- a/internal/resources/google/cloud_scheduler.go
+++ b/internal/resources/google/cloud_scheduler.go
@@ -1,0 +1,68 @@
+package google
+
+import (
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
+	"github.com/shopspring/decimal"
+)
+
+type CloudScheduler struct {
+	Address         string
+	Region          string
+	MonthlyJobCount *int64 `infracost_usage:"monthly_job_count"`
+}
+
+func (r *CloudScheduler) CoreType() string {
+	return "CloudScheduler"
+}
+
+func (r *CloudScheduler) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{
+		{Key: "monthly_job_count", ValueType: schema.Int64, DefaultValue: 0},
+	}
+}
+
+func (r *CloudScheduler) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+func (r *CloudScheduler) BuildResource() *schema.Resource {
+	var jobCount int64
+	if r.MonthlyJobCount != nil {
+		jobCount = *r.MonthlyJobCount
+	}
+
+	tierLimits := []int{3} // First 3 jobs are free
+	tierQuantities := usage.CalculateTierBuckets( decimal.NewFromInt(jobCount), tierLimits)
+
+	costComponents := []*schema.CostComponent{}
+
+	if tierQuantities[1].GreaterThan(decimal.Zero) {
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:            "Cloud Scheduler jobs (above free tier)",
+			Unit:            "jobs",
+			UnitMultiplier:  decimal.NewFromInt(1),
+			MonthlyQuantity: &tierQuantities[1],
+			ProductFilter: &schema.ProductFilter{
+				VendorName:    strPtr("gcp"),
+				Region:        strPtr(r.Region),
+				Service:       strPtr("Cloud Scheduler"),
+				ProductFamily: strPtr("ApplicationServices"),
+				AttributeFilters: []*schema.AttributeFilter{
+					{Key: "resourceGroup", Value: strPtr("CloudScheduler")},
+					{Key: "description", Value: strPtr("Cloud Scheduler jobs")},
+				},
+			},
+			PriceFilter: &schema.PriceFilter{
+				StartUsageAmount: strPtr("3"),
+			},
+		})
+	}
+
+	return &schema.Resource{
+		Name:           r.Address,
+		CostComponents: costComponents,
+		UsageSchema:    r.UsageSchema(),
+	}
+}


### PR DESCRIPTION
Add support for google_cloud_scheduler

Closes: #1357 

This PR adds cost estimation for the google_cloud_scheduler Terraform resource based on [Google Cloud Scheduler pricing](https://cloud.google.com/scheduler/pricing).
 - Supports usage-based pricing with free tier for the first 3 jobs per month.
 -  New usage field: monthly_schedules.

Example:

```yml
resource_usage:
  google_cloud_scheduler.usage:
    monthly_schedules: 10000
```

This enables Cloud Scheduler cost visibility in Infracost reports.