### PR TITLE
fix(pricing): stop failing pricing lookups for custom-priced components

### DIFF
--- a/internal/apiclient/pricing.go
+++ b/internal/apiclient/pricing.go
@@ -333,27 +333,38 @@ func (c *PricingAPIClient) PerformRequest(req BatchRequest) ([]PriceQueryResult,
 		}
 
 		res[i].Query = query
+
+		// Custom-priced components have no product filter and can't be looked up via
+		// the API, so mark them filled to skip the request. Their price is applied
+		// from the custom price when the result is processed.
+		if req.keys[i].CostComponent.ProductFilter == nil {
+			res[i].filled = true
+		}
 	}
 
 	// first filter any queries that have been stored in the cache. We don't need to
 	// send requests for these as we already have the results in memory.
 	var serverQueries []pricingQuery
-	if c.cache == nil {
-		serverQueries = queries
-	} else {
-		var hit int
-		for i, query := range queries {
-			v, ok := c.cache.Get(query.hash)
-			if ok {
+	var hit int
+	for i, query := range queries {
+		if res[i].filled {
+			continue
+		}
+
+		if c.cache != nil {
+			if v, ok := c.cache.Get(query.hash); ok {
 				logging.Logger.Debug().Msgf("cache hit for query hash: %d", query.hash)
 				hit++
 				res[i].Result = v.Result
 				res[i].filled = true
-			} else {
-				serverQueries = append(serverQueries, query)
+				continue
 			}
 		}
 
+		serverQueries = append(serverQueries, query)
+	}
+
+	if c.cache != nil {
 		logging.Logger.Debug().Msgf("%d/%d queries were built from cache", hit, len(queries))
 	}
 

--- a/internal/providers/terraform/azure/testdata/automation_account_test/automation_account_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_account_test/automation_account_test.golden
@@ -3,14 +3,14 @@
                                                                                                 
  azurerm_automation_account.allUsageEx                                                          
  ├─ Job run time                                         5  minutes                    $0.01  * 
- ├─ Non-azure config nodes                               2  nodes                     $12.00  * 
+ └─ Non-azure config nodes                               2  nodes                     $12.00  * 
                                                                                                 
  azurerm_automation_account.someUsageEx                                                         
- ├─ Job run time                                        20  minutes                    $0.04  * 
+ └─ Job run time                                        20  minutes                    $0.04  * 
                                                                                                 
  azurerm_automation_account.without_usage                                                       
  ├─ Job run time                           Monthly cost depends on usage: $0.002 per minutes    
- ├─ Non-azure config nodes                 Monthly cost depends on usage: $6.00 per nodes       
+ └─ Non-azure config nodes                 Monthly cost depends on usage: $6.00 per nodes       
                                                                                                 
  OVERALL TOTAL                                                                        $12.05 
 

--- a/internal/providers/terraform/azure/testdata/automation_dsc_configuration_test/automation_dsc_configuration_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_dsc_configuration_test/automation_dsc_configuration_test.golden
@@ -6,8 +6,7 @@
                                                                                                           
  azurerm_automation_account.example                                                                       
  ├─ Job run time                                     Monthly cost depends on usage: $0.002 per minutes    
- ├─ Non-azure config nodes                           Monthly cost depends on usage: $6.00 per nodes       
- └─ Watchers                                         Monthly cost depends on usage: $0.002 per hours      
+ └─ Non-azure config nodes                           Monthly cost depends on usage: $6.00 per nodes       
                                                                                                           
  azurerm_automation_dsc_configuration.without_usage                                                       
  └─ Non-azure config nodes                           Monthly cost depends on usage: $6.00 per nodes       

--- a/internal/providers/terraform/azure/testdata/automation_dsc_nodeconfiguration_test/automation_dsc_nodeconfiguration_test.golden
+++ b/internal/providers/terraform/azure/testdata/automation_dsc_nodeconfiguration_test/automation_dsc_nodeconfiguration_test.golden
@@ -6,8 +6,7 @@
                                                                                                              
  azurerm_automation_account.example                                                                          
  ├─ Job run time                                        Monthly cost depends on usage: $0.002 per minutes    
- ├─ Non-azure config nodes                              Monthly cost depends on usage: $6.00 per nodes       
- └─ Watchers                                            Monthly cost depends on usage: $0.002 per hours      
+ └─ Non-azure config nodes                              Monthly cost depends on usage: $6.00 per nodes       
                                                                                                              
  azurerm_automation_dsc_configuration.example                                                                
  └─ Non-azure config nodes                              Monthly cost depends on usage: $6.00 per nodes       

--- a/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
+++ b/internal/providers/terraform/google/testdata/compute_instance_test/compute_instance_test.golden
@@ -16,7 +16,7 @@
  └─ NVIDIA L4 (on-demand)                                                  730  hours       $286.18   
                                                                                                       
  google_compute_instance.preemptible_gpu                                                              
- ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               730  hours       $176.06   
+ ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               730  hours       $169.39   
  ├─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
  └─ NVIDIA Tesla K80 (preemptible)                                       2,920  hours       $501.95   
                                                                                                       
@@ -51,8 +51,8 @@
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
                                                                                                       
  google_compute_instance.custom_preemptible                                                           
- ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)              730  hours        $46.82   
- ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)                730  hours        $20.00   
+ ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)              730  hours        $44.41   
+ ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)                730  hours        $19.84   
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
                                                                                                       
  google_compute_instance.local_ssd                                                                    
