### PR TITLE
fix(security): scope Terraform Cloud/registry tokens to trusted hosts

### DIFF
--- a/internal/extclient/authed_client.go
+++ b/internal/extclient/authed_client.go
@@ -43,6 +43,12 @@ func NewAuthedAPIClient(host, token string) *AuthedAPIClient {
 	}
 }
 
+// Host returns the trusted host that the authed API client sends
+// authenticated requests to.
+func (a *AuthedAPIClient) Host() string {
+	return a.host
+}
+
 // SetHost sets the host for base host for the authed API client.
 func (a *AuthedAPIClient) SetHost(host string) {
 	a.host = host

--- a/internal/hcl/parser.go
+++ b/internal/hcl/parser.go
@@ -217,15 +217,18 @@ func OptionWithRawCtyInput(input cty.Value) (op Option) {
 }
 
 // OptionWithTFCRemoteVarLoader accepts Terraform Cloud/Enterprise host and token
-// values to load remote execution variables.
-func OptionWithTFCRemoteVarLoader(host, token, localWorkspace string, loaderOpts ...TFCRemoteVariablesLoaderOption) Option {
+// values to load remote execution variables. hostConfigured indicates whether
+// the host was explicitly set by the user (rather than defaulted to
+// app.terraform.io), which controls how the loader handles a mismatching host
+// in the scanned Terraform.
+func OptionWithTFCRemoteVarLoader(host, token, localWorkspace string, hostConfigured bool, loaderOpts ...TFCRemoteVariablesLoaderOption) Option {
 	return func(p *Parser) {
 		if host == "" || token == "" {
 			return
 		}
 
 		client := extclient.NewAuthedAPIClient(host, token)
-		p.remoteVariableLoaders = append(p.remoteVariableLoaders, NewTFCRemoteVariablesLoader(client, localWorkspace, p.logger, loaderOpts...))
+		p.remoteVariableLoaders = append(p.remoteVariableLoaders, NewTFCRemoteVariablesLoader(client, localWorkspace, hostConfigured, p.logger, loaderOpts...))
 	}
 }
 

--- a/internal/hcl/remote_variables_loader.go
+++ b/internal/hcl/remote_variables_loader.go
@@ -35,6 +35,12 @@ type TFCRemoteVariablesLoader struct {
 	client         *extclient.AuthedAPIClient
 	localWorkspace string
 	remoteConfig   *TFCRemoteConfig
+	// hostConfigured is true when the user has explicitly set the Terraform
+	// Cloud host (via the TERRAFORM_CLOUD_HOST env var or terraform_cloud_host
+	// config option) rather than falling back to the app.terraform.io default.
+	// It controls how we react when the scanned Terraform requests a different
+	// host to the trusted one: see Load.
+	hostConfigured bool
 	logger         zerolog.Logger
 }
 
@@ -102,7 +108,7 @@ func RemoteVariablesLoaderWithRemoteConfig(config TFCRemoteConfig) TFCRemoteVari
 }
 
 // NewTFCRemoteVariablesLoader constructs a new loader for fetching remote variables.
-func NewTFCRemoteVariablesLoader(client *extclient.AuthedAPIClient, localWorkspace string, logger zerolog.Logger, opts ...TFCRemoteVariablesLoaderOption) *TFCRemoteVariablesLoader {
+func NewTFCRemoteVariablesLoader(client *extclient.AuthedAPIClient, localWorkspace string, hostConfigured bool, logger zerolog.Logger, opts ...TFCRemoteVariablesLoaderOption) *TFCRemoteVariablesLoader {
 	if localWorkspace == "" {
 		localWorkspace = os.Getenv("TF_WORKSPACE")
 	}
@@ -110,6 +116,7 @@ func NewTFCRemoteVariablesLoader(client *extclient.AuthedAPIClient, localWorkspa
 	r := &TFCRemoteVariablesLoader{
 		client:         client,
 		localWorkspace: localWorkspace,
+		hostConfigured: hostConfigured,
 		logger:         logger,
 	}
 
@@ -153,7 +160,28 @@ func (r *TFCRemoteVariablesLoader) Load(options RemoteVarLoaderOptions) (map[str
 		}
 	}
 
+	// config.Host may have come from the scanned Terraform (the cloud/backend
+	// "hostname" attribute), which is untrusted input. We must never send the
+	// configured Terraform Cloud token to a host other than the trusted one,
+	// otherwise a malicious .tf could exfiltrate the token to an attacker host.
+	trustedHost := r.client.Host()
+	if config.Host != "" && !hostsEqual(config.Host, trustedHost) {
+		if r.hostConfigured {
+			// The user pinned a trusted host but the scanned Terraform asks for a
+			// different one. Don't send the token to the unverified host, just
+			// skip loading remote variables.
+			r.logger.Warn().Msgf("Terraform config sets hostname %q which does not match the configured Terraform Cloud host %q, not sending token to the unverified host and skipping remote variable loading", config.Host, trustedHost)
+			return vars, nil
+		}
+
+		// The user has a Terraform Cloud token set but has not pinned a trusted
+		// host, and the scanned Terraform is trying to point us at its own host.
+		// Refuse to run rather than risk sending the token to an untrusted host.
+		return vars, errors.Errorf("the Terraform being scanned sets a Terraform Cloud/Enterprise hostname (%q), but no trusted host is configured. Infracost will not send your Terraform Cloud token to an unverified host. If %q is trusted, set the TERRAFORM_CLOUD_HOST environment variable (or terraform_cloud_host config option) to it.", config.Host, config.Host)
+	}
+
 	if config.Host != "" {
+		// config.Host has been verified to match the trusted host.
 		r.client.SetHost(config.Host)
 	}
 
@@ -359,6 +387,12 @@ func (r *TFCRemoteVariablesLoader) getVarValue(variable tfcVar) cty.Value {
 	}
 
 	return cty.StringVal(variable.Value)
+}
+
+// hostsEqual reports whether two Terraform Cloud/Enterprise hostnames refer to
+// the same host, ignoring case and any trailing dot.
+func hostsEqual(a, b string) bool {
+	return strings.EqualFold(strings.TrimSuffix(a, "."), strings.TrimSuffix(b, "."))
 }
 
 func getAttribute(block *Block, name string) string {

--- a/internal/hcl/remote_variables_loader_tfc_test.go
+++ b/internal/hcl/remote_variables_loader_tfc_test.go
@@ -1,0 +1,84 @@
+package hcl
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/infracost/infracost/internal/config"
+	"github.com/infracost/infracost/internal/extclient"
+	"github.com/infracost/infracost/internal/hcl/modules"
+	"github.com/infracost/infracost/internal/sync"
+)
+
+// blocksFromHCL parses the given Terraform source into a set of Blocks so the
+// remote variables loader can be exercised against realistic input.
+func blocksFromHCL(t *testing.T, contents string) Blocks {
+	t.Helper()
+
+	path := createTestFile("main.tf", contents)
+	logger := newDiscardLogger()
+	loader := modules.NewModuleLoader(modules.ModuleLoaderOptions{
+		CachePath:         filepath.Dir(path),
+		HCLParser:         modules.NewSharedHCLParser(),
+		CredentialsSource: nil,
+		SourceMap:         config.TerraformSourceMap{},
+		SourceMapRegex:    nil,
+		Logger:            logger,
+		ModuleSync:        &sync.KeyMutex{},
+	})
+	parser := NewParser(
+		RootPath{DetectedPath: filepath.Dir(path)},
+		CreateEnvFileMatcher([]string{}, nil),
+		loader,
+		logger,
+	)
+
+	module, err := parser.ParseDirectory()
+	require.NoError(t, err)
+
+	return module.Blocks
+}
+
+// TestTFCRemoteVariablesLoader_Load_HostValidation verifies that the loader
+// never sends the configured Terraform Cloud token to a host derived from the
+// (untrusted) scanned Terraform when that host does not match the trusted one.
+func TestTFCRemoteVariablesLoader_Load_HostValidation(t *testing.T) {
+	// A cloud block that points at an attacker-controlled host.
+	blocks := blocksFromHCL(t, `
+terraform {
+  cloud {
+    organization = "my-org"
+    hostname     = "attacker.example.com"
+    workspaces {
+      name = "my-workspace"
+    }
+  }
+}
+`)
+
+	t.Run("errors when scanned Terraform sets a host and no host is configured", func(t *testing.T) {
+		client := extclient.NewAuthedAPIClient("app.terraform.io", "secret-token")
+		loader := NewTFCRemoteVariablesLoader(client, "", false, newDiscardLogger())
+
+		_, err := loader.Load(RemoteVarLoaderOptions{Blocks: blocks})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "attacker.example.com")
+		assert.Contains(t, err.Error(), "TERRAFORM_CLOUD_HOST")
+		// The client must not have been repointed at the untrusted host.
+		assert.Equal(t, "app.terraform.io", client.Host())
+	})
+
+	t.Run("skips without error when a different trusted host is configured", func(t *testing.T) {
+		client := extclient.NewAuthedAPIClient("tfe.mycorp.com", "secret-token")
+		loader := NewTFCRemoteVariablesLoader(client, "", true, newDiscardLogger())
+
+		vars, err := loader.Load(RemoteVarLoaderOptions{Blocks: blocks})
+		require.NoError(t, err)
+		assert.Empty(t, vars)
+		// The client must not have been repointed at the untrusted host.
+		assert.Equal(t, "tfe.mycorp.com", client.Host())
+	})
+}

--- a/internal/providers/terraform/cloud.go
+++ b/internal/providers/terraform/cloud.go
@@ -4,12 +4,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/infracost/infracost/internal/credentials"
 	"github.com/infracost/infracost/internal/logging"
 )
+
+// hostsEqual reports whether two Terraform Cloud/Enterprise hostnames refer to
+// the same host, ignoring case and any trailing dot.
+func hostsEqual(a, b string) bool {
+	return strings.EqualFold(strings.TrimSuffix(a, "."), strings.TrimSuffix(b, "."))
+}
 
 func cloudAPI(host string, path string, token string) ([]byte, error) {
 	client := &http.Client{}

--- a/internal/providers/terraform/cloud_security_test.go
+++ b/internal/providers/terraform/cloud_security_test.go
@@ -1,0 +1,61 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDirProvider_tokenForRemoteHost verifies that the primary Terraform Cloud
+// token is only sent to the trusted host, and never to a host derived from the
+// (untrusted) remote-run output URL.
+func TestDirProvider_tokenForRemoteHost(t *testing.T) {
+	t.Run("returns token when host matches the default", func(t *testing.T) {
+		p := &DirProvider{TerraformCloudToken: "primary-token"}
+		token, err := p.tokenForRemoteHost("app.terraform.io")
+		require.NoError(t, err)
+		assert.Equal(t, "primary-token", token)
+	})
+
+	t.Run("returns token when host matches the configured host", func(t *testing.T) {
+		p := &DirProvider{TerraformCloudToken: "primary-token", TerraformCloudHost: "tfe.mycorp.com"}
+		token, err := p.tokenForRemoteHost("tfe.mycorp.com")
+		require.NoError(t, err)
+		assert.Equal(t, "primary-token", token)
+	})
+
+	t.Run("errors on non-default host when no host is configured", func(t *testing.T) {
+		p := &DirProvider{TerraformCloudToken: "primary-token"}
+		_, err := p.tokenForRemoteHost("attacker.example.com")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "attacker.example.com")
+		assert.Contains(t, err.Error(), "TERRAFORM_CLOUD_HOST")
+	})
+
+	t.Run("errors on host mismatch when a host is configured", func(t *testing.T) {
+		p := &DirProvider{TerraformCloudToken: "primary-token", TerraformCloudHost: "tfe.mycorp.com"}
+		_, err := p.tokenForRemoteHost("attacker.example.com")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "attacker.example.com")
+		assert.Contains(t, err.Error(), "tfe.mycorp.com")
+	})
+}
+
+// TestIsTrustedRegistryHost verifies the allowlist used to decide whether the
+// TG_TF_REGISTRY_TOKEN may be attached to a registry request.
+func TestIsTrustedRegistryHost(t *testing.T) {
+	assert.True(t, isTrustedRegistryHost("registry.terraform.io"))
+	assert.True(t, isTrustedRegistryHost("registry.opentofu.org"))
+	assert.True(t, isTrustedRegistryHost("app.terraform.io"))
+	assert.True(t, isTrustedRegistryHost("REGISTRY.TERRAFORM.IO"), "host matching should be case-insensitive")
+
+	assert.False(t, isTrustedRegistryHost("attacker.example.com"))
+	assert.False(t, isTrustedRegistryHost("registry.terraform.io.attacker.example.com"))
+
+	t.Run("honors TERRAFORM_CLOUD_HOST", func(t *testing.T) {
+		t.Setenv("TERRAFORM_CLOUD_HOST", "tfe.mycorp.com")
+		assert.True(t, isTrustedRegistryHost("tfe.mycorp.com"))
+		assert.False(t, isTrustedRegistryHost("attacker.example.com"))
+	})
+}

