### PR TITLE
fix(docker): bump builder to golang 1.26.6 for CVE-2026-39821

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 
 ARG ARCH=linux
 ARG DEFAULT_TERRAFORM_VERSION=0.15.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ ARG TERRAGRUNT_VERSION=0.31.8
 SHELL ["/bin/bash", "-c"]
 ENV HOME=/app
 ENV CGO_ENABLED=0
+# Force the golang image tag above to be in sync with the `toolchain` directive
+# in go.mod: the build fails if they drift, instead of silently downloading
+# another toolchain (or, with the image default GOTOOLCHAIN=local, silently
+# building with the wrong one).
+ENV GOTOOLCHAIN=path
 
 # Install Packages
 RUN apt-get update -q && apt-get -y install unzip && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.26.6 AS builder
+ARG GO_VERSION=1.26.6
+
+FROM golang:${GO_VERSION} AS builder
 
 ARG ARCH=linux
 ARG DEFAULT_TERRAFORM_VERSION=0.15.5
@@ -8,7 +10,7 @@ ARG TERRAGRUNT_VERSION=0.31.8
 SHELL ["/bin/bash", "-c"]
 ENV HOME=/app
 ENV CGO_ENABLED=0
-# force the golang image tag above to be in sync with the `toolchain` directive in go.mod.
+# force the GO_VERSION above to be in sync with the `toolchain` directive in go.mod.
 # This avoids downloading other Go Toolchains, which happens silently and would slow
 # down our image builds.
 ENV GOTOOLCHAIN=path

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,9 @@ ARG TERRAGRUNT_VERSION=0.31.8
 SHELL ["/bin/bash", "-c"]
 ENV HOME=/app
 ENV CGO_ENABLED=0
-# Force the golang image tag above to be in sync with the `toolchain` directive
-# in go.mod: the build fails if they drift, instead of silently downloading
-# another toolchain (or, with the image default GOTOOLCHAIN=local, silently
-# building with the wrong one).
+# force the golang image tag above to be in sync with the `toolchain` directive in go.mod.
+# This avoids downloading other Go Toolchains, which happens silently and would slow
+# down our image builds.
 ENV GOTOOLCHAIN=path
 
 # Install Packages

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.6 AS builder
 
 ARG ARCH=linux64
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,6 +6,11 @@ ARG ARCH=linux64
 SHELL ["/bin/bash", "-c"]
 ENV HOME=/app
 ENV CGO_ENABLED=0
+# Force the golang image tag above to be in sync with the `toolchain` directive
+# in go.mod: the build fails if they drift, instead of silently downloading
+# another toolchain (or, with the image default GOTOOLCHAIN=local, silently
+# building with the wrong one).
+ENV GOTOOLCHAIN=path
 
 WORKDIR /app
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,10 +6,9 @@ ARG ARCH=linux64
 SHELL ["/bin/bash", "-c"]
 ENV HOME=/app
 ENV CGO_ENABLED=0
-# Force the golang image tag above to be in sync with the `toolchain` directive
-# in go.mod: the build fails if they drift, instead of silently downloading
-# another toolchain (or, with the image default GOTOOLCHAIN=local, silently
-# building with the wrong one).
+# force the golang image tag above to be in sync with the `toolchain` directive in go.mod.
+# This avoids downloading other Go Toolchains, which happens silently and would slow
+# down our image builds.
 ENV GOTOOLCHAIN=path
 
 WORKDIR /app

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,6 @@
-FROM golang:1.26.6 AS builder
+ARG GO_VERSION=1.26.6
+
+FROM golang:${GO_VERSION} AS builder
 
 ARG ARCH=linux64
 
@@ -6,7 +8,7 @@ ARG ARCH=linux64
 SHELL ["/bin/bash", "-c"]
 ENV HOME=/app
 ENV CGO_ENABLED=0
-# force the golang image tag above to be in sync with the `toolchain` directive in go.mod.
+# force the GO_VERSION above to be in sync with the `toolchain` directive in go.mod.
 # This avoids downloading other Go Toolchains, which happens silently and would slow
 # down our image builds.
 ENV GOTOOLCHAIN=path


### PR DESCRIPTION
Follow-up to #3606: the `golang` Docker images set `GOTOOLCHAIN=local`, so the `toolchain go1.26.6` directive in go.mod is ignored inside Docker builds and the published `edge`/`ci-edge` images still ship binaries built with the 1.26.5 stdlib (confirmed via scans of downstream images that embed them).

- Bumps the builder stage in `Dockerfile` and `Dockerfile.ci` to `golang:1.26.6`, which is what actually controls the stdlib in the published images.
- #3606 remains correct for the non-Docker release paths, which run `actions/setup-go` with the default `GOTOOLCHAIN=auto`.
- Adds `GOTOOLCHAIN=path` to both builder stages (suggested by tommyknows) so image/toolchain-directive drift fails the build loudly instead of silently building with the image's stdlib.