### PR TITLE
fix(azure): support FC1 Flex Consumption pricing for azurerm_service_plan

### DIFF
--- a/internal/providers/terraform/azure/function_app.go
+++ b/internal/providers/terraform/azure/function_app.go
@@ -67,6 +67,8 @@ func newFunctionAppFromAppServicePlanRef(d *schema.ResourceData, data *schema.Re
 	skuName := data.Get("sku_name").String()
 	if strings.HasPrefix(strings.ToLower(skuName), "ep") {
 		tier = "premium"
+	} else if strings.HasPrefix(strings.ToLower(skuName), "fc") {
+		tier = "flexconsumption"
 	}
 
 	return &azure.FunctionApp{

--- a/internal/providers/terraform/azure/testdata/function_linux_app_test/function_linux_app_test.golden
+++ b/internal/providers/terraform/azure/testdata/function_linux_app_test/function_linux_app_test.golden
@@ -97,6 +97,10 @@
  ├─ vCPU (EP1)                                                                                                                      1  vCPU                           $126.29    
  └─ Memory (EP1)                                                                                                                  3.5  GB                              $31.43    
                                                                                                                                                                                  
+ azurerm_linux_function_app.function_with_usage["plan-Linux-FC1"]                                                                                                                
+ ├─ Execution time                                                                                                       876,180.4425  GB-seconds                      $22.78  * 
+ └─ Executions                                                                                                                 3.5401  1M requests                      $1.42  * 
+                                                                                                                                                                                 
  azurerm_linux_function_app.function_with_usage["plan-Linux-Y1"]                                                                                                                 
  ├─ Execution time                                                                                                       876,180.4425  GB-seconds                      $14.02  * 
  └─ Executions                                                                                                                 3.5401  1M requests                      $0.71  * 
@@ -128,6 +132,10 @@
  azurerm_linux_function_app.legacy_service_plan_function_with_usage["legacy-plan-Standard-Y1-elastic"]                                                                           
  ├─ Execution time                                                                                                       876,180.4425  GB-seconds                      $14.02  * 
  └─ Executions                                                                                                                 3.5401  1M requests                      $0.71  * 
+                                                                                                                                                                                 
+ azurerm_linux_function_app.function["plan-Linux-FC1"]                                                                                                                           
+ ├─ Execution time                                                                                                 Monthly cost depends on usage: $0.000026 per GB-seconds       
+ └─ Executions                                                                                                     Monthly cost depends on usage: $0.40 per 1M requests          
                                                                                                                                                                                  
  azurerm_linux_function_app.function["plan-Linux-Y1"]                                                                                                                            
  ├─ Execution time                                                                                                 Monthly cost depends on usage: $0.000016 per GB-seconds       
@@ -171,17 +179,17 @@
  ├─ Blob index                                                                                                     Monthly cost depends on usage: $0.03 per 10k tags             
  └─ Early deletion                                                                                                 Monthly cost depends on usage: $0.0152 per GB                 
                                                                                                                                                                                  
- OVERALL TOTAL                                                                                                                                                     $13,366.00 
+ OVERALL TOTAL                                                                                                                                                     $13,390.20 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-63 cloud resources were detected:
-∙ 41 were estimated
-∙ 22 were free
+66 cloud resources were detected:
+∙ 43 were estimated
+∙ 23 were free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃       $13,248 ┃        $118 ┃    $13,366 ┃
+┃ main                                               ┃       $13,248 ┃        $142 ┃    $13,390 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/function_linux_app_test/function_linux_app_test.tf
+++ b/internal/providers/terraform/azure/testdata/function_linux_app_test/function_linux_app_test.tf
@@ -34,10 +34,13 @@ resource "azurerm_storage_account" "example" {
 locals {
   os_types = ["Linux"]
   skus     = ["EP1", "EP2", "EP3", "Y1"]
+  # FC1 (Flex Consumption) only exists on the modern azurerm_service_plan resource, so it's
+  # kept out of `skus`, which also seeds the legacy azurerm_app_service_plan permutations below.
+  plan_skus = concat(local.skus, ["FC1"])
 
   permutations = distinct(flatten([
     for os_type in local.os_types : [
-      for sku in local.skus : {
+      for sku in local.plan_skus : {
         sku     = sku
         os_type = os_type
       }

--- a/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.golden
+++ b/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.golden
@@ -816,9 +816,9 @@
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-334 cloud resources were detected:
+343 cloud resources were detected:
 ∙ 270 were estimated
-∙ 64 were free
+∙ 73 were free
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃

--- a/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.tf
+++ b/internal/providers/terraform/azure/testdata/service_plan_test/service_plan_test.tf
@@ -44,6 +44,7 @@ locals {
     "EP1",
     "EP2",
     "EP3",
+    "FC1",
     "WS1",
     "WS2",
     "WS3",

--- a/internal/resources/azure/function_app.go
+++ b/internal/resources/azure/function_app.go
@@ -89,6 +89,22 @@ func (r *FunctionApp) BuildResource() *schema.Resource {
 		}
 	}
 
+	if r.Tier == "flexconsumption" {
+		// Always-ready instance costs aren't modelled yet since they depend on the
+		// site_config.always_ready block, which isn't currently read from Terraform data.
+		costComponents = append(
+			costComponents,
+			r.appFunctionFlexConsumptionExecutionTimeCostComponent(),
+			r.appFunctionFlexConsumptionExecutionsCostComponent(),
+		)
+
+		return &schema.Resource{
+			Name:           r.Address,
+			CostComponents: costComponents,
+			UsageSchema:    r.UsageSchema(),
+		}
+	}
+
 	costComponents = append(
 		costComponents,
 		r.appFunctionConsumptionExecutionTimeCostComponent(),
@@ -225,6 +241,69 @@ func (r *FunctionApp) appFunctionConsumptionExecutionsCostComponent() *schema.Co
 		PriceFilter: &schema.PriceFilter{
 			PurchaseOption:   strPtr("Consumption"),
 			StartUsageAmount: strPtr("100000"),
+		},
+		UsageBased: true,
+	}
+}
+
+// appFunctionFlexConsumptionExecutionTimeCostComponent prices the "On Demand" execution time meter
+// used by Flex Consumption (FC1) plans. Verified against the Azure Retail Prices API: Flex
+// Consumption gives 100,000 free GB-seconds/month before "On Demand Execution Time" is billed.
+func (r *FunctionApp) appFunctionFlexConsumptionExecutionTimeCostComponent() *schema.CostComponent {
+	gbSeconds := r.calculateFunctionAppGBSeconds()
+	return &schema.CostComponent{
+		Name:            "Execution time",
+		Unit:            "GB-seconds",
+		UnitMultiplier:  decimal.NewFromInt(1),
+		MonthlyQuantity: gbSeconds,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Functions"),
+			ProductFamily: strPtr("Compute"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "meterName", ValueRegex: regexPtr("Execution Time$")},
+				{Key: "skuName", Value: strPtr("On Demand")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("100000"),
+		},
+		UsageBased: true,
+	}
+}
+
+// appFunctionFlexConsumptionExecutionsCostComponent prices the "On Demand" executions meter used by
+// Flex Consumption (FC1) plans. Verified against the Azure Retail Prices API: Flex Consumption
+// gives 250,000 free executions/month (tierMinimumUnits 25000, in units of 10 executions) before
+// "On Demand Total Executions" is billed.
+func (r *FunctionApp) appFunctionFlexConsumptionExecutionsCostComponent() *schema.CostComponent {
+	// Azure's pricing API returns prices per 10 executions so if the user has provided
+	// the number of executions, we should divide it by 10
+	var executions *decimal.Decimal
+	if r.MonthlyExecutions != nil {
+		executions = decimalPtr(decimal.NewFromInt(*r.MonthlyExecutions).Div(decimal.NewFromInt(10)))
+	}
+
+	return &schema.CostComponent{
+		Name:            "Executions",
+		Unit:            "1M requests",
+		UnitMultiplier:  decimal.NewFromInt(100000),
+		MonthlyQuantity: executions,
+		ProductFilter: &schema.ProductFilter{
+			VendorName:    strPtr("azure"),
+			Region:        strPtr(r.Region),
+			Service:       strPtr("Functions"),
+			ProductFamily: strPtr("Compute"),
+			AttributeFilters: []*schema.AttributeFilter{
+				{Key: "meterName", ValueRegex: regexPtr("Total Executions$")},
+				{Key: "skuName", Value: strPtr("On Demand")},
+			},
+		},
+		PriceFilter: &schema.PriceFilter{
+			PurchaseOption:   strPtr("Consumption"),
+			StartUsageAmount: strPtr("25000"),
 		},
 		UsageBased: true,
 	}

--- a/internal/resources/azure/service_plan.go
+++ b/internal/resources/azure/service_plan.go
@@ -43,7 +43,10 @@ func (r *ServicePlan) BuildResource() *schema.Resource {
 	productName := "Standard Plan"
 	sku := r.SKUName
 
-	if len(r.SKUName) < 2 || strings.ToLower(r.SKUName[:2]) == "ep" || strings.ToLower(r.SKUName[:2]) == "ws" || strings.ToLower(r.SKUName[:2]) == "y1" {
+	if len(r.SKUName) < 2 || strings.ToLower(r.SKUName[:2]) == "ep" || strings.ToLower(r.SKUName[:2]) == "ws" || strings.ToLower(r.SKUName[:2]) == "y1" || strings.ToLower(r.SKUName[:2]) == "fc" {
+		// Flex Consumption ("FC1") plans have no direct cost of their own - Azure bills
+		// executions/GB-seconds on the linked Function App resource instead, so this plan
+		// is skipped here in the same way as WS/Y1 (see FunctionApp for the actual pricing).
 		return &schema.Resource{
 			Name:        r.Address,
 			IsSkipped:   true,


### PR DESCRIPTION
## Summary

Fixes [ENG-963](https://linear.app/infracost/issue/ENG-963/azurerm-service-plan-fc1-flex-consumption-misrouted-to-free) — `azurerm_service_plan` with `sku_name="FC1"` (Azure Functions Flex Consumption) reported price missing/not found instead of a cost estimate. Raised by a trial customer via [Pylon #1906](https://app.usepylon.com/issues?issueNumber=1906).

**Root cause:** any `sku_name` starting with `f` was unconditionally routed into the Free Plan (`F1`) pricing branch without reassigning the lookup SKU string, so the product filter searched for a nonexistent `"Free Plan"` + `"FC1"` combination and silently resolved to nothing.

**Fix:**
- `azurerm_service_plan`: FC1 now skips as no-price, consistent with the existing EP/WS/Y1 handling — Flex Consumption has no direct cost on the Service Plan itself.
- `azurerm_linux_function_app` / `azurerm_windows_function_app`: now price FC1-backed function apps using the correct Flex Consumption meters. Verified live against the Azure Retail Prices API:
  - `Flex Consumption` / `On Demand` skuName (not `Standard`, which is the legacy Y1 Consumption meter)
  - 100,000 free GB-seconds/month, 250,000 free executions/month
- Mirrors the existing Y1 Consumption cost component pattern (same usage fields: `monthly_executions`, `execution_duration_ms`, `memory_mb`).

**Known limitation:** Always Ready (pre-warmed) instance costs aren't modelled yet — that depends on `site_config.always_ready`, which isn't currently read from Terraform data. Left as a follow-up.

A companion one-line fix for the newer pricing engine is in [infracost/providers](https://github.com/infracost/providers) (same ticket).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/resources/azure/... ./internal/providers/terraform/azure/...` (short mode) passes
- [x] Golden file tests (`TestAzureRMServicePlan`, `TestAzureRMLinuxAppFunctionGoldenFile`) regenerated and pass for `HCL`/`HCL Graph`. `Terraform CLI` subtest fails identically on unmodified `master` (pre-existing azurerm-v5-provider fixture incompatibility, unrelated to this change) — verified via `git stash`.
- [x] Manually verified with a locally built binary against a reproduction of the customer's scenario: `azurerm_service_plan` (FC1) now shows as free/no-cost instead of a broken price lookup, and the linked `azurerm_linux_function_app` shows a real, non-zero cost ($22.78 execution time + $1.42 executions) computed from live pricing data.