@@ -61,18 +61,18 @@
  └─ Local SSD provisioned storage                                          750  GB           $60.00   
                                                                                                       
  google_compute_instance.custom_n2d                                                                   
- ├─ Custom instance CPU (Linux/UNIX, preemptible, N2D 4 vCPUs)             730  hours        $17.52   
- ├─ Custom Instance RAM (Linux/UNIX, preemptible, N2D 20 GB)               730  hours        $11.72   
+ ├─ Custom instance CPU (Linux/UNIX, preemptible, N2D 4 vCPUs)             730  hours        $20.18   
+ ├─ Custom Instance RAM (Linux/UNIX, preemptible, N2D 20 GB)               730  hours        $13.52   
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
-                                                                                                      
- google_compute_instance.ssd                                                                          
- ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)                       730  hours         $3.88   
- └─ SSD provisioned storage (pd-ssd)                                        40  GB            $6.80   
                                                                                                       
  google_compute_instance.preemptible_local_ssd                                                        
  ├─ Instance usage (Linux/UNIX, preemptible, f1-micro)                     730  hours         $0.50   
  ├─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
- └─ Local SSD provisioned storage                                          375  GB            $9.45   
+ └─ Local SSD provisioned storage                                          375  GB           $13.28   
+                                                                                                      
+ google_compute_instance.ssd                                                                          
+ ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)                       730  hours         $3.88   
+ └─ SSD provisioned storage (pd-ssd)                                        40  GB            $6.80   
                                                                                                       
  google_compute_instance.standard                                                                     
  ├─ Instance usage (Linux/UNIX, on-demand, f1-micro)                       730  hours         $3.88   
@@ -86,7 +86,7 @@
  ├─ Instance usage (Linux/UNIX, preemptible, f1-micro)                     730  hours         $0.50   
  └─ Standard provisioned storage (pd-standard)                              10  GB            $0.40   
                                                                                                       
- OVERALL TOTAL                                                                          $10,377.17 
+ OVERALL TOTAL                                                                          $10,376.20 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -99,7 +99,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $10,377 ┃           - ┃    $10,377 ┃
+┃ main                                               ┃       $10,376 ┃           - ┃    $10,376 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
+++ b/internal/providers/terraform/google/testdata/container_cluster_test/container_cluster_test.golden
@@ -10,7 +10,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 8,760  hours                  $4,660.30    
  │  └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $2,112.74    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $2,032.67    
     └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00    
                                                                                                                          
  google_container_cluster.with_node_pools_regional                                                                       
