### PR TITLE
chore: prepare v1 repo for v2 cli split

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -90,22 +90,3 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta-ci.outputs.tags }}
           push: true
-
-  update-homebrew-formula:
-    if: ${{ !contains(github.ref, '-alpha') && !contains(github.ref, '-beta') }}
-    name: Update Homebrew formula
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install brew
-        run: |
-          # Add brew to the path. This is required as brew is no longer supported by runner-images.
-          # see: https://github.com/actions/runner-images/issues/6283 for more context
-          echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-          # Setup brew environment for coming steps.
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-
-      - uses: dawidd6/action-homebrew-bump-formula@baf2b60c51fc1f8453c884b0c61052668a71bd1d # v3
-        with:
-          token: ${{secrets.HOMEBREW_RELEASE_TOKEN}}
-          formula: infracost

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,15 @@ If you believe you have found a security vulnerability within Infracost, please 
 
 Once we've received your email we'll keep you updated as we fix the vulnerability.
 
+## Scope
+
+This repository contains the v1 release line of the Infracost CLI (versions `0.x`). The v2 release line lives in [`infracost/cli`](https://github.com/infracost/cli) and is covered by [its own security policy](https://github.com/infracost/cli/blob/main/SECURITY.md).
+
+The v1 line receives **security patches only**. Bug fixes and new features land in v2.
+
 ## Supported versions
 
-We release patches for security vulnerabilities as soon as they are found and fixed. Please refer to the below table to understand which CLI versions are eligible for security patches. 
+We release patches for security vulnerabilities as soon as they are found and fixed. Please refer to the below table to understand which CLI versions are eligible for security patches.
 
 | Version | Supported  |
 |---------|------------|


### PR DESCRIPTION
## Summary

Two changes to support the v1/v2 split tracked in [DEV-242](https://linear.app/infracost/issue/DEV-242):

- **`SECURITY.md`** — adds a scope section clarifying that this repository contains the v1 release line (`0.x`) and links to [`infracost/cli`](https://github.com/infracost/cli) for v2. Calls out that v1 receives security patches only; bug fixes and new features land in v2.
- **`.github/workflows/create-release.yml`** — removes the explicit `update-homebrew-formula` job. The `infracost`, `infracost@1`, and `infracost@2` formulae will rely on Homebrew's autobump bot instead, removing the need to maintain a `HOMEBREW_RELEASE_TOKEN` PAT here.

The `HOMEBREW_RELEASE_TOKEN` secret on this repo can be deleted after this PR merges — it's no longer referenced.