### PR TITLE
perf: add ldflags -s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY := infracost
 PKG := github.com/infracost/infracost/cmd/infracost
 VERSION := $(shell scripts/get_version.sh HEAD $(NO_DIRTY))
-LD_FLAGS := -ldflags="-X 'github.com/infracost/infracost/internal/version.Version=$(VERSION)'"
+LD_FLAGS := -ldflags="-s -X 'github.com/infracost/infracost/internal/version.Version=$(VERSION)'"
 BUILD_FLAGS := $(LD_FLAGS) -v
 
 DEV_ENV := dev


### PR DESCRIPTION
## Summary

I added "-s" to the ldflags to reduce the binary size.

```diff
$ make build && du -h ./build/infracost
- 140M	./build/infracost
+ 101M	./build/infracost
```

## Description

This flag omit the symbol table and debug information.
It should be harmless unless you use the nm or objdump commands on a daily basis.
The contents of the stack trace output will not change either.

cf. https://pkg.go.dev/cmd/link
```
-s
	Omit the symbol table and debug information.
	Implies the -w flag, which can be negated with -w=0.
```