### PR TITLE
fix(usage): nested resource usage should override type defaults

### DIFF
--- a/internal/schema/usage_data.go
+++ b/internal/schema/usage_data.go
@@ -373,7 +373,7 @@ func mergeUsage(dst *UsageData, src *UsageData) {
 				logging.Logger.Err(err).Msgf("failed to merge UsageData attributes, could not unmarshal src attribute key: %q", key)
 				continue
 			}
-			err = mergo.Map(&destJson, srcJson)
+			err = mergo.Map(&destJson, srcJson, mergo.WithOverwriteWithEmptyValue)
 			if err != nil {
 				logging.Logger.Err(err).Msgf("failed to merge UsageData attributes, could not merge attribute key: %q", key)
 				continue

--- a/internal/schema/usage_data_test.go
+++ b/internal/schema/usage_data_test.go
@@ -213,3 +213,37 @@ func TestUsageMap_Get(t *testing.T) {
 		})
 	}
 }
+
+func TestUsageMap_GetNestedOverride(t *testing.T) {
+	usage := NewUsageMapFromInterface(map[string]interface{}{
+		"aws_s3_bucket": map[string]interface{}{
+			"object_tags": 10,
+			"standard": map[string]interface{}{
+				"storage_gb": 100,
+			},
+			"intelligent_tiering": map[string]interface{}{
+				"frequent_access_storage_gb": 100,
+				"monthly_tier_2_requests":    1000,
+			},
+		},
+		"aws_s3_bucket.example": map[string]interface{}{
+			"object_tags": 0,
+			"standard": map[string]interface{}{
+				"storage_gb": 200,
+			},
+			"intelligent_tiering": map[string]interface{}{
+				"frequent_access_storage_gb": 0,
+			},
+		},
+	})
+
+	got := usage.Get("aws_s3_bucket.example")
+	require.NotNil(t, got)
+
+	assert.Equal(t, 0.0, got.Get("object_tags").Float())
+	assert.Equal(t, 200.0, got.Get("standard").Get("storage_gb").Float())
+
+	it := got.Get("intelligent_tiering")
+	assert.Equal(t, 0.0, it.Get("frequent_access_storage_gb").Float())
+	assert.Equal(t, 1000.0, it.Get("monthly_tier_2_requests").Float())
+}

--- a/internal/schema/usage_data_test.go
+++ b/internal/schema/usage_data_test.go
@@ -229,7 +229,8 @@ func TestUsageMap_GetNestedOverride(t *testing.T) {
 		"aws_s3_bucket.example": map[string]interface{}{
 			"object_tags": 0,
 			"standard": map[string]interface{}{
-				"storage_gb": 200,
+				"storage_gb":              200,
+				"monthly_tier_1_requests": 300,
 			},
 			"intelligent_tiering": map[string]interface{}{
 				"frequent_access_storage_gb": 0,
@@ -242,6 +243,7 @@ func TestUsageMap_GetNestedOverride(t *testing.T) {
 
 	assert.Equal(t, 0.0, got.Get("object_tags").Float())
 	assert.Equal(t, 200.0, got.Get("standard").Get("storage_gb").Float())
+	assert.Equal(t, 300.0, got.Get("standard").Get("monthly_tier_1_requests").Float())
 
 	it := got.Get("intelligent_tiering")
 	assert.Equal(t, 0.0, it.Get("frequent_access_storage_gb").Float())


### PR DESCRIPTION
## Bug
- `UsageMap.Get` says a more specific usage key always overwrites the same key at a more general level. That holds for scalars. Nested blocks go through `mergo.Map` with no overwrite, so the type default wins.

```
resource_type_default_usage:
  aws_s3_bucket:
    standard:
      storage_gb: 100

resource_usage:
  aws_s3_bucket.example:
    standard:
      storage_gb: 200
```
      
- `Get("aws_s3_bucket.example")` currently returns 100, instead of 200 for `storage_gb`. After this change it gets 200.
- Intentionally not using `WithOverride`: `mergo` still treats `0` as empty, so it would keep the default.

## What changed
- Pass `mergo.WithOverwriteWithEmptyValue` so nested keys behave like scalars:
   - omitted key → inherit the type default
   - `200` → `200`
   - `0` → unused (do not inherit the 100 `storage_gb`)