### PR TITLE
chore: pin golangci-lint and terraform versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.14.0
 
       - name: Check Terraform format
         run: make tf_fmt_check
@@ -81,6 +83,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.14.0
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -100,6 +104,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.14.0
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -119,6 +125,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.14.0
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: latest
+          version: v2.11.4
           args: --timeout 5m
 
       - name: Install Terragrunt v0.31.8


### PR DESCRIPTION
Two CI pins to unblock builds:

- golangci-lint: `version: latest` rolled to v2.12.1, which has a gosec G710 false positive on `internal/apiclient/auth.go:107` (origin is validated against `a.Host` first, so it's safe). Pinned to v2.11.4.
- terraform: `setup-terraform@v3` rolled to terraform 1.15.x, which silently succeeds on `-var-file=<missing>` instead of erroring, breaking `TestBreakdownPlanError`. Pinned to 1.14.0.