### PR TITLE
Add CPU credit support for burstable RDS DB instances

### DIFF
--- a/infracost-usage-defaults.large.yml
+++ b/infracost-usage-defaults.large.yml
@@ -119,6 +119,7 @@ resource_type_default_usage:
     additional_backup_storage_gb: 952 # Amount of backup storage used that is in excess of 100% of the storage size for all databases in GB.
     monthly_standard_io_requests: 200000000 # Monthly number of input/output requests for database.
     monthly_additional_performance_insights_requests: 2000000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
+    monthly_cpu_credit_hrs: 133
   aws_directory_service_directory:
     additional_domain_controllers: 0.54 # The number of domain controllers in the directory service provisioned in addition to the minimum 2 controllers
     shared_accounts: 1.5 # Number of accounts that Microsoft AD directory is shared with

--- a/infracost-usage-defaults.large.yml
+++ b/infracost-usage-defaults.large.yml
@@ -119,7 +119,7 @@ resource_type_default_usage:
     additional_backup_storage_gb: 952 # Amount of backup storage used that is in excess of 100% of the storage size for all databases in GB.
     monthly_standard_io_requests: 200000000 # Monthly number of input/output requests for database.
     monthly_additional_performance_insights_requests: 2000000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
-    monthly_cpu_credit_hrs: 133
+    monthly_cpu_credit_hrs: 133 # Monthly CPU credits used over the instance baseline in vCPU-hours, only applicable for T3 and T4g instances.
   aws_directory_service_directory:
     additional_domain_controllers: 0.54 # The number of domain controllers in the directory service provisioned in addition to the minimum 2 controllers
     shared_accounts: 1.5 # Number of accounts that Microsoft AD directory is shared with

--- a/infracost-usage-defaults.medium.yml
+++ b/infracost-usage-defaults.medium.yml
@@ -119,6 +119,7 @@ resource_type_default_usage:
     additional_backup_storage_gb: 476 # Amount of backup storage used that is in excess of 100% of the storage size for all databases in GB.
     monthly_standard_io_requests: 100000000 # Monthly number of input/output requests for database.
     monthly_additional_performance_insights_requests: 1000000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
+    monthly_cpu_credit_hrs: 67
   aws_directory_service_directory:
     additional_domain_controllers: 0.27 # The number of domain controllers in the directory service provisioned in addition to the minimum 2 controllers
     shared_accounts: 0.75 # Number of accounts that Microsoft AD directory is shared with

--- a/infracost-usage-defaults.medium.yml
+++ b/infracost-usage-defaults.medium.yml
@@ -119,7 +119,7 @@ resource_type_default_usage:
     additional_backup_storage_gb: 476 # Amount of backup storage used that is in excess of 100% of the storage size for all databases in GB.
     monthly_standard_io_requests: 100000000 # Monthly number of input/output requests for database.
     monthly_additional_performance_insights_requests: 1000000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
-    monthly_cpu_credit_hrs: 67
+    monthly_cpu_credit_hrs: 67 # Monthly CPU credits used over the instance baseline in vCPU-hours, only applicable for T3 and T4g instances.
   aws_directory_service_directory:
     additional_domain_controllers: 0.27 # The number of domain controllers in the directory service provisioned in addition to the minimum 2 controllers
     shared_accounts: 0.75 # Number of accounts that Microsoft AD directory is shared with

--- a/infracost-usage-defaults.small.yml
+++ b/infracost-usage-defaults.small.yml
@@ -119,7 +119,7 @@ resource_type_default_usage:
     additional_backup_storage_gb: 238 # Amount of backup storage used that is in excess of 100% of the storage size for all databases in GB.
     monthly_standard_io_requests: 50000000 # Monthly number of input/output requests for database.
     monthly_additional_performance_insights_requests: 500000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
-    monthly_cpu_credit_hrs: 33
+    monthly_cpu_credit_hrs: 33 # Monthly CPU credits used over the instance baseline in vCPU-hours, only applicable for T3 and T4g instances.
   aws_directory_service_directory:
     additional_domain_controllers: 0.135 # The number of domain controllers in the directory service provisioned in addition to the minimum 2 controllers
     shared_accounts: 0.375 # Number of accounts that Microsoft AD directory is shared with

--- a/infracost-usage-defaults.small.yml
+++ b/infracost-usage-defaults.small.yml
@@ -119,6 +119,7 @@ resource_type_default_usage:
     additional_backup_storage_gb: 238 # Amount of backup storage used that is in excess of 100% of the storage size for all databases in GB.
     monthly_standard_io_requests: 50000000 # Monthly number of input/output requests for database.
     monthly_additional_performance_insights_requests: 500000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
