### PR TITLE
fix(aws): avoid panic on malformed ElastiCache node_type with reserved options

### DIFF
--- a/internal/resources/aws/elasticache_cluster.go
+++ b/internal/resources/aws/elasticache_cluster.go
@@ -183,7 +183,11 @@ func (r elasticacheReservationResolver) PriceFilter() (*schema.PriceFilter, erro
 	if !stringInSlice(validOptions, r.paymentOption) {
 		return def, fmt.Errorf("Invalid reserved_instance_payment_option, ignoring reserved options. Expected: %s. Got: %s", strings.Join(validOptions, ", "), r.paymentOption)
 	}
-	nodeType := strings.Split(r.cacheNodeType, ".")[1] // Get node type from cache node type. cache.m3.large -> m3
+	cacheNodeTypeParts := strings.Split(r.cacheNodeType, ".")
+	if len(cacheNodeTypeParts) < 2 {
+		return def, fmt.Errorf("Invalid cache node type, ignoring reserved options. Expected format like 'cache.m3.large'. Got: %s", r.cacheNodeType)
+	}
+	nodeType := cacheNodeTypeParts[1] // Get node type from cache node type. cache.m3.large -> m3
 	if stringInSlice(elasticacheReservedNodeLegacyTypes, nodeType) {
 		logging.Logger.Warn().Msgf("No products found is possible for legacy nodes %s if provided payment option is not supported by the region.", strings.Join(elasticacheReservedNodeLegacyTypes, ", "))
 	}

--- a/internal/resources/aws/elasticache_cluster_test.go
+++ b/internal/resources/aws/elasticache_cluster_test.go
@@ -1,0 +1,17 @@
+package aws
+
+import "testing"
+
+func TestElasticacheReservationResolverPriceFilterMalformedNodeType(t *testing.T) {
+	for _, nodeType := range []string{"", "invalid"} {
+		r := elasticacheReservationResolver{
+			term:          "1_year",
+			paymentOption: "no_upfront",
+			cacheNodeType: nodeType,
+		}
+		_, err := r.PriceFilter()
+		if err == nil {
+			t.Errorf("expected an error for malformed cacheNodeType %q, got nil", nodeType)
+		}
+	}
+}


### PR DESCRIPTION
### Problem
`elasticacheReservationResolver.PriceFilter()` reads the second segment of the cache node type without checking the length:

```go
nodeType := strings.Split(r.cacheNodeType, ".")[1] // cache.m3.large -> m3
```

`cacheNodeType` comes from the resource's `node_type`. When it's empty — which happens whenever Infracost can't resolve the value — or otherwise isn't in the expected `cache.<type>.<size>` form, `strings.Split` returns a single-element slice and `[1]` panics:

```
panic: runtime error: index out of range [1] with length 1
.../internal/resources/aws/elasticache_cluster.go:186
```

This crashes a cost run for any `aws_elasticache_cluster` that has `reserved_instance_term` set but an unresolved/odd `node_type`.

### Fix
Guard the split and return an error, consistent with the other validations in the same function. The caller already handles that path gracefully (logs a warning and falls back to the on-demand price filter), so the run no longer crashes.

### Tests
Adds `TestElasticacheReservationResolverPriceFilterMalformedNodeType` covering empty and dot-less node types. It panics on `master` and passes with this change; `go test ./internal/resources/aws/` is green, `gofmt`/`go vet` clean.
