### PR TITLE
chore(deps): move Go to the 1.26 line

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG ARCH=linux
 ARG DEFAULT_TERRAFORM_VERSION=0.15.5

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM golang:1.25.11 AS builder
+FROM golang:1.26.5 AS builder
 
 ARG ARCH=linux64
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/infracost/infracost
 
-go 1.25.11
+go 1.26.5
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect


### PR DESCRIPTION
Follow-up to #3597, which patched within the 1.25 line. This moves the repo onto 1.26.

Go supports a major release until two newer majors exist, so 1.25 and 1.26 are both currently supported. Go 1.25.0 landed 2025-08-12 and 1.26.0 landed 2026-02-10, so on the usual six-month cadence 1.27 is due in the next few weeks. The `Go1.27` milestone is open with no published date, so that is inference from cadence rather than an announced date. Once 1.27 ships, 1.25 stops receiving security patches and the next Go CVE becomes a scramble. The rest of the estate (cloud-data, coast, runner) is already on 1.26.

Every workflow resolves its toolchain from `go-version-file: go.mod`, so the `go` directive plus the two builder images are the whole change. No code changes.

## Verification

`make test` on this branch under Go 1.26.5, and the same tests on `master` (3d24c757) under Go 1.25.11 as a baseline. 23 packages pass on both. The same six tests fail on both, so 1.26.5 introduces no new failures:

| Test | Cause |
|---|---|
| `TestDiffTerragrunt`, `TestDiffTerragruntNested` | local terragrunt 0.92.1 vs the 0.31.8 CI pins |
| `TestHCLProvider_LoadPlanJSON`, `TestBreakdownFormatJsonWithTagsAftModule`, `TestBreakdownTerragruntWithRemoteSource` | remote module fetch blocked by local SSH agent |
| `TestCatchesRuntimeError` | golden-file panic text, fails identically on master |

`govulncheck` under 1.26.5 reports no stdlib vulnerabilities, confirming CVE-2026-39822 is cleared.

Local `golangci-lint` is 2.5.0 (built with go1.25.1) against CI's 2.11.4, so lint on a 1.26 module is left for CI to confirm.

## Out of scope

`govulncheck` flagged three dependency vulnerabilities unrelated to this change, worth a separate PR:

- [GO-2026-6061](https://pkg.go.dev/vuln/GO-2026-6061) `google.golang.org/grpc` v1.79.3, fixed in v1.82.1
- [GO-2026-5970](https://pkg.go.dev/vuln/GO-2026-5970) `golang.org/x/text` v0.37.0, fixed in v0.39.0
- [GO-2026-5932](https://pkg.go.dev/vuln/GO-2026-5932) `golang.org/x/crypto` v0.52.0, no fix available

## Checklist

- [x] [Technical docs](https://github.com/infracost/technical-docs) updated (or not needed)