+    monthly_cpu_credit_hrs: 33
   aws_directory_service_directory:
     additional_domain_controllers: 0.135 # The number of domain controllers in the directory service provisioned in addition to the minimum 2 controllers
     shared_accounts: 0.375 # Number of accounts that Microsoft AD directory is shared with

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -104,7 +104,7 @@ resource_usage:
     monthly_additional_performance_insights_requests: 10000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
     reserved_instance_term: 1_year                          # Term for Reserved Instances, can be: 1_year, 3_year.
     reserved_instance_payment_option: partial_upfront       # Payment option for Reserved Instances, can be: no_upfront (only for 1_year term), partial_upfront, all_upfront.
-    monthly_cpu_credit_hrs: 30
+    monthly_cpu_credit_hrs: 30                              # Monthly CPU credits used over the instance baseline in vCPU-hours, only applicable for T3 and T4g instances.
 
   aws_directory_service_directory.my_directory:
     additional_domain_controllers: 3 # The number of domain controllers in the directory service provisioned in addition to the minimum 2 controllers

--- a/infracost-usage-example.yml
+++ b/infracost-usage-example.yml
@@ -104,6 +104,7 @@ resource_usage:
     monthly_additional_performance_insights_requests: 10000 # Monthly Performance Insights API requests above the 1000000 requests included in the free tier.
     reserved_instance_term: 1_year                          # Term for Reserved Instances, can be: 1_year, 3_year.
     reserved_instance_payment_option: partial_upfront       # Payment option for Reserved Instances, can be: no_upfront (only for 1_year term), partial_upfront, all_upfront.
+    monthly_cpu_credit_hrs: 30
 
   aws_directory_service_directory.my_directory:
     additional_domain_controllers: 3 # The number of domain controllers in the directory service provisioned in addition to the minimum 2 controllers

--- a/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
+++ b/internal/providers/terraform/aws/testdata/db_instance_test/db_instance_test.golden
@@ -188,6 +188,13 @@
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $119.72    
  └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
                                                                                                                          
+ aws_db_instance.mysql-performance-insights-usage                                                                        
+ ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28    
+ ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
+ ├─ Performance Insights Long Term Retention (db.t3.large)                    2  vCPU-month                     $5.90    
+ ├─ Performance Insights API                                             12.345  1000 requests                  $0.12  * 
+ └─ CPU credits                                                              60  vCPU-hours                     $4.50  * 
+                                                                                                                         
  aws_db_instance.gp3["above_high_baseline"]                                                                              
  ├─ Database instance (on-demand, Single-AZ, db.t4g.small)                  730  hours                         $23.36    
  ├─ Storage (general purpose SSD, gp3)                                      400  GB                            $46.00    
@@ -208,12 +215,6 @@
  aws_db_instance.extended_support["postgres-16"]                                                                         
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                        $105.85    
  └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
-                                                                                                                         
- aws_db_instance.mysql-performance-insights-usage                                                                        
- ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28    
- ├─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
- ├─ Performance Insights Long Term Retention (db.t3.large)                    2  vCPU-month                     $5.90    
- └─ Performance Insights API                                             12.345  1000 requests                  $0.12  * 
                                                                                                                          
  aws_db_instance.mysql-magnetic                                                                                          
  ├─ Database instance (on-demand, Single-AZ, db.t3.large)                   730  hours                         $99.28    
@@ -312,7 +313,7 @@
  ├─ Database instance (reserved, Single-AZ, db.t3.large)                    730  hours                          $0.00    
  └─ Storage (general purpose SSD, gp2)                                       20  GB                             $2.30    
                                                                                                                          
- OVERALL TOTAL                                                                                             $12,756.39 
+ OVERALL TOTAL                                                                                             $12,760.89 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -323,5 +324,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $11,595 ┃      $1,161 ┃    $12,756 ┃
+┃ main                                               ┃       $11,595 ┃      $1,166 ┃    $12,761 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -397,6 +397,7 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 			costComponents = append(costComponents, r.cpuCreditsCostComponent(databaseEngine, instanceFamily, cpuCreditQuantity))
 		}
 	}