--- a/internal/providers/terraform/cloud_security_test.go
+++ b/internal/providers/terraform/cloud_security_test.go
@@ -45,17 +45,31 @@ func TestDirProvider_tokenForRemoteHost(t *testing.T) {
 // TestIsTrustedRegistryHost verifies the allowlist used to decide whether the
 // TG_TF_REGISTRY_TOKEN may be attached to a registry request.
 func TestIsTrustedRegistryHost(t *testing.T) {
-	assert.True(t, isTrustedRegistryHost("registry.terraform.io"))
-	assert.True(t, isTrustedRegistryHost("registry.opentofu.org"))
-	assert.True(t, isTrustedRegistryHost("app.terraform.io"))
-	assert.True(t, isTrustedRegistryHost("REGISTRY.TERRAFORM.IO"), "host matching should be case-insensitive")
+	g := &TerraformRegistryGetter{}
 
-	assert.False(t, isTrustedRegistryHost("attacker.example.com"))
-	assert.False(t, isTrustedRegistryHost("registry.terraform.io.attacker.example.com"))
+	assert.True(t, g.isTrustedRegistryHost("registry.terraform.io"))
+	assert.True(t, g.isTrustedRegistryHost("registry.opentofu.org"))
+	assert.True(t, g.isTrustedRegistryHost("app.terraform.io"))
+	assert.True(t, g.isTrustedRegistryHost("REGISTRY.TERRAFORM.IO"), "host matching should be case-insensitive")
+
+	assert.False(t, g.isTrustedRegistryHost("attacker.example.com"))
+	assert.False(t, g.isTrustedRegistryHost("registry.terraform.io.attacker.example.com"))
+
+	t.Run("honors the configured trusted host (terraform_cloud_host config value)", func(t *testing.T) {
+		gc := &TerraformRegistryGetter{TrustedHosts: []string{"tfe.mycorp.com"}}
+		assert.True(t, gc.isTrustedRegistryHost("tfe.mycorp.com"))
+		assert.False(t, gc.isTrustedRegistryHost("attacker.example.com"))
+	})
 
 	t.Run("honors TERRAFORM_CLOUD_HOST", func(t *testing.T) {
 		t.Setenv("TERRAFORM_CLOUD_HOST", "tfe.mycorp.com")
-		assert.True(t, isTrustedRegistryHost("tfe.mycorp.com"))
-		assert.False(t, isTrustedRegistryHost("attacker.example.com"))
+		assert.True(t, g.isTrustedRegistryHost("tfe.mycorp.com"))
+		assert.False(t, g.isTrustedRegistryHost("attacker.example.com"))
+	})
+
+	t.Run("honors TG_TF_DEFAULT_REGISTRY_HOST", func(t *testing.T) {
+		t.Setenv("TG_TF_DEFAULT_REGISTRY_HOST", "registry.mycorp.com")
+		assert.True(t, g.isTrustedRegistryHost("registry.mycorp.com"))
+		assert.False(t, g.isTrustedRegistryHost("attacker.example.com"))
 	})
 }

--- a/internal/providers/terraform/dir_provider.go
+++ b/internal/providers/terraform/dir_provider.go
@@ -426,12 +426,9 @@ func (p *DirProvider) runRemotePlan(opts *CmdOptions, args []string) ([]byte, er
 	s := strings.Split(u.Path, "/")
 	runID := s[len(s)-1]
 
-	token := p.TerraformCloudToken
-	if token == "" {
-		token = credentials.FindTerraformCloudToken(host)
-	}
-	if token == "" {
-		return []byte{}, credentials.ErrMissingCloudToken
+	token, err := p.tokenForRemoteHost(host)
+	if err != nil {
+		return []byte{}, err
 	}
 
 	body, err := cloudAPI(host, fmt.Sprintf("/api/v2/runs/%s/plan", runID), token)
@@ -453,6 +450,41 @@ func (p *DirProvider) runRemotePlan(opts *CmdOptions, args []string) ([]byte, er
 		return []byte{}, errors.New("Could not parse path to plan JSON from remote")
 	}
 	return cloudAPI(host, jsonPath, token)
+}
+
+// tokenForRemoteHost returns the Terraform Cloud token to use for a remote run
+// hosted at the given host. host is derived from the terraform remote-run output
+// URL, which is driven by the (untrusted) .tf cloud/backend hostname, so we only
+// send the configured token to the trusted host (TERRAFORM_CLOUD_HOST if set,
+// otherwise app.terraform.io). When the host does not match we refuse rather
+// than risk leaking the token, falling back to a host-scoped lookup only when no
+// primary token is configured.
+func (p *DirProvider) tokenForRemoteHost(host string) (string, error) {
+	trustedHost := p.TerraformCloudHost
+	hostConfigured := trustedHost != ""
+	if trustedHost == "" {
+		trustedHost = "app.terraform.io"
+	}
+
+	var token string
+	if hostsEqual(host, trustedHost) {
+		token = p.TerraformCloudToken
+	} else if p.TerraformCloudToken != "" {
+		// A token is configured but the remote run lives on a different host.
+		// Refuse to run rather than risk leaking the token to an unverified host.
+		if hostConfigured {
+			return "", errors.Errorf("the remote Terraform run is hosted at %q, which does not match the configured Terraform Cloud host %q; Infracost will not send your Terraform Cloud token to an unverified host", host, trustedHost)
+		}
+		return "", errors.Errorf("the remote Terraform run is hosted at %q, but no trusted host is configured. Infracost will not send your Terraform Cloud token to an unverified host. If %q is trusted, set the TERRAFORM_CLOUD_HOST environment variable (or terraform_cloud_host config option) to it.", host, host)
+	}
+	if token == "" {
+		token = credentials.FindTerraformCloudToken(host)
+	}
+	if token == "" {
+		return "", credentials.ErrMissingCloudToken
+	}
+
+	return token, nil
 }
 
 func (p *DirProvider) runShow(opts *CmdOptions, planFile string, initOnFail bool) ([]byte, error) {

--- a/internal/providers/terraform/hcl_provider.go
+++ b/internal/providers/terraform/hcl_provider.go
@@ -143,6 +143,7 @@ func NewHCLProvider(ctx *config.ProjectContext, rootPath hcl.RootPath, config *H
 			credsSource.BaseCredentialSet.Host,
 			credsSource.BaseCredentialSet.Token,
 			localWorkspace,
+			ctx.ProjectConfig.TerraformCloudHost != "",
 			loaderOpts...),
 		)
 	}

--- a/internal/providers/terraform/terragrunt_hcl_provider.go
+++ b/internal/providers/terraform/terragrunt_hcl_provider.go
@@ -133,10 +133,20 @@ func NewTerragruntHCLProvider(rootPath hcl.RootPath, ctx *config.ProjectContext)
 		}
 	}
 