@@ -22,7 +22,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 4,380  hours                  $2,330.15    
  │  └─ Standard provisioned storage (pd-standard)                               600  GB                        $24.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $2,112.74    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $2,032.67    
     └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00    
                                                                                                                          
  google_container_cluster.with_node_config                                                                               
@@ -42,17 +42,8 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 5,840  hours                  $3,106.86    
  │  └─ Standard provisioned storage (pd-standard)                               800  GB                        $32.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $704.25    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $677.56    
     └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
-                                                                                                                         
- google_container_cluster.with_unsupported_node_pool                                                                     
- ├─ Cluster management fee                                                      730  hours                     $73.00    
- ├─ default_pool                                                                                                         
- │  ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                      6,570  hours                    $220.13    
- │  └─ Standard provisioned storage (pd-standard)                               900  GB                        $36.00    
- └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $2,112.74    
-    └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00    
                                                                                                                          
  google_container_cluster.with_node_pools_zonal_withUsage                                                                
  ├─ Cluster management fee                                                      730  hours                     $73.00    
@@ -63,8 +54,17 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 2,920  hours                  $1,553.43    
  │  └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $704.25    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $677.56    
     └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
+                                                                                                                         
+ google_container_cluster.with_unsupported_node_pool                                                                     
+ ├─ Cluster management fee                                                      730  hours                     $73.00    
+ ├─ default_pool                                                                                                         
+ │  ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                      6,570  hours                    $220.13    
+ │  └─ Standard provisioned storage (pd-standard)                               900  GB                        $36.00    
+ └─ node_pool[1]                                                                                                         
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               8,760  hours                  $2,032.67    
+    └─ Standard provisioned storage (pd-standard)                             1,200  GB                        $48.00    
                                                                                                                          
  google_container_cluster.with_node_pools_node_locations                                                                 
  ├─ Cluster management fee                                                      730  hours                     $73.00    
@@ -75,7 +75,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 2,920  hours                  $1,553.43    
  │  └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               1,460  hours                    $352.12    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               1,460  hours                    $338.78    
     └─ Standard provisioned storage (pd-standard)                               200  GB                         $8.00    
                                                                                                                          
  google_container_cluster.with_node_pools_zonal                                                                          
@@ -87,7 +87,7 @@
  │  ├─ Instance usage (Linux/UNIX, on-demand, n1-standard-16)                 1,460  hours                    $776.72    
  │  └─ Standard provisioned storage (pd-standard)                               200  GB                         $8.00    
  └─ node_pool[1]                                                                                                         
-    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $704.25    
+    ├─ Instance usage (Linux/UNIX, preemptible, n1-standard-16)               2,920  hours                    $677.56    
     └─ Standard provisioned storage (pd-standard)                               400  GB                        $16.00    
                                                                                                                          
  google_container_cluster.autopilot_with_usage                                                                           
@@ -138,7 +138,7 @@
  ├─ Autopilot memory                                                Monthly cost depends on usage: $3.59 per GB          
  └─ Autopilot ephemeral storage                                     Monthly cost depends on usage: $0.040004 per GB      
                                                                                                                          
- OVERALL TOTAL                                                                                             $31,356.10 
+ OVERALL TOTAL                                                                                             $31,022.49 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -149,7 +149,7 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $30,848 ┃        $509 ┃    $31,356 ┃
+┃ main                                               ┃       $30,514 ┃        $509 ┃    $31,022 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛
 Logs:
 

--- a/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
+++ b/internal/providers/terraform/google/testdata/container_node_pool_test/container_node_pool_test.golden
@@ -65,13 +65,13 @@
  └─ Standard provisioned storage (pd-standard)                         800  GB           $32.00   
                                                                                                   
  google_container_node_pool.with_preemptible_instance                                             
- ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours       $140.47   
- ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $60.01   
+ ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours       $133.24   
+ ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $59.52   
  └─ Standard provisioned storage (pd-standard)                         300  GB           $12.00   
                                                                                                   
  google_container_node_pool.with_spot_instance                                                    
- ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours       $140.47   
- ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $60.01   
+ ├─ Custom instance CPU (Linux/UNIX, preemptible, N1 6 vCPUs)        2,190  hours       $133.24   
+ ├─ Custom Instance RAM (Linux/UNIX, preemptible, N1 20 GB)          2,190  hours        $59.52   
  └─ Standard provisioned storage (pd-standard)                         300  GB           $12.00   
                                                                                                   
  google_container_node_pool.autoscaling_zonal                                                     
@@ -122,7 +122,7 @@
  ├─ Instance usage (Linux/UNIX, on-demand, e2-medium)                1,460  hours        $48.92   
  └─ Standard provisioned storage (pd-standard)                         200  GB            $8.00   
                                                                                                   
- OVERALL TOTAL                                                                      $28,130.41 
+ OVERALL TOTAL                                                                      $28,114.99 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
@@ -133,5 +133,5 @@
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $28,130 ┃           - ┃    $28,130 ┃
+┃ main                                               ┃       $28,115 ┃           - ┃    $28,115 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/resources/azure/backup_protected_vm.go
+++ b/internal/resources/azure/backup_protected_vm.go
@@ -82,7 +82,7 @@ func (r *BackupProtectedVM) additionalCostForSizeOfVM() *schema.CostComponent {
 	quantity := decimal.NewFromInt(1)
 	filter := &schema.AttributeFilter{
 		Key:   "meterName",
-		Value: strPtr("Azure Files Protected Instances"),
+		Value: strPtr("Azure Files Protected Instance"),
 	}
 
 	utilization := r.diskUtilization()
@@ -138,7 +138,7 @@ func (r *BackupProtectedVM) storageCostsForVM() *schema.CostComponent {
 			ProductFamily: strPtr("Storage"),
 			AttributeFilters: []*schema.AttributeFilter{
 				{Key: "productName", Value: strPtr("Backup")},
-				{Key: "skuName", Value: strPtr("Standard")},
+				{Key: "skuName", Value: strPtr("Azure VM")},
 				{Key: "meterName", ValueRegex: strPtr(fmt.Sprintf("/^%s/i", dataStored))},
 			},
 		},

--- a/internal/resources/azure/postgresql_flexible_server.go
+++ b/internal/resources/azure/postgresql_flexible_server.go
@@ -183,10 +183,6 @@ func getFlexibleServerFilterAttributes(tier, instanceType, instanceVersion strin
 		skuName = fmt.Sprintf("%s vCore", cores)
 
 		series = coreRegex.ReplaceAllString(instanceType, "") + instanceVersion
-
-		if series == "Esv3" {
-			productName = "Az DB for PGSQL Flexible Server"
-		}
 	}
 
 	return flexibleServerFilterAttributes{


### PR DESCRIPTION
The Azure and Google integration tests have been failing on master since at least May, from a mix of causes that this fixes: (1) Azure's `TestCognitiveAccount` errored on an unparseable API response, because the LUIS "Speech requests" component has always been custom-priced with no `ProductFilter` (since 2024) yet the client still queried the API for it, and the API now rejects the resulting null `productFilter` mid-batch (due to https://github.com/infracost/cloud-pricing-api/pull/539); `PerformRequest` now skips the API call for custom-priced components. (2) The PostgreSQL flexible server Memory Optimized `Esv3` compute price stopped resolving because Azure renamed the product to the standard `Azure Database for PostgreSQL Flexible Server Memory Optimized Esv3 Series Compute`, so the obsolete special-case product name is removed. (3) Golden files are refreshed for live pricing drift and for the earlier Watcher pricing move out of `azurerm_automation_account`.