+
 	extendedSupport := extendedSupportCostComponent(r.Version, r.Region, r.Engine, r.InstanceClass)
 	if extendedSupport != nil {
 		costComponents = append(costComponents, extendedSupport)

--- a/internal/resources/aws/db_instance.go
+++ b/internal/resources/aws/db_instance.go
@@ -32,6 +32,8 @@ type DBInstance struct {
 	MonthlyAdditionalPerformanceInsightsRequests *int64   `infracost_usage:"monthly_additional_performance_insights_requests"`
 	ReservedInstanceTerm                         *string  `infracost_usage:"reserved_instance_term"`
 	ReservedInstancePaymentOption                *string  `infracost_usage:"reserved_instance_payment_option"`
+	MonthlyCPUCreditHrs                          *int64   `infracost_usage:"monthly_cpu_credit_hrs"`
+	VCPUCount                                    *int64   `infracost_usage:"vcpu_count"`
 }
 
 func (r *DBInstance) CoreType() string {
@@ -48,6 +50,8 @@ var DBInstanceUsageSchema = []*schema.UsageItem{
 	{Key: "monthly_additional_performance_insights_requests", ValueType: schema.Int64, DefaultValue: 0},
 	{Key: "reserved_instance_term", DefaultValue: "", ValueType: schema.String},
 	{Key: "reserved_instance_payment_option", DefaultValue: "", ValueType: schema.String},
+	{Key: "monthly_cpu_credit_hrs", ValueType: schema.Int64, DefaultValue: 0},
+	{Key: "vcpu_count", ValueType: schema.Int64, DefaultValue: 0},
 }
 
 func (r *DBInstance) PopulateUsage(u *schema.UsageData) {
@@ -375,6 +379,24 @@ func (r *DBInstance) BuildResource() *schema.Resource {
 		}
 	}
 
+	if instanceFamily := getBurstableInstanceFamily([]string{"db.t3", "db.t4g"}, r.InstanceClass); instanceFamily != "" {
+		instanceCPUCreditHours := decimal.Zero
+		if r.MonthlyCPUCreditHrs != nil {
+			instanceCPUCreditHours = decimal.NewFromInt(*r.MonthlyCPUCreditHrs)
+		}
+
+		instanceVCPUCount := decimal.Zero
+		if r.VCPUCount != nil {
+			instanceVCPUCount = decimal.NewFromInt(*r.VCPUCount)
+		} else if count, ok := InstanceTypeToVCPU[strings.TrimPrefix(r.InstanceClass, "db.")]; ok {
+			instanceVCPUCount = decimal.NewFromInt(count)
+		}
+
+		if instanceCPUCreditHours.GreaterThan(decimal.Zero) {
+			cpuCreditQuantity := instanceVCPUCount.Mul(instanceCPUCreditHours)
+			costComponents = append(costComponents, r.cpuCreditsCostComponent(databaseEngine, instanceFamily, cpuCreditQuantity))
+		}
+	}
 	extendedSupport := extendedSupportCostComponent(r.Version, r.Region, r.Engine, r.InstanceClass)
 	if extendedSupport != nil {
 		costComponents = append(costComponents, extendedSupport)
@@ -621,4 +643,24 @@ func extendedSupportCostComponent(version string, region string, engine string, 
 	}
 
 	return nil
+}
+
+func (r *DBInstance) cpuCreditsCostComponent(databaseEngine, instanceFamily string, vCPUCount decimal.Decimal) *schema.CostComponent {
+	return &schema.CostComponent{
+		Name:            "CPU credits",
+		Unit:            "vCPU-hours",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: &vCPUCount,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("aws"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("AmazonRDS"),
+			ProductFamily: strPtr("CPU Credits"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "databaseEngine", Value: strPtr(databaseEngine)},
+				{Key: "usagetype", ValueRegex: regexPtr("CPUCredits:" + instanceFamily + "$")},
+			},
+		},
+		UsageBased: true,
+	}
 }


### PR DESCRIPTION
## What does this PR do?
Adds CPU credit cost support for burstable RDS DB instances (db.t3, db.t4g) 
in the same way it is already supported for RDS Cluster Instances.

## Why is this needed?
Burstable RDS instances use a CPU credit system where AWS charges extra 
when the instance bursts beyond its baseline CPU. Previously InfraCost 
was not calculating this cost, resulting in incomplete cost estimates.

## Changes
- Added `MonthlyCPUCreditHrs` and `VCPUCount` fields to `DBInstance` struct
- Added new usage schema items for both fields
- Added burstable instance check in `BuildResource` for db.t3 and db.t4g families
- Added `cpuCreditsCostComponent` method to `DBInstance`
- Updated golden test file to include CPU credits cost component

## Testing
- Existing test `TestDBInstanceGoldenFile` updated and passing
- CPU credits now correctly appear for `mysql-performance-insights-usage` 
  test case with 60 vCPU-hours at $4.50/month

Fixes #1372