### PR TITLE
Populate EBS throughput for instance and autoscaling group resources

### DIFF
--- a/internal/providers/terraform/aws/autoscaling_group.go
+++ b/internal/providers/terraform/aws/autoscaling_group.go
@@ -98,10 +98,11 @@ func newLaunchConfiguration(d *schema.ResourceData, region string, instanceCount
 	}
 
 	a.RootBlockDevice = &aws.EBSVolume{
-		Address: "root_block_device",
-		Region:  region,
-		Type:    d.Get("root_block_device.0.volume_type").String(),
-		IOPS:    d.Get("root_block_device.0.iops").Int(),
+		Address:    "root_block_device",
+		Region:     region,
+		Type:       d.Get("root_block_device.0.volume_type").String(),
+		IOPS:       d.Get("root_block_device.0.iops").Int(),
+		Throughput: d.Get("root_block_device.0.throughput").Int(),
 	}
 
 	if d.Get("root_block_device.0.volume_size").Type != gjson.Null {
@@ -110,10 +111,11 @@ func newLaunchConfiguration(d *schema.ResourceData, region string, instanceCount
 
 	for i, data := range d.Get("ebs_block_device").Array() {
 		ebsBlockDevice := &aws.EBSVolume{
-			Address: fmt.Sprintf("ebs_block_device[%d]", i),
-			Region:  region,
-			Type:    data.Get("volume_type").String(),
-			IOPS:    data.Get("iops").Int(),
+			Address:    fmt.Sprintf("ebs_block_device[%d]", i),
+			Region:     region,
+			Type:       data.Get("volume_type").String(),
+			IOPS:       data.Get("iops").Int(),
+			Throughput: data.Get("throughput").Int(),
 		}
 
 		if data.Get("volume_size").Type != gjson.Null {
@@ -147,10 +149,11 @@ func newLaunchTemplate(d *schema.ResourceData, region string, instanceCount, onD
 
 	for i, data := range d.Get("block_device_mappings.#.ebs|@flatten").Array() {
 		ebsBlockDevice := &aws.EBSVolume{
-			Address: fmt.Sprintf("block_device_mapping[%d]", i),
-			Region:  region,
-			Type:    data.Get("volume_type").String(),
-			IOPS:    data.Get("iops").Int(),
+			Address:    fmt.Sprintf("block_device_mapping[%d]", i),
+			Region:     region,
+			Type:       data.Get("volume_type").String(),
+			IOPS:       data.Get("iops").Int(),
+			Throughput: data.Get("throughput").Int(),
 		}
 
 		if data.Get("volume_size").Type != gjson.Null {

--- a/internal/providers/terraform/aws/instance.go
+++ b/internal/providers/terraform/aws/instance.go
@@ -58,9 +58,10 @@ func NewInstance(d *schema.ResourceData) schema.CoreResource {
 		for _, data := range ref.Get("block_device_mappings").Array() {
 			deviceName := data.Get("device_name").String()
 			ebsBlockDevice := &aws.EBSVolume{
-				Region: region,
-				Type:   data.Get("ebs.0.volume_type").String(),
-				IOPS:   data.Get("ebs.0.iops").Int(),
+				Region:     region,
+				Type:       data.Get("ebs.0.volume_type").String(),
+				IOPS:       data.Get("ebs.0.iops").Int(),
+				Throughput: data.Get("ebs.0.throughput").Int(),
 			}
 
 			if v := data.Get("ebs.0.volume_size"); v.Exists() {
@@ -93,10 +94,11 @@ func NewInstance(d *schema.ResourceData) schema.CoreResource {
 	}
 
 	a.RootBlockDevice = &aws.EBSVolume{
-		Address: "root_block_device",
-		Region:  region,
-		Type:    d.Get("root_block_device.0.volume_type").String(),
-		IOPS:    d.Get("root_block_device.0.iops").Int(),
+		Address:    "root_block_device",
+		Region:     region,
+		Type:       d.Get("root_block_device.0.volume_type").String(),
+		IOPS:       d.Get("root_block_device.0.iops").Int(),
+		Throughput: d.Get("root_block_device.0.throughput").Int(),
 	}
 
 	if d.Get("root_block_device.0.volume_size").Type != gjson.Null {
@@ -139,12 +141,18 @@ func NewInstance(d *schema.ResourceData) schema.CoreResource {
 			iops = v.Int()
 		}
 
+		throughput := ltDevice.Throughput
+		if v := data.Get("throughput"); v.Exists() {
+			throughput = v.Int()
+		}
+
 		ebsBlockDevice := &aws.EBSVolume{
-			Address: fmt.Sprintf("ebs_block_device[%d]", i),
-			Region:  region,
-			Type:    volumeType,
-			Size:    volumeSize,
-			IOPS:    iops,
+			Address:    fmt.Sprintf("ebs_block_device[%d]", i),
+			Region:     region,
+			Type:       volumeType,
+			Size:       volumeSize,
+			IOPS:       iops,
+			Throughput: throughput,
 		}
 
 		delete(ltEBSBlockDevices, deviceName)


### PR DESCRIPTION
The Throughput field on EBSVolume was never set when the volume was created from an `aws_instance` (`root_block_device`, `ebs_block_device`, or launch template `block_device_mappings`) or from an autoscaling group launch configuration/template. This caused gp3 provisioned throughput costs to be silently omitted from cost estimates. Only standalone `aws_ebs_volume` resources had throughput costs calculated correctly.