### PR TITLE
feat(azure/aks): support priority=Spot on kubernetes_cluster_node_pool

### DIFF
--- a/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
+++ b/internal/providers/terraform/azure/kubernetes_cluster_node_pool.go
@@ -44,6 +44,11 @@ func NewKubernetesClusterNodePool(d *schema.ResourceData) schema.CoreResource {
 		}
 	}
 
+	priority := ""
+	if d.Get("priority").Type != gjson.Null {
+		priority = d.Get("priority").String()
+	}
+
 	r := &azure.KubernetesClusterNodePool{
 		Address:      d.Address,
 		Region:       d.Region,
@@ -53,6 +58,7 @@ func NewKubernetesClusterNodePool(d *schema.ResourceData) schema.CoreResource {
 		OSDiskSizeGB: d.Get("os_disk_size_gb").Int(),
 		NodeCount:    nodeCount,
 		IsDevTest:    d.ProjectMetadata["isProduction"] == "false",
+		Priority:     priority,
 	}
 	return r
 }

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.golden
@@ -48,17 +48,27 @@
  └─ os_disk                                                                                                  
     └─ Storage (S10, LRS)                                                          1  months         $5.89   
                                                                                                              
- OVERALL TOTAL                                                                                  $1,310.20 
+ azurerm_kubernetes_cluster_node_pool.spot_linux                                                             
+ ├─ Instance usage (Linux, spot, Standard_D2as_v5)                               730  hours         $13.65   
+ └─ os_disk                                                                                                  
+    └─ Storage (P10, LRS)                                                          1  months        $19.71   
+                                                                                                             
+ azurerm_kubernetes_cluster_node_pool.spot_windows                                                           
+ ├─ Instance usage (Windows, spot, Standard_D2as_v5)                             730  hours         $13.65   
+ └─ os_disk                                                                                                  
+    └─ Storage (P10, LRS)                                                          1  months        $19.71   
+                                                                                                             
+ OVERALL TOTAL                                                                                  $1,376.93 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-11 cloud resources were detected:
-∙ 10 were estimated
+13 cloud resources were detected:
+∙ 12 were estimated
 ∙ 1 was free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃        $1,310 ┃           - ┃     $1,310 ┃
+┃ main                                               ┃        $1,377 ┃           - ┃     $1,377 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
+++ b/internal/providers/terraform/azure/testdata/kubernetes_cluster_node_pool_test/kubernetes_cluster_node_pool_test.tf
@@ -86,3 +86,24 @@ resource "azurerm_kubernetes_cluster_node_pool" "non_premium" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
   vm_size               = "Standard_D2_v3"
 }
