### PR TITLE
fix: add prominent warnings for missing price data

### DIFF
--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -140,6 +140,10 @@ func runMain(cmd *cobra.Command, runCtx *config.RunContext) error {
 	r.Currency = runCtx.Config.Currency
 	r.Metadata = output.NewMetadata(runCtx)
 
+	// Add missing prices information to the output for better user warnings
+	r.MissingPricesCount = pr.pricingFetcher.MissingPricesLen()
+	r.MissingPricesComponents = pr.pricingFetcher.MissingPricesComponents()
+
 	if runCtx.IsCloudUploadExplicitlyEnabled() {
 		dashboardClient := apiclient.NewDashboardAPIClient(runCtx)
 		result, err := dashboardClient.AddRun(runCtx, r)

--- a/internal/output/combined.go
+++ b/internal/output/combined.go
@@ -228,6 +228,8 @@ func CompareTo(c *config.Config, current, prior Root) (Root, error) {
 	out.Summary = current.Summary
 	out.FullSummary = current.FullSummary
 	out.Currency = current.Currency
+	out.MissingPricesCount = current.MissingPricesCount
+	out.MissingPricesComponents = current.MissingPricesComponents
 	return out, nil
 }
 

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -133,6 +133,17 @@ func ToDiff(out Root, opts Options) ([]byte, error) {
 		s += "\n"
 	}
 
+	// Show missing prices warning prominently in diff output
+	if out.MissingPricesCount > 0 {
+		s += "\n"
+		warningMsg := ui.WarningString("WARNING:")
+		if out.MissingPricesCount == 1 {
+			s += fmt.Sprintf("%s 1 price missing, cost estimates may be incomplete or inaccurate.\n", warningMsg)
+		} else {
+			s += fmt.Sprintf("%s %d prices missing, cost estimates may be incomplete or inaccurate.\n", warningMsg, out.MissingPricesCount)
+		}
+	}
+
 	unsupportedMsg := out.summaryMessage(opts.ShowSkipped)
 	if unsupportedMsg != "" {
 		s += "\n"

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -814,7 +814,7 @@ func (r *Root) summaryMessage(showSkipped bool) string {
 		} else {
 			msg += fmt.Sprintf("\n\n%s %d prices missing, costs may be incomplete", warningMsg, r.MissingPricesCount)
 		}
-		
+
 		if showSkipped && len(r.MissingPricesComponents) > 0 {
 			msg += "\nMissing prices for:"
 			for _, component := range r.MissingPricesComponents {

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -42,6 +42,8 @@ type Root struct {
 	Summary                   *Summary         `json:"summary"`
 	FullSummary               *Summary         `json:"-"`
 	IsCIRun                   bool             `json:"-"`
+	MissingPricesCount        int              `json:"missingPricesCount,omitempty"`
+	MissingPricesComponents   []string         `json:"missingPricesComponents,omitempty"`
 }
 
 // HasUnsupportedResources returns if the summary has any unsupported resources.
@@ -800,6 +802,25 @@ func (r *Root) summaryMessage(showSkipped bool) string {
 			msg += fmt.Sprintf(", see %s:", ui.SecondaryLinkString("https://infracost.io/requested-resources"))
 			msg += formatCounts(r.Summary.UnsupportedResourceCounts)
 		} else {
+			msg += seeDetailsMessage
+		}
+	}
+
+	// Add missing prices warning - this is the key fix for the bug
+	if r.MissingPricesCount > 0 {
+		warningMsg := ui.WarningString("WARNING:")
+		if r.MissingPricesCount == 1 {
+			msg += fmt.Sprintf("\n\n%s 1 price missing, costs may be incomplete", warningMsg)
+		} else {
+			msg += fmt.Sprintf("\n\n%s %d prices missing, costs may be incomplete", warningMsg, r.MissingPricesCount)
+		}
+		
+		if showSkipped && len(r.MissingPricesComponents) > 0 {
+			msg += "\nMissing prices for:"
+			for _, component := range r.MissingPricesComponents {
+				msg += fmt.Sprintf("\n  ∙ %s", component)
+			}
+		} else if len(r.MissingPricesComponents) > 0 {
 			msg += seeDetailsMessage
 		}
 	}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -94,6 +94,19 @@ func ToTable(out Root, opts Options) ([]byte, error) {
 		s += "\n"
 	}
 
+	// Show missing prices warning prominently in table output
+	if out.MissingPricesCount > 0 {
+		if !hasUsageFootnote {
+			s += "\n"
+		}
+		warningMsg := ui.WarningString("WARNING:")
+		if out.MissingPricesCount == 1 {
+			s += fmt.Sprintf("\n%s 1 price missing, cost estimates may be incomplete.\n", warningMsg)
+		} else {
+			s += fmt.Sprintf("\n%s %d prices missing, cost estimates may be incomplete.\n", warningMsg, out.MissingPricesCount)
+		}
+	}
+
 	summaryMsg := out.summaryMessage(opts.ShowSkipped)
 
 	if summaryMsg != "" {


### PR DESCRIPTION
 ## 🚨 Problem

  When users run `infracost diff` with unavailable AWS resources (e.g., `x2gd.2xlarge` in `eu-central-1`):

  - **Misleading `$0.00` display** - makes resources appear free
  - **False savings message** - shows "Monthly estimate decreased by $355 ↓"
  - **No warnings** - users think they found cost optimizations

  ## ✅ Solution

  Added prominent warning messages to all output formats when prices are missing:

  ### Key Changes
  - 🔧 Enhanced `Root` struct with missing price tracking fields
  - 🔧 Fixed JSON serialization to preserve data in diff operations
  - 🔧 Added warning displays across breakdown, diff, and table formats

  ## 📊 Before vs After

  ### Before (misleading)
  Instance usage (x2gd.2xlarge): $0.00
  Monthly estimate decreased by $355 ↓

  ### After (clear warnings)
  ⚠️  WARNING: 1 price missing, cost estimates may be incomplete or inaccurate.
  Instance usage (x2gd.2xlarge): $0.00Monthly estimate decreased by $355 ↓
  ⚠️  WARNING: 1 price missing, costs may be incomplete

  ## 🧪 Testing

  - [x] Verified with unavailable instance types (`x2gd.2xlarge` in `eu-central-1`)
  - [x] Tested all output formats (breakdown, diff, table, JSON)
  - [x] Confirmed warnings appear in both CLI and diff operations
  - [x] Validated backward compatibility


