### PR TITLE
perf: `rm -rf /var/lib/apt/lists/*` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV HOME=/app
 ENV CGO_ENABLED=0
 
 # Install Packages
-RUN apt-get update -q && apt-get -y install unzip
+RUN apt-get update -q && apt-get -y install unzip && rm -rf /var/lib/apt/lists/*
 
 # Install latest of each Terraform version after 0.12 as we don't support versions before that
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.12.31 0.13.7 0.14.11 ${DEFAULT_TERRAFORM_VERSION} 1.0.2 1.0.10" && \


### PR DESCRIPTION
## Summary

I removed the apt cache in the Dockerfile to reduce image(the stage builder) size..
```diff
$ docker build --target builder -t infracost-builder-(before|after) . && docker image ls
- infracost-builder-before         latest    d3997c9c529c   About a minute ago   12.7GB
+ infracost-builder-after          latest    0eca0a4a9ba7   3 minutes ago        12.6GB
```

## Description

cf. https://docs.docker.com/build/building/best-practices/#run
> when you clean up the apt cache by removing /var/lib/apt/lists it reduces the image size, since the apt cache isn't stored in a layer.