+
+resource "azurerm_kubernetes_cluster_node_pool" "spot_linux" {
+  name                  = "spotlinux"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
+  vm_size               = "Standard_D2as_v5"
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = -1
+  node_count            = 1
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "spot_windows" {
+  name                  = "spotwin"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.example.id
+  vm_size               = "Standard_D2as_v5"
+  os_type               = "Windows"
+  priority              = "Spot"
+  eviction_policy       = "Delete"
+  spot_max_price        = -1
+  node_count            = 1
+}

--- a/internal/resources/azure/kubernetes_cluster.go
+++ b/internal/resources/azure/kubernetes_cluster.go
@@ -108,8 +108,10 @@ func (r *KubernetesCluster) BuildResource() *schema.Resource {
 		monthlyHours = r.DefaultNodePool.MonthlyHours
 	}
 
+	// Azure forbids Spot priority on the default_node_pool (must be Regular):
+	// pass an empty priority so PAYG pricing is used.
 	subResources = []*schema.Resource{
-		aksClusterNodePool("default_node_pool", region, r.DefaultNodePoolVMSize, r.DefaultNodePoolOS, r.DefaultNodePoolOSDiskType, r.DefaultNodePoolOSDiskSizeGB, nodeCount, monthlyHours, r.IsDevTest),
+		aksClusterNodePool("default_node_pool", region, r.DefaultNodePoolVMSize, r.DefaultNodePoolOS, r.DefaultNodePoolOSDiskType, r.DefaultNodePoolOSDiskSizeGB, nodeCount, monthlyHours, r.IsDevTest, ""),
 	}
 
 	if strings.ToLower(r.NetworkProfileLoadBalancerSKU) == "standard" {

--- a/internal/resources/azure/kubernetes_cluster_node_pool.go
+++ b/internal/resources/azure/kubernetes_cluster_node_pool.go
@@ -19,6 +19,11 @@ type KubernetesClusterNodePool struct {
 	OS           string
 	OSDiskType   string
 	OSDiskSizeGB int64
+	// Priority is the scheduling priority of the node pool, mapping to the
+	// Terraform attribute `priority` on azurerm_kubernetes_cluster_node_pool.
+	// When set to "Spot", instances are costed at Spot pricing; any other
+	// value (including the default "Regular") uses pay-as-you-go.
+	Priority     string
 	Nodes        *int64   `infracost_usage:"nodes"`
 	MonthlyHours *float64 `infracost_usage:"monthly_hrs"`
 	IsDevTest    bool
@@ -48,12 +53,12 @@ func (r *KubernetesClusterNodePool) BuildResource() *schema.Resource {
 		nodeCount = decimal.NewFromInt(*r.Nodes)
 	}
 
-	pool := aksClusterNodePool(r.Address, r.Region, r.VMSize, r.OS, r.OSDiskType, r.OSDiskSizeGB, nodeCount, r.MonthlyHours, r.IsDevTest)
+	pool := aksClusterNodePool(r.Address, r.Region, r.VMSize, r.OS, r.OSDiskType, r.OSDiskSizeGB, nodeCount, r.MonthlyHours, r.IsDevTest, r.Priority)
 	pool.UsageSchema = r.UsageSchema()
 	return pool
 }
 
-func aksClusterNodePool(name, region, instanceType, os string, osDiskType string, osDiskSizeGB int64, nodeCount decimal.Decimal, monthlyHours *float64, isDevTest bool) *schema.Resource {
+func aksClusterNodePool(name, region, instanceType, os string, osDiskType string, osDiskSizeGB int64, nodeCount decimal.Decimal, monthlyHours *float64, isDevTest bool, priority string) *schema.Resource {
 	var costComponents []*schema.CostComponent
 	var subResources []*schema.Resource
 
@@ -62,9 +67,9 @@ func aksClusterNodePool(name, region, instanceType, os string, osDiskType string
 	}
 
 	if strings.EqualFold(os, "windows") {
-		costComponents = append(costComponents, windowsVirtualMachineCostComponent(region, instanceType, "None", monthlyHours, isDevTest))
+		costComponents = append(costComponents, windowsVirtualMachineCostComponentWithPriority(region, instanceType, "None", monthlyHours, isDevTest, priority))
 	} else {
-		costComponents = append(costComponents, linuxVirtualMachineCostComponent(region, instanceType, monthlyHours))
+		costComponents = append(costComponents, linuxVirtualMachineCostComponentWithPriority(region, instanceType, monthlyHours, priority))
 	}
 
 	mainResource.CostComponents = costComponents

--- a/internal/resources/azure/linux_virtual_machine.go
+++ b/internal/resources/azure/linux_virtual_machine.go
@@ -70,8 +70,26 @@ func (r *LinuxVirtualMachine) BuildResource() *schema.Resource {
 }
 
 func linuxVirtualMachineCostComponent(region string, instanceType string, monthlyHours *float64) *schema.CostComponent {
+	return linuxVirtualMachineCostComponentWithPriority(region, instanceType, monthlyHours, "")
+}
+
+// linuxVirtualMachineCostComponentWithPriority returns the per-hour instance
+// cost component for a Linux VM/node, optionally selecting Spot pricing.
+//
+// priority="Spot" matches SKUs ending with " Spot" in the Azure retail catalog
+// (variable market price; the catalog snapshot is used as a point estimate
+// — actual Spot prices fluctuate with demand).
+// priority="" or "Regular" excludes Low Priority/Spot SKUs, falling back to
+// the standard pay-as-you-go price.
+func linuxVirtualMachineCostComponentWithPriority(region string, instanceType string, monthlyHours *float64, priority string) *schema.CostComponent {
 	purchaseOption := "Consumption"
 	purchaseOptionLabel := "pay as you go"
+	skuNameRe := "/^(?!.*(Low Priority|Spot)$).*$/i"
+	if strings.EqualFold(priority, "Spot") {
+		purchaseOption = "Spot"
+		purchaseOptionLabel = "spot"
+		skuNameRe = "/^.*Spot$/i"
+	}
 
 	productNameRe := "/Series( Linux)?$/i"
 	if strings.HasPrefix(strings.ToLower(instanceType), "basic_") {
@@ -97,7 +115,7 @@ func linuxVirtualMachineCostComponent(region string, instanceType string, monthl
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "meterName", ValueRegex: strPtr("/^(?!.*(Expired|Free)$).*$/i")},
-				{Key: "skuName", ValueRegex: strPtr("/^(?!.*(Low Priority|Spot)$).*$/i")},
+				{Key: "skuName", ValueRegex: strPtr(skuNameRe)},
 				{Key: "armSkuName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", instanceType))},
 				{Key: "productName", ValueRegex: strPtr(productNameRe)},
 			},

--- a/internal/resources/azure/windows_virtual_machine.go
+++ b/internal/resources/azure/windows_virtual_machine.go
@@ -84,8 +84,22 @@ func (r *WindowsVirtualMachine) BuildResource() *schema.Resource {
 }
 
 func windowsVirtualMachineCostComponent(region string, instanceType string, licenseType string, monthlyHours *float64, isDevTest bool) *schema.CostComponent {
+	return windowsVirtualMachineCostComponentWithPriority(region, instanceType, licenseType, monthlyHours, isDevTest, "")
+}
+
+// windowsVirtualMachineCostComponentWithPriority is the Windows counterpart of
+// linuxVirtualMachineCostComponentWithPriority. See its godoc for the priority
+// argument semantics.
+func windowsVirtualMachineCostComponentWithPriority(region string, instanceType string, licenseType string, monthlyHours *float64, isDevTest bool, priority string) *schema.CostComponent {
 	purchaseOption := "Consumption"
 	purchaseOptionLabel := "pay as you go"
+	skuNameRe := "/^(?!.*(Low Priority|Spot)$).*$/i"
+	isSpot := strings.EqualFold(priority, "Spot")
+	if isSpot {
+		purchaseOption = "Spot"
+		purchaseOptionLabel = "spot"
+		skuNameRe = "/^.*Spot$/i"
+	}
 
 	productNameRe := "/(Series )?Windows$/i"
 	if strings.HasPrefix(instanceType, "Basic_") {
@@ -94,14 +108,19 @@ func windowsVirtualMachineCostComponent(region string, instanceType string, lice
 		instanceType = fmt.Sprintf("Standard_%s", instanceType)
 	}
 
-	if strings.ToLower(licenseType) == "windows_client" || strings.ToLower(licenseType) == "windows_server" {
-		purchaseOption = "DevTestConsumption"
-		purchaseOptionLabel = "hybrid benefit"
-	}
+	// Hybrid benefit and dev/test are mutually exclusive with Spot in Azure:
+	// Spot VMs cannot use Azure Hybrid Benefit licensing, and dev/test rates
+	// are not offered for Spot SKUs. Keep PAYG for Spot regardless of licenseType.
+	if !isSpot {
+		if strings.ToLower(licenseType) == "windows_client" || strings.ToLower(licenseType) == "windows_server" {
+			purchaseOption = "DevTestConsumption"
+			purchaseOptionLabel = "hybrid benefit"
+		}
 
-	if isDevTest {
-		purchaseOption = "DevTestConsumption"
-		purchaseOptionLabel = "dev/test"
+		if isDevTest {
+			purchaseOption = "DevTestConsumption"
+			purchaseOptionLabel = "dev/test"
+		}
 	}
 
 	qty := schema.HourToMonthUnitMultiplier
@@ -120,7 +139,7 @@ func windowsVirtualMachineCostComponent(region string, instanceType string, lice
 			Service:       strPtr("Virtual Machines"),
 			ProductFamily: strPtr("Compute"),
 			AttributeFilters: []*schema.AttributeFilter{
-				{Key: "skuName", ValueRegex: strPtr("/^(?!.*(Low Priority|Spot)$).*$/i")},
+				{Key: "skuName", ValueRegex: strPtr(skuNameRe)},
 				{Key: "armSkuName", ValueRegex: strPtr(fmt.Sprintf("/^%s$/i", instanceType))},
 				{Key: "productName", ValueRegex: strPtr(productNameRe)},
 			},


### PR DESCRIPTION
## Summary

Closes the longstanding gap raised in #1449 (closed `NOT_PLANNED` 2026-04 with a maintainer note about moving feature work to a contribution model). This PR is the contribution.

Before this change, an AKS node pool declared as:

```hcl
resource "azurerm_kubernetes_cluster_node_pool" "spot" {
  vm_size  = "Standard_D2as_v5"
  priority = "Spot"
  ...
}
```

was costed at pay-as-you-go rates (`$0.101/h` for `D2as_v5` Linux in `eastus`) instead of the actual Spot rate (`$0.0187/h`) — a ~5× overestimate.

## Root cause (three separate things)

1. The Terraform `priority` attribute was not read by the provider in `internal/providers/terraform/azure/kubernetes_cluster_node_pool.go`.
2. The shared Linux/Windows VM cost component actively *excluded* Spot SKUs:
   ```go
   {Key: "skuName", ValueRegex: strPtr("/^(?!.*(Low Priority|Spot)$).*$/i")}
   ```
3. The price filter requested `purchaseOption: "Consumption"`, but the Infracost pricing API exposes Spot prices under `purchaseOption: "Spot"`. Confirmed via:
   ```graphql
   { products(filter: {service: "Virtual Machines", region: "eastus",
       attributeFilters: [{key: "skuName", value: "Standard_D2as_v5 Spot"}]}) {
     prices { USD unit purchaseOption }
   }}
   # → "0.018705", "1 Hour", "Spot"
   ```

## Change

Introduces `linuxVirtualMachineCostComponentWithPriority` and `windowsVirtualMachineCostComponentWithPriority` helpers. Existing exported helpers remain unchanged (delegate with `priority=""`), so no other callers are affected.

The AKS resource and parser are updated to thread `priority` through. `default_node_pool` inside `azurerm_kubernetes_cluster` is forced to PAYG since Azure forbids Spot on the default pool.

## Test plan

- [x] Unit tests pass: `go test ./internal/resources/azure/...` ✅
- [x] Golden file regenerated under `-update`:
  - New `spot_linux` fixture → `Instance usage (Linux, spot, Standard_D2as_v5)` at `$13.65/month` (730h × $0.0187)
  - New `spot_windows` fixture → `Instance usage (Windows, spot, Standard_D2as_v5)` ✅
- [x] Existing PAYG fixtures unchanged in golden diff ✅

## Caveats

- **Pricing API data quality (Windows Spot)**: The pricing API returns `USD 0.018705` for `Standard_D2as_v5 Spot` regardless of `productName` (Linux vs Windows variant), whereas Azure Retail API shows distinct prices (`$0.038751` for Windows Spot in `eastus`). This is an upstream data ingestion question, out of scope for this PR — the golden reflects what the API actually returns today.
- **Hybrid benefit & dev/test rates** are skipped for Spot Windows VMs, since those programmes are mutually exclusive with Spot in Azure billing. Code comment explains.
- **Spot price volatility**: Spot rates fluctuate with demand; the catalog snapshot is used as a point estimate, same approach Infracost uses for AWS Spot.

## Out of scope (deliberately)

The same priority/SKU plumbing applies to:
- `azurerm_linux_virtual_machine` / `azurerm_windows_virtual_machine` (when `priority = "Spot"`)
- `azurerm_*_virtual_machine_scale_set` (Spot VMSS, common for non-AKS workloads)

Happy to extend in a follow-up PR if the maintainers prefer this stays narrow.

## Background

Production AKS cluster using a Spot node pool for non-prod test workloads. Today's workaround is a hand-tuned `monthly_hrs` multiplier in `infracost-usage.yml`, which works for absolute totals but breaks down when SKU/region change (Spot/PAYG ratios vary by region) and confuses readers because the value loses its wall-clock semantics. Documented [in the issue comment](https://github.com/infracost/infracost/issues/1449#issuecomment-4537446340) before drafting this PR.