### PR TITLE
fix(security): resolve intermediate symlinks in path confinement

### DIFF
--- a/internal/config/template/parser.go
+++ b/internal/config/template/parser.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/infracost/infracost/internal/config"
 	"github.com/infracost/infracost/internal/logging"
+	"github.com/infracost/infracost/internal/security"
 )
 
 var (
@@ -225,17 +226,18 @@ func (p *Parser) pathExists(base, path string) bool {
 		base = filepath.Join(p.repoDir, base)
 	}
 
-	// Ensure the base path is within the repo directory
-	baseAbs, _ := filepath.Abs(base)
-	repoDirAbs, _ := filepath.Abs(p.repoDir)
-
-	// Add a file separator at the end to ensure we don't match a directory that starts with the same prefix
-	// e.g. `/path/to/infracost` shouldn't match `/path/to/infra`.
-	if !strings.HasPrefix(fmt.Sprintf("%s%s", baseAbs, string(filepath.Separator)), fmt.Sprintf("%s%s", repoDirAbs, string(filepath.Separator))) {
+	// Ensure the base path is within the repo directory. IsPathAllowed
+	// resolves symlinks (including intermediate ones) so an in-repo symlink
+	// can't be used to escape the repository root.
+	if !security.IsPathAllowed(base, p.repoDir) {
 		return false
 	}
 
 	targetPath := filepath.Join(base, path)
+	if !security.IsPathAllowed(targetPath, p.repoDir) {
+		return false
+	}
+
 	if _, err := os.Stat(targetPath); err == nil {
 		return true
 	}
@@ -275,6 +277,12 @@ func (p *Parser) matchPaths(pattern string) []map[interface{}]interface{} {
 
 	var matches []map[interface{}]interface{}
 	_ = filepath.WalkDir(p.repoDir, func(path string, d fs.DirEntry, err error) error {
+		// Skip entries that resolve outside the repository root (e.g. an
+		// in-repo symlink pointing elsewhere) so matches stay confined.
+		if !security.IsPathAllowed(path, p.repoDir) {
+			return nil
+		}
+
 		rel, _ := filepath.Rel(p.repoDir, path)
 		res, _ := match(rel)
 		if res != nil {
@@ -328,6 +336,10 @@ func (p *Parser) relPath(basepath string, tarpath string) string {
 // isDir returns is path points to a directory.
 func (p *Parser) isDir(path string) bool {
 	fullPath := filepath.Join(p.repoDir, path)
+	if !security.IsPathAllowed(fullPath, p.repoDir) {
+		return false
+	}
+
 	info, err := os.Stat(fullPath)
 	if err != nil {
 		return false
@@ -338,11 +350,11 @@ func (p *Parser) isDir(path string) bool {
 
 // readFile reads the named file and returns the contents.
 func (p *Parser) readFile(path string) string {
-	if !isSubdirectory(p.repoDir, path) {
+	fullPath := filepath.Join(p.repoDir, path)
+	if !security.IsPathAllowed(fullPath, p.repoDir) {
 		panic(fmt.Sprintf("%q must be within the repository root %q", path, filepath.Base(p.repoDir)))
 	}
 
-	fullPath := filepath.Join(p.repoDir, path)
 	b, err := os.ReadFile(fullPath)
 	if err != nil {
 		panic(err)
@@ -380,31 +392,6 @@ func (p *Parser) parseJson(contents string) map[string]interface{} {
 // isProduction returns true if the project is production.
 func (p *Parser) isProduction(value string) bool {
 	return p.config.IsProduction(value)
-}
-
-func isSubdirectory(base, target string) bool {
-	full := filepath.Join(base, target)
-	fileInfo, err := os.Lstat(full)
-	if err != nil {
-		return false
-	}
-
-	absBasePath, err := filepath.Abs(base)
-	if err != nil {
-		return false
-	}
-
-	absTargetPath, err := filepath.Abs(full)
-	if err != nil {
-		return false
-	}
-
-	relPath, err := filepath.Rel(absBasePath, absTargetPath)
-	if err != nil {
-		return false
-	}
-
-	return !strings.HasPrefix(relPath, "..") && fileInfo.Mode()&os.ModeSymlink == 0
 }
 
 // strval returns the string representation of v.

--- a/internal/config/template/security_test.go
+++ b/internal/config/template/security_test.go
@@ -1,0 +1,119 @@
+package template
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupSymlinkRepo builds a repo tree that mirrors the FIX-313 PoC:
+//
+//	repo/                 -- the repository root the parser is confined to
+//	  inside/secret.tf    -- a legitimate in-repo file
+//	  evil -> outside     -- an intermediate symlink escaping the repo
+//	  finlink -> outside/secret  -- a leaf symlink escaping the repo
+//	outside/secret        -- a secret that lives outside the repo root
+//
+// It returns the repo dir.
+func setupSymlinkRepo(t *testing.T) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	outside := filepath.Join(tmp, "outside")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "inside"), 0700))
+	require.NoError(t, os.MkdirAll(outside, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "inside", "secret.tf"), []byte("in-repo"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret"), []byte("TOP-SECRET"), 0600))
+	require.NoError(t, os.Symlink(outside, filepath.Join(repo, "evil")))
+	require.NoError(t, os.Symlink(filepath.Join(outside, "secret"), filepath.Join(repo, "finlink")))
+
+	return repo
+}
+
+func TestParser_readFile_confinement(t *testing.T) {
+	repo := setupSymlinkRepo(t)
+	p := NewParser(repo, Variables{}, nil)
+
+	// Legitimate in-repo read works.
+	assert.Equal(t, "in-repo", p.readFile("inside/secret.tf"))
+
+	// Lexical parent traversal is blocked.
+	assert.Panics(t, func() { p.readFile("../outside/secret") },
+		"parent-directory traversal must be blocked")
+
+	// Leaf symlink escaping the repo is blocked.
+	assert.Panics(t, func() { p.readFile("finlink") },
+		"leaf symlink escaping the repo must be blocked")
+
+	// Intermediate symlink escaping the repo is blocked (the FIX-313 gap).
+	assert.Panics(t, func() { p.readFile("evil/secret") },
+		"intermediate symlink escaping the repo must be blocked")
+}
+
+func TestParser_pathExists_confinement(t *testing.T) {
+	repo := setupSymlinkRepo(t)
+	p := NewParser(repo, Variables{}, nil)
+
+	// Legitimate in-repo path exists.
+	assert.True(t, p.pathExists("inside", "secret.tf"))
+
+	// Parent traversal to a real file outside the repo reports false.
+	assert.False(t, p.pathExists(".", "../outside/secret"),
+		"parent-directory traversal must not be reported as existing")
+
+	// Intermediate symlink escaping the repo reports false even though the
+	// underlying file exists.
+	assert.False(t, p.pathExists("evil", "secret"),
+		"path traversing an intermediate symlink must not be reported as existing")
+
+	// A base that is itself an escaping symlink reports false.
+	assert.False(t, p.pathExists("evil", ""),
+		"a base that escapes the repo via a symlink must not be reported as existing")
+}
+
+func TestParser_isDir_confinement(t *testing.T) {
+	repo := setupSymlinkRepo(t)
+	p := NewParser(repo, Variables{}, nil)
+
+	// Legitimate in-repo directory.
+	assert.True(t, p.isDir("inside"))
+
+	// The intermediate symlink resolves to an out-of-repo directory and must
+	// not be reported as an in-repo directory.
+	assert.False(t, p.isDir("evil"),
+		"a symlinked directory escaping the repo must not be reported as a dir")
+}
+
+func TestParser_matchPaths_confinement(t *testing.T) {
+	repo := setupSymlinkRepo(t)
+	p := NewParser(repo, Variables{}, nil)
+
+	matches := p.matchPaths(":dir/secret")
+
+	// Nothing reached via the escaping `evil` symlink may appear.
+	for _, m := range matches {
+		assert.NotEqual(t, "evil", m["_dir"],
+			"matchPaths must not return entries reached via an escaping symlink")
+	}
+}
+
+// TestParser_Compile_readFile_blocksIntermediateSymlink drives the real
+// template entrypoint (Compile) with the exact PoC payload from FIX-313 and
+// asserts the out-of-repo secret is never rendered into the output.
+func TestParser_Compile_readFile_blocksIntermediateSymlink(t *testing.T) {
+	repo := setupSymlinkRepo(t)
+	p := NewParser(repo, Variables{}, nil)
+
+	var buf bytes.Buffer
+	err := p.Compile(`{{ readFile "evil/secret" }}`, &buf)
+
+	require.Error(t, err, "rendering a template that escapes the repo must error")
+	assert.NotContains(t, buf.String(), "TOP-SECRET",
+		"the out-of-repo secret must never be rendered into the output")
+}

--- a/internal/hcl/funcs/filesystem.go
+++ b/internal/hcl/funcs/filesystem.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/bmatcuk/doublestar"
 	homedir "github.com/mitchellh/go-homedir"
@@ -13,6 +12,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function"
 
 	"github.com/infracost/infracost/internal/logging"
+	"github.com/infracost/infracost/internal/security"
 )
 
 func MakeFileFunc(baseDir string, encBase64 bool) function.Function {
@@ -254,33 +254,13 @@ func isPathInRepo(path string) error {
 		path = filepath.Join(wd, path)
 	}
 
-	// ensure the path resolves to the real symlink path
-	path = symlinkPath(path)
-
-	clean := filepath.Clean(wd)
-	if wd != "" && !strings.HasPrefix(path, clean) {
+	// security.IsPathAllowed resolves symlinks anywhere in the path (leaf and
+	// intermediate directory symlinks) before checking containment, so an
+	// in-repo symlink can't be used to escape the repository directory via a
+	// path like dir-link/secret whose leaf isn't itself a symlink.
+	if wd != "" && !security.IsPathAllowed(path, wd) {
 		return fmt.Errorf("file %s is not within the repository directory %s", path, wd)
 	}
 
 	return nil
-}
-
-// symlinkPath checks the given file path and returns the real path if it is a
-// symlink.
-func symlinkPath(filepathStr string) string {
-	fileInfo, err := os.Lstat(filepathStr)
-	if err != nil {
-		return filepathStr
-	}
-
-	if fileInfo.Mode()&os.ModeSymlink != 0 {
-		realPath, err := filepath.EvalSymlinks(filepathStr)
-		if err != nil {
-			return filepathStr
-		}
-
-		return realPath
-	}
-
-	return filepathStr
 }

--- a/internal/hcl/funcs/filesystem_test.go
+++ b/internal/hcl/funcs/filesystem_test.go
@@ -2,8 +2,12 @@ package funcs
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/function/stdlib"
@@ -495,4 +499,54 @@ func TestFileBase64(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIsFullPathWithinRepo_BlocksIntermediateSymlink locks in the FIX-318
+// hardening of the hosted-app file()/templatefile() guard: when running in the
+// github/gitlab app environment, a path that escapes the repository directory
+// via an intermediate directory symlink (whose leaf isn't itself a symlink)
+// must be rejected. The previous leaf-only symlinkPath resolver let it through.
+func TestIsFullPathWithinRepo_BlocksIntermediateSymlink(t *testing.T) {
+	// repo/                -- the working directory / repository root
+	//   inside/main.tf     -- a legitimate in-repo file
+	//   evil -> outside    -- an intermediate symlink escaping the repo
+	// outside/secret       -- a secret living outside the repo root
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	outside := filepath.Join(tmp, "outside")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "inside"), 0700))
+	require.NoError(t, os.MkdirAll(outside, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "inside", "main.tf"), []byte("# tf"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret"), []byte("TOP-SECRET"), 0600))
+	require.NoError(t, os.Symlink(outside, filepath.Join(repo, "evil")))
+
+	// isPathInRepo checks against the process working directory.
+	t.Chdir(repo)
+	t.Setenv("INFRACOST_CI_PLATFORM", "github_app")
+
+	// Legitimate in-repo path is allowed.
+	require.NoError(t, isFullPathWithinRepo(repo, "inside/main.tf"),
+		"an in-repo path must be allowed")
+
+	// Intermediate symlink escaping the repo is rejected (the FIX-318 gap).
+	assert.Error(t, isFullPathWithinRepo(repo, "evil/secret"),
+		"a path traversing an intermediate symlink out of the repo must be rejected")
+}
+
+// TestIsFullPathWithinRepo_NoopOutsideHostedApp confirms the guard stays a
+// no-op when not running in the github/gitlab app environment, preserving the
+// existing behaviour for the standalone CLI.
+func TestIsFullPathWithinRepo_NoopOutsideHostedApp(t *testing.T) {
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	outside := filepath.Join(tmp, "outside")
+	require.NoError(t, os.MkdirAll(repo, 0700))
+	require.NoError(t, os.MkdirAll(outside, 0700))
+	require.NoError(t, os.Symlink(outside, filepath.Join(repo, "evil")))
+
+	t.Chdir(repo)
+	t.Setenv("INFRACOST_CI_PLATFORM", "")
+
+	assert.NoError(t, isFullPathWithinRepo(repo, "evil/secret"),
+		"the guard must be a no-op outside the hosted github/gitlab app environment")
 }

--- a/internal/security/files.go
+++ b/internal/security/files.go
@@ -1,0 +1,112 @@
+// Package security contains security related functions, mainly checking a file
+// is within a given path, and symlink handling.
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// IsPathAllowed checks if a path is within any of the supplied parent paths.
+// It is the containment security boundary: it resolves symlinks anywhere in
+// the path (leaf AND intermediate directory symlinks) before comparing against
+// the resolved parents, and returns false if the resolved path escapes every
+// supplied parent. An in-repo symlink (e.g. evil -> /etc) therefore cannot be
+// used to read files outside the allowed parents via a path like evil/passwd
+// whose leaf isn't itself a symlink.
+//
+// Symlink resolution is cached process-wide via resolveCache so repeated calls
+// during a parse session don't repeat the (multiple) syscalls per path.
+func IsPathAllowed(path string, allowedParents ...string) bool {
+	if path == "" {
+		path = "."
+	}
+
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+
+	pathResolved := resolvePathCached(pathAbs)
+
+	for _, parent := range allowedParents {
+		if parent == "" {
+			continue
+		}
+		parentAbs, err := filepath.Abs(parent)
+		if err != nil {
+			continue
+		}
+		parentResolved := resolvePathCached(parentAbs)
+
+		if strings.HasPrefix(pathResolved+string(filepath.Separator), parentResolved+string(filepath.Separator)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// resolveCache memoises symlink resolution keyed by absolute, uncleaned input
+// path. Filesystem state changes during a parse session would invalidate the
+// cache, but parser usage doesn't mutate the paths it's inspecting — sources
+// are read-only during evaluation.
+var resolveCache sync.Map
+
+func resolvePathCached(pathAbs string) string {
+	if v, ok := resolveCache.Load(pathAbs); ok {
+		return v.(string)
+	}
+	resolved, err := RecursivelyResolveSymlink(pathAbs)
+	if err != nil {
+		resolved = pathAbs
+	}
+	resolved = filepath.Clean(resolved)
+	resolveCache.Store(pathAbs, resolved)
+	return resolved
+}
+
+// RecursivelyResolveSymlink resolves symlinks anywhere in the path, not just
+// at the leaf. A leaf-only implementation misses intermediate directory
+// symlinks: a legitimate-looking path like /repo-root/dir-link/passwd, where
+// dir-link -> /etc, would pass an IsPathAllowed(/repo-root, ...) check because
+// the leaf "passwd" isn't a symlink — but reading the path actually opens
+// /etc/passwd, which is a path-traversal escape from the allowed-dirs sandbox.
+//
+// filepath.EvalSymlinks normally errors when any component of the path doesn't
+// exist (e.g. existence checks for candidate paths that aren't there yet). For
+// those cases we walk up to the longest existing prefix, resolve that, then
+// rejoin the missing tail — so prefix-matching still aligns with how parents
+// are themselves resolved.
+func RecursivelyResolveSymlink(path string) (string, error) {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved, nil
+	}
+	// path or some ancestor doesn't exist. Walk up until we find an existing
+	// ancestor, resolve that, then append the missing tail.
+	missing := []string{}
+	dir := path
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// hit root without finding anything that exists; nothing to
+			// resolve, return the original cleaned path.
+			return filepath.Clean(path), nil
+		}
+		missing = append([]string{filepath.Base(dir)}, missing...)
+		dir = parent
+		resolved, err := filepath.EvalSymlinks(dir)
+		if err != nil {
+			continue
+		}
+		return filepath.Join(append([]string{resolved}, missing...)...), nil
+	}
+}
+
+// IsSymlink returns true if the path's leaf is a symlink.
+func IsSymlink(path string) bool {
+	fileInfo, err := os.Lstat(path)
+	return err == nil && fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink
+}

--- a/internal/security/files_test.go
+++ b/internal/security/files_test.go
@@ -1,0 +1,68 @@
+package security
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsPathAllowed_BlocksIntermediateSymlinkTraversal locks in the security
+// posture that intermediate directory symlinks are resolved before the
+// allowed-parents check. Before this fix, a legitimately-named path like
+// /repo-root/dir-link/passwd where dir-link points outside the repo would
+// pass IsPathAllowed because the leaf wasn't a symlink — letting parser/
+// template code read files outside the sandbox.
+func TestIsPathAllowed_BlocksIntermediateSymlinkTraversal(t *testing.T) {
+	// repo/    -- the allowed parent
+	//   inside/ -- a directory inside repo (touched so it exists)
+	//   link  -- symlink pointing OUTSIDE repo to ../outside
+	// outside/
+	//   secret -- the file we shouldn't be able to reach via repo/link/secret
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	outside := filepath.Join(tmp, "outside")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, "inside"), 0700))
+	require.NoError(t, os.MkdirAll(outside, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret"), []byte("nope"), 0600))
+	require.NoError(t, os.Symlink(outside, filepath.Join(repo, "link")))
+
+	// /repo/inside/file (entirely within repo) — allowed
+	assert.True(t, IsPathAllowed(filepath.Join(repo, "inside", "anything"), repo),
+		"a path inside the allowed parent should be allowed")
+
+	// /repo/link/secret — link points OUTSIDE repo. The leaf "secret" is
+	// not a symlink, but the intermediate "link" is. This is the case the
+	// old leaf-only resolver missed.
+	assert.False(t, IsPathAllowed(filepath.Join(repo, "link", "secret"), repo),
+		"a path traversing an intermediate symlink that escapes the allowed parent must be rejected")
+
+	// /repo/link (the symlink itself, leaf is the symlink) — also points
+	// outside, must be rejected.
+	assert.False(t, IsPathAllowed(filepath.Join(repo, "link"), repo),
+		"a leaf-symlink that targets outside the allowed parent must be rejected")
+}
+
+// TestIsPathAllowed_HandlesNonExistentPaths verifies the longest-existing-
+// prefix resolver — existence checks walk candidate paths that don't exist
+// yet, and the security check must still recognize them as inside the allowed
+// parent.
+func TestIsPathAllowed_HandlesNonExistentPaths(t *testing.T) {
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	require.NoError(t, os.MkdirAll(repo, 0700))
+
+	// Candidate file doesn't exist yet. Still inside repo.
+	assert.True(t, IsPathAllowed(filepath.Join(repo, "doesnotexist.tf"), repo),
+		"a non-existent path inside the allowed parent should be allowed")
+
+	// Candidate file with a non-existent intermediate dir, still inside repo.
+	assert.True(t, IsPathAllowed(filepath.Join(repo, "missing", "nested", "file.tf"), repo),
+		"a deeply nested non-existent path inside the allowed parent should be allowed")
+
+	// Candidate file outside the repo — even if it doesn't exist, must be rejected.
+	assert.False(t, IsPathAllowed(filepath.Join(tmp, "elsewhere", "file.tf"), repo),
+		"a non-existent path outside the allowed parent must be rejected")
+}


### PR DESCRIPTION
## Why

The config-template parser (`readFile`/`pathExists`/`isDir`/`matchPaths`) and the hosted-app `file()`/`templatefile()` guard both confined paths with a lexical `Rel`/`HasPrefix` check plus a leaf-only `Lstat`/`EvalSymlinks`. An intermediate in-repo directory symlink (`evil -> /etc`, then `readFile "evil/passwd"`) defeats both: the path is lexically clean and the leaf isn't a symlink, so it passes — but the read follows the symlink out of the repo, allowing arbitrary out-of-checkout file reads by an untrusted PR author.

## What

- New `internal/security.IsPathAllowed`: the single containment boundary. Resolves symlinks anywhere in the path (leaf **and** intermediate) before a segment-aware prefix compare against the resolved parent, with a longest-existing-prefix fallback for not-yet-existent paths and a process-wide resolve cache.
- Route the template parser and the Terraform funcs guard through it; drop the old `isSubdirectory`/`symlinkPath` helpers.

Mirrors the recent fix in the v2 `config` repo.

Tests cover the PoC tree driven through the real `Compile` entrypoint and the hosted-app guard (intermediate/leaf symlink rejection, no-op outside github/gitlab app mode).