### PR TITLE
fix: support for_each'd providers with indexed references

### DIFF
--- a/internal/hcl/attribute.go
+++ b/internal/hcl/attribute.go
@@ -215,6 +215,22 @@ func (attr *Attribute) ProvidersValue() cty.Value {
 	return attr.Value()
 }
 
+func decodeProviderKey(keyExpr *hclsyntax.ObjectConsKeyExpr, ctx *hcl.EvalContext) (string, bool) {
+	if wrapped, ok := keyExpr.Wrapped.(*hclsyntax.ScopeTraversalExpr); ok {
+		return traversalAsString(wrapped.AsTraversal()), true
+	}
+
+	keyValue, diags := keyExpr.Value(ctx)
+	if diags.HasErrors() || !keyValue.IsKnown() || keyValue.IsNull() {
+		return "", false
+	}
+	var key string
+	if err := gocty.FromCtyValue(keyValue, &key); err != nil {
+		return "", false
+	}
+	return key, true
+}
+
 // DecodeProviders decodes the providers block into a map of provider names to provider aliases.
 // This is used by the graph evaluator to make sure the correct edges are created when providers are
 // inherited from parent modules.
@@ -228,16 +244,60 @@ func (attr *Attribute) DecodeProviders() map[string]string {
 				continue
 			}
 
-			valExpr, ok := item.ValueExpr.(*hclsyntax.ScopeTraversalExpr)
-			if !ok {
+			var traversal hcl.Traversal
+			switch valExpr := item.ValueExpr.(type) {
+			case *hclsyntax.ScopeTraversalExpr:
+				traversal = valExpr.AsTraversal()
+			case *hclsyntax.IndexExpr:
+				var diags hcl.Diagnostics
+				traversal, diags = hcl.AbsTraversalForExpr(valExpr.Collection)
+				if diags.HasErrors() {
+					continue
+				}
+			default:
 				continue
 			}
 
-			key := traversalAsString(keyExpr.AsTraversal())
-			val := traversalAsString(valExpr.AsTraversal())
+			key, ok := decodeProviderKey(keyExpr, attr.Ctx.Inner())
+			if !ok {
+				continue
+			}
+			val := traversalAsString(traversal)
 
 			providers[key] = val
 		}
