### PR TITLE
fix(deps): bump Go toolchain to 1.26.6 to patch CVE-2026-39821

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/infracost/infracost
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect


### PR DESCRIPTION
Bumps the `toolchain` directive 1.26.5 → 1.26.6 so released binaries are built with a Go stdlib patched for CVE-2026-39821, which affects images embedding the `infracost` binary (dashboard-api-worker, hosted-cloud-pricing-api).

- The prerelease workflow builds with `go-version-file: go.mod`, so the `preview` release republishes with the patched stdlib as soon as this merges — no other change needed.
- The grpc ([GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf)) and x/text (CVE-2026-56852) findings on those same images are already fixed on master (grpc 1.82.1, x/text 0.39.0); downstream images just need rebuilding against a fresh binary.

- [x] `/review` at commit [ebff70b](https://github.com/infracost/infracost/commit/ebff70b5f7282cc84b1148901090cb53cfcbb9a1) produced a risk score of 3/10. One-line `toolchain` patch bump; affects all released binaries but is a patch-level stdlib change validated by the full CI matrix.
