### PR TITLE
fix(aws): omit I/O requests cost for Aurora I/O-Optimized clusters

### DIFF
--- a/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
+++ b/internal/providers/terraform/aws/testdata/rds_cluster_test/rds_cluster_test.golden
@@ -43,7 +43,6 @@
  aws_rds_cluster.my_sql_serverless_io_optimized                                                                     
  ├─ Aurora serverless                              Monthly cost depends on usage: $0.06 per ACU-hours               
  ├─ Storage (I/O-optimized)                        Monthly cost depends on usage: $0.23 per GB                      
- ├─ I/O requests                                   Monthly cost depends on usage: $0.20 per 1M requests             
  └─ Snapshot export                                Monthly cost depends on usage: $0.01 per GB                      
                                                                                                                     
  aws_rds_cluster.mysql_backtrack_withoutU                                                                           
@@ -56,7 +55,6 @@
  aws_rds_cluster.postgres_serverless_io_optimized                                                                   
  ├─ Aurora serverless                              Monthly cost depends on usage: $0.06 per ACU-hours               
  ├─ Storage (I/O-optimized)                        Monthly cost depends on usage: $0.23 per GB                      
- ├─ I/O requests                                   Monthly cost depends on usage: $0.20 per 1M requests             
  └─ Snapshot export                                Monthly cost depends on usage: $0.01 per GB                      
                                                                                                                     
  aws_rds_cluster.postgres_serverless_withoutU                                                                       

--- a/internal/resources/aws/rds_cluster.go
+++ b/internal/resources/aws/rds_cluster.go
@@ -169,7 +169,7 @@ func (r *RDSCluster) auroraStorageCostComponents(databaseEngineStorageType strin
 		usageType = "Aurora:IO-OptimizedStorageUsage$"
 	}
 
-	return []*schema.CostComponent{
+	costComponents := []*schema.CostComponent{
 		{
 			Name:            label,
 			Unit:            "GB",
@@ -187,7 +187,12 @@ func (r *RDSCluster) auroraStorageCostComponents(databaseEngineStorageType strin
 			},
 			UsageBased: true,
 		},
-		{
+	}
+
+	// Aurora I/O-Optimized clusters bundle I/O into the instance and storage
+	// rates, so there is no per-request "Aurora:StorageIOUsage" charge.
+	if !r.IOOptimized {
+		costComponents = append(costComponents, &schema.CostComponent{
 			Name:            "I/O requests",
 			Unit:            "1M requests",
 			UnitMultiplier:  decimal.NewFromInt(1000000),
@@ -203,8 +208,10 @@ func (r *RDSCluster) auroraStorageCostComponents(databaseEngineStorageType strin
 				},
 			},
 			UsageBased: true,
-		},
+		})
 	}
+
+	return costComponents
 }
 
 func (r *RDSCluster) auroraBackupStorageCostComponent(totalBackupStorageGB *decimal.Decimal, databaseEngine string) *schema.CostComponent {


### PR DESCRIPTION
## Summary

For `aws_rds_cluster` with `storage_type = "aurora-iopt1"` (Aurora I/O-Optimized), Infracost still prices an **"I/O requests"** cost component when the usage file provides `read_requests_per_sec` / `write_requests_per_sec`. On I/O-Optimized clusters AWS bundles I/O into the instance and storage rates — there is no per-request `Aurora:StorageIOUsage` charge — so this component should not exist.

Because the phantom I/O charge appears on **both** sides of a `diff` between `aurora` and `aurora-iopt1`, it cancels out and the diff reports the **wrong direction** for exactly the decision I/O-Optimized exists to inform.

Fixes #3591.

## Cause

In `internal/resources/aws/rds_cluster.go`, `auroraStorageCostComponents` unconditionally appended the "I/O requests" component; `r.IOOptimized` only switched the storage label/usagetype.

## Fix

Only append the "I/O requests" component when `!r.IOOptimized`, matching AWS's pricing model where `Aurora:StorageIOUsage` exists solely for Standard (`aurora`) clusters.

## Tests

Updated the `rds_cluster` golden file: the two existing `aurora-iopt1` clusters no longer emit an "I/O requests" line. The overall total is unchanged (those clusters are usage-based), so the golden diff is exactly the two removed phantom lines — which now serves as regression coverage for this behavior.