### PR TITLE
fix(usage): avoid panic when usage file nests a scalar reference key

### DIFF
--- a/internal/usage/usage_file.go
+++ b/internal/usage/usage_file.go
@@ -274,8 +274,16 @@ func findInvalidKeys(item *schema.UsageItem, refMap map[string]interface{}) []st
 	if refVal, ok := refMap[item.Key]; !ok {
 		invalidKeys = append(invalidKeys, item.Key)
 	} else if item.ValueType == schema.SubResourceUsage && item.Value != nil {
+		// The user provided a nested map for this key, but the reference file may
+		// define it as a scalar. In that case the user's value is invalid, so report
+		// the key rather than panicking on the type assertion.
+		refSubMap, ok := refVal.(map[string]interface{})
+		if !ok {
+			invalidKeys = append(invalidKeys, item.Key)
+			return invalidKeys
+		}
 		for _, subItem := range item.Value.(*ResourceUsage).Items {
-			invalidKeys = append(invalidKeys, findInvalidKeys(subItem, refVal.(map[string]interface{}))...)
+			invalidKeys = append(invalidKeys, findInvalidKeys(subItem, refSubMap)...)
 		}
 	}
 

--- a/internal/usage/usage_file_test.go
+++ b/internal/usage/usage_file_test.go
@@ -37,6 +37,25 @@ func TestUsageFileEmpty(t *testing.T) {
 	tftest.GoldenFileUsageSyncTest(t, "usage_file_empty")
 }
 
+// TestInvalidKeysSubResourceOverScalar checks that InvalidKeys does not panic
+// when the user provides a nested map for a key that the reference usage file
+// defines as a scalar (e.g. aws_lambda_function.monthly_requests). The key
+// should be reported as invalid instead.
+func TestInvalidKeysSubResourceOverScalar(t *testing.T) {
+	usageFile, err := usage.LoadUsageFileFromString(
+		`version: 0.1
+resource_usage:
+  aws_lambda_function.my_function:
+    monthly_requests:
+      nested: 1
+`)
+	assert.NoError(t, err)
+
+	invalidKeys, err := usageFile.InvalidKeys()
+	assert.NoError(t, err)
+	assert.Contains(t, invalidKeys, "monthly_requests")
+}
+
 // This should really be in schema.usage_data_test but I need to put it here so I can use LoadUsageFileFromString without
 // getting import cycles.
 func TestUsageDataEmpty(t *testing.T) {


### PR DESCRIPTION
## What's broken

`infracost breakdown --usage-file <file>` panics when a usage file provides a nested map for a key that the bundled reference usage file defines as a scalar. For example the reference defines `aws_lambda_function.monthly_requests` as a scalar int; a usage file that nests it crashes the CLI:

```yaml
resource_usage:
  aws_lambda_function.my_function:
    monthly_requests:
      nested: 1
```
```
panic: interface conversion: interface {} is int, not map[string]interface {}
  internal/usage/usage_file.go:278  (findInvalidKeys)
```

## Why it happens

`findInvalidKeys` assumes that when the *user's* item is a nested map, the matching *reference* value is also a map, and does an unchecked `refVal.(map[string]interface{})`. The reference value's type comes from the reference file, not the user's input.

## Fix

Guard the assertion with the comma-ok form; on mismatch report the key as invalid (the user's nested value genuinely is invalid here) instead of panicking.

## Test

`TestInvalidKeysSubResourceOverScalar` feeds a nested value over a scalar reference key: panics before, reports the key as invalid after.