+	// Use Infracost's own registry getter (rather than tgterraform.RegistryGetter)
+	// so we can scope the TG_TF_REGISTRY_TOKEN to trusted hosts. TrustedHosts is
+	// seeded with the configured Terraform Cloud host (terraform_cloud_host config
+	// value / TERRAFORM_CLOUD_HOST env var) so tokens are also sent to a private
+	// Terraform Enterprise registry when the user has pinned one.
+	var trustedRegistryHosts []string
+	if h := ctx.ProjectConfig.TerraformCloudHost; h != "" {
+		trustedRegistryHosts = append(trustedRegistryHosts, h)
+	}
 	fetcher := modules.NewPackageFetcher(remoteCache, logger, modules.WithGetters(map[string]getter.Getter{
-		"tfr": &tgterraform.RegistryGetter{
+		"tfr": &TerraformRegistryGetter{
 			ProxyForDomains: []string{".terraform.io"},
 			ProxyURL:        os.Getenv("INFRACOST_REGISTRY_PROXY"),
+			TrustedHosts:    trustedRegistryHosts,
 		},
 		"file": &tgcliterraform.FileCopyGetter{},
 	}), modules.WithPublicModuleChecker(modules.NewHttpPublicModuleChecker()))

--- a/internal/providers/terraform/terragrunt_registry_service.go
+++ b/internal/providers/terraform/terragrunt_registry_service.go
@@ -31,6 +31,32 @@ const (
 	authTokenEnvVarName   = "TG_TF_REGISTRY_TOKEN" //nolint
 )
 
+// isTrustedRegistryHost reports whether the TG_TF_REGISTRY_TOKEN may be sent to
+// the given host. The token is a Terraform Cloud/Enterprise registry token, so
+// we only attach it to the well-known public registries and to the configured
+// Terraform Cloud/Enterprise host - never to a host derived from an untrusted
+// module source.
+func isTrustedRegistryHost(host string) bool {
+	trusted := []string{
+		"registry.terraform.io", // public Terraform registry
+		"registry.opentofu.org", // public OpenTofu registry
+		"app.terraform.io",      // Terraform Cloud (incl. private module registry)
+	}
+	// TERRAFORM_CLOUD_HOST lets Terraform Enterprise users point at their own
+	// host, so trust it too when it is explicitly configured.
+	if h := os.Getenv("TERRAFORM_CLOUD_HOST"); h != "" {
+		trusted = append(trusted, h)
+	}
+
+	for _, t := range trusted {
+		if hostsEqual(host, t) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // TerraformRegistryServicePath is a struct for extracting the modules service path in the Registry.
 type TerraformRegistryServicePath struct {
 	ModulesPath string `json:"modules.v1"`
@@ -257,9 +283,11 @@ func httpGETAndGetResponse(ctx context.Context, getURL url.URL) ([]byte, *http.H
 	}
 
 	// Handle authentication via env var. Authentication is done by providing the registry token as a bearer token in
-	// the request header.
+	// the request header. The request host is derived from the (untrusted) module source, so we only attach the token
+	// when the host is a trusted registry - otherwise a malicious module source could exfiltrate the token to an
+	// attacker-controlled host.
 	authToken := os.Getenv(authTokenEnvVarName)
-	if authToken != "" {
+	if authToken != "" && isTrustedRegistryHost(getURL.Host) {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authToken))
 	}
 

--- a/internal/providers/terraform/terragrunt_registry_service.go
+++ b/internal/providers/terraform/terragrunt_registry_service.go
@@ -1,6 +1,15 @@
 package terraform
 
-// Contents of this file were copied from github.com/gruntwork-io/terragrunt
+// Contents of this file were copied from github.com/gruntwork-io/terragrunt (the
+// tfr:// registry getter) and adapted so that Infracost controls the getter that
+// is actually wired up. On top of the upstream getter we add:
+//   - a trusted-host allowlist so the configured registry token (TG_TF_REGISTRY_TOKEN)
+//     is only ever sent to a trusted host, never to a host derived from an
+//     untrusted module source (see isTrustedRegistryHost / httpGETAndGetResponse);
+//   - support for the TG_TF_DEFAULT_REGISTRY_HOST env var, both as the default
+//     registry domain and as a trusted host;
+//   - the INFRACOST_REGISTRY_PROXY support (ProxyForDomains/ProxyURL) carried
+//     over from Infracost's terragrunt fork.
 import (
 	"context"
 	"fmt"
@@ -29,33 +38,11 @@ const (
 	serviceDiscoveryPath  = "/.well-known/terraform.json"
 	versionQueryKey       = "version"
 	authTokenEnvVarName   = "TG_TF_REGISTRY_TOKEN" //nolint
+	// defaultRegistryHostEnvVarName lets users point Terragrunt at a private
+	// default registry (used when a module source omits the registry host). When
+	// set we both resolve unqualified sources to it and trust it as a token host.
+	defaultRegistryHostEnvVarName = "TG_TF_DEFAULT_REGISTRY_HOST"
 )
-
-// isTrustedRegistryHost reports whether the TG_TF_REGISTRY_TOKEN may be sent to
-// the given host. The token is a Terraform Cloud/Enterprise registry token, so
-// we only attach it to the well-known public registries and to the configured
-// Terraform Cloud/Enterprise host - never to a host derived from an untrusted
-// module source.
-func isTrustedRegistryHost(host string) bool {
-	trusted := []string{
-		"registry.terraform.io", // public Terraform registry
-		"registry.opentofu.org", // public OpenTofu registry
-		"app.terraform.io",      // Terraform Cloud (incl. private module registry)
-	}
-	// TERRAFORM_CLOUD_HOST lets Terraform Enterprise users point at their own
-	// host, so trust it too when it is explicitly configured.
-	if h := os.Getenv("TERRAFORM_CLOUD_HOST"); h != "" {
-		trusted = append(trusted, h)
-	}
-
-	for _, t := range trusted {
-		if hostsEqual(host, t) {
-			return true
-		}
-	}
-
-	return false
-}
 
 // TerraformRegistryServicePath is a struct for extracting the modules service path in the Registry.
 type TerraformRegistryServicePath struct {
@@ -77,7 +64,8 @@ type TerraformRegistryServicePath struct {
 //
 // Authentication to private module registries is handled via environment variables. The authorization API token is
 // expected to be provided to Terragrunt via the TG_TF_REGISTRY_TOKEN environment variable. This token can be any
-// registry API token generated on Terraform Cloud / Enterprise.
+// registry API token generated on Terraform Cloud / Enterprise. The token is only ever attached to requests to a
+// trusted host (see isTrustedRegistryHost); it is never sent to a host derived from an untrusted module source.
 //
 // MAINTAINER'S NOTE: Ideally we implement the full credential system that terraform uses as part of `terraform login`,
 // but all the relevant packages are internal to the terraform repository, thus making it difficult to use as a
@@ -91,6 +79,15 @@ type TerraformRegistryServicePath struct {
 // GH issue: https://github.com/gruntwork-io/terragrunt/issues/1772
 type TerraformRegistryGetter struct {
 	client *getter.Client
+	// ProxyForDomains / ProxyURL route requests to matching hosts through the
+	// INFRACOST_REGISTRY_PROXY (carried over from Infracost's terragrunt fork).
+	ProxyForDomains []string
+	ProxyURL        string
+	// TrustedHosts are additional hosts the registry token may be sent to, on top
+	// of the well-known public registries and the TG_TF_DEFAULT_REGISTRY_HOST env
+	// var. This is populated from the resolved terraform_cloud_host config value
+	// (which also covers the TERRAFORM_CLOUD_HOST env var).
+	TrustedHosts []string
 }
 
 // SetClient allows the getter to know what getter client (different from the underlying HTTP client) to use for
@@ -112,7 +109,7 @@ func (tfrGetter *TerraformRegistryGetter) ClientMode(ctx context.Context, u *url
 func (tfrGetter *TerraformRegistryGetter) Get(ctx context.Context, dstPath string, srcURL *url.URL) error {
 	registryDomain := srcURL.Host
 	if registryDomain == "" {
-		registryDomain = defaultRegistryDomain
+		registryDomain = defaultRegistryHost()
 	}
 	queryValues := srcURL.Query()
 	modulePath, moduleSubDir := getter.SourceDirSubdir(srcURL.Path)
@@ -126,7 +123,7 @@ func (tfrGetter *TerraformRegistryGetter) Get(ctx context.Context, dstPath strin
 	}
 	version := versionList[0]
 
-	moduleRegistryBasePath, err := getModuleRegistryURLBasePath(ctx, registryDomain)
+	moduleRegistryBasePath, err := tfrGetter.getModuleRegistryURLBasePath(ctx, registryDomain)
 	if err != nil {
 		return err
 	}
@@ -136,7 +133,7 @@ func (tfrGetter *TerraformRegistryGetter) Get(ctx context.Context, dstPath strin
 		return err
 	}
 
-	terraformGet, err := getTerraformGetHeader(ctx, *moduleURL)
+	terraformGet, err := tfrGetter.getTerraformGetHeader(ctx, *moduleURL)
 	if err != nil {
 		return err
 	}
@@ -164,7 +161,7 @@ func (tfrGetter *TerraformRegistryGetter) Get(ctx context.Context, dstPath strin
 
 // GetFile is not implemented for the Terraform module registry Getter since the terraform module registry doesn't serve
 // a single file.
-func (tfrGetter *TerraformRegistryGetter) GetFile(dst string, src *url.URL) error {
+func (tfrGetter *TerraformRegistryGetter) GetFile(ctx context.Context, dst string, src *url.URL) error {
 	return errors.WithStackTrace(fmt.Errorf("GetFile is not implemented for the Terraform Registry Getter"))
 }
 
@@ -220,13 +217,13 @@ func (tfrGetter *TerraformRegistryGetter) getSubdir(ctx context.Context, dstPath
 // (https://www.terraform.io/docs/internals/remote-service-discovery.html)
 // to figure out where the modules are stored. This will return the base
 // path where the modules can be accessed
-func getModuleRegistryURLBasePath(ctx context.Context, domain string) (string, error) {
+func (tfrGetter *TerraformRegistryGetter) getModuleRegistryURLBasePath(ctx context.Context, domain string) (string, error) {
 	sdURL := url.URL{
 		Scheme: "https",
 		Host:   domain,
 		Path:   serviceDiscoveryPath,
 	}
-	bodyData, _, err := httpGETAndGetResponse(ctx, sdURL)
+	bodyData, _, err := tfrGetter.httpGETAndGetResponse(ctx, sdURL)
 	if err != nil {
 		return "", err
 	}
@@ -241,8 +238,8 @@ func getModuleRegistryURLBasePath(ctx context.Context, domain string) (string, e
 
 // getTerraformGetHeader makes an http GET call to the given registry URL and return the contents of the header
 // X-Terraform-Get. This function will return an error if the response does not contain the header.
-func getTerraformGetHeader(ctx context.Context, url url.URL) (string, error) {
-	_, header, err := httpGETAndGetResponse(ctx, url)
+func (tfrGetter *TerraformRegistryGetter) getTerraformGetHeader(ctx context.Context, url url.URL) (string, error) {
+	_, header, err := tfrGetter.httpGETAndGetResponse(ctx, url)
 	if err != nil {
 		details := "error receiving HTTP data"
 		return "", errors.WithStackTrace(ModuleDownloadErr{sourceURL: url.String(), details: details})
@@ -276,7 +273,7 @@ func getDownloadURLFromHeader(moduleURL url.URL, terraformGet string) (string, e
 
 // httpGETAndGetResponse is a helper function to make a GET request to the given URL using the http client. This
 // function will then read the response and return the contents + the response header.
-func httpGETAndGetResponse(ctx context.Context, getURL url.URL) ([]byte, *http.Header, error) {
+func (tfrGetter *TerraformRegistryGetter) httpGETAndGetResponse(ctx context.Context, getURL url.URL) ([]byte, *http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", getURL.String(), nil)
 	if err != nil {
 		return nil, nil, errors.WithStackTrace(err)
@@ -287,11 +284,31 @@ func httpGETAndGetResponse(ctx context.Context, getURL url.URL) ([]byte, *http.H
 	// when the host is a trusted registry - otherwise a malicious module source could exfiltrate the token to an
 	// attacker-controlled host.
 	authToken := os.Getenv(authTokenEnvVarName)
-	if authToken != "" && isTrustedRegistryHost(getURL.Host) {
+	if authToken != "" && tfrGetter.isTrustedRegistryHost(getURL.Host) {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authToken))
 	}
 
-	resp, err := httpClient.Do(req)
+	client := httpClient
+	if tfrGetter.ProxyURL != "" {
+		var shouldProxy bool
+		for _, suffix := range tfrGetter.ProxyForDomains {
+			if strings.HasSuffix(getURL.Host, suffix) {
+				shouldProxy = true
+				break
+			}
+		}
+		if shouldProxy {
+			if parsed, err := url.Parse(tfrGetter.ProxyURL); err == nil {
+				client = &http.Client{
+					Transport: &http.Transport{
+						Proxy: http.ProxyURL(parsed),
+					},
+				}
+			}
+		}
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, nil, errors.WithStackTrace(err)
 	}
@@ -303,6 +320,55 @@ func httpGETAndGetResponse(ctx context.Context, getURL url.URL) ([]byte, *http.H
 
 	bodyData, err := io.ReadAll(resp.Body)
 	return bodyData, &resp.Header, errors.WithStackTrace(err)
+}
+
+// defaultRegistryHost returns the registry host to use when a module source omits
+// it. Users can point at a private default registry via TG_TF_DEFAULT_REGISTRY_HOST,
+// otherwise we fall back to the public Terraform registry.
+func defaultRegistryHost() string {
+	if h := os.Getenv(defaultRegistryHostEnvVarName); h != "" {
+		return h
+	}
+	return defaultRegistryDomain
+}
+
+// isTrustedRegistryHost reports whether the TG_TF_REGISTRY_TOKEN may be sent to
+// the given host. The token is a Terraform Cloud/Enterprise registry token, so
+// we only attach it to the well-known public registries, to the configured
+// Terraform Cloud/Enterprise host (terraform_cloud_host config / TERRAFORM_CLOUD_HOST
+// env var, passed in via TrustedHosts) and to a configured default registry
+// (TG_TF_DEFAULT_REGISTRY_HOST) - never to a host derived from an untrusted
+// module source.
+func (tfrGetter *TerraformRegistryGetter) isTrustedRegistryHost(host string) bool {
+	trusted := []string{
+		"registry.terraform.io", // public Terraform registry
+		"registry.opentofu.org", // public OpenTofu registry
+		"app.terraform.io",      // Terraform Cloud (incl. private module registry)
+	}
+	// The resolved terraform_cloud_host config value lets Terraform Enterprise
+	// users point at their own host, so trust it too when it is explicitly
+	// configured.
+	trusted = append(trusted, tfrGetter.TrustedHosts...)
+	// Also read TERRAFORM_CLOUD_HOST directly so the token is scoped correctly
+	// even when the getter is constructed without a resolved config (the config
+	// value above already covers this env var, but reading it here keeps the
+	// getter self-contained).
+	if h := os.Getenv("TERRAFORM_CLOUD_HOST"); h != "" {
+		trusted = append(trusted, h)
+	}
+	// TG_TF_DEFAULT_REGISTRY_HOST points unqualified module sources at a private
+	// registry, so trust that host as well when it is configured.
+	if h := os.Getenv(defaultRegistryHostEnvVarName); h != "" {
+		trusted = append(trusted, h)
+	}
+
+	for _, t := range trusted {
+		if t != "" && hostsEqual(host, t) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // buildRequestUrl - create url to download module using moduleRegistryBasePath


### PR DESCRIPTION
Several code paths attached a configured secret token (Terraform Cloud/Enterprise token, or the terragrunt registry token) to an HTTP request whose destination host was derived from untrusted `.tf` / module-source input, with no check that the host was the trusted endpoint. An attacker supplying Terraform that Infracost scans (e.g. a PR) could set the host to their own domain and receive the victim's token as a `Bearer` credential.

The fix applies one rule across all three paths: **only send a configured token to a host that matches the trusted/configured endpoint** (`TERRAFORM_CLOUD_HOST` if set, otherwise `app.terraform.io`).

- **Remote-variables loader** (`remote_variables_loader.go`): the `.tf` `hostname` no longer blindly overrides the trusted host. If it matches, proceed; if a different host is explicitly configured, skip loading (don't send the token); if only a token is set and the `.tf` points elsewhere, error out and tell the user to set `TERRAFORM_CLOUD_HOST`.
- **Remote-plan** (`runRemotePlan`/`cloudAPI`): the primary token is only used when the remote-run host matches the trusted host; otherwise it refuses rather than leaking the token, falling back to the existing host-scoped lookup when no primary token is set.
- **Terragrunt registry** (`terragrunt_registry_service.go`): the registry token is only attached when the request host is in an allowlist (`registry.terraform.io`, `registry.opentofu.org`, `app.terraform.io`, plus `TERRAFORM_CLOUD_HOST` when configured).

## Testing

- New unit tests cover all three paths (loader error/skip cases, remote-plan token selection, registry host allowlist).
- `go build ./...`, `gofmt`, and `go vet` clean on the touched packages.