### PR TITLE
ci: pin terraform to 1.14.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.14.0
 
       - name: Check Terraform format
         run: make tf_fmt_check
@@ -81,6 +83,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.14.0
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -100,6 +104,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.14.0
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
@@ -119,6 +125,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.14.0
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: latest
+          version: v2.11.4
           args: --timeout 5m
 
       - name: Install Terragrunt v0.31.8


### PR DESCRIPTION
## Why

`hashicorp/setup-terraform@v3` installs the latest terraform by default. terraform 1.15.x (released 2026-05-01) introduced a behaviour change: `terraform plan -var-file=<missing>` now silently succeeds where it previously errored with `Failed to read variables file`.

`TestBreakdownPlanError` relies on this failure path to verify the breakdown error output. With terraform 1.15.x, the plan succeeds and produces cost data, breaking the test.

This pins terraform to 1.14.0 - confirmed locally to error correctly on missing var-files. Builds on top of #3561 (lint pin).

## Validation

- terraform 1.6.3: errors with "Failed to read variables file" (correct)
- terraform 1.14.0: errors with "Failed to read variables file" (correct)
- terraform 1.15.1: silently succeeds, returns plan output (broken)