### PR TITLE
feat: add support for azurerm_managed_redis

### DIFF
--- a/internal/providers/terraform/azure/managed_redis.go
+++ b/internal/providers/terraform/azure/managed_redis.go
@@ -1,0 +1,31 @@
+package azure
+
+import (
+	"github.com/infracost/infracost/internal/resources/azure"
+	"github.com/infracost/infracost/internal/schema"
+	"github.com/tidwall/gjson"
+)
+
+func getManagedRedisRegistryItem() *schema.RegistryItem {
+	return &schema.RegistryItem{
+		Name:      "azurerm_managed_redis",
+		CoreRFunc: newManagedRedis,
+		ReferenceAttributes: []string{
+			"resource_group_name",
+		},
+	}
+}
+
+func newManagedRedis(d *schema.ResourceData) schema.CoreResource {
+	highAvailability := true
+	if d.Get("high_availability_enabled").Type != gjson.Null && !d.Get("high_availability_enabled").Bool() {
+		highAvailability = false
+	}
+
+	return &azure.ManagedRedis{
+		Address:          d.Address,
+		Region:           d.Region,
+		SKU:              d.Get("sku_name").String(),
+		HighAvailability: highAvailability,
+	}
+}

--- a/internal/providers/terraform/azure/managed_redis_test.go
+++ b/internal/providers/terraform/azure/managed_redis_test.go
@@ -1,0 +1,18 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/infracost/infracost/internal/providers/terraform/tftest"
+)
+
+func TestAzureManagedRedisGoldenFile(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	tftest.GoldenFileResourceTestsWithOpts(t, "managed_redis_test", &tftest.GoldenFileOptions{
+		IgnoreCLI: true,
+	})
+}