+	}
+
+	return providers
+}
+
+// DecodeProviderValues evaluates the provider instances passed to a child
+// module, keyed by the provider names used within that module.
+func (attr *Attribute) DecodeProviderValues() map[string]cty.Value {
+	providers := make(map[string]cty.Value)
+
+	origExpr, ok := attr.HCLAttr.Expr.(*hclsyntax.ObjectConsExpr)
+	if !ok {
+		return providers
+	}
+
+	for _, item := range origExpr.Items {
+		keyExpr, ok := item.KeyExpr.(*hclsyntax.ObjectConsKeyExpr)
+		if !ok {
+			continue
+		}
+		key, ok := decodeProviderKey(keyExpr, attr.Ctx.Inner())
+		if !ok {
+			continue
+		}
+		providers[key] = cty.DynamicVal
+
+		value, diags := item.ValueExpr.Value(attr.Ctx.Inner())
+		if diags.HasErrors() {
+			continue
+		}
+
+		providers[key] = value
 	}
 
 	return providers
@@ -1133,6 +1193,14 @@ func (attr *Attribute) VerticesReferenced(b *Block) []VertexReference {
 		}
 
 		isProviderReference := usesProviderConfiguration(b) && attr.Name() == "provider"
+		if b.Type() == "module" && attr.Name() == "providers" {
+			for _, provider := range attr.DecodeProviders() {
+				if key == provider {
+					isProviderReference = true
+					break
+				}
+			}
+		}
 		if isProviderReference {
 			key = fmt.Sprintf("provider.%s", strings.TrimSuffix(key, "."))
 		}

--- a/internal/hcl/block.go
+++ b/internal/hcl/block.go
@@ -743,8 +743,8 @@ func (b *Block) Provider() string {
 		value := attr.AsString()
 		r, err := attr.Reference()
 		if err == nil {
-			// An explicit provider is provided so use that
-			return r.String()
+			// Provider config keys do not include count or for_each indices.
+			return strings.TrimSuffix(stripCount(r.String()), ".")
 		}
 
 		if value != "" {

--- a/internal/hcl/evaluator.go
+++ b/internal/hcl/evaluator.go
@@ -127,6 +127,9 @@ func NewEvaluator(
 	if module.ProviderReferences == nil {
 		module.ProviderReferences = make(map[string]*Block)
 	}
+	if module.ProviderReferenceValues == nil {
+		module.ProviderReferenceValues = make(map[string]cty.Value)
+	}
 
 	providerBlocks := module.Blocks.OfType("provider")
 	for _, block := range providerBlocks {
@@ -137,10 +140,14 @@ func NewEvaluator(
 			k = k + "." + alias.AsString()
 		}
 		module.ProviderReferences[k] = block
+		delete(module.ProviderReferenceValues, k)
 	}
 
 	for key, provider := range module.ProviderReferences {
 		ctx.Set(provider.Values(), key)
+	}
+	for key, provider := range module.ProviderReferenceValues {
+		ctx.Set(provider, key)
 	}
 
 	if visitedModules == nil {
@@ -272,6 +279,9 @@ func (e *Evaluator) collectModules() *Module {
 	for name, providerBlock := range root.ProviderReferences {
 		e.ctx.Set(providerBlock.Values(), name)
 	}
+	for name, providerValue := range root.ProviderReferenceValues {
+		e.ctx.Set(providerValue, name)
+	}
 
 	if v := e.MissingVars(); len(v) > 0 {
 		root.Warnings = append(root.Warnings, schema.NewDiagMissingVars(v...))
@@ -353,16 +363,17 @@ func (e *Evaluator) evaluateModules() {
 
 		moduleEvaluator := NewEvaluator(
 			Module{
-				Name:               fullName,
-				Source:             moduleCall.Module.Source,
-				Blocks:             moduleCall.Module.RawBlocks,
-				RawBlocks:          moduleCall.Module.RawBlocks,
-				RootPath:           e.module.RootPath,
-				ModulePath:         moduleCall.Path,
-				Modules:            nil,
-				Parent:             &e.module,
-				SourceURL:          moduleCall.Module.SourceURL,
-				ProviderReferences: moduleCall.Module.ProviderReferences,
+				Name:                    fullName,
+				Source:                  moduleCall.Module.Source,
+				Blocks:                  moduleCall.Module.RawBlocks,
+				RawBlocks:               moduleCall.Module.RawBlocks,
+				RootPath:                e.module.RootPath,
+				ModulePath:              moduleCall.Path,
+				Modules:                 nil,
+				Parent:                  &e.module,
+				SourceURL:               moduleCall.Module.SourceURL,
+				ProviderReferences:      moduleCall.Module.ProviderReferences,
+				ProviderReferenceValues: moduleCall.Module.ProviderReferenceValues,
 			},
 			e.workingDir,
 			vars,
@@ -913,9 +924,13 @@ func (e *Evaluator) evaluateProvider(b *Block, values map[string]cty.Value) cty.
 		return cty.ObjectVal(values)
 	}
 
+	// Expand for_each instances so that indexed references like
+	// aws.by_region["us-east-1"] evaluate to the per-instance values.
+	aliasVal := e.expandProviderForEach(b)
+
 	if !exists {
 		return cty.ObjectVal(map[string]cty.Value{
-			str: b.Values(),
+			str: aliasVal,
 		})
 	}
 
@@ -923,8 +938,45 @@ func (e *Evaluator) evaluateProvider(b *Block, values map[string]cty.Value) cty.
 	if ob == nil {
 		ob = make(map[string]cty.Value)
 	}
-	ob[str] = b.Values()
+	ob[str] = aliasVal
 	return cty.ObjectVal(ob)
+}
+
+// expandProviderForEach returns one entry per for_each instance so indexed
+// provider references like aws.by_region["us-east-1"] resolve to values
+// evaluated with the corresponding each.key and each.value.
+func (e *Evaluator) expandProviderForEach(b *Block) cty.Value {
+	forEachAttr := b.GetAttribute("for_each")
+	if forEachAttr == nil || !forEachAttr.IsIterable() {
+		return b.Values()
+	}
+
+	forEachVal := forEachAttr.Value()
+	if forEachVal.IsNull() || !forEachVal.IsKnown() {
+		return b.Values()
+	}
+
+	expandedMap := map[string]cty.Value{}
+	forEachVal.ForEachElement(func(key cty.Value, val cty.Value) bool {
+		var keyStr string
+		if err := gocty.FromCtyValue(key, &keyStr); err != nil {
+			e.logger.Debug().Err(err).Msgf("could not marshal for_each provider key to string")
+			return false
+		}
+
+		clone := e.blockBuilder.CloneBlock(b, key)
+		clone.SetLabels(append([]string(nil), b.Labels()...))
+		ctx := clone.Context()
+		ctx.SetByDot(key, "each.key")
+		ctx.SetByDot(val, "each.value")
+		expandedMap[keyStr] = clone.Values()
+		return false
+	})
+
+	if len(expandedMap) == 0 {
+		return b.Values()
+	}
+	return cty.ObjectVal(expandedMap)
 }
 
 // evaluateResourceOrData evaluates a resource or data block.
@@ -1029,9 +1081,13 @@ func (e *Evaluator) loadModuleWithProviders(b *Block) (*ModuleCall, error) {
 	// module, as well as any explicit provider references that are passed in
 	// via the "providers" attribute.
 	providerRefs := map[string]*Block{}
+	providerValues := map[string]cty.Value{}
 
 	for key, block := range e.module.ProviderReferences {
 		providerRefs[key] = block
+	}
+	for key, value := range e.module.ProviderReferenceValues {
+		providerValues[key] = value
 	}
 
 	providerAttr := b.GetAttribute("providers")
@@ -1040,9 +1096,14 @@ func (e *Evaluator) loadModuleWithProviders(b *Block) (*ModuleCall, error) {
 		for key, val := range decodedProviders {
 			providerRefs[key] = providerRefs[val]
 		}
+		for key, val := range providerAttr.DecodeProviderValues() {
+			delete(providerRefs, key)
+			providerValues[key] = val
+		}
 	}
 
 	modCall.Module.ProviderReferences = providerRefs
+	modCall.Module.ProviderReferenceValues = providerValues
 
 	return modCall, nil
 }

--- a/internal/hcl/graph_vertex_data.go
+++ b/internal/hcl/graph_vertex_data.go
@@ -51,6 +51,9 @@ func (v *VertexData) Visit(mutex *sync.Mutex) error {
 		for name, providerBlock := range e.module.ProviderReferences {
 			e.ctx.Set(providerBlock.Values(), name)
 		}
+		for name, providerValue := range e.module.ProviderReferenceValues {
+			e.ctx.Set(providerValue, name)
+		}
 
 		err := v.evaluate(e, blockInstance)
 		if err != nil {

--- a/internal/hcl/module.go
+++ b/internal/hcl/module.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/infracost/infracost/internal/schema"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // ModuleCall represents a call to a defined Module by a parent Module.
@@ -48,9 +49,13 @@ type Module struct {
 	// ProviderReferences is a map of provider names (relative to the module) to
 	// the provider block that defines that provider. We keep track of this so we
 	// can re-evaluate the provider blocks when we need to.
-	ProviderReferences  map[string]*Block
-	TerraformVersion    string
-	ProviderConstraints *ProviderConstraints
+	ProviderReferences map[string]*Block
+	// ProviderReferenceValues contains provider instances selected by a module
+	// call's providers map. These values take precedence over the corresponding
+	// unexpanded provider blocks in ProviderReferences.
+	ProviderReferenceValues map[string]cty.Value
+	TerraformVersion        string
+	ProviderConstraints     *ProviderConstraints
 }
 
 // Index returns the count index of the Module using the name.

--- a/internal/hcl/modules/loader.go
+++ b/internal/hcl/modules/loader.go
@@ -19,6 +19,7 @@ import (
 	giturls "github.com/chainguard-dev/git-urls"
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/infracost/infracost/internal/metrics"
 	"github.com/otiai10/copy"
@@ -699,6 +700,59 @@ func HasOpenTofuExtension(name string) bool {
 	return filepath.Ext(name) == ".tofu" || strings.HasSuffix(name, ".tofu.json")
 }
 
+// filterOpenTofuProviderIndexDiagnostics removes the diagnostic emitted by
+// terraform-config-inspect for OpenTofu's indexed provider syntax. The module
+// loader only consumes ModuleCalls from tfconfig; provider expressions are
+// evaluated later from the original, unmodified HCL syntax tree.
+func filterOpenTofuProviderIndexDiagnostics(file *hcl.File, diags hcl.Diagnostics) hcl.Diagnostics {
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return diags
+	}
+
+	providerIndexRanges := make(map[hcl.Range]struct{})
+	for _, block := range body.Blocks {
+		if block.Type != "resource" && block.Type != "data" {
+			continue
+		}
+
+		attr, ok := block.Body.Attributes["provider"]
+		if !ok {
+			continue
+		}
+
+		indexExpr, ok := attr.Expr.(*hclsyntax.IndexExpr)
+		if !ok {
+			continue
+		}
+
+		traversal, traversalDiags := hcl.AbsTraversalForExpr(indexExpr.Collection)
+		if traversalDiags.HasErrors() || len(traversal) != 2 {
+			continue
+		}
+		if _, ok := traversal[0].(hcl.TraverseRoot); !ok {
+			continue
+		}
+		if _, ok := traversal[1].(hcl.TraverseAttr); !ok {
+			continue
+		}
+
+		providerIndexRanges[attr.Expr.Range()] = struct{}{}
+	}
+
+	filtered := make(hcl.Diagnostics, 0, len(diags))
+	for _, diag := range diags {
+		if diag.Summary == "Invalid provider reference" && diag.Subject != nil {
+			if _, ok := providerIndexRanges[*diag.Subject]; ok {
+				continue
+			}
+		}
+		filtered = append(filtered, diag)
+	}
+
+	return filtered
+}
+
 func (m *ModuleLoader) loadModuleFromPath(fullPath string) (*tfconfig.Module, error) {
 	mod := tfconfig.NewModule(fullPath)
 
@@ -762,6 +816,7 @@ func (m *ModuleLoader) loadModuleFromPath(fullPath string) (*tfconfig.Module, er
 		}
 
 		contentDiag := tfconfig.LoadModuleFromFile(f, mod)
+		contentDiag = filterOpenTofuProviderIndexDiagnostics(f, contentDiag)
 		if contentDiag != nil && contentDiag.HasErrors() {
 			return nil, fmt.Errorf("failed to load module from file %s diag: %w", path, contentDiag)
 		}

--- a/internal/hcl/modules/loader_test.go
+++ b/internal/hcl/modules/loader_test.go
@@ -26,6 +26,55 @@ type TestLoaderE2EOpts = struct {
 	IgnoreDir      bool
 }
 
+func TestLoadModuleFromPathAllowsOpenTofuProviderIndex(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+provider "aws" {
+  alias    = "by_region"
+  for_each = { east = "us-east-2" }
+  region   = each.value
+}
+
+data "aws_region" "current" {
+  for_each = { selected = "east" }
+  provider = aws.by_region[each.value]
+}
+
+module "child" {
+  source = "./child"
+}
+`), 0600)
+	require.NoError(t, err)
+
+	loader := NewModuleLoader(ModuleLoaderOptions{
+		CachePath: dir,
+		HCLParser: NewSharedHCLParser(),
+		Logger:    zerolog.New(io.Discard),
+	})
+	mod, err := loader.loadModuleFromPath(dir)
+	require.NoError(t, err)
+	require.Contains(t, mod.ModuleCalls, "child")
+	assert.Equal(t, "./child", mod.ModuleCalls["child"].Source)
+}
+
+func TestLoadModuleFromPathRejectsInvalidProviderIndex(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+data "aws_region" "current" {
+  provider = aws.by_region.extra[each.value]
+}
+`), 0600)
+	require.NoError(t, err)
+
+	loader := NewModuleLoader(ModuleLoaderOptions{
+		CachePath: dir,
+		HCLParser: NewSharedHCLParser(),
+		Logger:    zerolog.New(io.Discard),
+	})
+	_, err = loader.loadModuleFromPath(dir)
+	require.ErrorContains(t, err, "Invalid provider reference")
+}
+
 func testLoaderE2E(t *testing.T, path string, expectedModules []*ManifestModule, opts TestLoaderE2EOpts) {
 
 	ResetGlobalModuleCache()

--- a/internal/hcl/parser_test.go
+++ b/internal/hcl/parser_test.go
@@ -1611,6 +1611,209 @@ data "aws_availability_zones" "ne" {
 	assert.JSONEq(t, `{"group_names":["us-east-1","us-east-1","us-east-1","us-east-1","us-east-1","us-east-1","us-east-1-atl-1","us-east-1-bos-1","us-east-1-bue-1","us-east-1-chi-2","us-east-1-dfw-2","us-east-1-iah-2","us-east-1-lim-1","us-east-1-mci-1","us-east-1-mia-1","us-east-1-msp-1","us-east-1-nyc-1","us-east-1-phl-1","us-east-1-qro-1","us-east-1-scl-1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1","us-east-1-wl1"],"id":"us-east-1","names":["us-east-1a","us-east-1b","us-east-1c","us-east-1d","us-east-1e","us-east-1f","us-east-1-atl-1a","us-east-1-bos-1a","us-east-1-bue-1a","us-east-1-chi-2a","us-east-1-dfw-2a","us-east-1-iah-2a","us-east-1-lim-1a","us-east-1-mci-1a","us-east-1-mia-1a","us-east-1-msp-1a","us-east-1-nyc-1a","us-east-1-phl-1a","us-east-1-qro-1a","us-east-1-scl-1a","us-east-1-wl1-atl-wlz-1","us-east-1-wl1-bna-wlz-1","us-east-1-wl1-bos-wlz-1","us-east-1-wl1-chi-wlz-1","us-east-1-wl1-clt-wlz-1","us-east-1-wl1-dfw-wlz-1","us-east-1-wl1-dtw-wlz-1","us-east-1-wl1-iah-wlz-1","us-east-1-wl1-mia-wlz-1","us-east-1-wl1-msp-wlz-1","us-east-1-wl1-nyc-wlz-1","us-east-1-wl1-tpa-wlz-1","us-east-1-wl1-was-wlz-1"],"zone_ids":["use1-az6","use1-az1","use1-az2","use1-az4","use1-az3","use1-az5","use1-atl1-az1","use1-bos1-az1","use1-bue1-az1","use1-chi2-az1","use1-dfw2-az1","use1-iah2-az1","use1-lim1-az1","use1-mci1-az1","use1-mia1-az1","use1-msp1-az1","use1-nyc1-az1","use1-phl1-az1","use1-qro1-az1","use1-scl1-az1","use1-wl1-atl-wlz1","use1-wl1-bna-wlz1","use1-wl1-bos-wlz1","use1-wl1-chi-wlz1","use1-wl1-clt-wlz1","use1-wl1-dfw-wlz1","use1-wl1-dtw-wlz1","use1-wl1-iah-wlz1","use1-wl1-mia-wlz1","use1-wl1-msp-wlz1","use1-wl1-nyc-wlz1","use1-wl1-tpa-wlz1","use1-wl1-was-wlz1"]}`, string(b))
 }
 
+func Test_ProvideMockRegionForDynamicForEachProvider(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		options []Option
+	}{
+		{name: "legacy evaluator"},
+		{name: "graph evaluator", options: []Option{OptionGraphEvaluator()}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := createTestFile("test.tf", `
+provider "aws" {
+	alias = "by_region"
+	for_each = {
+		east   = { region = "us-east-2" }
+		region = { region = "eu-west-1" }
+	}
+	region = each.value.region
+
+	skip_credentials_validation = true
+	skip_requesting_account_id  = true
+	access_key                  = "mock_access_key"
+	secret_key                  = "mock_secret_key"
+}
+
+data "aws_region" "by_key" {
+	for_each = {
+		east   = true
+		region = true
+	}
+	provider = aws.by_region[each.key]
+}
+
+data "aws_region" "by_value" {
+	for_each = {
+		first  = "region"
+		second = "east"
+	}
+	provider = aws.by_region[each.value]
+}
+`)
+
+			logger := newDiscardLogger()
+			loader := modules.NewModuleLoader(modules.ModuleLoaderOptions{
+				CachePath:         filepath.Dir(path),
+				HCLParser:         modules.NewSharedHCLParser(),
+				CredentialsSource: nil,
+				SourceMap:         config.TerraformSourceMap{},
+				Logger:            logger,
+				ModuleSync:        &sync.KeyMutex{},
+			})
+			parser := NewParser(
+				RootPath{DetectedPath: filepath.Dir(path)},
+				CreateEnvFileMatcher([]string{}, nil),
+				loader,
+				logger,
+				tc.options...,
+			)
+			module, err := parser.ParseDirectory()
+			require.NoError(t, err)
+
+			blocks := module.Blocks
+			require.Len(t, blocks.OfType("data"), 4)
+			for label, region := range map[string]string{
+				`aws_region.by_key["east"]`:     "us-east-2",
+				`aws_region.by_key["region"]`:   "eu-west-1",
+				`aws_region.by_value["first"]`:  "eu-west-1",
+				`aws_region.by_value["second"]`: "us-east-2",
+			} {
+				regionBlock := blocks.Matching(BlockMatcher{Label: label, Type: "data"})
+				require.NotNil(t, regionBlock)
+				require.Equal(t, label, regionBlock.Label())
+				assert.Equal(t, "aws.by_region", regionBlock.ProviderConfigKey())
+				assert.Equal(t, region, regionBlock.Values().GetAttr("name").AsString())
+			}
+		})
+	}
+}
+
+func Test_ModuleForEachWithIndexedForEachProvider(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		options []Option
+	}{
+		{name: "legacy evaluator"},
+		{name: "graph evaluator", options: []Option{OptionGraphEvaluator()}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := createTestFileWithModule(`
+provider "aws" {
+  alias = "by_region"
+  for_each = {
+    east = { region = "us-east-2" }
+    west = { region = "eu-west-1" }
+  }
+  region = each.value.region
+
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+}
+
+locals {
+  provider_keys = {
+    east = "east"
+    west = "west"
+  }
+}
+
+module "by_key" {
+  source = "../."
+  for_each = {
+    east = true
+    west = true
+  }
+  providers = {
+    "aws" = aws.by_region[each.key]
+  }
+}
+
+module "by_value" {
+  source = "../."
+  for_each = {
+    primary   = { provider = "west" }
+    secondary = { provider = "east" }
+  }
+  providers = {
+    aws = aws.by_region[local.provider_keys[each.value.provider]]
+  }
+}
+`, `
+module "leaf" {
+  source = "./leaf"
+  providers = {
+    aws = aws
+  }
+}
+
+output "region" {
+  value = module.leaf.region
+}
+`, "")
+			leafPath := filepath.Join(filepath.Dir(path), "leaf")
+			require.NoError(t, os.Mkdir(leafPath, 0755))
+			require.NoError(t, os.WriteFile(filepath.Join(leafPath, "main.tf"), []byte(`
+data "aws_region" "current" {}
+
+output "region" {
+  value = data.aws_region.current.name
+}
+`), 0600))
+
+			logger := newDiscardLogger()
+			loader := modules.NewModuleLoader(modules.ModuleLoaderOptions{
+				CachePath:         filepath.Dir(path),
+				HCLParser:         modules.NewSharedHCLParser(),
+				CredentialsSource: nil,
+				SourceMap:         config.TerraformSourceMap{},
+				Logger:            logger,
+				ModuleSync:        &sync.KeyMutex{},
+			})
+			parser := NewParser(
+				RootPath{DetectedPath: path},
+				CreateEnvFileMatcher([]string{}, nil),
+				loader,
+				logger,
+				tc.options...,
+			)
+
+			module, err := parser.ParseDirectory()
+			require.NoError(t, err)
+			require.Len(t, module.Modules, 4)
+
+			for name, region := range map[string]string{
+				`module.by_key["east"]`:        "us-east-2",
+				`module.by_key["west"]`:        "eu-west-1",
+				`module.by_value["primary"]`:   "eu-west-1",
+				`module.by_value["secondary"]`: "us-east-2",
+			} {
+				var child *Module
+				for _, candidate := range module.Modules {
+					if candidate.Name == name {
+						child = candidate
+						break
+					}
+				}
+				require.NotNil(t, child, "module %s not found", name)
+
+				require.Len(t, child.Modules, 1)
+				leaf := child.Modules[0]
+				regionBlock := leaf.Blocks.Matching(BlockMatcher{Type: "data", Label: "aws_region.current"})
+				require.NotNil(t, regionBlock)
+				require.Equal(t, "aws_region.current", regionBlock.Label())
+				assert.Equal(t, region, regionBlock.Values().GetAttr("name").AsString())
+				assert.Equal(t, "aws.by_region", regionBlock.ProviderConfigKey())
+
+				outputs := child.Blocks.Outputs(false).AsValueMap()
+				assert.Equal(t, region, outputs["region"].AsString())
+			}
+		})
+	}
+}
+
 func Test_RandomShuffleSetsResult(t *testing.T) {
 	path := createTestFile("test.tf", `
 resource "random_shuffle" "one" {


### PR DESCRIPTION
## Summary

Adds support for OpenTofu provider configurations that use `for_each`.

Infracost can now resolve indexed provider instances selected dynamically by resources and data sources:

```hcl
provider = aws.by_region[each.value.region]
```

It also supports passing an indexed provider instance to each instance of a child module:

```hcl
module "regional" {
  for_each = var.regions
  source   = "./regional"

  providers = {
    aws = aws.by_region[each.key]
  }
}
```

## Implementation

- Allows valid OpenTofu indexed provider expressions through module discovery, which otherwise rejects dynamic provider indexes.
- Evaluates every provider instance with the corresponding `each.key` and `each.value` in an isolated context.
- Preserves the unindexed provider configuration key, such as `aws.by_region`, in generated plan data.
- Passes the selected provider instance through module `providers` mappings, including nested module calls.
- Preserves provider and index-expression dependencies in the graph evaluator.

Closes #3369
References #3594

## Testing

```sh
go test ./internal/hcl/modules ./internal/hcl -count=1
```

Coverage includes:

- legacy and graph evaluators
- literal and dynamic provider indexes
- `each.key` and nested `each.value` expressions
- indexes derived from locals
- resource, data source, and module provider selection
- nested module provider forwarding
- malformed provider-reference handling
