### PR TITLE
Add Azure PremiumV2_LRS (Premium SSD v2) managed disk pricing

### DIFF
--- a/internal/providers/terraform/azure/testdata/managed_disk_test/managed_disk_test.golden
+++ b/internal/providers/terraform/azure/testdata/managed_disk_test/managed_disk_test.golden
@@ -1,32 +1,44 @@
 
- Name                                         Monthly Qty  Unit                      Monthly Cost    
-                                                                                                     
- azurerm_managed_disk.ultra                                                                          
- ├─ Storage (ultra, 2048 GiB)                       2,048  GiB                            $245.19    
- ├─ Provisioned IOPS                                4,000  IOPS                           $198.56    
- └─ Throughput                                         20  MB/s                             $6.99    
-                                                                                                     
- azurerm_managed_disk.custom_size_ssd                                                                
- ├─ Storage (E30, LRS)                                  1  months                          $76.80    
- └─ Disk operations                                     2  10k operations                   $0.00  * 
-                                                                                                     
- azurerm_managed_disk.premium                                                                        
- └─ Storage (P4, LRS)                                   1  months                           $5.28    
-                                                                                                     
- azurerm_managed_disk.standard                                                                       
- ├─ Storage (S4, LRS)                                   1  months                           $1.54    
- └─ Disk operations                    Monthly cost depends on usage: $0.0005 per 10k operations     
-                                                                                                     
- OVERALL TOTAL                                                                            $534.36 
+ Name                                           Monthly Qty  Unit                      Monthly Cost    
+                                                                                                       
+ azurerm_managed_disk.premiumv2_custom                                                                 
+ ├─ Storage (provisioned)                            10,752  GiB                            $863.39    
+ ├─ Provisioned IOPS (included)                       3,000  IOPS                             $0.00    
+ ├─ Provisioned IOPS                                  3,000  IOPS                            $15.33    
+ ├─ Provisioned throughput (included)                   125  MBps                             $0.00    
+ └─ Provisioned throughput                              375  MBps                            $15.06    
+                                                                                                       
+ azurerm_managed_disk.ultra                                                                            
+ ├─ Storage (ultra, 2048 GiB)                         2,048  GiB                            $245.19    
+ ├─ Provisioned IOPS                                  4,000  IOPS                           $198.56    
+ └─ Throughput                                           20  MB/s                             $6.99    
+                                                                                                       
+ azurerm_managed_disk.premiumv2_default                                                                
+ ├─ Storage (provisioned)                             1,024  GiB                             $82.23    
+ ├─ Provisioned IOPS (included)                       3,000  IOPS                             $0.00    
+ └─ Provisioned throughput (included)                   125  MBps                             $0.00    
+                                                                                                       
+ azurerm_managed_disk.custom_size_ssd                                                                  
+ ├─ Storage (E30, LRS)                                    1  months                          $76.80    
+ └─ Disk operations                                       2  10k operations                   $0.00  * 
+                                                                                                       
+ azurerm_managed_disk.premium                                                                          
+ └─ Storage (P4, LRS)                                     1  months                           $5.28    
+                                                                                                       
+ azurerm_managed_disk.standard                                                                         
+ ├─ Storage (S4, LRS)                                     1  months                           $1.54    
+ └─ Disk operations                      Monthly cost depends on usage: $0.0005 per 10k operations     
+                                                                                                       
+ OVERALL TOTAL                                                                            $1,510.36 
 
 *Usage costs can be estimated by updating Infracost Cloud settings, see docs for other options.
 
 ──────────────────────────────────
-4 cloud resources were detected:
-∙ 4 were estimated
+6 cloud resources were detected:
+∙ 6 were estimated
 
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
 ┃ Project                                            ┃ Baseline cost ┃ Usage cost* ┃ Total cost ┃
 ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━╋━━━━━━━━━━━━┫
-┃ main                                               ┃          $534 ┃       $0.00 ┃       $534 ┃
+┃ main                                               ┃        $1,510 ┃       $0.00 ┃     $1,510 ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┻━━━━━━━━━━━━┛

--- a/internal/providers/terraform/azure/testdata/managed_disk_test/managed_disk_test.tf
+++ b/internal/providers/terraform/azure/testdata/managed_disk_test/managed_disk_test.tf
@@ -42,3 +42,26 @@ resource "azurerm_managed_disk" "ultra" {
   disk_iops_read_write = 4000
   disk_mbps_read_write = 20
 }
