### PR TITLE
chore(deps): disable dependabot version update PRs, keep security only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    open-pull-requests-limit: 0
     reviewers:
       - infracost/engineering
     labels:
@@ -12,7 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     reviewers:
       - infracost/engineering
     labels:


### PR DESCRIPTION
Sets `open-pull-requests-limit: 0` for both `gomod` and `github-actions` ecosystems to stop version-update PRs. Security update PRs are unaffected - they're controlled by repo settings and still open automatically.