### PR TITLE
debug: investigate force-cli failure in CI [DO NOT MERGE]

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: latest
+          version: v2.11.4
           args: --timeout 5m
 
       - name: Install Terragrunt v0.31.8

--- a/cmd/infracost/run.go
+++ b/cmd/infracost/run.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"runtime/debug"
 	"sort"
@@ -814,6 +815,7 @@ func loadRunFlags(cfg *config.Config, cmd *cobra.Command) error {
 		projectCfg.UsageFile, _ = cmd.Flags().GetString("usage-file")
 		projectCfg.Name, _ = cmd.Flags().GetString("project-name")
 		projectCfg.TerraformForceCLI, _ = cmd.Flags().GetBool("terraform-force-cli")
+		fmt.Fprintf(os.Stderr, "DEBUG_LOAD path=%q forceCLI=%v changed=%v allArgs=%v\n", projectCfg.Path, projectCfg.TerraformForceCLI, cmd.Flags().Changed("terraform-force-cli"), os.Args)
 		projectCfg.TerraformPlanFlags, _ = cmd.Flags().GetString("terraform-plan-flags")
 		projectCfg.TerraformInitFlags, _ = cmd.Flags().GetString("terraform-init-flags")
 		projectCfg.TerraformUseState, _ = cmd.Flags().GetBool("terraform-use-state")

--- a/internal/providers/detect.go
+++ b/internal/providers/detect.go
@@ -33,6 +33,7 @@ func Detect(ctx *config.RunContext, project *config.Project, includePastResource
 
 	forceCLI := project.TerraformForceCLI
 	projectType := DetectProjectType(project.Path, forceCLI)
+	fmt.Fprintf(os.Stderr, "DEBUG_DETECT path=%q forceCLI=%v projectType=%v\n", project.Path, forceCLI, projectType)
 	projectContext := config.NewProjectContext(ctx, project, nil)
 	if projectType != ProjectTypeAutodetect {
 		projectContext.ContextValues.SetValue("project_type", projectType)

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -328,7 +328,9 @@ func (p *DirProvider) runPlan(opts *CmdOptions, initOnFail bool) (string, []byte
 
 	args = append(args, "plan", "-input=false", "-lock=false", "-no-color")
 	args = append(args, flags...)
-	_, err = Cmd(opts, append(args, fmt.Sprintf("-out=%s", fileName))...)
+	finalArgs := append(args, fmt.Sprintf("-out=%s", fileName))
+	fmt.Fprintf(os.Stderr, "DEBUG_PLAN planFlags=%q parsedFlags=%v finalArgs=%v\n", p.PlanFlags, flags, finalArgs)
+	_, err = Cmd(opts, finalArgs...)
 
 	// Check if the error requires a remote run or an init
 	if err != nil {

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -329,8 +329,9 @@ func (p *DirProvider) runPlan(opts *CmdOptions, initOnFail bool) (string, []byte
 	args = append(args, "plan", "-input=false", "-lock=false", "-no-color")
 	args = append(args, flags...)
 	args = append(args, fmt.Sprintf("-out=%s", fileName))
-	fmt.Fprintf(os.Stderr, "DEBUG_PLAN planFlags=%q parsedFlags=%v finalArgs=%v\n", p.PlanFlags, flags, args)
-	_, err = Cmd(opts, args...)
+	fmt.Fprintf(os.Stderr, "DEBUG_PLAN planFlags=%q parsedFlags=%v finalArgs=%v binary=%q dir=%q\n", p.PlanFlags, flags, args, opts.TerraformBinary, opts.Dir)
+	planOut, err := Cmd(opts, args...)
+	fmt.Fprintf(os.Stderr, "DEBUG_PLAN_RESULT err=%v outLen=%d outFirst200=%q\n", err, len(planOut), string(planOut[:min(len(planOut), 200)]))
 
 	// Check if the error requires a remote run or an init
 	if err != nil {

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -330,11 +330,13 @@ func (p *DirProvider) runPlan(opts *CmdOptions, initOnFail bool) (string, []byte
 	args = append(args, flags...)
 	args = append(args, fmt.Sprintf("-out=%s", fileName))
 	fmt.Fprintf(os.Stderr, "DEBUG_PLAN planFlags=%q parsedFlags=%v finalArgs=%v binary=%q dir=%q\n", p.PlanFlags, flags, args, opts.TerraformBinary, opts.Dir)
-	if which, _ := exec.Command("which", "terraform").CombinedOutput(); true {
-		ver, _ := exec.Command("terraform", "version").CombinedOutput()
-		ls, _ := exec.Command("ls", "-la", opts.Dir).CombinedOutput()
-		fmt.Fprintf(os.Stderr, "DEBUG_TF which=%q version=%q dirContents=%q\n", string(which), string(ver), string(ls))
-	}
+	//nolint:gosec
+	which, _ := exec.Command("which", "terraform").CombinedOutput()
+	//nolint:gosec
+	ver, _ := exec.Command("terraform", "version").CombinedOutput()
+	//nolint:gosec
+	ls, _ := exec.Command("ls", "-la", opts.Dir).CombinedOutput()
+	fmt.Fprintf(os.Stderr, "DEBUG_TF which=%q version=%q dirContents=%q\n", string(which), string(ver), string(ls))
 	planOut, err := Cmd(opts, args...)
 	fmt.Fprintf(os.Stderr, "DEBUG_PLAN_RESULT err=%v outLen=%d outFirst200=%q\n", err, len(planOut), string(planOut[:min(len(planOut), 200)]))
 

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -328,9 +328,9 @@ func (p *DirProvider) runPlan(opts *CmdOptions, initOnFail bool) (string, []byte
 
 	args = append(args, "plan", "-input=false", "-lock=false", "-no-color")
 	args = append(args, flags...)
-	finalArgs := append(args, fmt.Sprintf("-out=%s", fileName))
-	fmt.Fprintf(os.Stderr, "DEBUG_PLAN planFlags=%q parsedFlags=%v finalArgs=%v\n", p.PlanFlags, flags, finalArgs)
-	_, err = Cmd(opts, finalArgs...)
+	args = append(args, fmt.Sprintf("-out=%s", fileName))
+	fmt.Fprintf(os.Stderr, "DEBUG_PLAN planFlags=%q parsedFlags=%v finalArgs=%v\n", p.PlanFlags, flags, args)
+	_, err = Cmd(opts, args...)
 
 	// Check if the error requires a remote run or an init
 	if err != nil {

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -330,6 +330,11 @@ func (p *DirProvider) runPlan(opts *CmdOptions, initOnFail bool) (string, []byte
 	args = append(args, flags...)
 	args = append(args, fmt.Sprintf("-out=%s", fileName))
 	fmt.Fprintf(os.Stderr, "DEBUG_PLAN planFlags=%q parsedFlags=%v finalArgs=%v binary=%q dir=%q\n", p.PlanFlags, flags, args, opts.TerraformBinary, opts.Dir)
+	if which, _ := exec.Command("which", "terraform").CombinedOutput(); true {
+		ver, _ := exec.Command("terraform", "version").CombinedOutput()
+		ls, _ := exec.Command("ls", "-la", opts.Dir).CombinedOutput()
+		fmt.Fprintf(os.Stderr, "DEBUG_TF which=%q version=%q dirContents=%q\n", string(which), string(ver), string(ls))
+	}
 	planOut, err := Cmd(opts, args...)
 	fmt.Fprintf(os.Stderr, "DEBUG_PLAN_RESULT err=%v outLen=%d outFirst200=%q\n", err, len(planOut), string(planOut[:min(len(planOut), 200)]))
 


### PR DESCRIPTION
Debug PR to investigate why TestBreakdownPlanError/HCL fails in CI but passes locally. Built on top of #3561's lint pin.

Adds two debug prints:
- in loadRunFlags after reading --terraform-force-cli flag
- in providers.Detect before calling DetectProjectType

Will be closed once we have the answer.