### PR TITLE
fix(aws): fix cost calculation for AWS EC2 bare metal instances

### DIFF
--- a/internal/resources/aws/instance.go
+++ b/internal/resources/aws/instance.go
@@ -196,6 +196,12 @@ func (a *Instance) computeCostComponent() *schema.CostComponent {
 		qty = decimal.NewFromFloat(*a.MonthlyHours)
 	}
 
+	// metal instances have a different ProductFamily in AWS pricing data
+	productFamily := "Compute Instance"
+	if strings.Contains(strings.ToLower(a.InstanceType), "metal") {
+		productFamily = "Compute Instance (bare metal)"
+	}
+
 	return &schema.CostComponent{
 		Name:            fmt.Sprintf("Instance usage (%s, %s, %s)", osLabel, purchaseOptionLabel, a.InstanceType),
 		Unit:            "hours",
@@ -205,7 +211,7 @@ func (a *Instance) computeCostComponent() *schema.CostComponent {
 			VendorName:    strPtr("aws"),
 			Region:        strPtr(a.Region),
 			Service:       strPtr("AmazonEC2"),
-			ProductFamily: strPtr("Compute Instance"),
+			ProductFamily: strPtr(productFamily),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "instanceType", Value: strPtr(a.InstanceType)},
 				{Key: "tenancy", Value: strPtr(a.Tenancy)},


### PR DESCRIPTION
bare metal instances on EC2 have a separate product_family attribute. currently infracost ignores this and hence the cost for `metal` instances show up as $0.00

Before
```
 module.ec2["metal-infracost-test-machine"].aws_instance.this
 ├─ Instance usage (Linux/UNIX, on-demand, c5n.metal)                               730  hours                    not found
 └─ root_block_device
    └─ Storage (general purpose SSD, gp3)                                            50  GB                           $4.56
```

After
```
 module.ec2["metal-infracost-test-machine"].aws_instance.this
 ├─ Instance usage (Linux/UNIX, on-demand, c5n.metal)                               730  hours                    $2,838.24
 └─ root_block_device
    └─ Storage (general purpose SSD, gp3)                                            50  GB                           $4.56
```


Corresponding issue: https://github.com/infracost/infracost/issues/3472