### PR TITLE
fix: surface v2 upgrade notice in v0.10 update check (DEV-250)

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -3,6 +3,7 @@ package update
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,6 +27,25 @@ type Info struct {
 	Cmd           string
 }
 
+// installMethod identifies how the running binary was installed. The CLI
+// has moved to github.com/infracost/cli for v2+, so the suggested upgrade
+// command depends on which package manager (if any) owns the binary.
+type installMethodKind int
+
+const (
+	installMethodUnknown installMethodKind = iota
+	installMethodBrew
+	installMethodChocolatey
+)
+
+// installMethod carries the detection result. ChocoPkg distinguishes the
+// three Chocolatey packages we publish ("infracost", "infracost1",
+// "infracost2") so the upgrade hint matches what choco actually expects.
+type installMethod struct {
+	Kind     installMethodKind
+	ChocoPkg string
+}
+
 func CheckForUpdate(ctx *config.RunContext) (*Info, error) {
 	if skipUpdateCheck(ctx) {
 		return nil, nil
@@ -42,28 +62,18 @@ func CheckForUpdate(ctx *config.RunContext) (*Info, error) {
 		return nil, nil
 	}
 
-	isBrew, err := isBrewInstall()
-	if err != nil {
-		// don't fail if we can't detect brew, just fallback to other update method
-		logging.Logger.Debug().Msgf("error checking if executable was installed via brew: %v", err)
-	}
-
-	var cmd string
-	if isBrew {
-		cmd = "$ brew upgrade infracost"
-	} else {
-		cmd = "Go to https://www.infracost.io/docs/update for instructions"
-		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-			cmd = "$ curl -fsSL https://raw.githubusercontent.com/infracost/infracost/master/scripts/install.sh | sh"
-		}
-	}
+	method := detectInstallMethod()
+	cmd := upgradeCommand(method)
 
 	// Get the latest version
 	latestVersion := cachedLatestVersion
 	if latestVersion == "" {
-		if isBrew {
+		switch method.Kind {
+		case installMethodBrew:
 			latestVersion, err = getLatestBrewVersion()
-		} else {
+		case installMethodChocolatey:
+			latestVersion, err = getLatestChocolateyVersion(method.ChocoPkg)
+		default:
 			latestVersion, err = getLatestGitHubVersion()
 		}
 		if err != nil {
@@ -94,7 +104,7 @@ func skipUpdateCheck(ctx *config.RunContext) bool {
 }
 
 func isBrewInstall() (bool, error) {
-	if runtime.GOOS != "darwin" {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
 		return false, nil
 	}
 
@@ -170,7 +180,9 @@ func getLatestGitHubVersion() (string, error) {
 		TagName string `json:"tag_name"`
 	}
 
-	resp, err := http.Get("https://api.github.com/repos/infracost/infracost/releases/latest")
+	// Point at infracost/cli — the v2+ repo. This is the whole point of the
+	// v0.10 patch: surface v2 to users still running the legacy series.
+	resp, err := http.Get("https://api.github.com/repos/infracost/cli/releases/latest")
 	if err != nil {
 		return "", err
 	}
@@ -216,4 +228,162 @@ func setCachedLatestVersion(ctx *config.RunContext, latestVersion string) error 
 	ctx.State.LatestReleaseCheckedAt = time.Now().Format(time.RFC3339)
 
 	return ctx.State.Save()
+}
+
+// detectInstallMethod is overridable in tests. Detection is best-effort —
+// any error is swallowed and reported as unknown so a transient detection
+// hiccup never blocks the user's command.
+var detectInstallMethod = func() installMethod {
+	if isBrew, err := isBrewInstall(); err == nil && isBrew {
+		return installMethod{Kind: installMethodBrew}
+	} else if err != nil {
+		logging.Logger.Debug().Msgf("error checking brew install: %v", err)
+	}
+
+	if pkg := chocolateyPackage(); pkg != "" {
+		return installMethod{Kind: installMethodChocolatey, ChocoPkg: pkg}
+	}
+
+	return installMethod{Kind: installMethodUnknown}
+}
+
+// chocolateyPackage returns the choco package that owns the running binary
+// ("infracost", "infracost1", "infracost2"), or "" if the binary doesn't
+// live under the Chocolatey install root. Detection relies on os.Executable
+// resolving to <ChocolateyInstall>\lib\<pkg>\... — which is what happens
+// when chocolatey's shim launches the real binary.
+func chocolateyPackage() string {
+	if runtime.GOOS != "windows" {
+		return ""
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return ""
+	}
+
+	root := os.Getenv("ChocolateyInstall")
+	if root == "" {
+		root = `C:\ProgramData\chocolatey`
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		return ""
+	}
+
+	return chocolateyPackageFromPath(exe, root)
+}
+
+// chocolateyPackageFromPath is the pure-function half of choco detection so
+// it's testable without faking os.Executable() on non-Windows hosts. Both
+// inputs are compared case-insensitively because Windows filesystems are
+// case-insensitive in practice.
+func chocolateyPackageFromPath(exe, root string) string {
+	libPrefix := strings.ToLower(filepath.Join(root, "lib")) + string(filepath.Separator)
+	exeLower := strings.ToLower(exe)
+	if !strings.HasPrefix(exeLower, libPrefix) {
+		return ""
+	}
+
+	rel := exeLower[len(libPrefix):]
+	if i := strings.IndexRune(rel, filepath.Separator); i >= 0 {
+		rel = rel[:i]
+	}
+	return rel
+}
+
+// upgradeCommand returns the shell hint we render in the update notice. For
+// users on the legacy `infracost` choco package we also point out that
+// installing `infracost1` keeps them on the v0.10 series, in case they
+// don't want to roll forward to v2.
+func upgradeCommand(method installMethod) string {
+	switch method.Kind {
+	case installMethodBrew:
+		return "$ brew upgrade infracost"
+	case installMethodChocolatey:
+		pkg := method.ChocoPkg
+		if pkg == "" {
+			pkg = "infracost"
+		}
+		cmd := fmt.Sprintf("$ choco upgrade %s", pkg)
+		if pkg == "infracost" {
+			cmd += "\n(To stay on the v0.10 series, install the infracost1 package instead.)"
+		}
+		return cmd
+	default:
+		if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+			return "$ curl -fsSL https://raw.githubusercontent.com/infracost/cli/master/scripts/install.sh | sh"
+		}
+		return "Go to https://www.infracost.io/docs/update for instructions"
+	}
+}
+
+// getLatestChocolateyVersion queries the community Chocolatey OData feed
+// for the latest published version of the given package.
+func getLatestChocolateyVersion(pkg string) (string, error) {
+	if pkg == "" {
+		pkg = "infracost"
+	}
+
+	resp, err := http.Get(chocolateyFeedURL(pkg))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Errorf("error getting latest chocolatey version: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	v, err := parseChocolateyFeed(body)
+	if err != nil {
+		return "", err
+	}
+	if v == "" {
+		return "", errors.Errorf("chocolatey feed returned no version for %s", pkg)
+	}
+	return v, nil
+}
+
+// chocolateyFeedURL builds the OData filter URL. Package names are
+// constrained to [a-z0-9.-] by Chocolatey, so no escaping is needed.
+func chocolateyFeedURL(pkg string) string {
+	return "https://community.chocolatey.org/api/v2/Packages()?$filter=Id%20eq%20%27" + pkg + "%27%20and%20IsLatestVersion"
+}
+
+// parseChocolateyFeed extracts the first non-empty <Version> from the ATOM
+// feed body, prefixed with "v" for downstream semver comparison. Returns
+// "" if the feed has no usable entry (caller decides how to report that).
+func parseChocolateyFeed(body []byte) (string, error) {
+	var feed struct {
+		Entries []struct {
+			Properties struct {
+				Version string `xml:"Version"`
+			} `xml:"properties"`
+		} `xml:"entry"`
+	}
+	if err := xml.Unmarshal(body, &feed); err != nil {
+		return "", errors.Wrap(err, "parsing chocolatey feed")
+	}
+
+	for _, e := range feed.Entries {
+		v := strings.TrimSpace(e.Properties.Version)
+		if v == "" {
+			continue
+		}
+		if !strings.HasPrefix(v, "v") {
+			v = "v" + v
+		}
+		return v, nil
+	}
+	return "", nil
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,144 @@
+package update
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestChocolateyPackageFromPath(t *testing.T) {
+	root := filepath.Join("C:", "ProgramData", "chocolatey")
+
+	cases := []struct {
+		name string
+		exe  string
+		want string
+	}{
+		{
+			name: "infracost package",
+			exe:  filepath.Join(root, "lib", "infracost", "tools", "infracost.exe"),
+			want: "infracost",
+		},
+		{
+			name: "infracost1 package",
+			exe:  filepath.Join(root, "lib", "infracost1", "tools", "infracost.exe"),
+			want: "infracost1",
+		},
+		{
+			name: "infracost2 package",
+			exe:  filepath.Join(root, "lib", "infracost2", "tools", "infracost.exe"),
+			want: "infracost2",
+		},
+		{
+			name: "case insensitive",
+			exe:  filepath.Join("C:", "PROGRAMDATA", "Chocolatey", "Lib", "Infracost1", "tools", "infracost.exe"),
+			want: "infracost1",
+		},
+		{
+			name: "shim path (under bin, not lib) — not detected",
+			exe:  filepath.Join(root, "bin", "infracost.exe"),
+			want: "",
+		},
+		{
+			name: "binary outside choco — not detected",
+			exe:  filepath.Join("C:", "Users", "foo", "Downloads", "infracost.exe"),
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := chocolateyPackageFromPath(tc.exe, root); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUpgradeCommand(t *testing.T) {
+	cases := []struct {
+		name       string
+		method     installMethod
+		wantPrefix string
+		wantPin    bool
+	}{
+		{
+			name:       "brew",
+			method:     installMethod{Kind: installMethodBrew},
+			wantPrefix: "$ brew upgrade infracost",
+		},
+		{
+			name:       "choco infracost — includes pin hint",
+			method:     installMethod{Kind: installMethodChocolatey, ChocoPkg: "infracost"},
+			wantPrefix: "$ choco upgrade infracost",
+			wantPin:    true,
+		},
+		{
+			name:       "choco infracost1 — no pin hint",
+			method:     installMethod{Kind: installMethodChocolatey, ChocoPkg: "infracost1"},
+			wantPrefix: "$ choco upgrade infracost1",
+		},
+		{
+			name:       "choco infracost2 — no pin hint",
+			method:     installMethod{Kind: installMethodChocolatey, ChocoPkg: "infracost2"},
+			wantPrefix: "$ choco upgrade infracost2",
+		},
+		{
+			name:       "choco missing pkg — defaults to infracost",
+			method:     installMethod{Kind: installMethodChocolatey, ChocoPkg: ""},
+			wantPrefix: "$ choco upgrade infracost",
+			wantPin:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := upgradeCommand(tc.method)
+			if !strings.HasPrefix(got, tc.wantPrefix) {
+				t.Errorf("got %q, want prefix %q", got, tc.wantPrefix)
+			}
+			hasPin := strings.Contains(got, "infracost1 package")
+			if hasPin != tc.wantPin {
+				t.Errorf("pin hint = %v, want %v (full cmd: %q)", hasPin, tc.wantPin, got)
+			}
+		})
+	}
+}
+
+func TestParseChocolateyFeed(t *testing.T) {
+	v, err := parseChocolateyFeed([]byte(`<?xml version="1.0" encoding="utf-8"?>
+<feed>
+  <entry>
+    <properties>
+      <Version>0.10.46</Version>
+    </properties>
+  </entry>
+</feed>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != "v0.10.46" {
+		t.Errorf("got %q, want v0.10.46", v)
+	}
+
+	empty, err := parseChocolateyFeed([]byte(`<?xml version="1.0"?><feed></feed>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if empty != "" {
+		t.Errorf("expected empty version for feed with no entries, got %q", empty)
+	}
+}
+
+func TestChocolateyFeedURL(t *testing.T) {
+	for _, pkg := range []string{"infracost", "infracost1", "infracost2"} {
+		url := chocolateyFeedURL(pkg)
+		want := "%27" + pkg + "%27"
+		if !strings.Contains(url, want) {
+			t.Errorf("for pkg=%q, expected URL to contain %q, got %s", pkg, want, url)
+		}
+		if !strings.Contains(url, "IsLatestVersion") {
+			t.Errorf("for pkg=%q, expected URL to filter IsLatestVersion, got %s", pkg, url)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Point `getLatestGitHubVersion` at `infracost/cli/releases/latest` so v0.10 users finally see the v2 release in the end-of-run notice (this is the whole reason for the patch — closes [DEV-250](https://linear.app/infracost/issue/DEV-250)).
- Detect brew (now on linux too — the old logic only matched darwin) and chocolatey installs, then suggest the package manager's own upgrade command rather than `curl install.sh`.
- For users on the legacy `infracost` chocolatey package, the notice also includes `(To stay on the v0.10 series, install the infracost1 package instead.)` as an off-ramp.
- For unknown install methods on linux/darwin, the curl one-liner now points at `infracost/cli`'s install.sh.