### PR TITLE
fix(deps): bump Go to 1.25.12 to patch CVE-2026-39822

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG ARCH=linux
 ARG DEFAULT_TERRAFORM_VERSION=0.15.5

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM golang:1.25.11 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG ARCH=linux64
 

--- a/cmd/infracost/cmd_test.go
+++ b/cmd/infracost/cmd_test.go
@@ -32,7 +32,7 @@ var (
 	urlRegex         = regexp.MustCompile(`https://dashboard.infracost.io/share/.*`)
 	projectPathRegex = regexp.MustCompile(`(Project:) .*/(examples|cmd/infracost)/(.*)`)
 	versionRegex     = regexp.MustCompile(`Infracost (v|preview).*`)
-	panicRegex       = regexp.MustCompile(`runtime\serror:([\w\d\n\r\[\]\:\/\.\\(\)\+\,\{\}\*\@\s\?]*)Environment`)
+	panicRegex       = regexp.MustCompile(`(?s)runtime\serror:(.*?)Environment`)
 	pathRegex        = regexp.MustCompile(`(:\s*"|^|\s|')([a-zA-Z0-9-_/]+/)*(testdata/[^\s"']*)`)
 	credsRegex       = regexp.MustCompile(`/.*/credentials\.yml`)
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/infracost/infracost
 
-go 1.25.11
+go 1.26.0
+
+toolchain go1.26.5
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect


### PR DESCRIPTION
Image scanning flagged `go/stdlib 1.25.11` on the `dashboard-api-worker` and `hosted-cloud-pricing-api` images. Neither builds Go, both bake in the CLI binary, so the fix has to happen here. [CVE-2026-39822](https://nvd.nist.gov/vuln/detail/CVE-2026-39822) is an `os.Root` symlink escape fixed in 1.25.12; some aggregators still list 1.25.11 because they read the original backport milestone, which slipped. Both images need a CLI release and rebuild once this lands.
