### PR TITLE
perf: optimize dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,4 +13,4 @@ infracost-example.yml
 infracost-usage-defaults.large.yml
 infracost-usage-defaults.medium.yml
 infracost-usage-defaults.small.yml
-LISENCE
+LICENSE


### PR DESCRIPTION
## Summary

We optimized the .dockerignore file to reduce image(the stage `builder`) size.

```diff
$ docker build --target builder -t infracost-builder-(before|after) . && docker image ls
- infracost-builder-before         latest    fd356b95dbff   3 minutes ago        12.7GB
+ infracost-builder-after          latest    6f1203cc622f   About a minute ago   7.06GB
```

## Description

Upon checking the contents of the intermediate layer using [dive](https://github.com/wagoodman/dive), it was confirmed that the capacity was being occupied by testdata.
Files that are not necessary for Docker, including testdata, have been excluded.


<img width="400" height="1062" alt="image" src="https://github.com/user-attachments/assets/c893288f-aa1e-464c-8556-67cfb4bd3104" />


cf. https://docs.docker.com/build/concepts/context/#dockerignore-files