+
+resource "azurerm_managed_disk" "premiumv2_default" {
+  name                = "premiumv2_default"
+  resource_group_name = "fake_resource_group"
+  location            = "eastus"
+
+  create_option        = "Empty"
+  storage_account_type = "PremiumV2_LRS"
+  disk_size_gb         = 1024
+}
+
+resource "azurerm_managed_disk" "premiumv2_custom" {
+  name                = "premiumv2_custom"
+  resource_group_name = "fake_resource_group"
+  location            = "eastus"
+
+  create_option        = "Empty"
+  storage_account_type = "PremiumV2_LRS"
+  disk_size_gb         = 10752
+  disk_iops_read_write = 6000
+  disk_mbps_read_write = 500
+  zone                 = "1"
+}

--- a/internal/resources/azure/managed_disk.go
+++ b/internal/resources/azure/managed_disk.go
@@ -4,6 +4,7 @@ import (
 	"github.com/infracost/infracost/internal/logging"
 	"github.com/infracost/infracost/internal/resources"
 	"github.com/infracost/infracost/internal/schema"
+	"github.com/infracost/infracost/internal/usage"
 
 	"fmt"
 	"math"
@@ -143,7 +144,104 @@ func managedDiskCostComponents(region, diskType string, diskSizeGB, diskIOPSRead
 		return ultraDiskCostComponents(region, storageReplicationType, diskSizeGB, diskIOPSReadWrite, diskMBPSReadWrite)
 	}
 
+	if strings.ToLower(diskTypePrefix) == "premiumv2" {
+		return premiumV2DiskCostComponents(region, storageReplicationType, diskSizeGB, diskIOPSReadWrite, diskMBPSReadWrite)
+	}
+
 	return standardPremiumDiskCostComponents(region, diskTypePrefix, storageReplicationType, diskSizeGB, monthlyDiskOperations)
+}
+
+// premiumV2IncludedIOPS and premiumV2IncludedThroughput are the amounts of
+// provisioned IOPS/throughput that Azure includes at no extra cost with every
+// Premium SSD v2 disk, regardless of provisioned size.
+var premiumV2IncludedIOPS = 3000
+var premiumV2IncludedThroughput = 125
+
+func premiumV2DiskCostComponents(region string, storageReplicationType string, diskSizeGB, diskIOPSReadWrite, diskMBPSReadWrite int64) []*schema.CostComponent {
+	requestedSize := 1024
+	iops := premiumV2IncludedIOPS
+	throughput := premiumV2IncludedThroughput
+
+	if diskSizeGB > 0 {
+		requestedSize = int(diskSizeGB)
+	}
+
+	if diskIOPSReadWrite > 0 {
+		iops = int(diskIOPSReadWrite)
+	}
+
+	if diskMBPSReadWrite > 0 {
+		throughput = int(diskMBPSReadWrite)
+	}
+
+	costComponents := []*schema.CostComponent{
+		{
+			Name:           "Storage (provisioned)",
+			Unit:           "GiB",
+			UnitMultiplier: schema.HourToMonthUnitMultiplier,
+			HourlyQuantity: decimalPtr(decimal.NewFromInt(int64(requestedSize))),
+			ProductFilter:  premiumV2ProductFilter(region, storageReplicationType, "Provisioned Capacity$"),
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption: strPtr("Consumption"),
+			},
+		},
+	}
+
+	costComponents = append(costComponents, premiumV2TieredCostComponents("Provisioned IOPS", "IOPS", region, storageReplicationType, "Provisioned IOPS$", iops, premiumV2IncludedIOPS)...)
+	costComponents = append(costComponents, premiumV2TieredCostComponents("Provisioned throughput", "MBps", region, storageReplicationType, "Provisioned Throughput \\(MBps\\)$", throughput, premiumV2IncludedThroughput)...)
+
+	return costComponents
+}
+
+// premiumV2TieredCostComponents builds cost components for a Premium SSD v2
+// meter that has a free included amount followed by a paid amount above that,
+// e.g. the first 3,000 provisioned IOPS and 125 MBps of throughput are
+// included at no cost, with usage above that billed per unit.
+func premiumV2TieredCostComponents(name, unit, region, storageReplicationType, meterNameRegex string, requested, included int) []*schema.CostComponent {
+	tiers := usage.CalculateTierBuckets(decimal.NewFromInt(int64(requested)), []int{included})
+
+	data := []struct {
+		name       string
+		startUsage string
+	}{
+		{name: fmt.Sprintf("%s (included)", name), startUsage: "0"},
+		{name: name, startUsage: fmt.Sprintf("%d", included)},
+	}
+
+	var costComponents []*schema.CostComponent
+	for i, d := range data {
+		if i >= len(tiers) || !tiers[i].GreaterThan(decimal.Zero) {
+			continue
+		}
+
+		costComponents = append(costComponents, &schema.CostComponent{
+			Name:           d.name,
+			Unit:           unit,
+			UnitMultiplier: schema.HourToMonthUnitMultiplier,
+			HourlyQuantity: decimalPtr(tiers[i]),
+			ProductFilter:  premiumV2ProductFilter(region, storageReplicationType, meterNameRegex),
+			PriceFilter: &schema.PriceFilter{
+				PurchaseOption:   strPtr("Consumption"),
+				StartUsageAmount: strPtr(d.startUsage),
+			},
+		})
+	}
+
+	return costComponents
+}
+
+func premiumV2ProductFilter(region, storageReplicationType, meterNameRegex string) *schema.ProductFilter {
+	return &schema.ProductFilter{
+		VendorName:    strPtr("azure"),
+		Region:        strPtr(region),
+		Service:       strPtr("Storage"),
+		ProductFamily: strPtr("Storage"),
+		AttributeFilters: []*schema.AttributeFilter{
+			{Key: "productName", Value: strPtr("Azure Premium SSD v2")},
+			{Key: "skuName", Value: strPtr(fmt.Sprintf("Premium %s", storageReplicationType))},
+			{Key: "meterName", ValueRegex: regexPtr(meterNameRegex)},
+		},
+	}
 }
 
 func standardPremiumDiskCostComponents(region string, diskTypePrefix string, storageReplicationType string, diskSizeGB int64, monthlyDiskOperations *decimal.Decimal) []*schema.CostComponent {


### PR DESCRIPTION
## Summary
- Fixes #3612 — `azurerm_managed_disk` with `storage_account_type = "PremiumV2_LRS"` previously fell through the legacy tiered P-series disk-name lookup, failed to match, and silently priced at $0 (only a debug-level `WARN` was logged, and it did not appear in the "not supported yet" list).
- Adds a dedicated pricing path for Premium SSD v2, matching Azure's actual billing model: per-GiB-provisioned storage, plus separately billed provisioned IOPS and throughput, each with a free included baseline (3,000 IOPS / 125 MBps) before paid usage applies.
- Meter names, product name, sku name, and units were verified directly against Azure's public Retail Prices API (`productName: "Azure Premium SSD v2"`, `skuName: "Premium LRS"`, meters `Premium LRS Provisioned Capacity` / `Provisioned IOPS` / `Provisioned Throughput (MBps)`).
- Tiering (free baseline vs. paid overage) reuses the existing `usage.CalculateTierBuckets` helper, following the same pattern already used for Azure Storage Account tiered pricing.

## Verification
Built and tested locally (`go build`, `go vet`, and the `TestAzureRMManagedDiskGoldenFile` golden-file test) against the real Infracost Cloud Pricing API:

- `HCL` and `HCL_Graph` golden subtests **pass**.
- Regenerated `managed_disk_test.golden` shows correct real-dollar pricing:
  - `premiumv2_custom` (10,752 GB / 6,000 IOPS / 500 MBps): Storage $863.39, IOPS included (3,000 @ $0) + overage (3,000 @ $15.33), throughput included (125 @ $0) + overage (375 @ $15.06) — all consistent with Azure's published per-unit overage rates.
  - `premiumv2_default` (1,024 GB, defaults): Storage $82.23, IOPS/throughput both fully within the free included tier ($0, overage component correctly omitted).
  - Existing `Standard`/`StandardSSD`/`Premium`/`UltraSSD` disk pricing is byte-identical to before (no regression).
- `Terraform_CLI` golden subtest still fails, but only due to a **pre-existing, unrelated** issue: the shared test fixture's provider block uses `skip_provider_registration`, an argument removed in `azurerm` provider v5+ (the fixture pins no provider version, so Terraform auto-installed v5.3.0). This affects every resource in this golden file, not just PremiumV2, and predates this change — flagging for maintainers rather than fixing as part of this PR's scope.

## Test plan
- [x] Added `premiumv2_default` (defaults only, exercises the free-tier-only path) and `premiumv2_custom` (10752 GB / 6000 IOPS / 500 MBps, reproducing the exact repro from #3612) resources to `managed_disk_test.tf`.
- [x] `go build ./...` (targeted at changed packages) and `go vet` pass clean.
- [x] Golden file regenerated and verified against real pricing data (see above).
- [ ] Maintainer call on whether to fix the unrelated `skip_provider_registration` fixture issue separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)