--- a/internal/providers/terraform/azure/registry.go
+++ b/internal/providers/terraform/azure/registry.go
@@ -73,6 +73,7 @@ var ResourceRegistry []*schema.RegistryItem = []*schema.RegistryItem{
 	getLinuxVirtualMachineScaleSetRegistryItem(),
 	getLogAnalyticsWorkspaceRegistryItem(),
 	getManagedDiskRegistryItem(),
+	getManagedRedisRegistryItem(),
 	GetAzureRMMariaDBServerRegistryItem(),
 	getMSSQLDatabaseRegistryItem(),
 	GetAzureRMMySQLServerRegistryItem(),

--- a/internal/providers/terraform/azure/testdata/managed_redis_test/managed_redis_test.golden
+++ b/internal/providers/terraform/azure/testdata/managed_redis_test/managed_redis_test.golden
@@ -1,0 +1,32 @@
+
+ Name                                                 Monthly Qty  Unit       Monthly Cost   
+                                                                                             
+ azurerm_managed_redis.flash_optimized                                                       
+ └─ Cache usage (FlashOptimized_A700)                           2  instances     $6,832.80   
+                                                                                             
+ azurerm_managed_redis.compute_optimized                                                     
+ └─ Cache usage (ComputeOptimized_X10)                          2  instances       $851.18   
+                                                                                             
+ azurerm_managed_redis.memory_optimized                                                      
+ └─ Cache usage (MemoryOptimized_M10)                           2  instances       $315.36   
+                                                                                             
+ azurerm_managed_redis.balanced                                                              
+ └─ Cache usage (Balanced_B3)                                   2  instances        $94.90   
+                                                                                             
+ azurerm_managed_redis.balanced_no_high_availability                                         
+ └─ Cache usage (Balanced_B3)                                   1  instances        $47.45   
+                                                                                             
+ OVERALL TOTAL                                                                  $8,141.69 
+
+*Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
+
+──────────────────────────────────
+6 cloud resources were detected:
+∙ 5 were estimated
+∙ 1 was free
+
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
+┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
+┃ main                                               ┃        $8,142 ┃           - ┃     $8,142 ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/managed_redis_test/managed_redis_test.golden
+++ b/internal/providers/terraform/azure/testdata/managed_redis_test/managed_redis_test.golden
@@ -1,22 +1,22 @@
 
- Name                                                 Monthly Qty  Unit       Monthly Cost   
-                                                                                             
- azurerm_managed_redis.flash_optimized                                                       
- └─ Cache usage (FlashOptimized_A700)                           2  instances     $6,832.80   
-                                                                                             
- azurerm_managed_redis.compute_optimized                                                     
- └─ Cache usage (ComputeOptimized_X10)                          2  instances       $851.18   
-                                                                                             
- azurerm_managed_redis.memory_optimized                                                      
- └─ Cache usage (MemoryOptimized_M10)                           2  instances       $315.36   
-                                                                                             
- azurerm_managed_redis.balanced                                                              
- └─ Cache usage (Balanced_B3)                                   2  instances        $94.90   
-                                                                                             
- azurerm_managed_redis.balanced_no_high_availability                                         
- └─ Cache usage (Balanced_B3)                                   1  instances        $47.45   
-                                                                                             
- OVERALL TOTAL                                                                  $8,141.69 
+ Name                                                 Monthly Qty  Unit   Monthly Cost   
+                                                                                         
+ azurerm_managed_redis.flash_optimized                                                   
+ └─ Cache usage (FlashOptimized_A700)                       1,460  hours     $6,832.80   
+                                                                                         
+ azurerm_managed_redis.compute_optimized                                                 
+ └─ Cache usage (ComputeOptimized_X10)                      1,460  hours       $851.18   
+                                                                                         
+ azurerm_managed_redis.memory_optimized                                                  
+ └─ Cache usage (MemoryOptimized_M10)                       1,460  hours       $315.36   
+                                                                                         
+ azurerm_managed_redis.balanced                                                          
+ └─ Cache usage (Balanced_B3)                               1,460  hours        $94.90   
+                                                                                         
+ azurerm_managed_redis.balanced_no_high_availability                                     
+ └─ Cache usage (Balanced_B3)                                 730  hours        $47.45   
+                                                                                         
+ OVERALL TOTAL                                                              $8,141.69 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 

--- a/internal/providers/terraform/azure/testdata/managed_redis_test/managed_redis_test.tf
+++ b/internal/providers/terraform/azure/testdata/managed_redis_test/managed_redis_test.tf
@@ -1,0 +1,55 @@
+provider "azurerm" {
+  skip_provider_registration = true
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "eastus"
+}
+
+resource "azurerm_managed_redis" "balanced" {
+  name                = "balanced-managed-redis"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku_name            = "Balanced_B3"
+
+  default_database {}
+}
+
+resource "azurerm_managed_redis" "balanced_no_high_availability" {
+  name                      = "balanced-no-ha-managed-redis"
+  resource_group_name       = azurerm_resource_group.example.name
+  location                  = azurerm_resource_group.example.location
+  sku_name                  = "Balanced_B3"
+  high_availability_enabled = false
+
+  default_database {}
+}
+
+resource "azurerm_managed_redis" "memory_optimized" {
+  name                = "memory-managed-redis"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku_name            = "MemoryOptimized_M10"
+
+  default_database {}
+}
+
+resource "azurerm_managed_redis" "compute_optimized" {
+  name                = "compute-managed-redis"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku_name            = "ComputeOptimized_X10"
+
+  default_database {}
+}
+
+resource "azurerm_managed_redis" "flash_optimized" {
+  name                = "flash-managed-redis"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku_name            = "FlashOptimized_A700"
+
+  default_database {}
+}

--- a/internal/providers/terraform/provider_schemas/azurerm.tags.json
+++ b/internal/providers/terraform/provider_schemas/azurerm.tags.json
@@ -205,6 +205,7 @@
   "azurerm_managed_application_definition": true,
   "azurerm_managed_disk": true,
   "azurerm_managed_lustre_file_system": true,
+  "azurerm_managed_redis": true,
   "azurerm_management_group_template_deployment": true,
   "azurerm_maps_account": true,
   "azurerm_maps_creator": true,

--- a/internal/resources/azure/managed_redis.go
+++ b/internal/resources/azure/managed_redis.go
@@ -61,8 +61,8 @@ func (r *ManagedRedis) BuildResource() *schema.Resource {
 		CostComponents: []*schema.CostComponent{
 			{
 				Name:           fmt.Sprintf("Cache usage (%s)", r.SKU),
-				Unit:           "instances",
-				UnitMultiplier: schema.HourToMonthUnitMultiplier,
+				Unit:           "hours",
+				UnitMultiplier: decimal.NewFromInt(1),
 				HourlyQuantity: decimalPtr(decimal.NewFromInt(instanceCount)),
 				ProductFilter: &schema.ProductFilter{
 					VendorName:    strPtr(vendorName),

--- a/internal/resources/azure/managed_redis.go
+++ b/internal/resources/azure/managed_redis.go
@@ -1,0 +1,96 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/infracost/infracost/internal/resources"
+	"github.com/infracost/infracost/internal/schema"
+)
+
+var managedRedisFamilyNames = map[string]string{
+	"Balanced":         "Balanced",
+	"ComputeOptimized": "Compute Optimized",
+	"FlashOptimized":   "Flash Optimized",
+	"MemoryOptimized":  "Memory Optimized",
+}
+
+// ManagedRedis represents an Azure Managed Redis instance.
+//
+// Resource information: https://learn.microsoft.com/azure/redis/overview
+// Pricing information: https://azure.microsoft.com/en-us/pricing/details/managed-redis/
+type ManagedRedis struct {
+	Address          string
+	Region           string
+	SKU              string
+	HighAvailability bool
+}
+
+func (r *ManagedRedis) CoreType() string {
+	return "ManagedRedis"
+}
+
+func (r *ManagedRedis) UsageSchema() []*schema.UsageItem {
+	return []*schema.UsageItem{}
+}
+
+func (r *ManagedRedis) PopulateUsage(u *schema.UsageData) {
+	resources.PopulateArgsWithUsage(r, u)
+}
+
+func (r *ManagedRedis) BuildResource() *schema.Resource {
+	productName, shortSKU, ok := r.parseSKU()
+	if !ok {
+		return &schema.Resource{
+			Name:        r.Address,
+			IsSkipped:   true,
+			SkipMessage: fmt.Sprintf("Unrecognized Azure Managed Redis SKU %q", r.SKU),
+		}
+	}
+
+	instanceCount := int64(1)
+	if r.HighAvailability {
+		instanceCount = 2
+	}
+
+	return &schema.Resource{
+		Name:        r.Address,
+		UsageSchema: r.UsageSchema(),
+		CostComponents: []*schema.CostComponent{
+			{
+				Name:           fmt.Sprintf("Cache usage (%s)", r.SKU),
+				Unit:           "instances",
+				UnitMultiplier: schema.HourToMonthUnitMultiplier,
+				HourlyQuantity: decimalPtr(decimal.NewFromInt(instanceCount)),
+				ProductFilter: &schema.ProductFilter{
+					VendorName:    strPtr(vendorName),
+					Region:        strPtr(r.Region),
+					Service:       strPtr("Redis Cache"),
+					ProductFamily: strPtr("Databases"),
+					AttributeFilters: []*schema.AttributeFilter{
+						{Key: "productName", Value: strPtr(productName)},
+						{Key: "skuName", Value: strPtr(shortSKU)},
+						{Key: "meterName", Value: strPtr(fmt.Sprintf("%s Cache Instance", shortSKU))},
+					},
+				},
+				PriceFilter: priceFilterConsumption,
+			},
+		},
+	}
+}
+
+func (r *ManagedRedis) parseSKU() (string, string, bool) {
+	rawFamily, rawSKU, ok := strings.Cut(strings.TrimSpace(r.SKU), "_")
+	if !ok {
+		return "", "", false
+	}
+
+	familyName, ok := managedRedisFamilyNames[rawFamily]
+	if !ok || strings.TrimSpace(rawSKU) == "" {
+		return "", "", false
+	}
+
+	return fmt.Sprintf("Azure Managed Redis - %s", familyName), rawSKU, true
+}


### PR DESCRIPTION
Fixes #3495

## Summary
This adds support for `azurerm_managed_redis` in Infracost.

The implementation supports the 4 Azure Managed Redis SKU families:
- Balanced
- Memory Optimized
- Compute Optimized
- Flash Optimized

## Pricing model
This MVP calculates the fixed instance cost for Managed Redis by mapping Terraform `sku_name` values such as `Balanced_B3` to the Azure pricing catalog fields used by Infracost.

It currently matches the Redis Cache pricing data using:
- `service = Redis Cache`
- `productFamily = Databases`
- family-specific `productName` values
- matching `skuName` and `meterName`

## Scope
Included in this first version:
- `azurerm_managed_redis` resource support
- pricing for Balanced, Memory Optimized, Compute Optimized, and Flash Optimized SKUs
- golden tests for all 4 SKU families

Not included in this first version:
- High Availability-specific pricing
- usage-based pricing metrics
- persistence/backup/geo-replication cost modeling

## Testing
Ran:
- `INFRACOST_API_KEY=00000000000000000000000000000000 go test ./internal/providers/terraform/azure -run TestAzureManagedRedisGoldenFile -update`
- `INFRACOST_API_KEY=00000000000000000000000000000000 go test ./internal/providers/terraform/azure -run TestAzureManagedRedisGoldenFile`
- `golangci-lint run ./internal/resources/azure ./internal/providers/terraform/azure`